### PR TITLE
Add support for exposing additional bootstrap config options

### DIFF
--- a/internal/infrastructure/kubernetes/bootstrap.yaml.tpl
+++ b/internal/infrastructure/kubernetes/bootstrap.yaml.tpl
@@ -2,8 +2,8 @@ admin:
   access_log_path: /dev/null
   address:
     socket_address:
-      address: 127.0.0.1
-      port_value: 19000
+      address: {{ .AdminServerAddress }}
+      port_value: {{ .AdminServerPort }}
 dynamic_resources:
   cds_config:
     resource_api_version: V3
@@ -37,7 +37,7 @@ static_resources:
             address:
               socket_address:
                 address: {{ .XdsServerAddress }}
-                port_value: 18000
+                port_value: {{ .XdsServerPort }}
     http2_protocol_options: {}
     name: xds_cluster
     type: STRICT_DNS

--- a/internal/infrastructure/kubernetes/deployment.go
+++ b/internal/infrastructure/kubernetes/deployment.go
@@ -45,6 +45,12 @@ var bootstrapTmpl = template.Must(template.New(envoyCfgFileName).Parse(bootstrap
 var (
 	// envoyGatewayService is the name of the Envoy Gateway service.
 	envoyGatewayService = "envoy-gateway"
+	// envoyGatewayPort is the port used to expose envoyGatewayService.
+	envoyGatewayPort = int32(18000)
+	// envoyGatewayAdminService is the host address of the envoy admin interface.
+	envoyGatewayAdminService = "127.0.0.1"
+	// envoyGatewayAdminPort is the port used to expose admin interface.
+	envoyGatewayAdminPort = int32(19000)
 )
 
 // envoyBootstrap defines the envoy Bootstrap configuration.
@@ -59,6 +65,12 @@ type bootstrapConfig struct {
 type bootstrapParameters struct {
 	// XdsServerAddress is the address of the XDS Server that Envoy is managed by.
 	XdsServerAddress string
+	// XdsServerPort is the port of the XDS Server that Envoy is managed by.
+	XdsServerPort int32
+	// AdminServerAddress is the address of the Envoy admin interface.
+	AdminServerAddress string
+	// AdminServerPort is the port of the Envoy admin interface.
+	AdminServerPort int32
 }
 
 // render the stringified bootstrap config in yaml format.
@@ -167,7 +179,8 @@ func expectedContainers(infra *ir.Infra) ([]corev1.Container, error) {
 		},
 	}
 
-	cfg := bootstrapConfig{parameters: bootstrapParameters{XdsServerAddress: envoyGatewayService}}
+	cfg := bootstrapConfig{parameters: bootstrapParameters{XdsServerAddress: envoyGatewayService, XdsServerPort: envoyGatewayPort,
+		AdminServerAddress: envoyGatewayAdminService, AdminServerPort: envoyGatewayAdminPort}}
 	if err := cfg.render(); err != nil {
 		return nil, err
 	}

--- a/internal/infrastructure/kubernetes/deployment_test.go
+++ b/internal/infrastructure/kubernetes/deployment_test.go
@@ -111,7 +111,7 @@ func TestExpectedDeployment(t *testing.T) {
 	checkLabels(t, deploy, deploy.Labels)
 
 	// Create a bootstrap config, render it into an arg, and ensure it's as expected.
-	cfg := &bootstrapConfig{parameters: bootstrapParameters{XdsServerAddress: envoyGatewayService}}
+	cfg := &bootstrapConfig{parameters: bootstrapParameters{XdsServerAddress: envoyGatewayService, XdsServerPort: 18000, AdminServerAddress: "127.0.0.1", AdminServerPort: 19000}}
 	err = cfg.render()
 	require.NoError(t, err)
 	checkContainerHasArg(t, container, fmt.Sprintf("--config-yaml %s", cfg.rendered))

--- a/internal/infrastructure/kubernetes/deployment_test.go
+++ b/internal/infrastructure/kubernetes/deployment_test.go
@@ -111,7 +111,8 @@ func TestExpectedDeployment(t *testing.T) {
 	checkLabels(t, deploy, deploy.Labels)
 
 	// Create a bootstrap config, render it into an arg, and ensure it's as expected.
-	cfg := &bootstrapConfig{parameters: bootstrapParameters{XdsServerAddress: envoyGatewayService, XdsServerPort: 18000, AdminServerAddress: "127.0.0.1", AdminServerPort: 19000}}
+	cfg := &bootstrapConfig{parameters: bootstrapParameters{XdsServerAddress: envoyGatewayService, XdsServerPort: envoyGatewayPort,
+		AdminServerAddress: envoyGatewayAdminService, AdminServerPort: envoyGatewayAdminPort}}
 	err = cfg.render()
 	require.NoError(t, err)
 	checkContainerHasArg(t, container, fmt.Sprintf("--config-yaml %s", cfg.rendered))


### PR DESCRIPTION
With https://github.com/envoyproxy/gateway/pull/206, only the Xds server address is configurable. This PR add support to configure Xds server port, admin server host and port.

Fixes #212 

Signed-off-by: Lahiru De Silva <lahirude@wso2.com>