### PR TITLE
Adds HTTPRoute BackendRefs to Resource Map

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -43,6 +43,7 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 	gatewayClassesCh := r.ProviderResources.GatewayClasses.Subscribe(ctx)
 	gatewaysCh := r.ProviderResources.Gateways.Subscribe(ctx)
 	httpRoutesCh := r.ProviderResources.HTTPRoutes.Subscribe(ctx)
+	servicesCh := r.ProviderResources.Services.Subscribe(ctx)
 	namespacesCh := r.ProviderResources.Namespaces.Subscribe(ctx)
 
 	// Wait until provider resources have been initialized during startup
@@ -54,12 +55,14 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 		case <-gatewayClassesCh:
 		case <-gatewaysCh:
 		case <-httpRoutesCh:
+		case <-servicesCh:
 		case <-namespacesCh:
 		}
 		r.Logger.Info("received a notification")
 		// Load all resources required for translation
 		in.Gateways = r.ProviderResources.GetGateways()
 		in.HTTPRoutes = r.ProviderResources.GetHTTPRoutes()
+		in.Services = r.ProviderResources.GetServices()
 		in.Namespaces = r.ProviderResources.GetNamespaces()
 		gatewayClasses := r.ProviderResources.GetGatewayClasses()
 		// Fetch the first gateway class since there should be only 1

--- a/internal/message/types.go
+++ b/internal/message/types.go
@@ -18,6 +18,7 @@ type ProviderResources struct {
 	Gateways       watchable.Map[types.NamespacedName, *gwapiv1b1.Gateway]
 	HTTPRoutes     watchable.Map[types.NamespacedName, *gwapiv1b1.HTTPRoute]
 	Namespaces     watchable.Map[string, *corev1.Namespace]
+	Services       watchable.Map[types.NamespacedName, *corev1.Service]
 	// Initialized.Wait() will return once each of the maps in the
 	// structure have been initialized at startup.
 	Initialized sync.WaitGroup
@@ -64,6 +65,17 @@ func (p *ProviderResources) GetNamespaces() []*corev1.Namespace {
 
 	res := make([]*corev1.Namespace, 0, p.Namespaces.Len())
 	for _, v := range p.Namespaces.LoadAll() {
+		res = append(res, v)
+	}
+	return res
+}
+
+func (p *ProviderResources) GetServices() []*corev1.Service {
+	if p.Services.Len() == 0 {
+		return nil
+	}
+	res := make([]*corev1.Service, 0, p.Services.Len())
+	for _, v := range p.Services.LoadAll() {
 		res = append(res, v)
 	}
 	return res

--- a/internal/message/types_test.go
+++ b/internal/message/types_test.go
@@ -43,12 +43,19 @@ func TestProviderResources(t *testing.T) {
 			Namespace: "test",
 		},
 	}
+	s1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service1",
+			Namespace: "test",
+		},
+	}
 
 	// Check init state
 	assert.Nil(t, resources.GetNamespaces())
 	assert.Nil(t, resources.GetGatewayClasses())
 	assert.Nil(t, resources.GetGateways())
 	assert.Nil(t, resources.GetHTTPRoutes())
+	assert.Nil(t, resources.GetServices())
 
 	// Add resources
 	resources.Namespaces.Store("test-ns1", ns1)
@@ -66,6 +73,12 @@ func TestProviderResources(t *testing.T) {
 	}
 	resources.HTTPRoutes.Store(r1Key, r1)
 
+	s1Key := types.NamespacedName{
+		Namespace: s1.GetNamespace(),
+		Name:      s1.GetName(),
+	}
+	resources.Services.Store(s1Key, s1)
+
 	// Test
 	namespaces := resources.GetNamespaces()
 	assert.Equal(t, len(namespaces), 1)
@@ -78,6 +91,9 @@ func TestProviderResources(t *testing.T) {
 
 	hrs := resources.GetHTTPRoutes()
 	assert.Equal(t, len(hrs), 1)
+
+	svcs := resources.GetServices()
+	assert.Equal(t, len(svcs), 1)
 
 	// Add more resources
 	ns2 := &corev1.Namespace{
@@ -103,6 +119,12 @@ func TestProviderResources(t *testing.T) {
 			Namespace: "test",
 		},
 	}
+	s2 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service2",
+			Namespace: "test",
+		},
+	}
 
 	resources.Namespaces.Store("test-ns2", ns2)
 	resources.GatewayClasses.Store("test-gc2", gc2)
@@ -118,6 +140,12 @@ func TestProviderResources(t *testing.T) {
 	}
 	resources.HTTPRoutes.Store(r2Key, r2)
 
+	s2Key := types.NamespacedName{
+		Namespace: s2.GetNamespace(),
+		Name:      s2.GetName(),
+	}
+	resources.Services.Store(s2Key, s2)
+
 	// Test contents
 	namespaces = resources.GetNamespaces()
 	assert.ElementsMatch(t, namespaces, []*corev1.Namespace{ns1, ns2})
@@ -130,6 +158,9 @@ func TestProviderResources(t *testing.T) {
 
 	hrs = resources.GetHTTPRoutes()
 	assert.ElementsMatch(t, hrs, []*gwapiv1b1.HTTPRoute{r1, r2})
+
+	svcs = resources.GetServices()
+	assert.ElementsMatch(t, svcs, []*corev1.Service{s1, s2})
 }
 
 func TestXdsIR(t *testing.T) {


### PR DESCRIPTION
Adds HTTPRoute backendRefs to the watchable resource map.
- Adds backendRef validation to HTTPRoute controller. Note that only local Service object references are supported.
- Adds valid backendRefs to the watchable resource map.
- Updates Kube integration tests to ensure that valid backendRefs are added to the watchable resource map.
- Adds backendRefs, e.g. Services, to the gatewayapi runner.
- Adds  Services object type to ProviderResources and updates unit tests accordingly.

Fixes: https://github.com/envoyproxy/gateway/issues/189

Signed-off-by: danehans <daneyonhansen@gmail.com>