### PR TITLE
Fixes go.test.unit Make Target

### DIFF
--- a/pkg/provider/kubernetes/kubernetes_test.go
+++ b/pkg/provider/kubernetes/kubernetes_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package kubernetes
 
 import (

--- a/tools/make/golang.mk
+++ b/tools/make/golang.mk
@@ -36,8 +36,8 @@ go.test.unit: ## Run go unit tests
 	go test ./...
 
 .PHONY: go.test.coverage
-go.test.coverage: $(tools/setup-envtest) ## Run go unit tests in GitHub Actions
-	KUBEBUILDER_ASSETS="$(shell $(tools/setup-envtest) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -race -coverprofile=coverage.xml -covermode=atomic
+go.test.coverage: $(tools/setup-envtest) ## Run go unit and integration tests in GitHub Actions
+	KUBEBUILDER_ASSETS="$(shell $(tools/setup-envtest) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... --tags=integration -race -coverprofile=coverage.xml -covermode=atomic
 
 .PHONY: go.clean
 go.clean: ## Clean the building output files

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -13,7 +13,7 @@ generate: $(tools/controller-gen) ## Generate code containing DeepCopy, DeepCopy
 
 .PHONY: kube-test
 kube-test: manifests generate $(tools/setup-envtest) ## Run Kubernetes provider tests.
-	KUBEBUILDER_ASSETS="$(shell $(tools/setup-envtest) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(tools/setup-envtest) use $(ENVTEST_K8S_VERSION) -p path)" go test --tags=integration ./... -coverprofile cover.out
 
 ##@ Kubernetes Deployment
 


### PR DESCRIPTION
- Adds build tag to Kube provider integration tests.
- Update Mke targets to use the `integration` build tag.

Signed-off-by: danehans <daneyonhansen@gmail.com>