### PR TITLE
Adds Support for Control Plane TLS

### DIFF
--- a/api/config/v1alpha1/helpers.go
+++ b/api/config/v1alpha1/helpers.go
@@ -50,6 +50,9 @@ func DefaultProvider() *Provider {
 	}
 }
 
-func ProviderTypePtr(p ProviderType) *ProviderType {
-	return &p
+func (e *EnvoyGateway) GetProvider() *Provider {
+	if e.Provider != nil {
+		return e.Provider
+	}
+	return DefaultProvider()
 }

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v0.6.7 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
@@ -73,6 +74,8 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tsaarni/certyaml v0.9.0 // indirect
+	github.com/tsaarni/x500dn v0.0.0-20210331182804-14283c7f5a16 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,7 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc h1:PYXxkRUBGUMa5xgMVMDl62vEklZvKpVaxQeN9ie7Hfk=
 github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08/go.mod h1:pCxVEbcm3AMg7ejXyorUXi6HQCzOIBf7zEDVPtw0/U4=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
@@ -163,6 +164,9 @@ github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
+github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
+github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -485,6 +489,10 @@ github.com/tetratelabs/multierror v1.1.0 h1:cKmV/Pbf42K5wp8glxa2YIausbxIraPN8fzr
 github.com/tetratelabs/multierror v1.1.0/go.mod h1:kH3SzI/z+FwEbV9bxQDx4GiIgE2djuyb8wiB2DaUBnY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tsaarni/certyaml v0.9.0 h1:7/LvdyLtgHIyqNOBt+e2Am8vVx0rFt2Vk2MndKxJvQQ=
+github.com/tsaarni/certyaml v0.9.0/go.mod h1:roB034EZo2tTCA6G875Qo6rw3ythNEVr8KGgMbpyhdU=
+github.com/tsaarni/x500dn v0.0.0-20210331182804-14283c7f5a16 h1:pwy6wBo/3nIrPBWOAWKkRi888+dXPd78KSTxEtHFAdo=
+github.com/tsaarni/x500dn v0.0.0-20210331182804-14283c7f5a16/go.mod h1:RquKZ5rERbzqRQDFuh2zsgR1W1FH006YRw2pHIuMzvw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -588,6 +596,7 @@ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/cmd/certgen.go
+++ b/internal/cmd/certgen.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clicfg "sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/envoyproxy/gateway/internal/crypto"
+	"github.com/envoyproxy/gateway/internal/envoygateway"
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	"github.com/envoyproxy/gateway/internal/provider/kubernetes"
+)
+
+// getServerCommand returns the server cobra command to be executed.
+func getCertGenCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "certgen",
+		Short: "Generate Control Plane Certificates",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return certGen()
+		},
+	}
+
+	return cmd
+}
+
+// certGen generates control plane certificates.
+func certGen() error {
+	cfg, err := getConfig()
+	if err != nil {
+		return err
+	}
+	log := cfg.Logger
+
+	certs, err := crypto.GenerateCerts(cfg.EnvoyGateway)
+	if err != nil {
+		return fmt.Errorf("failed to generate certificates: %v", err)
+	}
+	log.Info("generated certificates")
+
+	cli, err := client.New(clicfg.GetConfigOrDie(), client.Options{Scheme: envoygateway.GetScheme()})
+	if err != nil {
+		return fmt.Errorf("failed to create controller-runtime client: %v", err)
+	}
+
+	if err := outputCerts(ctrl.SetupSignalHandler(), log, cli, certs); err != nil {
+		return fmt.Errorf("failed to output certificates: %v", err)
+	}
+
+	return nil
+}
+
+// outputCerts outputs the certs in certs as directed by config.
+func outputCerts(ctx context.Context, log logr.Logger, cli client.Client, certs *crypto.Certificates) error {
+	secrets, err := kubernetes.CreateOrUpdateSecrets(ctx, cli, kubernetes.CertsToSecret(config.EnvoyGatewayNamespace, certs))
+	if err != nil {
+		return fmt.Errorf("failed to create or update secrets: %v", err)
+	}
+
+	for i := range secrets {
+		s := secrets[i]
+		log.Info("created secret", "namespace", s.Namespace, "name", s.Name)
+	}
+
+	return nil
+}

--- a/internal/cmd/certgen_test.go
+++ b/internal/cmd/certgen_test.go
@@ -1,0 +1,12 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCertgenCommand(t *testing.T) {
+	got := getCertGenCommand()
+	assert.Equal(t, "certgen", got.Use)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -28,6 +28,7 @@ func GetRootCommand() *cobra.Command {
 
 	cmd.AddCommand(getServerCommand())
 	cmd.AddCommand(getxDSTestCommand())
+	cmd.AddCommand(getCertGenCommand())
 
 	return cmd
 }

--- a/internal/crypto/certgen.go
+++ b/internal/crypto/certgen.go
@@ -1,0 +1,278 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1" // nolint:gosec
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/envoyproxy/gateway/api/config/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+)
+
+const (
+	// DefaultEnvoyGatewayDNSPrefix defines the default Envoy Gateway DNS prefix.
+	DefaultEnvoyGatewayDNSPrefix = config.EnvoyGatewayServiceName
+
+	// DefaultEnvoyDNSPrefix defines the default Envoy DNS prefix.
+	DefaultEnvoyDNSPrefix = config.EnvoyServiceName
+
+	// DefaultNamespace is the default Namespace name where Envoy Gateway is running.
+	DefaultNamespace = config.EnvoyGatewayNamespace
+
+	// DefaultCertificateLifetime holds the default certificate lifetime (in days).
+	DefaultCertificateLifetime = 365
+
+	// DefaultDNSSuffix is the default DNS suffix name.
+	DefaultDNSSuffix = "cluster.local"
+
+	// keySize sets the RSA key size to 2048 bits. This is minimum recommended size
+	// for RSA keys.
+	keySize = 2048
+)
+
+// Configuration holds config parameters used for generating certificates.
+type Configuration struct {
+	// Provider defines the desired cert provider and provider-specific
+	// configuration.
+	Provider *CertProvider
+}
+
+func (c *Configuration) getProvider() {
+	if c.Provider == nil {
+		c.Provider = &CertProvider{
+			Type: ProviderTypeEnvoyGateway,
+		}
+	}
+}
+
+// CertProvider defines the provider of certificates.
+type CertProvider struct {
+	// Type is the type of provider to use for managing certificates.
+	Type ProviderType `json:"type"`
+}
+
+// ProviderType defines the types of supported certificate providers.
+type ProviderType string
+
+const (
+	// ProviderTypeEnvoyGateway defines the "EnvoyGateway" provider.
+	// EnvoyGateway implements a self-signed CA and generates server
+	// certs for Envoy Gateway and Envoy.
+	ProviderTypeEnvoyGateway ProviderType = "EnvoyGateway"
+)
+
+// Certificates contains a set of Certificates as []byte each holding
+// the CA Cert along with Envoy Gateway & Envoy certificates.
+type Certificates struct {
+	CACertificate           []byte
+	EnvoyGatewayCertificate []byte
+	EnvoyGatewayPrivateKey  []byte
+	EnvoyCertificate        []byte
+	EnvoyPrivateKey         []byte
+}
+
+// certificateRequest defines a certificate request.
+type certificateRequest struct {
+	caCertPEM  []byte
+	caKeyPEM   []byte
+	expiry     time.Time
+	commonName string
+	altNames   []string
+}
+
+// GenerateCerts generates a CA Certificate along with certificates for Envoy Gateway
+// and Envoy returning them as a *Certificates struct or error if encountered.
+func GenerateCerts(egCfg *v1alpha1.EnvoyGateway) (*Certificates, error) {
+	certCfg := new(Configuration)
+
+	// Check if the EG config is not provided, then default.
+	if egCfg == nil {
+		egCfg = v1alpha1.DefaultEnvoyGateway()
+	}
+
+	certCfg.getProvider()
+	switch certCfg.Provider.Type {
+	case ProviderTypeEnvoyGateway:
+		now := time.Now()
+		expiry := now.Add(24 * time.Duration(DefaultCertificateLifetime) * time.Hour)
+		caCertPEM, caKeyPEM, err := newCA(DefaultEnvoyGatewayDNSPrefix, expiry)
+		if err != nil {
+			return nil, err
+		}
+
+		var egDNSNames, envoyDNSNames []string
+		egProvider := egCfg.GetProvider().Type
+		switch egProvider {
+		case v1alpha1.ProviderTypeKubernetes:
+			egDNSNames = kubeServiceNames(DefaultEnvoyGatewayDNSPrefix, DefaultNamespace, DefaultDNSSuffix)
+			envoyDNSNames = kubeServiceNames(DefaultEnvoyDNSPrefix, DefaultNamespace, DefaultDNSSuffix)
+		default:
+			// Kubernetes is the only supported Envoy Gateway provider.
+			return nil, fmt.Errorf("unsupported provider type %v", egProvider)
+		}
+
+		egCertReq := &certificateRequest{
+			caCertPEM:  caCertPEM,
+			caKeyPEM:   caKeyPEM,
+			expiry:     expiry,
+			commonName: DefaultEnvoyGatewayDNSPrefix,
+			altNames:   egDNSNames,
+		}
+
+		egCert, egKey, err := newCert(egCertReq)
+		if err != nil {
+			return nil, err
+		}
+
+		envoyCertReq := &certificateRequest{
+			caCertPEM:  caCertPEM,
+			caKeyPEM:   caKeyPEM,
+			expiry:     expiry,
+			commonName: DefaultEnvoyDNSPrefix,
+			altNames:   envoyDNSNames,
+		}
+
+		envoyCert, envoyKey, err := newCert(envoyCertReq)
+		if err != nil {
+			return nil, err
+		}
+
+		return &Certificates{
+			CACertificate:           caCertPEM,
+			EnvoyGatewayCertificate: egCert,
+			EnvoyGatewayPrivateKey:  egKey,
+			EnvoyCertificate:        envoyCert,
+			EnvoyPrivateKey:         envoyKey,
+		}, nil
+	default:
+		// Envoy Gateway, e.g. self-signed CA, is the only supported certificate provider.
+		return nil, fmt.Errorf("unsupported certificate provider type %v", certCfg.Provider.Type)
+	}
+}
+
+// newCert generates a new keypair based on the given the request.
+// The return values are cert, key, err.
+func newCert(request *certificateRequest) ([]byte, []byte, error) {
+
+	caKeyPair, err := tls.X509KeyPair(request.caCertPEM, request.caKeyPEM)
+	if err != nil {
+		return nil, nil, err
+	}
+	caCert, err := x509.ParseCertificate(caKeyPair.Certificate[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	caKey, ok := caKeyPair.PrivateKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, nil, fmt.Errorf("CA private key has unexpected type %T", caKeyPair.PrivateKey)
+	}
+
+	newKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot generate key: %v", err)
+	}
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: newSerial(now),
+		Subject: pkix.Name{
+			CommonName: request.commonName,
+		},
+		NotBefore:    now.UTC().AddDate(0, 0, -1),
+		NotAfter:     request.expiry.UTC(),
+		SubjectKeyId: bigIntHash(newKey.N),
+		KeyUsage: x509.KeyUsageDigitalSignature |
+			x509.KeyUsageDataEncipherment |
+			x509.KeyUsageKeyEncipherment |
+			x509.KeyUsageContentCommitment,
+		DNSNames: request.altNames,
+	}
+	newCert, err := x509.CreateCertificate(rand.Reader, template, caCert, &newKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	newKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(newKey),
+	})
+	newCertPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: newCert,
+	})
+	return newCertPEM, newKeyPEM, nil
+
+}
+
+// newCA generates a new CA, given the CA's CN and an expiry time.
+// The return order is cacert, cakey, error.
+func newCA(cn string, expiry time.Time) ([]byte, []byte, error) {
+
+	key, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	now := time.Now()
+	serial := newSerial(now)
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   cn,
+			SerialNumber: serial.String(),
+		},
+		NotBefore:             now.UTC().AddDate(0, 0, -1),
+		NotAfter:              expiry.UTC(),
+		SubjectKeyId:          bigIntHash(key.N),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	certPEMData := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+	keyPEMData := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return certPEMData, keyPEMData, nil
+}
+
+func newSerial(now time.Time) *big.Int {
+	return big.NewInt(int64(now.Nanosecond()))
+}
+
+// bigIntHash generates a SubjectKeyId by hashing the modulus of the private
+// key. This isn't one of the methods listed in RFC 5280 4.2.1.2, but that also
+// notes that other methods are acceptable.
+//
+// gosec makes a blanket claim that SHA-1 is unacceptable, which is
+// false here. The core Go method of generations the SubjectKeyId (see
+// https://github.com/golang/go/issues/26676) also uses SHA-1, as recommended
+// by RFC 5280.
+func bigIntHash(n *big.Int) []byte {
+	h := sha1.New()    // nolint:gosec
+	h.Write(n.Bytes()) // nolint:errcheck
+	return h.Sum(nil)
+}
+
+func kubeServiceNames(service, namespace, dnsName string) []string {
+	return []string{
+		service,
+		fmt.Sprintf("%s.%s", service, namespace),
+		fmt.Sprintf("%s.%s.svc", service, namespace),
+		fmt.Sprintf("%s.%s.svc.%s", service, namespace, dnsName),
+	}
+}

--- a/internal/crypto/certgen_test.go
+++ b/internal/crypto/certgen_test.go
@@ -1,0 +1,133 @@
+package crypto
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/gateway/api/config/v1alpha1"
+)
+
+func TestGenerateCerts(t *testing.T) {
+	type testcase struct {
+		envoyGateway            *v1alpha1.EnvoyGateway
+		certConfig              *Configuration
+		wantEnvoyGatewayDNSName string
+		wantEnvoyDNSName        string
+	}
+
+	run := func(t *testing.T, name string, tc testcase) {
+		t.Helper()
+
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+
+			got, err := GenerateCerts(tc.envoyGateway)
+			require.NoError(t, err)
+
+			roots := x509.NewCertPool()
+			ok := roots.AppendCertsFromPEM(got.CACertificate)
+			require.Truef(t, ok, "Failed to set up CA cert for testing, maybe it's an invalid PEM")
+
+			currentTime := time.Now()
+
+			err = verifyCert(got.EnvoyGatewayCertificate, roots, tc.wantEnvoyGatewayDNSName, currentTime)
+			assert.NoErrorf(t, err, "Validating %s failed", name)
+
+			err = verifyCert(got.EnvoyCertificate, roots, tc.wantEnvoyDNSName, currentTime)
+			assert.NoErrorf(t, err, "Validating %s failed", name)
+		})
+	}
+
+	run(t, "no configuration - use defaults", testcase{
+		certConfig:              &Configuration{},
+		wantEnvoyGatewayDNSName: "envoy-gateway",
+		wantEnvoyDNSName:        "envoy",
+	})
+}
+
+func TestGeneratedValidKubeCerts(t *testing.T) {
+	now := time.Now()
+	expiry := now.Add(24 * 365 * time.Hour)
+
+	caCert, caKey, err := newCA("envoy-gateway", expiry)
+	require.NoErrorf(t, err, "Failed to generate CA cert")
+
+	egCertReq := &certificateRequest{
+		caCertPEM:  caCert,
+		caKeyPEM:   caKey,
+		expiry:     expiry,
+		commonName: "envoy-gateway",
+		altNames:   kubeServiceNames("envoy-gateway", "envoy-gateway-system", "cluster.local"),
+	}
+	egCert, _, err := newCert(egCertReq)
+	require.NoErrorf(t, err, "Failed to generate Envoy Gateway cert")
+
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM(caCert)
+	require.Truef(t, ok, "Failed to set up CA cert for testing, maybe it's an invalid PEM")
+
+	envoyCertReq := &certificateRequest{
+		caCertPEM:  caCert,
+		caKeyPEM:   caKey,
+		expiry:     expiry,
+		commonName: "envoy",
+		altNames:   kubeServiceNames("envoy", "envoy-gateway-system", "cluster.local"),
+	}
+	envoyCert, _, err := newCert(envoyCertReq)
+	require.NoErrorf(t, err, "Failed to generate Envoy cert")
+
+	tests := []struct {
+		name    string
+		cert    []byte
+		dnsName string
+	}{
+		{
+			name:    "envoy gateway cert",
+			cert:    egCert,
+			dnsName: "envoy-gateway",
+		},
+		{
+			name:    "envoy cert",
+			cert:    envoyCert,
+			dnsName: "envoy",
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyCert(tc.cert, roots, tc.dnsName, now)
+			assert.NoErrorf(t, err, "Validating %s failed", tc.name)
+		})
+	}
+
+}
+
+func verifyCert(certPEM []byte, roots *x509.CertPool, dnsname string, currentTime time.Time) error {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return fmt.Errorf("failed to decode %s certificate from PEM form", dnsname)
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return err
+	}
+
+	opts := x509.VerifyOptions{
+		DNSName:     dnsname,
+		Roots:       roots,
+		CurrentTime: currentTime,
+	}
+	if _, err = cert.Verify(opts); err != nil {
+		return fmt.Errorf("certificate verification failed: %s", err)
+	}
+
+	return nil
+}

--- a/internal/envoygateway/config/config.go
+++ b/internal/envoygateway/config/config.go
@@ -10,10 +10,14 @@ import (
 const (
 	// EnvoyGatewayNamespace is the namespace where envoy-gateway is running.
 	EnvoyGatewayNamespace = "envoy-gateway-system"
+	// EnvoyGatewayServiceName is the name of the Envoy Gateway service.
+	EnvoyGatewayServiceName = "envoy-gateway"
 	// EnvoyServiceName is the name of the Envoy Service.
 	EnvoyServiceName = "envoy"
 	// EnvoyDeploymentName is the name of the Envoy Deployment.
 	EnvoyDeploymentName = "envoy"
+	// EnvoyConfigMapName is the name of the Envoy ConfigMap.
+	EnvoyConfigMapName = "envoy"
 )
 
 // Server wraps the EnvoyGateway configuration and additional parameters

--- a/internal/infrastructure/kubernetes/bootstrap.yaml.tpl
+++ b/internal/infrastructure/kubernetes/bootstrap.yaml.tpl
@@ -41,6 +41,25 @@ static_resources:
     http2_protocol_options: {}
     name: xds_cluster
     type: STRICT_DNS
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            tls_maximum_protocol_version: TLSv1_3
+          tls_certificate_sds_secret_configs:
+          - name: xds_certificate
+            sds_config:
+              path_config_source:
+                path: "/sds/xds-certificate.json"
+              resource_api_version: V3
+          validation_context_sds_secret_config:
+            name: xds_trusted_ca
+            sds_config:
+              path_config_source:
+                path: "/sds/xds-trusted-ca.json"
+              resource_api_version: V3
 layered_runtime:
   layers:
     - name: runtime-0

--- a/internal/infrastructure/kubernetes/configmap.go
+++ b/internal/infrastructure/kubernetes/configmap.go
@@ -1,0 +1,104 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+)
+
+const (
+	sdsCAFilename   = "xds-trusted-ca.json"
+	sdsCertFilename = "xds-certificate.json"
+	// xdsTLSCertFilename is the fully qualified path of the file containing Envoy's
+	// xDS server TLS certificate.
+	xdsTLSCertFilename = "/certs/tls.crt"
+	// xdsTLSKeyFilename is the fully qualified path of the file containing Envoy's
+	// xDS server TLS key.
+	xdsTLSKeyFilename = "/certs/tls.key"
+	// xdsTLSCaFilename is the fully qualified path of the file containing Envoy's
+	// trusted CA certificate.
+	xdsTLSCaFilename = "/certs/ca.crt"
+)
+
+var (
+	// xDS certificate rotation is supported by using SDS path-based resource files.
+	sdsCAConfigMapData = fmt.Sprintf(`{"resources":[{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",`+
+		`"name":"xds_trusted_ca","validation_context":{"trusted_ca":{"filename":"%s"},`+
+		`"match_typed_subject_alt_names":[{"san_type":"DNS","matcher":{"exact":"envoy-gateway"}}]}}]}`, xdsTLSCaFilename)
+	sdsCertConfigMapData = fmt.Sprintf(`{"resources":[{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",`+
+		`"name":"xds_certificate","tls_certificate":{"certificate_chain":{"filename":"%s"},`+
+		`"private_key":{"filename":"%s"}}}]}`, xdsTLSCertFilename, xdsTLSKeyFilename)
+)
+
+// expectedConfigMap returns the expected ConfigMap based on the provided infra.
+func (i *Infra) expectedConfigMap() *corev1.ConfigMap {
+	ns := i.Namespace
+	name := config.EnvoyConfigMapName
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+		Data: map[string]string{
+			sdsCAFilename:   sdsCAConfigMapData,
+			sdsCertFilename: sdsCertConfigMapData,
+		},
+	}
+}
+
+// createOrUpdateConfigMap creates a ConfigMap in the Kube api server based on the provided
+// infra, if it doesn't exist and updates it if it does.
+func (i *Infra) createOrUpdateConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
+	cm := i.expectedConfigMap()
+
+	current := &corev1.ConfigMap{}
+	key := types.NamespacedName{
+		Namespace: i.Namespace,
+		Name:      config.EnvoyConfigMapName,
+	}
+
+	if err := i.Client.Get(ctx, key, current); err != nil {
+		// Create if not found.
+		if kerrors.IsNotFound(err) {
+			if err := i.Client.Create(ctx, cm); err != nil {
+				return nil, fmt.Errorf("failed to create configmap %s/%s: %w", cm.Namespace, cm.Name, err)
+			}
+		}
+	} else {
+		// Update if current value is different.
+		if !reflect.DeepEqual(cm.Data, current.Data) {
+			if err := i.Client.Update(ctx, cm); err != nil {
+				return nil, fmt.Errorf("failed to update configmap %s/%s: %w", cm.Namespace, cm.Name, err)
+			}
+		}
+	}
+
+	return cm, nil
+}
+
+// deleteConfigMap deletes the Envoy ConfigMap in the kube api server, if it exists.
+func (i *Infra) deleteConfigMap(ctx context.Context) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: i.Namespace,
+			Name:      config.EnvoyConfigMapName,
+		},
+	}
+
+	if err := i.Client.Delete(ctx, cm); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete configmap %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+
+	return nil
+}

--- a/internal/infrastructure/kubernetes/configmap_test.go
+++ b/internal/infrastructure/kubernetes/configmap_test.go
@@ -1,0 +1,122 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/envoyproxy/gateway/internal/envoygateway"
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+)
+
+func TestExpectedConfigMap(t *testing.T) {
+	// Setup the infra.
+	cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects().Build()
+	kube := NewInfra(cli)
+	cm := kube.expectedConfigMap()
+
+	require.Equal(t, "envoy", cm.Name)
+	require.Equal(t, "envoy-gateway-system", cm.Namespace)
+	require.Contains(t, cm.Data, sdsCAFilename)
+	assert.Equal(t, sdsCAConfigMapData, cm.Data[sdsCAFilename])
+	require.Contains(t, cm.Data, sdsCertFilename)
+	assert.Equal(t, sdsCertConfigMapData, cm.Data[sdsCertFilename])
+}
+
+func TestCreateOrUpdateConfigMap(t *testing.T) {
+	kube := NewInfra(nil)
+
+	testCases := []struct {
+		name    string
+		current *corev1.ConfigMap
+		expect  *corev1.ConfigMap
+	}{
+		{
+			name: "create configmap",
+			expect: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: config.EnvoyGatewayNamespace,
+					Name:      config.EnvoyConfigMapName,
+				},
+				Data: map[string]string{sdsCAFilename: sdsCAConfigMapData, sdsCertFilename: sdsCertConfigMapData},
+			},
+		},
+		{
+			name: "update configmap",
+			current: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: config.EnvoyGatewayNamespace,
+					Name:      config.EnvoyConfigMapName,
+				},
+				Data: map[string]string{"foo": "bar"},
+			},
+			expect: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: config.EnvoyGatewayNamespace,
+					Name:      config.EnvoyConfigMapName,
+				},
+				Data: map[string]string{sdsCAFilename: sdsCAConfigMapData, sdsCertFilename: sdsCertConfigMapData},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.current != nil {
+				kube.Client = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects(tc.current).Build()
+			} else {
+				kube.Client = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build()
+			}
+			cm, err := kube.createOrUpdateConfigMap(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, tc.expect.Namespace, cm.Namespace)
+			require.Equal(t, tc.expect.Name, cm.Name)
+			require.Equal(t, tc.expect.Data, cm.Data)
+		})
+	}
+}
+
+func TestDeleteConfigMap(t *testing.T) {
+	testCases := []struct {
+		name    string
+		current *corev1.ConfigMap
+		expect  bool
+	}{
+		{
+			name: "delete configmap",
+			current: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: config.EnvoyGatewayNamespace,
+					Name:      config.EnvoyConfigMapName,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "configmap not found",
+			current: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: config.EnvoyGatewayNamespace,
+					Name:      "foo",
+				},
+			},
+			expect: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			kube := NewInfra(fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects(tc.current).Build())
+			err := kube.deleteConfigMap(context.Background())
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/infrastructure/kubernetes/infra.go
+++ b/internal/infrastructure/kubernetes/infra.go
@@ -96,6 +96,10 @@ func (i *Infra) CreateInfra(ctx context.Context, infra *ir.Infra) error {
 		return err
 	}
 
+	if _, err := i.createOrUpdateConfigMap(ctx); err != nil {
+		return err
+	}
+
 	if err := i.createOrUpdateDeployment(ctx, infra); err != nil {
 		return err
 	}
@@ -118,6 +122,10 @@ func (i *Infra) DeleteInfra(ctx context.Context, infra *ir.Infra) error {
 	}
 
 	if err := i.deleteDeployment(ctx); err != nil {
+		return err
+	}
+
+	if err := i.deleteConfigMap(ctx); err != nil {
 		return err
 	}
 

--- a/internal/provider/kubernetes/config/envoy-gateway/certgen-job.yaml
+++ b/internal/provider/kubernetes/config/envoy-gateway/certgen-job.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: certgen
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: certgen
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: certgen
+subjects:
+- kind: ServiceAccount
+  name: certgen
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: certgen
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: certgen
+spec:
+  ttlSecondsAfterFinished: 0
+  template:
+    metadata:
+      labels:
+        app: "certgen"
+    spec:
+      containers:
+      - name: envoy-gateway-certgen
+        image: envoyproxy/gateway-dev:latest
+        imagePullPolicy: Always
+        command:
+        - envoy-gateway
+        - certgen
+      restartPolicy: Never
+      serviceAccountName: certgen
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+  parallelism: 1
+  completions: 1
+  backoffLimit: 1

--- a/internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml
+++ b/internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml
@@ -38,6 +38,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+              readOnly: true
           # TODO(user): Configure the resources accordingly based on the project requirements.
           # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
           resources:
@@ -47,5 +51,9 @@ spec:
             requests:
               cpu: 10m
               memory: 64Mi
+      volumes:
+        - name: certs
+          secret:
+            secretName: envoy-gateway
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10

--- a/internal/provider/kubernetes/config/envoy-gateway/kustomization.yaml
+++ b/internal/provider/kubernetes/config/envoy-gateway/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- certgen-job.yaml
 - deploy_and_ns.yaml
 - service.yaml
 

--- a/internal/provider/kubernetes/secrets.go
+++ b/internal/provider/kubernetes/secrets.go
@@ -1,0 +1,93 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/envoyproxy/gateway/internal/crypto"
+)
+
+// caCertificateKey is the key name for accessing TLS CA certificate bundles
+// in Kubernetes Secrets.
+const caCertificateKey = "ca.crt"
+
+func newSecret(secretType corev1.SecretType, name string, namespace string, data map[string][]byte) corev1.Secret {
+	return corev1.Secret{
+		Type: secretType,
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"control-plane": "envoy-gateway",
+			},
+		},
+		Data: data,
+	}
+}
+
+// CertsToSecret creates secrets in the provided namespace, in compact form, from the provided certs.
+func CertsToSecret(namespace string, certs *crypto.Certificates) []corev1.Secret {
+	return []corev1.Secret{
+		newSecret(
+			corev1.SecretTypeTLS,
+			"envoy-gateway",
+			namespace,
+			map[string][]byte{
+				caCertificateKey:        certs.CACertificate,
+				corev1.TLSCertKey:       certs.EnvoyGatewayCertificate,
+				corev1.TLSPrivateKeyKey: certs.EnvoyGatewayPrivateKey,
+			}),
+		newSecret(
+			corev1.SecretTypeTLS,
+			"envoy",
+			namespace,
+			map[string][]byte{
+				caCertificateKey:        certs.CACertificate,
+				corev1.TLSCertKey:       certs.EnvoyCertificate,
+				corev1.TLSPrivateKeyKey: certs.EnvoyPrivateKey,
+			}),
+	}
+}
+
+// CreateOrUpdateSecrets creates the provided secrets if they don't exist or updates
+// them if they do.
+func CreateOrUpdateSecrets(ctx context.Context, client client.Client, secrets []corev1.Secret) ([]corev1.Secret, error) {
+	var ret []corev1.Secret
+	for i := range secrets {
+		secret := secrets[i]
+		current := new(corev1.Secret)
+		key := types.NamespacedName{
+			Namespace: secret.Namespace,
+			Name:      secret.Name,
+		}
+		if err := client.Get(ctx, key, current); err != nil {
+			// Create if not found.
+			if kerrors.IsNotFound(err) {
+				if err := client.Create(ctx, &secret); err != nil {
+					return nil, fmt.Errorf("failed to create secret %s/%s: %w", secret.Namespace, secret.Name, err)
+				}
+			}
+		} else {
+			// Update if current value is different.
+			if !reflect.DeepEqual(secret.Data, current.Data) {
+				if err := client.Update(ctx, &secret); err != nil {
+					return nil, fmt.Errorf("failed to update secret %s/%s: %w", secret.Namespace, secret.Name, err)
+				}
+			}
+		}
+		ret = append(ret, secret)
+	}
+
+	return ret, nil
+}

--- a/internal/xds/server/runner/runner_test.go
+++ b/internal/xds/server/runner/runner_test.go
@@ -1,0 +1,179 @@
+package runner
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tsaarni/certyaml"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	"github.com/envoyproxy/gateway/internal/log"
+)
+
+func TestTLSConfig(t *testing.T) {
+	// Create trusted CA, server and client certs.
+	trustedCACert := certyaml.Certificate{
+		Subject: "cn=trusted-ca",
+	}
+	egCertBeforeRotation := certyaml.Certificate{
+		Subject:         "cn=eg-before-rotation",
+		SubjectAltNames: []string{"DNS:localhost"},
+		Issuer:          &trustedCACert,
+	}
+	egCertAfterRotation := certyaml.Certificate{
+		Subject:         "cn=eg-after-rotation",
+		SubjectAltNames: []string{"DNS:localhost"},
+		Issuer:          &trustedCACert,
+	}
+	trustedEnvoyCert := certyaml.Certificate{
+		Subject: "cn=trusted-envoy",
+		Issuer:  &trustedCACert,
+	}
+
+	// Create another CA and a client cert to test that untrusted clients are denied.
+	untrustedCACert := certyaml.Certificate{
+		Subject: "cn=untrusted-ca",
+	}
+	untrustedClientCert := certyaml.Certificate{
+		Subject: "cn=untrusted-client",
+		Issuer:  &untrustedCACert,
+	}
+
+	caCertPool := x509.NewCertPool()
+	ca, err := trustedCACert.X509Certificate()
+	require.NoError(t, err)
+	caCertPool.AddCert(&ca)
+
+	tests := map[string]struct {
+		serverCredentials *certyaml.Certificate
+		clientCredentials *certyaml.Certificate
+		expectError       bool
+	}{
+		"successful TLS connection established": {
+			serverCredentials: &egCertBeforeRotation,
+			clientCredentials: &trustedEnvoyCert,
+			expectError:       false,
+		},
+		"rotating server credentials returns new server cert": {
+			serverCredentials: &egCertAfterRotation,
+			clientCredentials: &trustedEnvoyCert,
+			expectError:       false,
+		},
+		"rotating server credentials again to ensure rotation can be repeated": {
+			serverCredentials: &egCertBeforeRotation,
+			clientCredentials: &trustedEnvoyCert,
+			expectError:       false,
+		},
+		"fail to connect with client certificate which is not signed by correct CA": {
+			serverCredentials: &egCertBeforeRotation,
+			clientCredentials: &untrustedClientCert,
+			expectError:       true,
+		},
+	}
+
+	// Create temporary directory to store certificates and key for the server.
+	configDir, err := os.MkdirTemp("", "eg-testdata-")
+	require.NoError(t, err)
+	defer os.RemoveAll(configDir)
+
+	caFile := filepath.Join(configDir, "ca.crt")
+	certFile := filepath.Join(configDir, "tls.crt")
+	keyFile := filepath.Join(configDir, "tls.key")
+
+	// Initial set of credentials must be written into temp directory before
+	// starting the tests to avoid error at server startup.
+	err = trustedCACert.WritePEM(caFile, keyFile)
+	require.NoError(t, err)
+	err = egCertBeforeRotation.WritePEM(certFile, keyFile)
+	require.NoError(t, err)
+
+	// Start a dummy server.
+	logger, err := log.NewLogger()
+	require.NoError(t, err)
+	cfg := &Config{
+		Server: config.Server{
+			Logger: logger,
+		},
+	}
+	r := New(cfg)
+	g := grpc.NewServer(grpc.Creds(credentials.NewTLS(r.tlsConfig(certFile, keyFile, caFile))))
+	if g == nil {
+		t.Error("failed to create server")
+	}
+
+	address := "localhost:8001"
+	l, err := net.Listen("tcp", address)
+	require.NoError(t, err)
+
+	go func() {
+		err := g.Serve(l)
+		require.NoError(t, err)
+	}()
+	defer g.GracefulStop()
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			// Store certificate and key to temp dir used by serveContext.
+			err = tc.serverCredentials.WritePEM(certFile, keyFile)
+			require.NoError(t, err)
+			clientCert, _ := tc.clientCredentials.TLSCertificate()
+			receivedCert, err := tryConnect(address, clientCert, caCertPool)
+			gotError := err != nil
+			if gotError != tc.expectError {
+				t.Errorf("Unexpected result when connecting to the server: %s", err)
+			}
+			if err == nil {
+				expectedCert, _ := tc.serverCredentials.X509Certificate()
+				assert.Equal(t, receivedCert, &expectedCert)
+			}
+		})
+	}
+}
+
+// tryConnect tries to establish TLS connection to the server.
+// If successful, return the server certificate.
+func tryConnect(address string, clientCert tls.Certificate, caCertPool *x509.CertPool) (*x509.Certificate, error) {
+	clientConfig := &tls.Config{
+		ServerName:   "localhost",
+		MinVersion:   tls.VersionTLS13,
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      caCertPool,
+	}
+	conn, err := tls.Dial("tcp", address, clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	err = peekError(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn.ConnectionState().PeerCertificates[0], nil
+}
+
+// peekError is a workaround for TLS 1.3: due to shortened handshake, TLS alert
+// from server is received at first read from the socket. To receive alert for
+// bad certificate, this function tries to read one byte.
+// Adapted from https://golang.org/src/crypto/tls/handshake_client_test.go
+func peekError(conn net.Conn) error {
+	_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	_, err := conn.Read(make([]byte, 1))
+	if err != nil {
+		if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- Adds a package for generating control plane auth certs.
- Adds a const to the EG config pkg to represent the default "envoy-gateway-system" ns.
- Updates `ObjectName()` method to get/set the default name of the ProxyInfra type.

fixes: #70 

Signed-off-by: danehans <daneyonhansen@gmail.com>