### PR TITLE
Assign reviewers to PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files
+*			@envoyproxy/gateway-maintainers


### PR DESCRIPTION
* Uses the CODEOWNERS file to automatically assign reviewers to files to speed up reviews

* As the project progresses, the CODEOWNERS file can be updated to
select a subset of the mantainers as owners for a specific area /
directory.

Signed-off-by: Arko Dasgupta <arko@tetrate.io>