### PR TITLE
Adds Kind Host-to-Container Port Mapping

### DIFF
--- a/tools/hack/create-cluster.sh
+++ b/tools/hack/create-cluster.sh
@@ -6,12 +6,16 @@ set -euo pipefail
 CLUSTER_NAME=${CLUSTER_NAME:-"envoy-gateway"}
 METALLB_VERSION=${METALLB_VERSION:-"v0.12.1"}
 KIND_NODE_TAG=${KIND_NODE_TAG:-"v1.24.0"}
+readonly HERE=$(cd "$(dirname "$0")" && pwd)
+readonly REPO=$(cd "${HERE}/../.." && pwd)
+readonly CONFIG_FILE="${REPO}/tools/hack/kind-expose-ports.yaml"
+
 
 ## Create kind cluster.
 if [[ -z "${KIND_NODE_TAG}" ]]; then
-  tools/bin/kind create cluster --name "${CLUSTER_NAME}"
+  tools/bin/kind create cluster --name "${CLUSTER_NAME}" --config "${CONFIG_FILE}"
 else
-  tools/bin/kind create cluster --image "kindest/node:${KIND_NODE_TAG}" --name "${CLUSTER_NAME}"
+  tools/bin/kind create cluster --image "kindest/node:${KIND_NODE_TAG}" --name "${CLUSTER_NAME}" --config "${CONFIG_FILE}"
 fi
 
 ## Install metallb.

--- a/tools/hack/kind-expose-ports.yaml
+++ b/tools/hack/kind-expose-ports.yaml
@@ -1,0 +1,12 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 9080
+        listenAddress: "0.0.0.0"
+      - containerPort: 443
+        hostPort: 9443
+        listenAddress: "0.0.0.0"


### PR DESCRIPTION
Maps host port 9080 to container port 80 and host port 9443 to container port 443 for kind cluster.

Fixes: #284 

Signed-off-by: danehans <daneyonhansen@gmail.com>