### PR TITLE
Fix xds server port

### DIFF
--- a/internal/infrastructure/kubernetes/deployment.go
+++ b/internal/infrastructure/kubernetes/deployment.go
@@ -36,7 +36,8 @@ const (
 	envoyHTTPPort = int32(8080)
 	// envoyHTTPSPort is the container port number of Envoy's HTTPS endpoint.
 	envoyHTTPSPort = int32(8443)
-	// envoyGatewayXdsServerHost is the address of the Xds Server within Envoy Gateway.
+	// envoyGatewayXdsServerHost is the DNS name of the Xds Server within Envoy Gateway.
+	// It defaults to the Envoy Gateway Kubernetes service.
 	envoyGatewayXdsServerHost = "envoy-gateway"
 	// envoyAdminAddress is the listening address of the envoy admin interface.
 	envoyAdminAddress = "127.0.0.1"

--- a/internal/infrastructure/kubernetes/deployment_test.go
+++ b/internal/infrastructure/kubernetes/deployment_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/envoyproxy/gateway/internal/envoygateway"
 	"github.com/envoyproxy/gateway/internal/ir"
+	xdsrunner "github.com/envoyproxy/gateway/internal/xds/server/runner"
 )
 
 func checkEnvVar(t *testing.T, deploy *appsv1.Deployment, container, name string) {
@@ -111,8 +112,14 @@ func TestExpectedDeployment(t *testing.T) {
 	checkLabels(t, deploy, deploy.Labels)
 
 	// Create a bootstrap config, render it into an arg, and ensure it's as expected.
-	cfg := &bootstrapConfig{parameters: bootstrapParameters{XdsServerAddress: envoyGatewayService, XdsServerPort: envoyGatewayPort,
-		AdminServerAddress: envoyGatewayAdminService, AdminServerPort: envoyGatewayAdminPort}}
+	cfg := &bootstrapConfig{
+		parameters: bootstrapParameters{
+			XdsServerAddress:   envoyGatewayXdsServerHost,
+			XdsServerPort:      xdsrunner.XdsServerPort,
+			AdminServerAddress: envoyAdminAddress,
+			AdminServerPort:    envoyAdminPort,
+		},
+	}
 	err = cfg.render()
 	require.NoError(t, err)
 	checkContainerHasArg(t, container, fmt.Sprintf("--config-yaml %s", cfg.rendered))

--- a/internal/xds/server/runner/runner.go
+++ b/internal/xds/server/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"net"
+	"strconv"
 
 	"google.golang.org/grpc"
 
@@ -17,6 +18,13 @@ import (
 	controlplane_service_runtime_v3 "github.com/envoyproxy/go-control-plane/envoy/service/runtime/v3"
 	controlplane_service_secret_v3 "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
 	controlplane_server_v3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+)
+
+const (
+	// XdsServerAddress is the listening address of the xds-server.
+	XdsServerAddress = "0.0.0.0"
+	// XdsServerPort is the listening port of the xds-server.
+	XdsServerPort = 18000
 )
 
 type Config struct {
@@ -54,8 +62,7 @@ func (r *Runner) setupXdsServer(ctx context.Context) {
 	r.cache = cache.NewSnapshotCache(false, r.Logger)
 	registerServer(controlplane_server_v3.NewServer(ctx, r.cache, r.cache), r.grpc)
 
-	// TODO: Make the listening address and port configurable
-	addr := net.JoinHostPort("0.0.0.0", "8001")
+	addr := net.JoinHostPort(XdsServerAddress, strconv.Itoa(XdsServerPort))
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
 		r.Logger.Error(err, "failed to listen on address", addr)


### PR DESCRIPTION
* fix xds-server's port within the runner to 18000
* make sure the envoy bootstrap config within the infra library
uses the same constant from the xds server runner
* moved vars to const within the kube infra library and renamed some

Signed-off-by: Arko Dasgupta <arko@tetrate.io>