### PR TITLE
Adds ProxyListener to Infra IR

### DIFF
--- a/internal/ir/infra.go
+++ b/internal/ir/infra.go
@@ -23,4 +23,16 @@ type ProxyInfra struct {
 	Config *cfgv1a1.EnvoyProxy
 	// Image is the container image used for the managed proxy infrastructure.
 	Image string
+	// Listeners define the listeners exposed by the proxy infrastructure.
+	Listeners []ProxyListener
+}
+
+// ProxyListener defines the listener configuration of the proxy infrastructure.
+type ProxyListener struct {
+	// Name is the name of the listener.
+	Name string
+	// Address is the address that the listener should listen on.
+	Address string
+	// Port is the network port that the listener should listen on.
+	Port int32
 }


### PR DESCRIPTION
Introduces the ProxyListener type that describes the listener(s) of the managed proxy infra. This will allow the Infra Manager to perform incremental updates of Kube Services whenever a Gateway address or listener is updated.

xref: #180 

Signed-off-by: danehans <daneyonhansen@gmail.com>