### PR TITLE
Add shebang in run-kube-local.sh

### DIFF
--- a/tools/hack/create-cluster.sh
+++ b/tools/hack/create-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/tools/hack/kind-load-image.sh
+++ b/tools/hack/kind-load-image.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset

--- a/tools/hack/run-kube-local.sh
+++ b/tools/hack/run-kube-local.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 GOARCH=$(go env GOARCH)


### PR DESCRIPTION
Use consistent shebang for other scripts as well.

Otherwise it fails with:
```
tools/hack/run-kube-local.sh: 1: set: Illegal option -o pipefail
```

