### PR TITLE
fix: sync unmatched eg namespace

### DIFF
--- a/internal/provider/kubernetes/config/crd/patches/webhook_in_envoyproxies.yaml
+++ b/internal/provider/kubernetes/config/crd/patches/webhook_in_envoyproxies.yaml
@@ -9,7 +9,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          namespace: system
+          namespace: envoy-gateway-system
           name: webhook-service
           path: /convert
       conversionReviewVersions:

--- a/internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml
+++ b/internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: envoy-gateway
-  name: system
+  name: envoy-gateway-system
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/internal/provider/kubernetes/config/prometheus/monitor.yaml
+++ b/internal/provider/kubernetes/config/prometheus/monitor.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     control-plane: envoy-gateway
   name: envoy-gateway-metrics-monitor
-  namespace: system
+  namespace: envoy-gateway-system
 spec:
   endpoints:
     - path: /metrics

--- a/internal/provider/kubernetes/config/rbac/auth_proxy_role_binding.yaml
+++ b/internal/provider/kubernetes/config/rbac/auth_proxy_role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: envoy-gateway
-  namespace: system
+  namespace: envoy-gateway-system

--- a/internal/provider/kubernetes/config/rbac/auth_proxy_service.yaml
+++ b/internal/provider/kubernetes/config/rbac/auth_proxy_service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     control-plane: envoy-gateway
   name: envoy-gateway-metrics-service
-  namespace: system
+  namespace: envoy-gateway-system
 spec:
   ports:
   - name: https

--- a/internal/provider/kubernetes/config/rbac/leader_election_role_binding.yaml
+++ b/internal/provider/kubernetes/config/rbac/leader_election_role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: envoy-gateway
-  namespace: system
+  namespace: envoy-gateway-system

--- a/internal/provider/kubernetes/config/rbac/role_binding.yaml
+++ b/internal/provider/kubernetes/config/rbac/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: envoy-gateway
-  namespace: system
+  namespace: envoy-gateway-system

--- a/internal/provider/kubernetes/config/rbac/service_account.yaml
+++ b/internal/provider/kubernetes/config/rbac/service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: envoy-gateway
-  namespace: system
+  namespace: envoy-gateway-system


### PR DESCRIPTION
for `internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml`, 

ns and deployment are unmatched, it will cause deployment started failed.

and other files in `internal/provider/kubernetes/config/`, ns is not synced too, some called `system` and some called `envoy-gateway-system`.

Signed-off-by: Xunzhuo <mixdeers@gmail.com>