### PR TITLE
remove unimplemented liveness/readiness probes

### DIFF
--- a/internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml
+++ b/internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml
@@ -37,18 +37,6 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
         # TODO(user): Configure the resources accordingly based on the project requirements.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:


### PR DESCRIPTION
Just removing the probe definitions for now
since they're not implemented to unblock
running EG in-cluster, but we should circle
back and implement these eventually.

Updates #235.

Signed-off-by: Steve Kriss <krisss@vmware.com>