### PR TITLE
validate ir before sending it

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -78,10 +78,21 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 			}
 			// Translate to IR
 			result := t.Translate(&in)
+
 			// Publish the IRs. Use the service name as the key
-			// to ensure there is always one element in the map
-			r.XdsIR.Store(r.Name(), result.XdsIR)
-			r.InfraIR.Store(r.Name(), result.InfraIR)
+			// to ensure there is always one element in the map.
+			// Also validate the ir before sending it.
+			if err := result.XdsIR.Validate(); err != nil {
+				r.Logger.Error(err, "unable to validate xds ir, skipped sending it")
+			} else {
+				r.XdsIR.Store(r.Name(), result.XdsIR)
+			}
+
+			if err := result.InfraIR.Validate(); err != nil {
+				r.Logger.Error(err, "unable to validate infra ir, skipped sending it")
+			} else {
+				r.InfraIR.Store(r.Name(), result.InfraIR)
+			}
 		}
 	}
 	r.Logger.Info("shutting down")

--- a/internal/infrastructure/kubernetes/infra.go
+++ b/internal/infrastructure/kubernetes/infra.go
@@ -73,10 +73,6 @@ func (i *Infra) addResource(obj client.Object) error {
 
 // CreateInfra creates the managed kube infra if it doesn't exist.
 func (i *Infra) CreateInfra(ctx context.Context, infra *ir.Infra) error {
-	if err := ir.ValidateInfra(infra); err != nil {
-		return err
-	}
-
 	if infra == nil {
 		return errors.New("infra ir is nil")
 	}

--- a/internal/ir/infra.go
+++ b/internal/ir/infra.go
@@ -116,16 +116,16 @@ func (i *Infra) GetProxyInfra() *ProxyInfra {
 	return i.Proxy
 }
 
-// ValidateInfra validates the provided Infra.
-func ValidateInfra(infra *Infra) error {
-	if infra == nil {
+// Validate validates the provided Infra.
+func (i *Infra) Validate() error {
+	if i == nil {
 		return errors.New("infra ir is nil")
 	}
 
 	var errs []error
 
-	if infra.Proxy != nil {
-		if err := ValidateProxyInfra(infra.Proxy); err != nil {
+	if i.Proxy != nil {
+		if err := i.Proxy.Validate(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -133,25 +133,25 @@ func ValidateInfra(infra *Infra) error {
 	return utilerrors.NewAggregate(errs)
 }
 
-// ValidateProxyInfra validates the provided ProxyInfra.
-func ValidateProxyInfra(pInfra *ProxyInfra) error {
+// Validate validates the provided ProxyInfra.
+func (p *ProxyInfra) Validate() error {
 	var errs []error
 
-	if len(pInfra.Name) == 0 {
+	if len(p.Name) == 0 {
 		errs = append(errs, errors.New("name field required"))
 	}
 
-	if len(pInfra.Image) == 0 {
+	if len(p.Image) == 0 {
 		errs = append(errs, errors.New("image field required"))
 	}
 
-	if len(pInfra.Listeners) > 1 {
+	if len(p.Listeners) > 1 {
 		errs = append(errs, errors.New("no more than 1 listener is supported"))
 	}
 
-	if len(pInfra.Listeners) > 0 {
-		for i := range pInfra.Listeners {
-			listener := pInfra.Listeners[i]
+	if len(p.Listeners) > 0 {
+		for i := range p.Listeners {
+			listener := p.Listeners[i]
 			if len(listener.Ports) == 0 {
 				errs = append(errs, errors.New("listener ports field required"))
 			}

--- a/internal/ir/infra_test.go
+++ b/internal/ir/infra_test.go
@@ -105,7 +105,7 @@ func TestValidateInfra(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateInfra(tc.infra)
+			err := tc.infra.Validate()
 			if !tc.expect {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
* Validate the xds and infra IR in the gatewayapi runner
before sending it to the next stage consuming the IRs

* refactor infra ir validate

Signed-off-by: Arko Dasgupta <arko@tetrate.io>