### PR TITLE
Adds Owners File

### DIFF
--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,0 +1,3 @@
+# The following owners, listed in alphabetical order, own everything
+# in the repo.
+*       @alexgervais @arkodg @danehans @LukeShu @skriss @youngnick


### PR DESCRIPTION
Adds owners file based on GH code owners [spec](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

Fixes #25 

Signed-off-by: danehans <daneyonhansen@gmail.com>