### PR TITLE
Adds initial draft of Gateway API translator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/zap v1.19.1
+	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
 	sigs.k8s.io/controller-runtime v0.12.3
@@ -15,9 +16,18 @@ require (
 )
 
 require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/go-logr/logr v1.2.0
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/tetratelabs/multierror v1.1.0
 	google.golang.org/protobuf v1.28.0
@@ -25,22 +35,13 @@ require (
 )
 
 require (
-	github.com/PuerkitoBio/purell v1.1.1 // indirect
-	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc // indirect
-	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.6.7 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/go-openapi/jsonpointer v0.19.5 // indirect
-	github.com/go-openapi/jsonreference v0.19.5 // indirect
-	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
@@ -73,7 +74,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.24.2 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect

--- a/internal/gatewayapi/contexts.go
+++ b/internal/gatewayapi/contexts.go
@@ -1,0 +1,256 @@
+package gatewayapi
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// GatewayContext wraps a Gateway and provides helper methods for
+// setting conditions, accessing Listeners, etc.
+type GatewayContext struct {
+	*v1beta1.Gateway
+
+	listeners map[v1beta1.SectionName]*ListenerContext
+}
+
+func (g *GatewayContext) SetCondition(conditionType v1beta1.GatewayConditionType, status metav1.ConditionStatus, reason v1beta1.GatewayConditionReason, message string) {
+	cond := metav1.Condition{
+		Type:    string(conditionType),
+		Status:  status,
+		Reason:  string(reason),
+		Message: message,
+	}
+
+	idx := -1
+	for i, existing := range g.Status.Conditions {
+		if existing.Type == string(conditionType) {
+			idx = i
+			break
+		}
+	}
+
+	if idx > -1 {
+		g.Status.Conditions[idx] = cond
+	} else {
+		g.Status.Conditions = append(g.Status.Conditions, cond)
+	}
+}
+
+func (g *GatewayContext) GetListenerContext(listenerName v1beta1.SectionName) *ListenerContext {
+	if g.listeners == nil {
+		g.listeners = make(map[v1beta1.SectionName]*ListenerContext)
+	}
+
+	if ctx := g.listeners[listenerName]; ctx != nil {
+		return ctx
+	}
+
+	var listener *v1beta1.Listener
+	for i, l := range g.Spec.Listeners {
+		if l.Name == listenerName {
+			listener = &g.Spec.Listeners[i]
+			break
+		}
+	}
+	if listener == nil {
+		panic("listener not found")
+	}
+
+	listenerStatusIdx := -1
+	for i := range g.Status.Listeners {
+		if g.Status.Listeners[i].Name == listenerName {
+			listenerStatusIdx = i
+			break
+		}
+	}
+	if listenerStatusIdx == -1 {
+		g.Status.Listeners = append(g.Status.Listeners, v1beta1.ListenerStatus{Name: listenerName})
+		listenerStatusIdx = len(g.Status.Listeners) - 1
+	}
+
+	ctx := &ListenerContext{
+		Listener:          listener,
+		gateway:           g.Gateway,
+		listenerStatusIdx: listenerStatusIdx,
+	}
+	g.listeners[listenerName] = ctx
+	return ctx
+}
+
+// ListenerContext wraps a Listener and provides helper methods for
+// setting conditions and other status information on the associated
+// Gateway, etc.
+type ListenerContext struct {
+	*v1beta1.Listener
+
+	gateway           *v1beta1.Gateway
+	listenerStatusIdx int
+	namespaceSelector labels.Selector
+}
+
+func (l *ListenerContext) SetCondition(conditionType v1beta1.ListenerConditionType, status metav1.ConditionStatus, reason v1beta1.ListenerConditionReason, message string) {
+	cond := metav1.Condition{
+		Type:    string(conditionType),
+		Status:  status,
+		Reason:  string(reason),
+		Message: message,
+	}
+
+	idx := -1
+	for i, existing := range l.gateway.Status.Listeners[l.listenerStatusIdx].Conditions {
+		if existing.Type == string(conditionType) {
+			idx = i
+			break
+		}
+	}
+
+	if idx > -1 {
+		l.gateway.Status.Listeners[l.listenerStatusIdx].Conditions[idx] = cond
+	} else {
+		l.gateway.Status.Listeners[l.listenerStatusIdx].Conditions = append(l.gateway.Status.Listeners[l.listenerStatusIdx].Conditions, cond)
+	}
+}
+
+func (l *ListenerContext) SetSupportedKinds(kinds ...v1beta1.RouteGroupKind) {
+	l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds = kinds
+}
+
+func (l *ListenerContext) IncrementAttachedRoutes() {
+	l.gateway.Status.Listeners[l.listenerStatusIdx].AttachedRoutes++
+}
+
+func (l *ListenerContext) AllowsKind(kind v1beta1.RouteGroupKind) bool {
+	for _, allowed := range l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds {
+		if GroupDerefOr(allowed.Group, "") == GroupDerefOr(kind.Group, "") && allowed.Kind == kind.Kind {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (l *ListenerContext) AllowsNamespace(namespace *v1.Namespace) bool {
+	switch *l.AllowedRoutes.Namespaces.From {
+	case v1beta1.NamespacesFromAll:
+		return true
+	case v1beta1.NamespacesFromSelector:
+		return l.namespaceSelector.Matches(labels.Set(namespace.Labels))
+	default:
+		// NamespacesFromSame is the default
+		return l.gateway.Namespace == namespace.Name
+	}
+}
+
+func (l *ListenerContext) IsReady() bool {
+	for _, cond := range l.gateway.Status.Listeners[l.listenerStatusIdx].Conditions {
+		if cond.Type == string(v1beta1.ListenerConditionReady) && cond.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (l *ListenerContext) GetConditions() []metav1.Condition {
+	return l.gateway.Status.Listeners[l.listenerStatusIdx].Conditions
+}
+
+// HTTPRouteContext wraps an HTTPRoute and provides helper methods for
+// accessing the route's parents.
+type HTTPRouteContext struct {
+	*v1beta1.HTTPRoute
+
+	parentRefs map[v1beta1.ParentReference]*RouteParentContext
+}
+
+func (h *HTTPRouteContext) GetRouteParentContext(forParentRef v1beta1.ParentReference) *RouteParentContext {
+	if h.parentRefs == nil {
+		h.parentRefs = make(map[v1beta1.ParentReference]*RouteParentContext)
+	}
+
+	if ctx := h.parentRefs[forParentRef]; ctx != nil {
+		return ctx
+	}
+
+	var parentRef *v1beta1.ParentReference
+	for i, p := range h.Spec.ParentRefs {
+		if p == forParentRef {
+			parentRef = &h.Spec.ParentRefs[i]
+			break
+		}
+	}
+	if parentRef == nil {
+		panic("parentRef not found")
+	}
+
+	routeParentStatusIdx := -1
+	for i := range h.Status.Parents {
+		if h.Status.Parents[i].ParentRef == forParentRef {
+			routeParentStatusIdx = i
+			break
+		}
+	}
+	if routeParentStatusIdx == -1 {
+		h.Status.Parents = append(h.Status.Parents, v1beta1.RouteParentStatus{ParentRef: forParentRef})
+		routeParentStatusIdx = len(h.Status.Parents) - 1
+	}
+
+	ctx := &RouteParentContext{
+		ParentReference: parentRef,
+
+		route:                h.HTTPRoute,
+		routeParentStatusIdx: routeParentStatusIdx,
+	}
+	h.parentRefs[forParentRef] = ctx
+	return ctx
+}
+
+// RouteParentContext wraps a ParentReference and provides helper methods for
+// setting conditions and other status information on the associated
+// HTTPRoute, etc.
+type RouteParentContext struct {
+	*v1beta1.ParentReference
+
+	route                *v1beta1.HTTPRoute
+	routeParentStatusIdx int
+	listeners            []*ListenerContext
+}
+
+func (r *RouteParentContext) SetListeners(listeners ...*ListenerContext) {
+	r.listeners = append(r.listeners, listeners...)
+}
+
+func (r *RouteParentContext) SetCondition(conditionType v1beta1.RouteConditionType, status metav1.ConditionStatus, reason v1beta1.RouteConditionReason, message string) {
+	cond := metav1.Condition{
+		Type:    string(conditionType),
+		Status:  status,
+		Reason:  string(reason),
+		Message: message,
+	}
+
+	idx := -1
+	for i, existing := range r.route.Status.Parents[r.routeParentStatusIdx].Conditions {
+		if existing.Type == string(conditionType) {
+			idx = i
+			break
+		}
+	}
+
+	if idx > -1 {
+		r.route.Status.Parents[r.routeParentStatusIdx].Conditions[idx] = cond
+	} else {
+		r.route.Status.Parents[r.routeParentStatusIdx].Conditions = append(r.route.Status.Parents[r.routeParentStatusIdx].Conditions, cond)
+	}
+}
+
+func (r *RouteParentContext) IsAccepted() bool {
+	for _, cond := range r.route.Status.Parents[r.routeParentStatusIdx].Conditions {
+		if cond.Type == string(v1beta1.RouteConditionAccepted) && cond.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/gatewayapi/contexts_test.go
+++ b/internal/gatewayapi/contexts_test.go
@@ -1,0 +1,56 @@
+package gatewayapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func TestContexts(t *testing.T) {
+	gateway := &v1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "envoy-gateway",
+			Name:      "gateway-1",
+		},
+		Spec: v1beta1.GatewaySpec{
+			Listeners: []v1beta1.Listener{
+				{
+					Name: "http",
+				},
+			},
+		},
+	}
+
+	gctx := &GatewayContext{
+		Gateway: gateway,
+	}
+
+	gctx.SetCondition(v1beta1.GatewayConditionReady, metav1.ConditionTrue, v1beta1.GatewayReasonReady, "Gateway is ready")
+
+	require.Len(t, gateway.Status.Conditions, 1)
+	require.EqualValues(t, gateway.Status.Conditions[0].Type, v1beta1.GatewayConditionReady)
+	require.EqualValues(t, gateway.Status.Conditions[0].Status, metav1.ConditionTrue)
+	require.EqualValues(t, gateway.Status.Conditions[0].Reason, v1beta1.GatewayReasonReady)
+	require.EqualValues(t, gateway.Status.Conditions[0].Message, "Gateway is ready")
+
+	lctx := gctx.GetListenerContext("http")
+	require.NotNil(t, lctx)
+
+	lctx.SetCondition(v1beta1.ListenerConditionDetached, metav1.ConditionTrue, v1beta1.ListenerReasonUnsupportedProtocol, "HTTPS protocol is not supported yet")
+
+	require.Len(t, gateway.Status.Listeners, 1)
+	require.EqualValues(t, gateway.Status.Listeners[0].Name, "http")
+	require.Len(t, gateway.Status.Listeners[0].Conditions, 1)
+	require.EqualValues(t, gateway.Status.Listeners[0].Conditions[0].Type, v1beta1.ListenerConditionDetached)
+	require.EqualValues(t, gateway.Status.Listeners[0].Conditions[0].Status, metav1.ConditionTrue)
+	require.EqualValues(t, gateway.Status.Listeners[0].Conditions[0].Reason, v1beta1.ListenerReasonUnsupportedProtocol)
+	require.EqualValues(t, gateway.Status.Listeners[0].Conditions[0].Message, "HTTPS protocol is not supported yet")
+
+	lctx.SetSupportedKinds(v1beta1.RouteGroupKind{Group: GroupPtr(v1beta1.GroupName), Kind: "HTTPRoute"})
+
+	require.Len(t, gateway.Status.Listeners, 1)
+	require.Len(t, gateway.Status.Listeners[0].SupportedKinds, 1)
+	require.EqualValues(t, gateway.Status.Listeners[0].SupportedKinds[0].Kind, "HTTPRoute")
+}

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -1,0 +1,189 @@
+package gatewayapi
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func GroupPtr(name string) *v1beta1.Group {
+	group := v1beta1.Group(name)
+	return &group
+}
+
+func KindPtr(name string) *v1beta1.Kind {
+	kind := v1beta1.Kind(name)
+	return &kind
+}
+
+func NamespacePtr(name string) *v1beta1.Namespace {
+	namespace := v1beta1.Namespace(name)
+	return &namespace
+}
+
+func FromNamespacesPtr(fromNamespaces v1beta1.FromNamespaces) *v1beta1.FromNamespaces {
+	return &fromNamespaces
+}
+
+func StringPtr(val string) *string {
+	return &val
+}
+
+func Int32Ptr(val int32) *int32 {
+	return &val
+}
+
+func PortNumPtr(val int32) *v1beta1.PortNumber {
+	portNum := v1beta1.PortNumber(val)
+	return &portNum
+}
+
+func PathMatchTypeDerefOr(matchType *v1beta1.PathMatchType, defaultType v1beta1.PathMatchType) v1beta1.PathMatchType {
+	if matchType != nil {
+		return *matchType
+	}
+	return defaultType
+}
+
+func HeaderMatchTypeDerefOr(matchType *v1beta1.HeaderMatchType, defaultType v1beta1.HeaderMatchType) v1beta1.HeaderMatchType {
+	if matchType != nil {
+		return *matchType
+	}
+	return defaultType
+}
+
+func NamespaceDerefOr(namespace *v1beta1.Namespace, defaultNamespace string) string {
+	if namespace != nil && *namespace != "" {
+		return string(*namespace)
+	}
+	return defaultNamespace
+}
+
+func GroupDerefOr(group *v1beta1.Group, defaultGroup string) string {
+	if group != nil && *group != "" {
+		return string(*group)
+	}
+	return defaultGroup
+}
+
+// IsRefToGateway returns whether the provided parent ref is a reference
+// to a Gateway with the given namespace/name, irrespective of whether a
+// section/listener name has been specified (i.e. a parent ref to a listener
+// on the specified gateway will return "true").
+func IsRefToGateway(parentRef v1beta1.ParentReference, gateway types.NamespacedName) bool {
+	if parentRef.Group != nil && string(*parentRef.Group) != v1beta1.GroupName {
+		return false
+	}
+
+	if parentRef.Kind != nil && string(*parentRef.Kind) != KindGateway {
+		return false
+	}
+
+	if parentRef.Namespace != nil && string(*parentRef.Namespace) != gateway.Namespace {
+		return false
+	}
+
+	return string(parentRef.Name) == gateway.Name
+}
+
+// GetReferencedListeners returns whether a given parent ref references a Gateway
+// in the given list, and if so, a list of the Listeners within that Gateway that
+// are included by the parent ref (either one specific Listener, or all Listeners
+// in the Gateway, depending on whether section name is specified or not).
+func GetReferencedListeners(parentRef v1beta1.ParentReference, gateways []*GatewayContext) (bool, []*ListenerContext) {
+	var selectsGateway bool
+	var referencedListeners []*ListenerContext
+
+	for _, gateway := range gateways {
+		if !IsRefToGateway(parentRef, types.NamespacedName{Namespace: gateway.Namespace, Name: gateway.Name}) {
+			continue
+		}
+
+		selectsGateway = true
+
+		// The parentRef may be to the entire Gateway, or to a specific listener.
+		for listenerName, listener := range gateway.listeners {
+			if parentRef.SectionName == nil || *parentRef.SectionName == listenerName {
+				referencedListeners = append(referencedListeners, listener)
+			}
+		}
+	}
+
+	return selectsGateway, referencedListeners
+}
+
+// HasReadyListener returns true if at least one Listener in the
+// provided list has a condition of "Ready: true", and false otherwise.
+func HasReadyListener(listeners []*ListenerContext) bool {
+	for _, listener := range listeners {
+		if listener.IsReady() {
+			return true
+		}
+	}
+	return false
+}
+
+// ComputeHosts returns a list of the intersecting hostnames between the route
+// and the listener.
+func ComputeHosts(routeHostnames []v1beta1.Hostname, listenerHostname *v1beta1.Hostname) []string {
+	var listenerHostnameVal string
+	if listenerHostname != nil {
+		listenerHostnameVal = string(*listenerHostname)
+	}
+
+	// No route hostnames specified: use the listener hostname if specified,
+	// or else match all hostnames.
+	if len(routeHostnames) == 0 {
+		if len(listenerHostnameVal) > 0 {
+			return []string{listenerHostnameVal}
+		}
+
+		return []string{"*"}
+	}
+
+	var hostnames []string
+
+	for i := range routeHostnames {
+		routeHostname := string(routeHostnames[i])
+
+		// TODO ensure routeHostname is a valid hostname
+
+		switch {
+		// No listener hostname: use the route hostname.
+		case len(listenerHostnameVal) == 0:
+			hostnames = append(hostnames, routeHostname)
+
+		// Listener hostname matches the route hostname: use it.
+		case listenerHostnameVal == routeHostname:
+			hostnames = append(hostnames, routeHostname)
+
+		// Listener has a wildcard hostname: check if the route hostname matches.
+		case strings.HasPrefix(listenerHostnameVal, "*"):
+			if hostnameMatchesWildcardHostname(routeHostname, listenerHostnameVal) {
+				hostnames = append(hostnames, routeHostname)
+			}
+
+		// Route has a wildcard hostname: check if the listener hostname matches.
+		case strings.HasPrefix(routeHostname, "*"):
+			if hostnameMatchesWildcardHostname(listenerHostnameVal, routeHostname) {
+				hostnames = append(hostnames, listenerHostnameVal)
+			}
+
+		}
+	}
+
+	return hostnames
+}
+
+// hostnameMatchesWildcardHostname returns true if hostname has the non-wildcard
+// portion of wildcardHostname as a suffix, plus at least one DNS label matching the
+// wildcard.
+func hostnameMatchesWildcardHostname(hostname, wildcardHostname string) bool {
+	if !strings.HasSuffix(hostname, strings.TrimPrefix(wildcardHostname, "*")) {
+		return false
+	}
+
+	wildcardMatch := strings.TrimSuffix(hostname, strings.TrimPrefix(wildcardHostname, "*"))
+	return len(wildcardMatch) > 0
+}

--- a/internal/gatewayapi/testdata_test.go
+++ b/internal/gatewayapi/testdata_test.go
@@ -98,7 +98,7 @@ ir:
       address: 0.0.0.0
       port: 80
       routes:
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-*
           pathMatch:
             prefix: "/"
           destinations:
@@ -208,7 +208,7 @@ ir:
       address: 0.0.0.0
       port: 80
       routes:
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-*
           pathMatch:
             prefix: "/"
           destinations:
@@ -325,7 +325,7 @@ ir:
       address: 0.0.0.0
       port: 80
       routes:
-        - name: ""
+        - name: envoy-gateway-httproute-1-rule-0-match-0-*
           pathMatch:
             prefix: "/"
           destinations:
@@ -559,7 +559,7 @@ ir:
       hostnames:
         - foo.com
       routes:
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-foo.com
           pathMatch:
             prefix: "/"
           destinations:
@@ -572,7 +572,7 @@ ir:
       hostnames:
         - bar.com
       routes:
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-bar.com
           pathMatch:
             prefix: "/"
           destinations:
@@ -715,7 +715,7 @@ ir:
       hostnames:
         - bar.com
       routes:
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-bar.com
           pathMatch:
             prefix: "/"
           destinations:
@@ -830,7 +830,7 @@ ir:
       hostnames:
         - "*.envoyproxy.io"
       routes:
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
           pathMatch:
             prefix: "/"
           headerMatches:
@@ -950,7 +950,7 @@ ir:
       hostnames:
         - "*.envoyproxy.io"
       routes:
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
           pathMatch:
             prefix: "/"
           headerMatches:
@@ -960,7 +960,7 @@ ir:
             - host: 7.7.7.7
               port: 8080
               weight: 1
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-whales.envoyproxy.io
           pathMatch:
             prefix: "/"
           headerMatches:
@@ -1946,7 +1946,7 @@ ir:
       address: 0.0.0.0
       port: 80
       routes:
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-*
           pathMatch:
             prefix: "/pathprefix"
           headerMatches:
@@ -2060,7 +2060,7 @@ ir:
       address: 0.0.0.0
       port: 80
       routes:
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-*
           pathMatch:
             exact: "/exact"
           destinations:
@@ -2175,7 +2175,7 @@ ir:
       address: 0.0.0.0
       port: 80
       routes:
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-*
           pathMatch:
             prefix: "/"
           destinations:
@@ -2302,7 +2302,7 @@ ir:
       address: 0.0.0.0
       port: 80
       routes:
-        - name: ""
+        - name: default-httproute-1-rule-0-match-0-*
           pathMatch:
             prefix: "/"
           destinations:

--- a/internal/gatewayapi/testdata_test.go
+++ b/internal/gatewayapi/testdata_test.go
@@ -250,6 +250,16 @@ httpRoutes:
         backendRefs:
           - name: service-1
             port: 8080
+services:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: envoy-gateway
+    name: service-1
+  spec:
+    clusterIP: 7.7.7.7
+    ports:
+    - port: 8080
 `
 
 const GatewayAllowsSameNamespaceWithAllowedHTTPRouteOut = `

--- a/internal/gatewayapi/testdata_test.go
+++ b/internal/gatewayapi/testdata_test.go
@@ -1,0 +1,2308 @@
+package gatewayapi
+
+const BasicHTTPRouteAttachingToGatewayIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const BasicHTTPRouteAttachingToGatewayOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 80
+      routes:
+        - name: ""
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+`
+
+const BasicHTTPRouteAttachingToListenerIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const BasicHTTPRouteAttachingToListenerOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+          sectionName: http
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+            sectionName: http
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 80
+      routes:
+        - name: ""
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+`
+
+const GatewayAllowsSameNamespaceWithAllowedHTTPRouteIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: Same
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const GatewayAllowsSameNamespaceWithAllowedHTTPRouteOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: Same
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: envoy-gateway
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 80
+      routes:
+        - name: ""
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+`
+
+const GatewayAllowsSameNamespaceWithDisallowedHTTPRouteIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: Same
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const GatewayAllowsSameNamespaceWithDisallowedHTTPRouteOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: Same
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 0
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "False"
+              reason: NotAllowedByListeners
+              message: No listeners included by this parent ref allowed this attachment.
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 80
+`
+
+const HTTPRouteAttachingToGatewayWithTwoListenersIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http-1
+        protocol: HTTP
+        port: 80
+        hostname: foo.com
+        allowedRoutes:
+          namespaces:
+            from: All
+      - name: http-2
+        protocol: HTTP
+        port: 80
+        hostname: bar.com
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const HTTPRouteAttachingToGatewayWithTwoListenersOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http-1
+          protocol: HTTP
+          port: 80
+          hostname: foo.com
+          allowedRoutes:
+            namespaces:
+              from: All
+        - name: http-2
+          protocol: HTTP
+          port: 80
+          hostname: bar.com
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http-1
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+        - name: http-2
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http-1
+      address: 0.0.0.0
+      port: 80
+      hostnames:
+        - foo.com
+      routes:
+        - name: ""
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+    - name: envoy-gateway-gateway-1-http-2
+      address: 0.0.0.0
+      port: 80
+      hostnames:
+        - bar.com
+      routes:
+        - name: ""
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+`
+
+const HTTPRouteAttachingToListenerOnGatewayWithTwoListenersIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http-1
+        protocol: HTTP
+        port: 80
+        hostname: foo.com
+        allowedRoutes:
+          namespaces:
+            from: All
+      - name: http-2
+        protocol: HTTP
+        port: 80
+        hostname: bar.com
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http-2
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const HTTPRouteAttachingToListenerOnGatewayWithTwoListenersOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http-1
+          protocol: HTTP
+          port: 80
+          hostname: foo.com
+          allowedRoutes:
+            namespaces:
+              from: All
+        - name: http-2
+          protocol: HTTP
+          port: 80
+          hostname: bar.com
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http-1
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 0
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+        - name: http-2
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+          sectionName: http-2
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+            sectionName: http-2
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http-1
+      address: 0.0.0.0
+      port: 80
+      hostnames:
+        - foo.com
+    - name: envoy-gateway-gateway-1-http-2
+      address: 0.0.0.0
+      port: 80
+      hostnames:
+        - bar.com
+      routes:
+        - name: ""
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+`
+
+const HTTPRouteWithSpecificHostnameAttachingToGatewayWithWildcardHostnameIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        hostname: "*.envoyproxy.io"
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    hostnames:
+      - gateway.envoyproxy.io
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const HTTPRouteWithSpecificHostnameAttachingToGatewayWithWildcardHostnameOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          hostname: "*.envoyproxy.io"
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:
+        - gateway.envoyproxy.io
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 80
+      hostnames:
+        - "*.envoyproxy.io"
+      routes:
+        - name: ""
+          pathMatch:
+            prefix: "/"
+          headerMatches:
+            - name: ":authority"
+              exact: gateway.envoyproxy.io
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+`
+
+const HTTPRouteWithTwoSpecificHostnamesAttachingToGatewayWithWildcardHostnameIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        hostname: "*.envoyproxy.io"
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    hostnames:
+      - gateway.envoyproxy.io
+      - whales.envoyproxy.io
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const HTTPRouteWithTwoSpecificHostnamesAttachingToGatewayWithWildcardHostnameOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          hostname: "*.envoyproxy.io"
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:
+        - gateway.envoyproxy.io
+        - whales.envoyproxy.io
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 80
+      hostnames:
+        - "*.envoyproxy.io"
+      routes:
+        - name: ""
+          pathMatch:
+            prefix: "/"
+          headerMatches:
+            - name: ":authority"
+              exact: gateway.envoyproxy.io
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+        - name: ""
+          pathMatch:
+            prefix: "/"
+          headerMatches:
+            - name: ":authority"
+              exact: whales.envoyproxy.io
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+`
+
+const HTTPRouteWithNonMatchingSpecificHostnameAttachingToGatewayWithWildcardHostnameIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        hostname: "*.envoyproxy.io"
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    hostnames:
+      - whales.kubernetes.io
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const HTTPRouteWithNonMatchingSpecificHostnameAttachingToGatewayWithWildcardHostnameOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          hostname: "*.envoyproxy.io"
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 0
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:
+        - whales.kubernetes.io
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "False"
+              reason: NoMatchingListenerHostname
+              message: There were no hostname intersections between the HTTPRoute and this parent ref's Listener(s).
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 80
+      hostnames:
+        - "*.envoyproxy.io"
+`
+
+const GatewayWithListenerWithNonHTTPProtocolIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTPS
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const GatewayWithListenerWithNonHTTPProtocolOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTPS
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          attachedRoutes: 0
+          conditions:
+            - type: Detached
+              status: "True"
+              reason: UnsupportedProtocol
+              message: Protocol must be HTTP
+            - type: Ready
+              status: "False"
+              reason: Invalid
+              message: Listener is invalid, see other Conditions for details.
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "False"
+              reason: NoReadyListeners
+              message: There are no ready listeners for this parent ref
+ir:
+  name: ""
+`
+
+const GatewayWithListenerWithMissingAllowedNamespacesSelectorIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: Selector
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const GatewayWithListenerWithMissingAllowedNamespacesSelectorOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: Selector
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 0
+          conditions:
+            - type: Ready
+              status: "False"
+              reason: Invalid
+              message: The allowedRoutes.namespaces.selector field must be specified when allowedRoutes.namespaces.from is set to "Selector".
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "False"
+              reason: NoReadyListeners
+              message: There are no ready listeners for this parent ref
+ir:
+  name: ""
+`
+
+const GatewayWithListenerWithInvalidAllowedNamespacesSelectorIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: Selector
+            selector:
+              matchExpressions:
+                - key: foo
+                  operator: Exists
+                  values:
+                    - bar
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const GatewayWithListenerWithInvalidAllowedNamespacesSelectorOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: Selector
+              selector:
+                matchExpressions:
+                  - key: foo
+                    operator: Exists
+                    values:
+                      - bar
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 0
+          conditions:
+            - type: Ready
+              status: "False"
+              reason: Invalid
+              message: "The allowedRoutes.namespaces.selector could not be parsed: values: Invalid value: []string{\"bar\"}: values set must be empty for exists and does not exist."
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "False"
+              reason: NoReadyListeners
+              message: There are no ready listeners for this parent ref
+ir:
+  name: ""
+`
+
+const GatewayWithListenerWithInvalidAllowedRoutesGroupIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: All
+          kinds:
+            - group: foo.io
+              kind: HTTPRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const GatewayWithListenerWithInvalidAllowedRoutesGroupOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+            kinds:
+              - group: foo.io
+                kind: HTTPRoute
+    status:
+      listeners:
+        - name: http
+          attachedRoutes: 0
+          conditions:
+            - type: ResolvedRefs
+              status: "False"
+              reason: InvalidRouteKinds
+              message: "Group is not supported, group must be gateway.networking.k8s.io"
+            - type: Ready
+              status: "False"
+              reason: Invalid
+              message: Listener is invalid, see other Conditions for details.
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "False"
+              reason: NoReadyListeners
+              message: There are no ready listeners for this parent ref
+ir:
+  name: ""
+`
+
+const GatewayWithListenerWithInvalidAllowedRoutesKindIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: All
+          kinds:
+            - group: gateway.networking.k8s.io
+              kind: FooRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const GatewayWithListenerWithInvalidAllowedRoutesKindOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+            kinds:
+              - group: gateway.networking.k8s.io
+                kind: FooRoute
+    status:
+      listeners:
+        - name: http
+          attachedRoutes: 0
+          conditions:
+            - type: ResolvedRefs
+              status: "False"
+              reason: InvalidRouteKinds
+              message: "Kind is not supported, kind must be HTTPRoute"
+            - type: Ready
+              status: "False"
+              reason: Invalid
+              message: Listener is invalid, see other Conditions for details.
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "False"
+              reason: NoReadyListeners
+              message: There are no ready listeners for this parent ref
+ir:
+  name: ""
+`
+
+const GatewayWithTwoListenersWithSamePortAndHostnameIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http-1
+        protocol: HTTP
+        port: 80
+        hostname: foo.com
+        allowedRoutes:
+          namespaces:
+            from: All
+      - name: http-2
+        protocol: HTTP
+        port: 80
+        hostname: foo.com
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const GatewayWithTwoListenersWithSamePortAndHostnameOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http-1
+          protocol: HTTP
+          port: 80
+          hostname: foo.com
+          allowedRoutes:
+            namespaces:
+              from: All
+        - name: http-2
+          protocol: HTTP
+          port: 80
+          hostname: foo.com
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http-1
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          conditions:
+            - type: Conflicted
+              status: "True"
+              reason: HostnameConflict
+              message: All listeners for a given port must use a unique hostname
+            - type: Ready
+              status: "False"
+              reason: Invalid
+              message: Listener is invalid, see other Conditions for details.
+        - name: http-2
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          conditions:
+            - type: Conflicted
+              status: "True"
+              reason: HostnameConflict
+              message: All listeners for a given port must use a unique hostname
+            - type: Ready
+              status: "False"
+              reason: Invalid
+              message: Listener is invalid, see other Conditions for details.
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "False"
+              reason: NoReadyListeners
+              message: There are no ready listeners for this parent ref
+ir:
+  name: ""
+  http:
+`
+
+const GatewayWithTwoListenersWithSamePortAndIncompatibleProtocolsIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http-1
+        protocol: HTTP
+        port: 80
+        hostname: foo.com
+        allowedRoutes:
+          namespaces:
+            from: All
+      - name: http-2
+        protocol: HTTPS
+        port: 80
+        hostname: bar.com
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const GatewayWithTwoListenersWithSamePortAndIncompatibleProtocolsOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http-1
+          protocol: HTTP
+          port: 80
+          hostname: foo.com
+          allowedRoutes:
+            namespaces:
+              from: All
+        - name: http-2
+          protocol: HTTPS
+          port: 80
+          hostname: bar.com
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http-1
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          conditions:
+            - type: Conflicted
+              status: "True"
+              reason: ProtocolConflict
+              message: All listeners for a given port must use a compatible protocol
+            - type: Ready
+              status: "False"
+              reason: Invalid
+              message: Listener is invalid, see other Conditions for details.
+        - name: http-2
+          conditions:
+            - type: Conflicted
+              status: "True"
+              reason: ProtocolConflict
+              message: All listeners for a given port must use a compatible protocol
+            - type: Detached
+              status: "True"
+              reason: UnsupportedProtocol
+              message: Protocol must be HTTP
+            - type: Ready
+              status: "False"
+              reason: Invalid
+              message: Listener is invalid, see other Conditions for details.
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "False"
+              reason: NoReadyListeners
+              message: There are no ready listeners for this parent ref
+ir:
+  name: ""
+  http:
+`
+
+const HTTPRouteWithSingleRuleWithPathPrefixAndExactHeaderMatchesIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/pathprefix"
+            headers:
+              - name: Header-1
+                value: Val-1
+              - name: Header-2
+                value: Val-2
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const HTTPRouteWithSingleRuleWithPathPrefixAndExactHeaderMatchesOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+          - path:
+              value: "/pathprefix"
+            headers:
+              - name: Header-1
+                value: Val-1
+              - name: Header-2
+                value: Val-2
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 80
+      routes:
+        - name: ""
+          pathMatch:
+            prefix: "/pathprefix"
+          headerMatches:
+            - name: Header-1
+              exact: Val-1
+            - name: Header-2
+              exact: Val-2
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+`
+
+const HTTPRouteWithSingleRuleWithExactPathMatchIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              type: Exact
+              value: "/exact"
+        backendRefs:
+          - name: service-1
+            port: 8080
+`
+
+const HTTPRouteWithSingleRuleWithExactPathMatchOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+          - path:
+              type: Exact
+              value: "/exact"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 80
+      routes:
+        - name: ""
+          pathMatch:
+            exact: "/exact"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+`
+
+const HTTPRouteRuleWithMultipleBackendsAndNoWeightsIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+          - name: service-2
+            port: 8080
+          - name: service-3
+            port: 8080
+`
+
+const HTTPRouteRuleWithMultipleBackendsAndNoWeightsOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+          - name: service-2
+            port: 8080
+          - name: service-3
+            port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 80
+      routes:
+        - name: ""
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+`
+
+const HTTPRouteRuleWithMultipleBackendsAndWeightsIn = `
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+            weight: 1
+          - name: service-2
+            port: 8080
+            weight: 2
+          - name: service-3
+            port: 8080
+            weight: 3
+`
+
+const HTTPRouteRuleWithMultipleBackendsAndWeightsOut = `
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+            weight: 1
+          - name: service-2
+            port: 8080
+            weight: 2
+          - name: service-3
+            port: 8080
+            weight: 3
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          # controllerName: envoyproxy.io/gateway-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+ir:
+  name: ""
+  http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 80
+      routes:
+        - name: ""
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+            - host: 7.7.7.7
+              port: 8080
+              weight: 2
+            - host: 7.7.7.7
+              port: 8080
+              weight: 3
+`

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -1,0 +1,515 @@
+package gatewayapi
+
+import (
+	"fmt"
+
+	"github.com/envoyproxy/gateway/pkg/ir"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+const (
+	KindGateway   = "Gateway"
+	KindHTTPRoute = "HTTPRoute"
+	KindService   = "Service"
+)
+
+// Cache is an interface that the Translator requires
+// for getting Gateway API and related resources.
+type Cache interface {
+	ListGateways() []*v1beta1.Gateway
+	ListHTTPRoutes() []*v1beta1.HTTPRoute
+	GetNamespace(name string) *v1.Namespace
+	GetService(namespace, name string) *v1.Service
+}
+
+// Translator translates Gateway API resources to the IR,
+// and computes status for Gateway API resources.
+type Translator struct {
+	gatewayClassName v1beta1.ObjectName
+}
+
+type TranslateResult struct {
+	Gateways   []*v1beta1.Gateway
+	HTTPRoutes []*v1beta1.HTTPRoute
+	IR         *ir.Xds
+}
+
+func newTranslateResult(gateways []*GatewayContext, httpRoutes []*HTTPRouteContext, xdsIR *ir.Xds) *TranslateResult {
+	translateResult := &TranslateResult{
+		IR: xdsIR,
+	}
+
+	for _, gateway := range gateways {
+		translateResult.Gateways = append(translateResult.Gateways, gateway.Gateway)
+	}
+	for _, httpRoute := range httpRoutes {
+		translateResult.HTTPRoutes = append(translateResult.HTTPRoutes, httpRoute.HTTPRoute)
+	}
+
+	return translateResult
+}
+
+func (t *Translator) Translate(cache Cache) *TranslateResult {
+	xdsIR := &ir.Xds{}
+
+	// Get Gateways belonging to our GatewayClass.
+	gateways := t.GetRelevantGateways(cache.ListGateways())
+
+	// Process all Listeners for all relevant Gateways.
+	t.ProcessListeners(gateways, xdsIR)
+
+	// Process all relevant HTTPRoutes.
+	httpRoutes := t.ProcessHTTPRoutes(cache.ListHTTPRoutes(), gateways, cache, xdsIR)
+
+	return newTranslateResult(gateways, httpRoutes, xdsIR)
+}
+
+func (t *Translator) GetRelevantGateways(gateways []*v1beta1.Gateway) []*GatewayContext {
+	var relevant []*GatewayContext
+
+	for _, gateway := range gateways {
+		if gateway.Spec.GatewayClassName == t.gatewayClassName {
+			gc := &GatewayContext{
+				Gateway: gateway.DeepCopy(),
+			}
+
+			for _, listener := range gateway.Spec.Listeners {
+				gc.GetListenerContext(listener.Name)
+			}
+
+			relevant = append(relevant, gc)
+		}
+	}
+
+	return relevant
+}
+
+type portListeners struct {
+	listeners []*ListenerContext
+	protocols sets.String
+	hostnames map[string]int
+}
+
+func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR *ir.Xds) {
+	portListenerInfo := map[v1beta1.PortNumber]*portListeners{}
+
+	// Iterate through all listeners and collect info about protocols
+	// and hostnames per port.
+	for _, gateway := range gateways {
+		for _, listener := range gateway.listeners {
+			if portListenerInfo[listener.Port] == nil {
+				portListenerInfo[listener.Port] = &portListeners{
+					protocols: sets.NewString(),
+					hostnames: map[string]int{},
+				}
+			}
+
+			portListenerInfo[listener.Port].listeners = append(portListenerInfo[listener.Port].listeners, listener)
+
+			var protocol string
+			switch listener.Protocol {
+			// HTTPS and TLS can co-exist on the same port
+			case v1beta1.HTTPSProtocolType, v1beta1.TLSProtocolType:
+				protocol = "https/tls"
+			default:
+				protocol = string(listener.Protocol)
+			}
+			portListenerInfo[listener.Port].protocols.Insert(protocol)
+
+			var hostname string
+			if listener.Hostname != nil {
+				hostname = string(*listener.Hostname)
+			}
+
+			portListenerInfo[listener.Port].hostnames[hostname]++
+		}
+	}
+
+	// Set Conflicted conditions for any listeners with conflicting specs.
+	for _, info := range portListenerInfo {
+		for _, listener := range info.listeners {
+			if len(info.protocols) > 1 {
+				listener.SetCondition(
+					v1beta1.ListenerConditionConflicted,
+					metav1.ConditionTrue,
+					v1beta1.ListenerReasonProtocolConflict,
+					"All listeners for a given port must use a compatible protocol",
+				)
+			}
+
+			var hostname string
+			if listener.Hostname != nil {
+				hostname = string(*listener.Hostname)
+			}
+
+			if info.hostnames[hostname] > 1 {
+				listener.SetCondition(
+					v1beta1.ListenerConditionConflicted,
+					metav1.ConditionTrue,
+					v1beta1.ListenerReasonHostnameConflict,
+					"All listeners for a given port must use a unique hostname",
+				)
+			}
+		}
+	}
+
+	// Iterate through all listeners to validate spec
+	// and compute status for each, and add valid ones
+	// to the IR.
+	for _, gateway := range gateways {
+		for _, listener := range gateway.listeners {
+			// Process protocol & supported kinds
+			switch listener.Protocol {
+			case v1beta1.HTTPProtocolType:
+				if listener.AllowedRoutes == nil || len(listener.AllowedRoutes.Kinds) == 0 {
+					listener.SetSupportedKinds(v1beta1.RouteGroupKind{Group: GroupPtr(v1beta1.GroupName), Kind: KindHTTPRoute})
+				} else {
+					for _, kind := range listener.AllowedRoutes.Kinds {
+						if kind.Group != nil && string(*kind.Group) != v1beta1.GroupName {
+							listener.SetCondition(
+								v1beta1.ListenerConditionResolvedRefs,
+								metav1.ConditionFalse,
+								v1beta1.ListenerReasonInvalidRouteKinds,
+								fmt.Sprintf("Group is not supported, group must be %s", v1beta1.GroupName),
+							)
+						}
+
+						if kind.Kind != KindHTTPRoute {
+							listener.SetCondition(
+								v1beta1.ListenerConditionResolvedRefs,
+								metav1.ConditionFalse,
+								v1beta1.ListenerReasonInvalidRouteKinds,
+								fmt.Sprintf("Kind is not supported, kind must be %s", KindHTTPRoute),
+							)
+						}
+					}
+				}
+			default:
+				listener.SetCondition(
+					v1beta1.ListenerConditionDetached,
+					metav1.ConditionTrue,
+					v1beta1.ListenerReasonUnsupportedProtocol,
+					"Protocol must be HTTP",
+				)
+			}
+
+			// Validate allowed namespaces
+			if listener.AllowedRoutes != nil && listener.AllowedRoutes.Namespaces != nil && listener.AllowedRoutes.Namespaces.From != nil && *listener.AllowedRoutes.Namespaces.From == v1beta1.NamespacesFromSelector {
+				if listener.AllowedRoutes.Namespaces.Selector == nil {
+					listener.SetCondition(
+						v1beta1.ListenerConditionReady,
+						metav1.ConditionFalse,
+						v1beta1.ListenerReasonInvalid,
+						"The allowedRoutes.namespaces.selector field must be specified when allowedRoutes.namespaces.from is set to \"Selector\".",
+					)
+				} else {
+					selector, err := metav1.LabelSelectorAsSelector(listener.AllowedRoutes.Namespaces.Selector)
+					if err != nil {
+						listener.SetCondition(
+							v1beta1.ListenerConditionReady,
+							metav1.ConditionFalse,
+							v1beta1.ListenerReasonInvalid,
+							fmt.Sprintf("The allowedRoutes.namespaces.selector could not be parsed: %v.", err),
+						)
+					}
+
+					listener.namespaceSelector = selector
+				}
+			}
+
+			// Any condition on the listener indicates an error,
+			// so set "Ready: false" if it's not set already.
+			if len(listener.GetConditions()) > 0 {
+				var hasReadyCond bool
+				for _, existing := range listener.GetConditions() {
+					if existing.Type == string(v1beta1.ListenerConditionReady) {
+						hasReadyCond = true
+						break
+					}
+				}
+				if !hasReadyCond {
+					listener.SetCondition(
+						v1beta1.ListenerConditionReady,
+						metav1.ConditionFalse,
+						v1beta1.ListenerReasonInvalid,
+						"Listener is invalid, see other Conditions for details.",
+					)
+				}
+
+				continue
+			}
+
+			listener.SetCondition(v1beta1.ListenerConditionReady, metav1.ConditionTrue, v1beta1.ListenerReasonReady, "Listener is ready")
+
+			irListener := &ir.HTTPListener{
+				Name:    irListenerName(listener),
+				Address: "0.0.0.0",
+				Port:    uint32(listener.Port),
+			}
+			if listener.Hostname != nil {
+				irListener.Hostnames = append(irListener.Hostnames, string(*listener.Hostname))
+			}
+			xdsIR.HTTP = append(xdsIR.HTTP, irListener)
+		}
+	}
+}
+
+func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways []*GatewayContext, cache Cache, xdsIR *ir.Xds) []*HTTPRouteContext {
+	var relevantHTTPRoutes []*HTTPRouteContext
+
+	for _, h := range httpRoutes {
+		httpRoute := &HTTPRouteContext{HTTPRoute: h}
+
+		// Find out if this route attaches to one of our Gateway's listeners,
+		// and if so, get the list of listeners that allow it to attach for each
+		// parentRef.
+		var relevantRoute bool
+		for _, parentRef := range httpRoute.Spec.ParentRefs {
+			isRelevantParentRef, selectedListeners := GetReferencedListeners(parentRef, gateways)
+
+			// Parent ref is not to a Gateway that we control: skip it
+			if !isRelevantParentRef {
+				continue
+			}
+			relevantRoute = true
+
+			parentRefCtx := httpRoute.GetRouteParentContext(parentRef)
+
+			if !HasReadyListener(selectedListeners) {
+				parentRefCtx.SetCondition(v1beta1.RouteConditionAccepted, metav1.ConditionFalse, "NoReadyListeners", "There are no ready listeners for this parent ref")
+				continue
+			}
+
+			var allowedListeners []*ListenerContext
+			for _, listener := range selectedListeners {
+				if listener.AllowsKind(v1beta1.RouteGroupKind{Group: GroupPtr(v1beta1.GroupName), Kind: KindHTTPRoute}) && listener.AllowsNamespace(cache.GetNamespace(httpRoute.Namespace)) {
+					allowedListeners = append(allowedListeners, listener)
+				}
+			}
+
+			if len(allowedListeners) == 0 {
+				parentRefCtx.SetCondition(v1beta1.RouteConditionAccepted, metav1.ConditionFalse, v1beta1.RouteReasonNotAllowedByListeners, "No listeners included by this parent ref allowed this attachment.")
+				continue
+			}
+
+			parentRefCtx.SetListeners(allowedListeners...)
+
+			parentRefCtx.SetCondition(v1beta1.RouteConditionAccepted, metav1.ConditionTrue, v1beta1.RouteReasonAccepted, "Route is accepted")
+		}
+
+		if !relevantRoute {
+			continue
+		}
+
+		relevantHTTPRoutes = append(relevantHTTPRoutes, httpRoute)
+
+		for _, parentRef := range httpRoute.parentRefs {
+			// Skip parent refs that did not accept the route
+			if !parentRef.IsAccepted() {
+				continue
+			}
+
+			// Need to compute Route rules within the parentRef loop because
+			// any conditions that come out of it have to go on each RouteParentStatus,
+			// not on the Route as a whole.
+			var routeRoutes []*ir.HTTPRoute
+
+			// compute matches, filters, backends
+			for _, rule := range httpRoute.Spec.Rules {
+				var ruleRoutes []*ir.HTTPRoute
+
+				// A rule is matched if any one of its matches
+				// is satisfied (i.e. a logical "OR"), so generate
+				// a unique IR HTTPRoute per match.
+				for _, match := range rule.Matches {
+					irRoute := &ir.HTTPRoute{}
+
+					if match.Path != nil {
+						switch PathMatchTypeDerefOr(match.Path.Type, v1beta1.PathMatchPathPrefix) {
+						case v1beta1.PathMatchPathPrefix:
+							irRoute.PathMatch = &ir.StringMatch{
+								Prefix: match.Path.Value,
+							}
+						case v1beta1.PathMatchExact:
+							irRoute.PathMatch = &ir.StringMatch{
+								Exact: match.Path.Value,
+							}
+						}
+					}
+					for _, headerMatch := range match.Headers {
+						if HeaderMatchTypeDerefOr(headerMatch.Type, v1beta1.HeaderMatchExact) == v1beta1.HeaderMatchExact {
+							irRoute.HeaderMatches = append(irRoute.HeaderMatches, &ir.StringMatch{
+								Name:  string(headerMatch.Name),
+								Exact: StringPtr(headerMatch.Value),
+							})
+						}
+					}
+
+					ruleRoutes = append(ruleRoutes, irRoute)
+				}
+
+				// TODO implement core filters (header modifier, redirect)
+
+				for _, backendRef := range rule.BackendRefs {
+					if backendRef.Group != nil && *backendRef.Group != "" {
+						parentRef.SetCondition(
+							v1beta1.RouteConditionResolvedRefs,
+							metav1.ConditionFalse,
+							v1beta1.RouteReasonInvalidKind,
+							"Group is invalid, only the core API group (specified by omitting the group field or setting it to an empty string) is supported",
+						)
+						continue
+					}
+
+					if backendRef.Kind != nil && *backendRef.Kind != KindService {
+						parentRef.SetCondition(
+							v1beta1.RouteConditionResolvedRefs,
+							metav1.ConditionFalse,
+							v1beta1.RouteReasonInvalidKind,
+							"Kind is invalid, only Service is supported",
+						)
+						continue
+					}
+
+					if backendRef.Namespace != nil && string(*backendRef.Namespace) != httpRoute.Namespace {
+						// TODO implement ReferenceGrant
+						parentRef.SetCondition(
+							v1beta1.RouteConditionResolvedRefs,
+							metav1.ConditionFalse,
+							v1beta1.RouteReasonRefNotPermitted,
+							"Backend must be in the same namespace as the HTTPRoute",
+						)
+						continue
+					}
+
+					if backendRef.Port == nil {
+						parentRef.SetCondition(
+							v1beta1.RouteConditionResolvedRefs,
+							metav1.ConditionFalse,
+							"PortNotSpecified",
+							"A valid port number corresponding to a port on the Service must be specified",
+						)
+						continue
+					}
+
+					service := cache.GetService(NamespaceDerefOr(backendRef.Namespace, httpRoute.Namespace), string(backendRef.Name))
+					if service == nil {
+						parentRef.SetCondition(
+							v1beta1.RouteConditionResolvedRefs,
+							metav1.ConditionFalse,
+							v1beta1.RouteReasonBackendNotFound,
+							fmt.Sprintf("Service %s/%s not found", NamespaceDerefOr(backendRef.Namespace, httpRoute.Namespace), string(backendRef.Name)),
+						)
+						continue
+					}
+
+					var portFound bool
+					for _, port := range service.Spec.Ports {
+						if port.Port == int32(*backendRef.Port) {
+							portFound = true
+							break
+						}
+					}
+
+					if !portFound {
+						parentRef.SetCondition(
+							v1beta1.RouteConditionResolvedRefs,
+							metav1.ConditionFalse,
+							"PortNotFound",
+							fmt.Sprintf("Port %d not found on service %s/%s", *backendRef.Port, NamespaceDerefOr(backendRef.Namespace, httpRoute.Namespace), string(backendRef.Name)),
+						)
+						continue
+					}
+
+					weight := uint32(1)
+					if backendRef.Weight != nil {
+						weight = uint32(*backendRef.Weight)
+					}
+
+					for _, route := range ruleRoutes {
+						route.Destinations = append(route.Destinations, &ir.RouteDestination{
+							Host:   service.Spec.ClusterIP,
+							Port:   uint32(*backendRef.Port),
+							Weight: weight,
+						})
+					}
+				}
+
+				// TODO handle:
+				//	- no valid backend refs
+				//	- sum of weights for valid backend refs is 0
+				//	- returning 500's for invalid backend refs
+				//	- etc.
+
+				routeRoutes = append(routeRoutes, ruleRoutes...)
+			}
+
+			var hasHostnameIntersection bool
+			for _, listener := range parentRef.listeners {
+				hosts := ComputeHosts(httpRoute.Spec.Hostnames, listener.Hostname)
+				if len(hosts) == 0 {
+					continue
+				}
+				hasHostnameIntersection = true
+
+				var perHostRoutes []*ir.HTTPRoute
+				for _, host := range hosts {
+					var headerMatches []*ir.StringMatch
+
+					// If the intersecting host is more specific than the Listener's hostname,
+					// add an additional header match to all of the routes for it
+					if host != "*" && (listener.Hostname == nil || string(*listener.Hostname) != host) {
+						headerMatches = append(headerMatches, &ir.StringMatch{
+							Name:  ":authority",
+							Exact: StringPtr(host),
+						})
+					}
+
+					for _, routeRoute := range routeRoutes {
+						perHostRoutes = append(perHostRoutes, &ir.HTTPRoute{
+							PathMatch:         routeRoute.PathMatch,
+							HeaderMatches:     append(headerMatches, routeRoute.HeaderMatches...),
+							QueryParamMatches: routeRoute.QueryParamMatches,
+							Destinations:      routeRoute.Destinations,
+						})
+					}
+				}
+
+				irListener := xdsIR.GetListener(irListenerName(listener))
+				irListener.Routes = append(irListener.Routes, perHostRoutes...)
+
+				// Theoretically there should only be one parent ref per
+				// Route that attaches to a given Listener, so fine to just increment here, but we
+				// might want to check to ensure we're not double-counting.
+				if len(routeRoutes) > 0 {
+					listener.IncrementAttachedRoutes()
+				}
+			}
+
+			if !hasHostnameIntersection {
+				parentRef.SetCondition(
+					v1beta1.RouteConditionAccepted,
+					metav1.ConditionFalse,
+					v1beta1.RouteReasonNoMatchingListenerHostname,
+					"There were no hostname intersections between the HTTPRoute and this parent ref's Listener(s).",
+				)
+			} else {
+				parentRef.SetCondition(
+					v1beta1.RouteConditionAccepted,
+					metav1.ConditionTrue,
+					v1beta1.RouteReasonAccepted,
+					"Route is accepted",
+				)
+			}
+		}
+	}
+
+	return relevantHTTPRoutes
+}
+
+func irListenerName(listener *ListenerContext) string {
+	return fmt.Sprintf("%s-%s-%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name)
+}

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -1,0 +1,182 @@
+package gatewayapi
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/yaml"
+)
+
+type StaticCache struct {
+	Gateways   []*v1beta1.Gateway
+	HTTPRoutes []*v1beta1.HTTPRoute
+}
+
+func (c *StaticCache) ListGateways() []*v1beta1.Gateway {
+	return c.Gateways
+}
+
+func (c *StaticCache) ListHTTPRoutes() []*v1beta1.HTTPRoute {
+	return c.HTTPRoutes
+}
+
+func (c *StaticCache) GetNamespace(name string) *v1.Namespace {
+	return &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func (c *StaticCache) GetService(namespace, name string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "7.7.7.7",
+			Ports: []v1.ServicePort{
+				{Port: 8080},
+				{Port: 8443},
+			},
+		},
+	}
+}
+
+func mustUnmarshal(t *testing.T, val string, out interface{}) {
+	require.NoError(t, yaml.UnmarshalStrict([]byte(val), out, yaml.DisallowUnknownFields))
+}
+
+func TestTranslate(t *testing.T) {
+	tests := map[string]struct {
+		cache string
+		want  string
+	}{
+		// Route-Gateway attachment
+		"Gateway with one HTTP Listener, HTTPRoute attaching to the Gateway": {
+			cache: BasicHTTPRouteAttachingToGatewayIn,
+			want:  BasicHTTPRouteAttachingToGatewayOut,
+		},
+
+		"Gateway with one HTTP Listener, HTTPRoute attaching to the Listener": {
+			cache: BasicHTTPRouteAttachingToListenerIn,
+			want:  BasicHTTPRouteAttachingToListenerOut,
+		},
+
+		"Gateway that allows HTTPRoutes from the same namespace, HTTPRoute in the same namespace": {
+			cache: GatewayAllowsSameNamespaceWithAllowedHTTPRouteIn,
+			want:  GatewayAllowsSameNamespaceWithAllowedHTTPRouteOut,
+		},
+
+		"Gateway that allows HTTPRoutes from the same namespace, HTTPRoute not in the same namespace": {
+			cache: GatewayAllowsSameNamespaceWithDisallowedHTTPRouteIn,
+			want:  GatewayAllowsSameNamespaceWithDisallowedHTTPRouteOut,
+		},
+
+		"Gateway with two HTTP Listeners, HTTPRoute attaching to the Gateway": {
+			cache: HTTPRouteAttachingToGatewayWithTwoListenersIn,
+			want:  HTTPRouteAttachingToGatewayWithTwoListenersOut,
+		},
+
+		"Gateway with two HTTP Listeners, HTTPRoute attaching to one Listener": {
+			cache: HTTPRouteAttachingToListenerOnGatewayWithTwoListenersIn,
+			want:  HTTPRouteAttachingToListenerOnGatewayWithTwoListenersOut,
+		},
+
+		"Gateway with one HTTP Listener with wildcard hostname, HTTPRoute attaching to the Gateway with matching specific hostname": {
+			cache: HTTPRouteWithSpecificHostnameAttachingToGatewayWithWildcardHostnameIn,
+			want:  HTTPRouteWithSpecificHostnameAttachingToGatewayWithWildcardHostnameOut,
+		},
+
+		"Gateway with one HTTP Listener with wildcard hostname, HTTPRoute attaching to the Gateway with two matching specific hostnames": {
+			cache: HTTPRouteWithTwoSpecificHostnamesAttachingToGatewayWithWildcardHostnameIn,
+			want:  HTTPRouteWithTwoSpecificHostnamesAttachingToGatewayWithWildcardHostnameOut,
+		},
+
+		"Gateway with one HTTP Listener with wildcard hostname, HTTPRoute attaching to the Gateway with non-matching specific hostname": {
+			cache: HTTPRouteWithNonMatchingSpecificHostnameAttachingToGatewayWithWildcardHostnameIn,
+			want:  HTTPRouteWithNonMatchingSpecificHostnameAttachingToGatewayWithWildcardHostnameOut,
+		},
+
+		// Gateway/Listener error cases
+		"Gateway with one Listener with protocol other than HTTP": {
+			cache: GatewayWithListenerWithNonHTTPProtocolIn,
+			want:  GatewayWithListenerWithNonHTTPProtocolOut,
+		},
+
+		"Gateway with one Listener with missing allowed namespaces selector": {
+			cache: GatewayWithListenerWithMissingAllowedNamespacesSelectorIn,
+			want:  GatewayWithListenerWithMissingAllowedNamespacesSelectorOut,
+		},
+
+		"Gateway with one Listener with invalid allowed namespaces selector": {
+			cache: GatewayWithListenerWithInvalidAllowedNamespacesSelectorIn,
+			want:  GatewayWithListenerWithInvalidAllowedNamespacesSelectorOut,
+		},
+
+		"Gateway with one Listener with invalid allowed routes group": {
+			cache: GatewayWithListenerWithInvalidAllowedRoutesGroupIn,
+			want:  GatewayWithListenerWithInvalidAllowedRoutesGroupOut,
+		},
+
+		"Gateway with one Listener with invalid allowed routes kind": {
+			cache: GatewayWithListenerWithInvalidAllowedRoutesKindIn,
+			want:  GatewayWithListenerWithInvalidAllowedRoutesKindOut,
+		},
+
+		"Gateway with two Listeners with the same port and hostname": {
+			cache: GatewayWithTwoListenersWithSamePortAndHostnameIn,
+			want:  GatewayWithTwoListenersWithSamePortAndHostnameOut,
+		},
+
+		"Gateway with two Listeners with the same port and incompatible protocols": {
+			cache: GatewayWithTwoListenersWithSamePortAndIncompatibleProtocolsIn,
+			want:  GatewayWithTwoListenersWithSamePortAndIncompatibleProtocolsOut,
+		},
+
+		// Route matches
+		"HTTPRoute with single rule with path prefix and exact header matches": {
+			cache: HTTPRouteWithSingleRuleWithPathPrefixAndExactHeaderMatchesIn,
+			want:  HTTPRouteWithSingleRuleWithPathPrefixAndExactHeaderMatchesOut,
+		},
+
+		"HTTPRoute with single rule with exact path match": {
+			cache: HTTPRouteWithSingleRuleWithExactPathMatchIn,
+			want:  HTTPRouteWithSingleRuleWithExactPathMatchOut,
+		},
+
+		// Route backends
+		"HTTPRoute rule with multiple backends, no weights explicitly specified": {
+			cache: HTTPRouteRuleWithMultipleBackendsAndNoWeightsIn,
+			want:  HTTPRouteRuleWithMultipleBackendsAndNoWeightsOut,
+		},
+
+		"HTTPRoute rule with multiple backends, weights explicitly specified": {
+			cache: HTTPRouteRuleWithMultipleBackendsAndWeightsIn,
+			want:  HTTPRouteRuleWithMultipleBackendsAndWeightsOut,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			translator := &Translator{
+				gatewayClassName: "envoy-gateway-class",
+			}
+
+			cache := &StaticCache{}
+			mustUnmarshal(t, tc.cache, cache)
+
+			want := &TranslateResult{}
+			mustUnmarshal(t, tc.want, want)
+
+			got := translator.Translate(cache)
+
+			sort.Slice(got.IR.HTTP, func(i, j int) bool { return got.IR.HTTP[i].Name < got.IR.HTTP[j].Name })
+
+			assert.EqualValues(t, want, got)
+		})
+	}
+
+}

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -2,48 +2,15 @@ package gatewayapi
 
 import (
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/yaml"
 )
-
-type StaticCache struct {
-	Gateways   []*v1beta1.Gateway
-	HTTPRoutes []*v1beta1.HTTPRoute
-}
-
-func (c *StaticCache) ListGateways() []*v1beta1.Gateway {
-	return c.Gateways
-}
-
-func (c *StaticCache) ListHTTPRoutes() []*v1beta1.HTTPRoute {
-	return c.HTTPRoutes
-}
-
-func (c *StaticCache) GetNamespace(name string) *v1.Namespace {
-	return &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
-}
-
-func (c *StaticCache) GetService(namespace, name string) *v1.Service {
-	return &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		Spec: v1.ServiceSpec{
-			ClusterIP: "7.7.7.7",
-			Ports: []v1.ServicePort{
-				{Port: 8080},
-				{Port: 8443},
-			},
-		},
-	}
-}
 
 func mustUnmarshal(t *testing.T, val string, out interface{}) {
 	require.NoError(t, yaml.UnmarshalStrict([]byte(val), out, yaml.DisallowUnknownFields))
@@ -51,111 +18,111 @@ func mustUnmarshal(t *testing.T, val string, out interface{}) {
 
 func TestTranslate(t *testing.T) {
 	tests := map[string]struct {
-		cache string
-		want  string
+		resources string
+		want      string
 	}{
 		// Route-Gateway attachment
 		"Gateway with one HTTP Listener, HTTPRoute attaching to the Gateway": {
-			cache: BasicHTTPRouteAttachingToGatewayIn,
-			want:  BasicHTTPRouteAttachingToGatewayOut,
+			resources: BasicHTTPRouteAttachingToGatewayIn,
+			want:      BasicHTTPRouteAttachingToGatewayOut,
 		},
 
 		"Gateway with one HTTP Listener, HTTPRoute attaching to the Listener": {
-			cache: BasicHTTPRouteAttachingToListenerIn,
-			want:  BasicHTTPRouteAttachingToListenerOut,
+			resources: BasicHTTPRouteAttachingToListenerIn,
+			want:      BasicHTTPRouteAttachingToListenerOut,
 		},
 
 		"Gateway that allows HTTPRoutes from the same namespace, HTTPRoute in the same namespace": {
-			cache: GatewayAllowsSameNamespaceWithAllowedHTTPRouteIn,
-			want:  GatewayAllowsSameNamespaceWithAllowedHTTPRouteOut,
+			resources: GatewayAllowsSameNamespaceWithAllowedHTTPRouteIn,
+			want:      GatewayAllowsSameNamespaceWithAllowedHTTPRouteOut,
 		},
 
 		"Gateway that allows HTTPRoutes from the same namespace, HTTPRoute not in the same namespace": {
-			cache: GatewayAllowsSameNamespaceWithDisallowedHTTPRouteIn,
-			want:  GatewayAllowsSameNamespaceWithDisallowedHTTPRouteOut,
+			resources: GatewayAllowsSameNamespaceWithDisallowedHTTPRouteIn,
+			want:      GatewayAllowsSameNamespaceWithDisallowedHTTPRouteOut,
 		},
 
 		"Gateway with two HTTP Listeners, HTTPRoute attaching to the Gateway": {
-			cache: HTTPRouteAttachingToGatewayWithTwoListenersIn,
-			want:  HTTPRouteAttachingToGatewayWithTwoListenersOut,
+			resources: HTTPRouteAttachingToGatewayWithTwoListenersIn,
+			want:      HTTPRouteAttachingToGatewayWithTwoListenersOut,
 		},
 
 		"Gateway with two HTTP Listeners, HTTPRoute attaching to one Listener": {
-			cache: HTTPRouteAttachingToListenerOnGatewayWithTwoListenersIn,
-			want:  HTTPRouteAttachingToListenerOnGatewayWithTwoListenersOut,
+			resources: HTTPRouteAttachingToListenerOnGatewayWithTwoListenersIn,
+			want:      HTTPRouteAttachingToListenerOnGatewayWithTwoListenersOut,
 		},
 
 		"Gateway with one HTTP Listener with wildcard hostname, HTTPRoute attaching to the Gateway with matching specific hostname": {
-			cache: HTTPRouteWithSpecificHostnameAttachingToGatewayWithWildcardHostnameIn,
-			want:  HTTPRouteWithSpecificHostnameAttachingToGatewayWithWildcardHostnameOut,
+			resources: HTTPRouteWithSpecificHostnameAttachingToGatewayWithWildcardHostnameIn,
+			want:      HTTPRouteWithSpecificHostnameAttachingToGatewayWithWildcardHostnameOut,
 		},
 
 		"Gateway with one HTTP Listener with wildcard hostname, HTTPRoute attaching to the Gateway with two matching specific hostnames": {
-			cache: HTTPRouteWithTwoSpecificHostnamesAttachingToGatewayWithWildcardHostnameIn,
-			want:  HTTPRouteWithTwoSpecificHostnamesAttachingToGatewayWithWildcardHostnameOut,
+			resources: HTTPRouteWithTwoSpecificHostnamesAttachingToGatewayWithWildcardHostnameIn,
+			want:      HTTPRouteWithTwoSpecificHostnamesAttachingToGatewayWithWildcardHostnameOut,
 		},
 
 		"Gateway with one HTTP Listener with wildcard hostname, HTTPRoute attaching to the Gateway with non-matching specific hostname": {
-			cache: HTTPRouteWithNonMatchingSpecificHostnameAttachingToGatewayWithWildcardHostnameIn,
-			want:  HTTPRouteWithNonMatchingSpecificHostnameAttachingToGatewayWithWildcardHostnameOut,
+			resources: HTTPRouteWithNonMatchingSpecificHostnameAttachingToGatewayWithWildcardHostnameIn,
+			want:      HTTPRouteWithNonMatchingSpecificHostnameAttachingToGatewayWithWildcardHostnameOut,
 		},
 
 		// Gateway/Listener error cases
 		"Gateway with one Listener with protocol other than HTTP": {
-			cache: GatewayWithListenerWithNonHTTPProtocolIn,
-			want:  GatewayWithListenerWithNonHTTPProtocolOut,
+			resources: GatewayWithListenerWithNonHTTPProtocolIn,
+			want:      GatewayWithListenerWithNonHTTPProtocolOut,
 		},
 
 		"Gateway with one Listener with missing allowed namespaces selector": {
-			cache: GatewayWithListenerWithMissingAllowedNamespacesSelectorIn,
-			want:  GatewayWithListenerWithMissingAllowedNamespacesSelectorOut,
+			resources: GatewayWithListenerWithMissingAllowedNamespacesSelectorIn,
+			want:      GatewayWithListenerWithMissingAllowedNamespacesSelectorOut,
 		},
 
 		"Gateway with one Listener with invalid allowed namespaces selector": {
-			cache: GatewayWithListenerWithInvalidAllowedNamespacesSelectorIn,
-			want:  GatewayWithListenerWithInvalidAllowedNamespacesSelectorOut,
+			resources: GatewayWithListenerWithInvalidAllowedNamespacesSelectorIn,
+			want:      GatewayWithListenerWithInvalidAllowedNamespacesSelectorOut,
 		},
 
 		"Gateway with one Listener with invalid allowed routes group": {
-			cache: GatewayWithListenerWithInvalidAllowedRoutesGroupIn,
-			want:  GatewayWithListenerWithInvalidAllowedRoutesGroupOut,
+			resources: GatewayWithListenerWithInvalidAllowedRoutesGroupIn,
+			want:      GatewayWithListenerWithInvalidAllowedRoutesGroupOut,
 		},
 
 		"Gateway with one Listener with invalid allowed routes kind": {
-			cache: GatewayWithListenerWithInvalidAllowedRoutesKindIn,
-			want:  GatewayWithListenerWithInvalidAllowedRoutesKindOut,
+			resources: GatewayWithListenerWithInvalidAllowedRoutesKindIn,
+			want:      GatewayWithListenerWithInvalidAllowedRoutesKindOut,
 		},
 
 		"Gateway with two Listeners with the same port and hostname": {
-			cache: GatewayWithTwoListenersWithSamePortAndHostnameIn,
-			want:  GatewayWithTwoListenersWithSamePortAndHostnameOut,
+			resources: GatewayWithTwoListenersWithSamePortAndHostnameIn,
+			want:      GatewayWithTwoListenersWithSamePortAndHostnameOut,
 		},
 
 		"Gateway with two Listeners with the same port and incompatible protocols": {
-			cache: GatewayWithTwoListenersWithSamePortAndIncompatibleProtocolsIn,
-			want:  GatewayWithTwoListenersWithSamePortAndIncompatibleProtocolsOut,
+			resources: GatewayWithTwoListenersWithSamePortAndIncompatibleProtocolsIn,
+			want:      GatewayWithTwoListenersWithSamePortAndIncompatibleProtocolsOut,
 		},
 
 		// Route matches
 		"HTTPRoute with single rule with path prefix and exact header matches": {
-			cache: HTTPRouteWithSingleRuleWithPathPrefixAndExactHeaderMatchesIn,
-			want:  HTTPRouteWithSingleRuleWithPathPrefixAndExactHeaderMatchesOut,
+			resources: HTTPRouteWithSingleRuleWithPathPrefixAndExactHeaderMatchesIn,
+			want:      HTTPRouteWithSingleRuleWithPathPrefixAndExactHeaderMatchesOut,
 		},
 
 		"HTTPRoute with single rule with exact path match": {
-			cache: HTTPRouteWithSingleRuleWithExactPathMatchIn,
-			want:  HTTPRouteWithSingleRuleWithExactPathMatchOut,
+			resources: HTTPRouteWithSingleRuleWithExactPathMatchIn,
+			want:      HTTPRouteWithSingleRuleWithExactPathMatchOut,
 		},
 
 		// Route backends
 		"HTTPRoute rule with multiple backends, no weights explicitly specified": {
-			cache: HTTPRouteRuleWithMultipleBackendsAndNoWeightsIn,
-			want:  HTTPRouteRuleWithMultipleBackendsAndNoWeightsOut,
+			resources: HTTPRouteRuleWithMultipleBackendsAndNoWeightsIn,
+			want:      HTTPRouteRuleWithMultipleBackendsAndNoWeightsOut,
 		},
 
 		"HTTPRoute rule with multiple backends, weights explicitly specified": {
-			cache: HTTPRouteRuleWithMultipleBackendsAndWeightsIn,
-			want:  HTTPRouteRuleWithMultipleBackendsAndWeightsOut,
+			resources: HTTPRouteRuleWithMultipleBackendsAndWeightsIn,
+			want:      HTTPRouteRuleWithMultipleBackendsAndWeightsOut,
 		},
 	}
 
@@ -165,13 +132,42 @@ func TestTranslate(t *testing.T) {
 				gatewayClassName: "envoy-gateway-class",
 			}
 
-			cache := &StaticCache{}
-			mustUnmarshal(t, tc.cache, cache)
+			resources := &Resources{}
+			mustUnmarshal(t, tc.resources, resources)
+
+			// Add common test fixtures
+			for i := 1; i <= 3; i++ {
+				resources.Services = append(resources.Services,
+					&v1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "service-" + strconv.Itoa(i),
+						},
+						Spec: v1.ServiceSpec{
+							ClusterIP: "7.7.7.7",
+							Ports: []v1.ServicePort{
+								{Port: 8080},
+								{Port: 8443},
+							},
+						},
+					},
+				)
+			}
+
+			resources.Namespaces = append(resources.Namespaces, &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "envoy-gateway",
+				},
+			}, &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			})
 
 			want := &TranslateResult{}
 			mustUnmarshal(t, tc.want, want)
 
-			got := translator.Translate(cache)
+			got := translator.Translate(resources)
 
 			sort.Slice(got.IR.HTTP, func(i, j int) bool { return got.IR.HTTP[i].Name < got.IR.HTTP[j].Name })
 

--- a/pkg/ir/xds.go
+++ b/pkg/ir/xds.go
@@ -28,6 +28,16 @@ type HTTPListener struct {
 	Routes []*HTTPRoute
 }
 
+func (x *Xds) GetListener(name string) *HTTPListener {
+	for _, listener := range x.HTTP {
+		if listener.Name == name {
+			return listener
+		}
+	}
+
+	return nil
+}
+
 // HTTPRoute holds the route information associated with the HTTP Route
 type HTTPRoute struct {
 	// Name of the HTTPRoute


### PR DESCRIPTION
Updates #38.

Setting expectations, this should not be considered "done" but does cover much of the core translation logic and gives us something to refine/start integrating with; I didn't want this PR to get any larger than it already is. I have a list of follow-up issues to file to build out the rest of the functionality, including:

- add header modifier filter support
- add redirect filter support
- implement correct behavior for invalid backend refs (i.e. 500 responses)
- implement ReferenceGrant for cross-namespace service/secret references
- finalize approach to Host matching
- add TLS support
- add TLSRoute support

We obviously also need to work on integrating this with the resource providers and the xDS translator, I think that can be done in subsequent PRs.