### PR TITLE
Adds Envoy Gateway Service to Kubernetes Manifests

### DIFF
--- a/internal/provider/kubernetes/config/envoy-gateway/kustomization.yaml
+++ b/internal/provider/kubernetes/config/envoy-gateway/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - deploy_and_ns.yaml
+- service.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/internal/provider/kubernetes/config/envoy-gateway/service.yaml
+++ b/internal/provider/kubernetes/config/envoy-gateway/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-gateway
+  labels:
+    control-plane: envoy-gateway
+spec:
+  ports:
+    - name: grpc
+      port: 18000
+      targetPort: 18000
+  selector:
+    control-plane: envoy-gateway


### PR DESCRIPTION
Adds an Envoy Gateway Service to the Kubernetes provider manifests.

Fixes: 268

Signed-off-by: danehans <daneyonhansen@gmail.com>