### PR TITLE
chore: remove deprecated MAKE_IN_DOCKER option

### DIFF
--- a/tools/make/common.mk
+++ b/tools/make/common.mk
@@ -90,10 +90,6 @@ endef
 define USAGE_OPTIONS
 
 Options:
-  \033[36mMAKE_IN_DOCKER\033[0m	
-		 Run make inside a Docker container which has all the preinstalled tools needed to support all the make targets
-		 This option is available to all cmds.
-		 Example: \033[36mmake build MAKE_IN_DOCKER=1\033[0m
   \033[36mBINS\033[0m       
 		 The binaries to build. Default is all of cmd.
 		 This option is available when using: make build|build-multiarch


### PR DESCRIPTION
remove deprecated option in `make help`:
<img width="980" alt="image" src="https://user-images.githubusercontent.com/48784001/186987652-05b27eb0-de0b-4e7d-83f1-af74d827cada.png">

Signed-off-by: Xunzhuo <mixdeers@gmail.com>