### PR TITLE
Updates Integration Tests

### DIFF
--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -45,6 +45,10 @@ func ObjectNamePtr(val string) *v1alpha2.ObjectName {
 	return &objectName
 }
 
+func PathMatchTypePtr(pType v1beta1.PathMatchType) *v1beta1.PathMatchType {
+	return &pType
+}
+
 func PathMatchTypeDerefOr(matchType *v1beta1.PathMatchType, defaultType v1beta1.PathMatchType) v1beta1.PathMatchType {
 	if matchType != nil {
 		return *matchType


### PR DESCRIPTION
Adds `ResourceTable` coverage to the Kubernetes provider integration tests

Requires: https://github.com/envoyproxy/gateway/pull/194