### PR TITLE
Adds Make Target to Generate Release Manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ bin/
 
 # Visual Studio Code
 .vscode/
+
+# Release artifacts
+release/

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ bin/
 .vscode/
 
 # Release artifacts
-release/
+release-artifacts/

--- a/tools/hack/build-install-yaml.sh
+++ b/tools/hack/build-install-yaml.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly KUSTOMIZE=${KUSTOMIZE:-tools/bin/kustomize}
+readonly GATEWAY_API_VERSION="$1"
+
+mkdir -p release/
+
+# Download the supported Gateway API CRDs that will be supported by the release.
+curl -sLo release/gatewayapi-crds.yaml https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/experimental-install.yaml
+
+echo "Added:" release/gatewayapi-crds.yaml
+
+# Generate the envoy gateway installation manifest supported by the release.
+${KUSTOMIZE} build internal/provider/kubernetes/config/default > release/install.yaml
+
+echo "Generated:" release/install.yaml

--- a/tools/hack/kind-load-image.sh
+++ b/tools/hack/kind-load-image.sh
@@ -13,11 +13,13 @@ readonly TAG="$2"
 
 # Wrap sed to deal with GNU and BSD sed flags.
 run::sed() {
-    local -r vers="$(sed --version < /dev/null 2>&1 | grep -q GNU && echo gnu || echo bsd)"
-    case "$vers" in
-        gnu) sed -i "$@" ;;
-        *) sed -i '' "$@" ;;
-    esac
+  if sed --version </dev/null 2>&1 | grep -q GNU; then
+    # GNU sed
+    sed -i "$@"
+  else
+    # assume BSD sed
+    sed -i '' "$@"
+  fi
 }
 
 kind::cluster::exists() {

--- a/tools/hack/release-manifests.sh
+++ b/tools/hack/release-manifests.sh
@@ -6,8 +6,18 @@ set -o pipefail
 
 readonly KUSTOMIZE=${KUSTOMIZE:-tools/bin/kustomize}
 readonly GATEWAY_API_VERSION="$1"
+readonly TAG="$2"
 
 mkdir -p release/
+
+# Wrap sed to deal with GNU and BSD sed flags.
+run::sed() {
+    local -r vers="$(sed --version < /dev/null 2>&1 | grep -q GNU && echo gnu || echo bsd)"
+    case "$vers" in
+        gnu) sed -i "$@" ;;
+        *) sed -i '' "$@" ;;
+    esac
+}
 
 # Download the supported Gateway API CRDs that will be supported by the release.
 curl -sLo release/gatewayapi-crds.yaml https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/experimental-install.yaml
@@ -18,3 +28,10 @@ echo "Added:" release/gatewayapi-crds.yaml
 ${KUSTOMIZE} build internal/provider/kubernetes/config/default > release/install.yaml
 
 echo "Generated:" release/install.yaml
+
+# Update the image in the Envoy Gateway deployment manifest.
+run::sed \
+  "-es|image: envoyproxy/gateway-dev:.*$|image: envoyproxy/gateway:${TAG}|" \
+  "release/install.yaml"
+
+echo "Updated the envoy gateway image:" release/install.yaml

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -66,3 +66,7 @@ run-conformance: ## Run Gateway API conformance.
 .PHONY: delete-cluster
 delete-cluster: $(tools/kind) ## Delete kind cluster.
 	$(tools/kind) delete cluster --name envoy-gateway
+
+.PHONY: build-install-yaml
+build-install-yaml:
+	tools/hack/build-install-yaml.sh $(GATEWAY_API_VERSION)

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -1,5 +1,3 @@
-# RELEASE_VERSION refers to the version of Envoy Gateway,
-RELEASE_VERSION ?= v0.2.0-rc1
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.24.1
 # GATEWAY_API_VERSION refers to the version of Gateway API CRDs.
@@ -71,4 +69,4 @@ delete-cluster: $(tools/kind) ## Delete kind cluster.
 
 .PHONY: release-manifests
 release-manifests:
-	tools/hack/release-manifests.sh $(GATEWAY_API_VERSION) $(RELEASE_VERSION)
+	tools/hack/release-manifests.sh $(GATEWAY_API_VERSION) $(VERSION)

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -68,5 +68,5 @@ delete-cluster: $(tools/kind) ## Delete kind cluster.
 	$(tools/kind) delete cluster --name envoy-gateway
 
 .PHONY: release-manifests
-release-manifests:
+release-manifests: $(tools/kustomize)
 	tools/hack/release-manifests.sh $(GATEWAY_API_VERSION) $(VERSION)

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -1,3 +1,5 @@
+# RELEASE_VERSION refers to the version of Envoy Gateway,
+RELEASE_VERSION ?= v0.2.0-rc1
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.24.1
 # GATEWAY_API_VERSION refers to the version of Gateway API CRDs.
@@ -67,6 +69,6 @@ run-conformance: ## Run Gateway API conformance.
 delete-cluster: $(tools/kind) ## Delete kind cluster.
 	$(tools/kind) delete cluster --name envoy-gateway
 
-.PHONY: build-install-yaml
-build-install-yaml:
-	tools/hack/build-install-yaml.sh $(GATEWAY_API_VERSION)
+.PHONY: release-manifests
+release-manifests:
+	tools/hack/release-manifests.sh $(GATEWAY_API_VERSION) $(RELEASE_VERSION)


### PR DESCRIPTION
Adds a Make target to generate:

1. The Kube manifests to run EG.
2. The Gateway API manifests that are supported by the EG release.

This will support
```
kubectl apply -f https://github.com/envoyproxy/gateway/releases/download/${ENVOY_GATEWAY_RELEASE_TAG}/gatewayapi-crds.yaml
kubectl apply -f https://github.com/envoyproxy/gateway/releases/download/${ENVOY_GATEWAY_RELEASE_TAG}/install.yaml
```

xref: https://github.com/envoyproxy/gateway/issues/296
xref: https://github.com/envoyproxy/gateway/pull/298
xref: https://github.com/envoyproxy/gateway/issues/297

Signed-off-by: danehans <daneyonhansen@gmail.com>