### PR TITLE
Adds ENVTEST_K8S_VERSION to Makefile

### DIFF
--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -1,5 +1,5 @@
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24.1
+ENVTEST_K8S_VERSION ?= 1.24.1
 
 ##@ Kubernetes Development
 

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -1,3 +1,6 @@
+# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+ENVTEST_K8S_VERSION = 1.24.1
+
 ##@ Kubernetes Development
 
 .PHONY: manifests


### PR DESCRIPTION
Running `make go.test.coverage` produces:
```
/Library/Developer/CommandLineTools/usr/bin/make --warn-undefined-variables -f tools/make/common.mk go.test.coverage
tools/make/golang.mk:40: warning: undefined variable `ENVTEST_K8S_VERSION'
...
```

This PR adds the env var to the kube make file.

Signed-off-by: danehans <daneyonhansen@gmail.com>