### PR TITLE
Adds Gateway Status Support

### DIFF
--- a/internal/provider/kubernetes/gateway.go
+++ b/internal/provider/kubernetes/gateway.go
@@ -22,12 +22,14 @@ import (
 
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/message"
+	"github.com/envoyproxy/gateway/internal/status"
 )
 
 type gatewayReconciler struct {
 	client client.Client
 	// classController is the configured gatewayclass controller name.
 	classController gwapiv1b1.GatewayController
+	statusUpdater   status.Updater
 	log             logr.Logger
 
 	initializeOnce sync.Once
@@ -37,11 +39,12 @@ type gatewayReconciler struct {
 // newGatewayController creates a gateway controller. The controller will watch for
 // Gateway objects across all namespaces and reconcile those that match the configured
 // gatewayclass controller name.
-func newGatewayController(mgr manager.Manager, cfg *config.Server, resources *message.ProviderResources) error {
+func newGatewayController(mgr manager.Manager, cfg *config.Server, su status.Updater, resources *message.ProviderResources) error {
 	resources.Initialized.Add(1)
 	r := &gatewayReconciler{
 		client:          mgr.GetClient(),
 		classController: gwapiv1b1.GatewayController(cfg.EnvoyGateway.Gateway.ControllerName),
+		statusUpdater:   su,
 		log:             cfg.Logger,
 		resources:       resources,
 	}
@@ -114,6 +117,10 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 	if err := r.client.List(ctx, allGateways); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error listing gateways")
 	}
+	if len(allGateways.Items) == 0 {
+		r.log.Info("No gateways found for request", "namespace", request.Namespace, "name", request.Name)
+		return reconcile.Result{}, nil
+	}
 
 	// Get all the Gateways for the Accepted=true GatewayClass.
 	acceptedGateways := gatewaysOfClass(acceptedClass, allGateways)
@@ -132,8 +139,35 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 		r.resources.Gateways.Delete(request.NamespacedName)
 	}
 
+	// Find the oldest Gateway, using alphabetical order	// as a tiebreaker.
+	oldestGateway := oldestGateway(acceptedGateways)
+
+	// Set the "Scheduled" condition to false for all gateways except the oldest.
+	// The oldest will have its status set by the Resource Translator, so don't set it here.
+	for _, gw := range acceptedGateways {
+		oldest := false
+		if gw.Namespace == oldestGateway.Namespace && gw.Name == oldestGateway.Name {
+			oldest = true
+		}
+
+		r.statusUpdater.Send(status.Update{
+			NamespacedName: types.NamespacedName{Namespace: gw.Namespace, Name: gw.Name},
+			Resource:       &gwapiv1b1.Gateway{},
+			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+				gw, ok := obj.(*gwapiv1b1.Gateway)
+				if !ok {
+					panic(fmt.Sprintf("unsupported object type %T", obj))
+				}
+
+				return status.SetGatewayScheduled(gw.DeepCopy(), oldest)
+			}),
+		})
+	}
+
 	// Once we've processed `allGateways`, record that we've fully initialized.
 	defer r.initializeOnce.Do(r.resources.Initialized.Done)
+
+	r.log.WithName(request.Namespace).WithName(request.Name).Info("reconciled gateway")
 
 	return reconcile.Result{}, nil
 }
@@ -180,4 +214,24 @@ func gatewaysOfClass(gc *gwapiv1b1.GatewayClass, gwList *gwapiv1b1.GatewayList) 
 		}
 	}
 	return ret
+}
+
+// oldestGateway finds the oldest Gateway from the provides list,
+// using alphabetical order as a tiebreaker.
+func oldestGateway(gateways []gwapiv1b1.Gateway) *gwapiv1b1.Gateway {
+	var oldest gwapiv1b1.Gateway
+	for i, gw := range gateways {
+		switch {
+		case i == 0:
+			oldest = gw
+		case gw.CreationTimestamp.Before(&oldest.CreationTimestamp):
+			oldest = gw
+		case gw.CreationTimestamp.Equal(&oldest.CreationTimestamp):
+			if fmt.Sprintf("%s/%s", gw.Namespace, gw.Name) < fmt.Sprintf("%s/%s", oldest.Namespace, oldest.Name) {
+				oldest = gw
+			}
+		}
+	}
+
+	return &oldest
 }

--- a/internal/provider/kubernetes/gateway_test.go
+++ b/internal/provider/kubernetes/gateway_test.go
@@ -3,11 +3,9 @@ package kubernetes
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	fakeclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -285,136 +283,6 @@ func TestGatewaysOfClass(t *testing.T) {
 			gwList := &gwapiv1b1.GatewayList{Items: tc.gws}
 			actual := gatewaysOfClass(gc, gwList)
 			require.Equal(t, tc.expect, len(actual))
-		})
-	}
-}
-
-func TestOldestGateway(t *testing.T) {
-	// Create a fake clock and set different times for gateway CreationTimestamp.
-	fakeClock := fakeclock.NewFakeClock(time.Time{})
-	now := fakeClock.Now()
-	later := now.Add(1 * time.Minute)
-	latest := now.Add(2 * time.Minute)
-
-	testCases := []struct {
-		name   string
-		in     []gwapiv1b1.Gateway
-		expect *gwapiv1b1.Gateway
-	}{
-		{
-			name: "one gateway",
-			in: []gwapiv1b1.Gateway{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "first",
-						Namespace:         "test",
-						CreationTimestamp: metav1.NewTime(now),
-					},
-				},
-			},
-			expect: &gwapiv1b1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "first",
-					Namespace: "test",
-				},
-			},
-		},
-		{
-			name: "two gateways with different times",
-			in: []gwapiv1b1.Gateway{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "second",
-						Namespace:         "test",
-						CreationTimestamp: metav1.NewTime(later),
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "first",
-						Namespace:         "test",
-						CreationTimestamp: metav1.NewTime(now),
-					},
-				},
-			},
-			expect: &gwapiv1b1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "first",
-					Namespace: "test",
-				},
-			},
-		},
-		{
-			name: "three gateways with different times",
-			in: []gwapiv1b1.Gateway{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "first",
-						Namespace:         "test",
-						CreationTimestamp: metav1.NewTime(latest),
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "second",
-						Namespace:         "test",
-						CreationTimestamp: metav1.NewTime(later),
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "third",
-						Namespace:         "test",
-						CreationTimestamp: metav1.NewTime(now),
-					},
-				},
-			},
-			expect: &gwapiv1b1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "third",
-					Namespace: "test",
-				},
-			},
-		},
-		{
-			name: "three gateways with same time",
-			in: []gwapiv1b1.Gateway{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "third",
-						Namespace:         "test",
-						CreationTimestamp: metav1.NewTime(now),
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "second",
-						Namespace:         "test",
-						CreationTimestamp: metav1.NewTime(now),
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "first",
-						Namespace:         "test",
-						CreationTimestamp: metav1.NewTime(now),
-					},
-				},
-			},
-			expect: &gwapiv1b1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "first",
-					Namespace: "test",
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := oldestGateway(tc.in)
-			require.Equal(t, tc.expect.Name, actual.Name)
-			require.Equal(t, tc.expect.Namespace, actual.Namespace)
 		})
 	}
 }

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -37,18 +37,12 @@ type gatewayClassReconciler struct {
 // newGatewayClassController creates the gatewayclass controller. The controller
 // will be pre-configured to watch for cluster-scoped GatewayClass objects with
 // a controller field that matches name.
-func newGatewayClassController(mgr manager.Manager, cfg *config.Server, resources *message.ProviderResources) error {
-	cli := mgr.GetClient()
-	uh := status.NewUpdateHandler(cfg.Logger, cli)
-	if err := mgr.Add(uh); err != nil {
-		return fmt.Errorf("failed to add status update handler %v", err)
-	}
-
+func newGatewayClassController(mgr manager.Manager, cfg *config.Server, su status.Updater, resources *message.ProviderResources) error {
 	resources.Initialized.Add(1)
 	r := &gatewayClassReconciler{
-		client:        cli,
+		client:        mgr.GetClient(),
 		controller:    gwapiv1b1.GatewayController(cfg.EnvoyGateway.Gateway.ControllerName),
-		statusUpdater: uh.Writer(),
+		statusUpdater: su,
 		log:           cfg.Logger,
 		resources:     resources,
 	}

--- a/internal/provider/kubernetes/kubernetes.go
+++ b/internal/provider/kubernetes/kubernetes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/envoyproxy/gateway/internal/envoygateway"
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/message"
+	"github.com/envoyproxy/gateway/internal/status"
 )
 
 // Provider is the scaffolding for the Kubernetes provider. It sets up dependencies
@@ -37,11 +38,16 @@ func New(cfg *rest.Config, svr *config.Server, resources *message.ProviderResour
 		return nil, fmt.Errorf("failed to create manager: %w", err)
 	}
 
+	updateHandler := status.NewUpdateHandler(mgr.GetLogger(), mgr.GetClient())
+	if err := mgr.Add(updateHandler); err != nil {
+		return nil, fmt.Errorf("failed to add status update handler %v", err)
+	}
+
 	// Create and register the controllers with the manager.
-	if err := newGatewayClassController(mgr, svr, resources); err != nil {
+	if err := newGatewayClassController(mgr, svr, updateHandler.Writer(), resources); err != nil {
 		return nil, fmt.Errorf("failed to create gatewayclass controller: %w", err)
 	}
-	if err := newGatewayController(mgr, svr, resources); err != nil {
+	if err := newGatewayController(mgr, svr, updateHandler.Writer(), resources); err != nil {
 		return nil, fmt.Errorf("failed to create gateway controller: %w", err)
 	}
 	if err := newHTTPRouteController(mgr, svr, resources); err != nil {

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -36,6 +36,18 @@ func computeGatewayClassAcceptedCondition(gatewayClass *gwapiv1b1.GatewayClass, 
 	}
 }
 
+// computeGatewayScheduledCondition computes the Gateway Scheduled status condition.
+func computeGatewayScheduledCondition(gw *gwapiv1b1.Gateway, oldest bool) metav1.Condition {
+	switch oldest {
+	case true:
+		return newCondition(string(gwapiv1b1.GatewayConditionScheduled), metav1.ConditionTrue, "OldestGateway",
+			"Oldest Gateway for the accepted GatewayClass", time.Now(), gw.Generation)
+	default:
+		return newCondition(string(gwapiv1b1.GatewayConditionScheduled), metav1.ConditionFalse, "OlderGatewayExists",
+			"An older Gateway exists for the accepted GatewayClass", time.Now(), gw.Generation)
+	}
+}
+
 // mergeConditions adds or updates matching conditions, and updates the transition
 // time if details of a condition have changed. Returns the updated condition array.
 func mergeConditions(conditions []metav1.Condition, updates ...metav1.Condition) []metav1.Condition {
@@ -65,13 +77,14 @@ func mergeConditions(conditions []metav1.Condition, updates ...metav1.Condition)
 
 // TODO: Pass the Generation so we can set ObservedGeneration.
 // xref: https://github.com/envoyproxy/gateway/issues/166
-func newCondition(t string, status metav1.ConditionStatus, reason, msg string, lt time.Time) metav1.Condition {
+func newCondition(t string, status metav1.ConditionStatus, reason, msg string, lt time.Time, og int64) metav1.Condition {
 	return metav1.Condition{
 		Type:               t,
 		Status:             status,
 		Reason:             reason,
 		Message:            msg,
 		LastTransitionTime: metav1.NewTime(lt),
+		ObservedGeneration: og,
 	}
 }
 

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -37,14 +37,16 @@ func computeGatewayClassAcceptedCondition(gatewayClass *gwapiv1b1.GatewayClass, 
 }
 
 // computeGatewayScheduledCondition computes the Gateway Scheduled status condition.
-func computeGatewayScheduledCondition(gw *gwapiv1b1.Gateway, oldest bool) metav1.Condition {
-	switch oldest {
+func computeGatewayScheduledCondition(gw *gwapiv1b1.Gateway, scheduled bool) metav1.Condition {
+	switch scheduled {
 	case true:
-		return newCondition(string(gwapiv1b1.GatewayConditionScheduled), metav1.ConditionTrue, "OldestGateway",
-			"Oldest Gateway for the accepted GatewayClass", time.Now(), gw.Generation)
+		return newCondition(string(gwapiv1b1.GatewayConditionScheduled), metav1.ConditionTrue,
+			string(gwapiv1b1.GatewayReasonScheduled),
+			"The Gateway has been scheduled by Envoy Gateway", time.Now(), gw.Generation)
 	default:
-		return newCondition(string(gwapiv1b1.GatewayConditionScheduled), metav1.ConditionFalse, "OlderGatewayExists",
-			"An older Gateway exists for the accepted GatewayClass", time.Now(), gw.Generation)
+		return newCondition(string(gwapiv1b1.GatewayConditionScheduled), metav1.ConditionFalse,
+			string(gwapiv1b1.GatewayReasonScheduled),
+			"The Gateway has not been scheduled by Envoy Gateway", time.Now(), gw.Generation)
 	}
 }
 
@@ -75,8 +77,6 @@ func mergeConditions(conditions []metav1.Condition, updates ...metav1.Condition)
 	return conditions
 }
 
-// TODO: Pass the Generation so we can set ObservedGeneration.
-// xref: https://github.com/envoyproxy/gateway/issues/166
 func newCondition(t string, status metav1.ConditionStatus, reason, msg string, lt time.Time, og int64) metav1.Condition {
 	return metav1.Condition{
 		Type:               t,

--- a/internal/status/conditions_test.go
+++ b/internal/status/conditions_test.go
@@ -61,20 +61,20 @@ func TestComputeGatewayClassAcceptedCondition(t *testing.T) {
 func TestComputeGatewayScheduledCondition(t *testing.T) {
 	testCases := []struct {
 		name   string
-		oldest bool
+		sched  bool
 		expect metav1.Condition
 	}{
 		{
-			name:   "scheduled gateway",
-			oldest: true,
+			name:  "scheduled gateway",
+			sched: true,
 			expect: metav1.Condition{
 				Type:   string(gwapiv1b1.GatewayConditionScheduled),
 				Status: metav1.ConditionTrue,
 			},
 		},
 		{
-			name:   "not scheduled gateway",
-			oldest: false,
+			name:  "not scheduled gateway",
+			sched: false,
 			expect: metav1.Condition{
 				Type:   string(gwapiv1b1.GatewayConditionScheduled),
 				Status: metav1.ConditionFalse,
@@ -90,7 +90,7 @@ func TestComputeGatewayScheduledCondition(t *testing.T) {
 			},
 		}
 
-		got := computeGatewayScheduledCondition(gw, tc.oldest)
+		got := computeGatewayScheduledCondition(gw, tc.sched)
 
 		assert.Equal(t, tc.expect.Type, got.Type)
 		assert.Equal(t, tc.expect.Status, got.Status)

--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -1,0 +1,9 @@
+package status
+
+import gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+// SetGatewayScheduled adds or updates the Scheduled condition for the provided Gateway.
+func SetGatewayScheduled(gw *gwapiv1b1.Gateway, oldest bool) *gwapiv1b1.Gateway {
+	gw.Status.Conditions = mergeConditions(gw.Status.Conditions, computeGatewayScheduledCondition(gw, oldest))
+	return gw
+}

--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -3,7 +3,7 @@ package status
 import gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 // SetGatewayScheduled adds or updates the Scheduled condition for the provided Gateway.
-func SetGatewayScheduled(gw *gwapiv1b1.Gateway, oldest bool) *gwapiv1b1.Gateway {
-	gw.Status.Conditions = mergeConditions(gw.Status.Conditions, computeGatewayScheduledCondition(gw, oldest))
+func SetGatewayScheduled(gw *gwapiv1b1.Gateway, scheduled bool) *gwapiv1b1.Gateway {
+	gw.Status.Conditions = mergeConditions(gw.Status.Conditions, computeGatewayScheduledCondition(gw, scheduled))
 	return gw
 }


### PR DESCRIPTION
Previously, the gateway controller would not update the status of gateways. This PR adds the `StatusUpdater` interface to the gateway controller and sets the "Scheduled=True" status condition for gateways that match the configured GatewayClass controllerName.

Fixes: https://github.com/envoyproxy/gateway/issues/165
Fixes: https://github.com/envoyproxy/gateway/issues/166