### PR TITLE
servicePort to containerPort translation

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
@@ -84,6 +85,10 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 			}
 			// Translate to IR
 			result := t.Translate(&in)
+			yamlXdsIR, _ := yaml.Marshal(&result.XdsIR)
+			r.Logger.Info(string(yamlXdsIR))
+			yamlInfraIR, _ := yaml.Marshal(&result.InfraIR)
+			r.Logger.Info(string(yamlInfraIR))
 
 			// Publish the IRs. Use the service name as the key
 			// to ensure there is always one element in the map.

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
@@ -57,7 +57,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - "*"
       routes:
@@ -81,4 +81,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
@@ -58,8 +58,8 @@ xdsIR:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
       hostnames:
-        - "*"
-      port: 80
+      - "*"
+      port: 10080
 infraIR:
   proxy:
     metadata:
@@ -73,4 +73,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
@@ -1,65 +1,65 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http
-          protocol: HTTP
-          port: 80
-          allowedRoutes:
-            namespaces:
-              from: Same
-    status:
-      listeners:
-        - name: http
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-          attachedRoutes: 0
-          conditions:
-            - type: Ready
-              status: "True"
-              reason: Ready
-              message: Listener is ready
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 0
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: default
-      name: httproute-1
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
-          conditions:
-            - type: Accepted
-              status: "False"
-              reason: NotAllowedByListeners
-              message: No listeners included by this parent ref allowed this attachment.
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      # controllerName: envoyproxy.io/gateway-controller
+      conditions:
+      - type: Accepted
+        status: "False"
+        reason: NotAllowedByListeners
+        message: No listeners included by this parent ref allowed this attachment.
 xdsIR:
   http:
-    - name: envoy-gateway-gateway-1-http
-      address: 0.0.0.0
-      hostnames:
-      - "*"
-      port: 10080
+  - name: envoy-gateway-gateway-1-http
+    address: 0.0.0.0
+    hostnames:
+    - "*"
+    port: 10080
 infraIR:
   proxy:
     metadata:
@@ -69,9 +69,9 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
-        ports:
-          - name: envoy-gateway-gateway-1
-            protocol: "HTTP"
-            servicePort: 80
-            containerPort: 10080
+    - address: ""
+      ports:
+      - name: envoy-gateway-gateway-1
+        protocol: "HTTP"
+        servicePort: 80
+        containerPort: 10080

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -62,7 +62,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-tls
       address: 0.0.0.0
-      port: 443
+      port: 10443
       hostnames:
         - "*"
       tls:
@@ -89,4 +89,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTPS"
-            port: 443
+            servicePort: 443
+            containerPort: 10443

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
@@ -61,7 +61,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-tls
       address: 0.0.0.0
-      port: 443
+      port: 10443
       hostnames:
         - "*"
       tls:
@@ -88,4 +88,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTPS"
-            port: 443
+            servicePort: 443
+            containerPort: 10443

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -75,7 +75,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http-1
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - foo.com
       routes:
@@ -88,7 +88,7 @@ xdsIR:
               weight: 1
     - name: envoy-gateway-gateway-1-http-2
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - bar.com
       routes:
@@ -112,4 +112,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
@@ -57,7 +57,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - "*"
       routes:
@@ -81,4 +81,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -77,12 +77,12 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http-1
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - foo.com
     - name: envoy-gateway-gateway-1-http-2
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - bar.com
       routes:
@@ -106,4 +106,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
@@ -59,7 +59,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - "*"
       routes:
@@ -83,4 +83,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
@@ -61,7 +61,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - "*"
       routes:
@@ -91,4 +91,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -64,7 +64,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - "*"
       routes:
@@ -94,4 +94,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -59,7 +59,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - "*"
       routes:
@@ -83,4 +83,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -63,7 +63,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - "*"
       routes:
@@ -85,4 +85,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -60,9 +60,9 @@ xdsIR:
   http:
   - name: envoy-gateway-gateway-1-http
     address: 0.0.0.0
-    port: 80
+    port: 10080
     hostnames:
-    - "*.envoyproxy.io"
+        - "*.envoyproxy.io"
 infraIR:
   proxy:
     metadata:
@@ -74,6 +74,9 @@ infraIR:
     listeners:
     - address: ""
       ports:
-      - name: envoy-gateway-gateway-1
-        protocol: "HTTP"
-        port: 80
+      - address: ""
+        ports:
+          - name: envoy-gateway-gateway-1
+            protocol: "HTTP"
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -62,7 +62,7 @@ xdsIR:
     address: 0.0.0.0
     port: 10080
     hostnames:
-        - "*.envoyproxy.io"
+    - "*.envoyproxy.io"
 infraIR:
   proxy:
     metadata:
@@ -74,9 +74,7 @@ infraIR:
     listeners:
     - address: ""
       ports:
-      - address: ""
-        ports:
-          - name: envoy-gateway-gateway-1
-            protocol: "HTTP"
-            servicePort: 80
-            containerPort: 10080
+      - name: envoy-gateway-gateway-1
+        protocol: "HTTP"
+        containerPort: 10080
+        servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -70,7 +70,7 @@ xdsIR:
   http:
   - name: envoy-gateway-gateway-1-http
     address: 0.0.0.0
-    port: 80
+    port: 10080
     hostnames:
     - "*.envoyproxy.io"
     routes:
@@ -102,4 +102,5 @@ infraIR:
       ports:
       - name: envoy-gateway-gateway-1
         protocol: "HTTP"
-        port: 80
+        containerPort: 10080
+        servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -68,7 +68,7 @@ xdsIR:
   http:
   - name: envoy-gateway-gateway-1-http
     address: 0.0.0.0
-    port: 80
+    port: 10080
     hostnames:
     - "*.envoyproxy.io"
     routes:
@@ -99,4 +99,5 @@ infraIR:
       ports:
       - name: envoy-gateway-gateway-1
         protocol: "HTTP"
-        port: 80
+        containerPort: 10080
+        servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -71,7 +71,7 @@ xdsIR:
   http:
   - name: envoy-gateway-gateway-1-http
     address: 0.0.0.0
-    port: 80
+    port: 10080
     hostnames:
     - "*.envoyproxy.io"
     routes:
@@ -103,4 +103,5 @@ infraIR:
       ports:
       - name: envoy-gateway-gateway-1
         protocol: "HTTP"
-        port: 80
+        containerPort: 10080
+        servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -71,7 +71,7 @@ xdsIR:
   http:
   - name: envoy-gateway-gateway-1-http
     address: 0.0.0.0
-    port: 80
+    port: 10080
     hostnames:
     - "*.envoyproxy.io"
     routes:
@@ -100,4 +100,5 @@ infraIR:
       ports:
       - name: envoy-gateway-gateway-1
         protocol: "HTTP"
-        port: 80
+        containerPort: 10080
+        servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -71,7 +71,7 @@ xdsIR:
   http:
   - name: envoy-gateway-gateway-1-http
     address: 0.0.0.0
-    port: 80
+    port: 10080
     hostnames:
     - "*.envoyproxy.io"
     routes:
@@ -100,4 +100,5 @@ infraIR:
       ports:
       - name: envoy-gateway-gateway-1
         protocol: "HTTP"
-        port: 80
+        containerPort: 10080
+        servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -71,7 +71,7 @@ xdsIR:
   http:
   - name: envoy-gateway-gateway-1-http
     address: 0.0.0.0
-    port: 80
+    port: 10080
     hostnames:
     - "*.envoyproxy.io"
     routes:
@@ -104,4 +104,5 @@ infraIR:
       ports:
       - name: envoy-gateway-gateway-1
         protocol: "HTTP"
-        port: 80
+        containerPort: 10080
+        servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
@@ -58,7 +58,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - "*"
       routes:
@@ -82,4 +82,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
@@ -62,7 +62,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - "*"
       routes:
@@ -91,4 +91,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            serviceport: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -60,7 +60,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - "*.envoyproxy.io"
       routes:
@@ -87,4 +87,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -61,7 +61,7 @@ xdsIR:
   http:
     - name: envoy-gateway-gateway-1-http
       address: 0.0.0.0
-      port: 80
+      port: 10080
       hostnames:
         - "*.envoyproxy.io"
       routes:
@@ -98,4 +98,5 @@ infraIR:
         ports:
           - name: envoy-gateway-gateway-1
             protocol: "HTTP"
-            port: 80
+            servicePort: 80
+            containerPort: 10080

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -30,9 +30,9 @@ const (
 
 	// minEphemeralPort is the first port in the ephemeral port range.
 	minEphemeralPort = 1024
-	// privilegedPortShift is the constant added to the privileged port
+	// wellKnownPortShift is the constant added to the well known port (1-1023)
 	// to convert it into an ephemeral port.
-	privilegedPortShift = 10000
+	wellKnownPortShift = 10000
 )
 
 // Resources holds the Gateway API and related
@@ -490,7 +490,7 @@ func servicePortToContainerPort(servicePort int32) int32 {
 	// This allows the container to bind to the port without needing a
 	// CAP_NET_BIND_SERVICE capability.
 	if servicePort < minEphemeralPort {
-		return servicePort + privilegedPortShift
+		return servicePort + wellKnownPortShift
 	}
 	return servicePort
 }

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -27,6 +27,12 @@ const (
 	// OwningGatewayNamespaceLabel is the owner reference label used for managed infra.
 	// The value should be the namespace of the Gateway used to CRUD the Service.
 	OwningGatewayNamespaceLabel = "gateway.envoyproxy.io/owning-gateway-namespace"
+
+	// minEphemeralPort is the first port in the ephemeral port range.
+	minEphemeralPort = 1024
+	// privilegedPortShift is the constant added to the privileged port
+	// to convert it into an ephemeral port.
+	privilegedPortShift = 10000
 )
 
 // Resources holds the Gateway API and related
@@ -219,7 +225,7 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR *ir.Xds,
 	}
 
 	// Infra IR proxy ports must be unique.
-	var foundPorts []v1beta1.PortNumber
+	var foundPorts []int32
 
 	// Iterate through all listeners to validate spec
 	// and compute status for each, and add valid ones
@@ -437,11 +443,13 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR *ir.Xds,
 
 			listener.SetCondition(v1beta1.ListenerConditionReady, metav1.ConditionTrue, v1beta1.ListenerReasonReady, "Listener is ready")
 
+			servicePort := int32(listener.Port)
+			containerPort := servicePortToContainerPort(servicePort)
 			// Add the listener to the Xds IR.
 			irListener := &ir.HTTPListener{
 				Name:    irListenerName(listener),
 				Address: "0.0.0.0",
-				Port:    uint32(listener.Port),
+				Port:    uint32(containerPort),
 				TLS:     irTLSConfig(listener.tlsSecret),
 			}
 			if listener.Hostname != nil {
@@ -455,22 +463,36 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR *ir.Xds,
 			xdsIR.HTTP = append(xdsIR.HTTP, irListener)
 
 			// Add the listener to the Infra IR. Infra IR ports must have a unique port number.
-			if !slices.Contains(foundPorts, listener.Port) {
-				foundPorts = append(foundPorts, listener.Port)
+			if !slices.Contains(foundPorts, servicePort) {
+				foundPorts = append(foundPorts, servicePort)
 				proto := ir.HTTPProtocolType
 				if listener.Protocol == v1beta1.HTTPSProtocolType {
 					proto = ir.HTTPSProtocolType
 				}
 				infraPort := ir.ListenerPort{
-					Name:     irInfraPortName(listener),
-					Protocol: proto,
-					Port:     int32(listener.Port),
+					Name:          irInfraPortName(listener),
+					Protocol:      proto,
+					ServicePort:   servicePort,
+					ContainerPort: containerPort,
 				}
 				// Only 1 listener is supported.
 				infraIR.Proxy.Listeners[0].Ports = append(infraIR.Proxy.Listeners[0].Ports, infraPort)
 			}
 		}
 	}
+}
+
+// servicePortToContainerPort translates a service port into an ephemeral
+// container port.
+func servicePortToContainerPort(servicePort int32) int32 {
+	// If the service port is a privileged port (1-1023)
+	// add a constant to the value converting it into an ephemeral port.
+	// This allows the container to bind to the port without needing a
+	// CAP_NET_BIND_SERVICE capability.
+	if servicePort < minEphemeralPort {
+		return servicePort + privilegedPortShift
+	}
+	return servicePort
 }
 
 func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways []*GatewayContext, resources *Resources, xdsIR *ir.Xds) []*HTTPRouteContext {

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -301,3 +301,32 @@ func TestIsValidCrossNamespaceRef(t *testing.T) {
 		})
 	}
 }
+
+func TestServicePortToContainerPort(t *testing.T) {
+	testCases := []struct {
+		servicePort   int32
+		containerPort int32
+	}{
+		{
+			servicePort:   99,
+			containerPort: 10099,
+		},
+		{
+			servicePort:   1023,
+			containerPort: 11023,
+		},
+		{
+			servicePort:   1024,
+			containerPort: 1024,
+		},
+		{
+			servicePort:   8080,
+			containerPort: 8080,
+		},
+	}
+
+	for _, tc := range testCases {
+		got := servicePortToContainerPort(tc.servicePort)
+		assert.Equal(t, tc.containerPort, got)
+	}
+}

--- a/internal/infrastructure/kubernetes/service.go
+++ b/internal/infrastructure/kubernetes/service.go
@@ -17,10 +17,6 @@ import (
 const (
 	// envoyServiceName is the name of the Envoy Service resource.
 	envoyServiceName = "envoy"
-	// envoyServiceHTTPPort is the HTTP port number of the Envoy service.
-	envoyServiceHTTPPort = 80
-	// envoyServiceHTTPSPort is the HTTPS port number of the Envoy service.
-	envoyServiceHTTPSPort = 443
 )
 
 // expectedService returns the expected Service based on the provided infra.
@@ -28,15 +24,11 @@ func (i *Infra) expectedService(infra *ir.Infra) *corev1.Service {
 	var ports []corev1.ServicePort
 	for _, listener := range infra.Proxy.Listeners {
 		for _, port := range listener.Ports {
-			// Set the target port based on the protocol of the IR port.
-			target := intstr.IntOrString{IntVal: envoyHTTPPort}
-			if port.Protocol == ir.HTTPSProtocolType {
-				target = intstr.IntOrString{IntVal: envoyHTTPSPort}
-			}
+			target := intstr.IntOrString{IntVal: port.ContainerPort}
 			p := corev1.ServicePort{
 				Name:       port.Name,
 				Protocol:   corev1.ProtocolTCP,
-				Port:       port.Port,
+				Port:       port.ServicePort,
 				TargetPort: target,
 			}
 			ports = append(ports, p)

--- a/internal/infrastructure/kubernetes/service_test.go
+++ b/internal/infrastructure/kubernetes/service_test.go
@@ -54,22 +54,24 @@ func TestDesiredService(t *testing.T) {
 	infra := ir.NewInfra()
 	infra.Proxy.Listeners[0].Ports = []ir.ListenerPort{
 		{
-			Name:     "gateway-system-gateway-1",
-			Protocol: ir.HTTPProtocolType,
-			Port:     80,
+			Name:          "gateway-system-gateway-1",
+			Protocol:      ir.HTTPProtocolType,
+			ServicePort:   80,
+			ContainerPort: 2080,
 		},
 		{
-			Name:     "gateway-system-gateway-1",
-			Protocol: ir.HTTPSProtocolType,
-			Port:     443,
+			Name:          "gateway-system-gateway-1",
+			Protocol:      ir.HTTPSProtocolType,
+			ServicePort:   443,
+			ContainerPort: 2443,
 		},
 	}
 	svc := kube.expectedService(infra)
 
-	checkServiceHasPort(t, svc, envoyServiceHTTPPort)
-	checkServiceHasPort(t, svc, envoyServiceHTTPSPort)
-	checkServiceHasTargetPort(t, svc, envoyHTTPPort)
-	checkServiceHasTargetPort(t, svc, envoyHTTPSPort)
+	checkServiceHasPort(t, svc, 80)
+	checkServiceHasPort(t, svc, 443)
+	checkServiceHasTargetPort(t, svc, 2080)
+	checkServiceHasTargetPort(t, svc, 2443)
 
 	for _, port := range infra.Proxy.Listeners[0].Ports {
 		checkServiceHasPortName(t, svc, port.Name)

--- a/internal/ir/infra.go
+++ b/internal/ir/infra.go
@@ -61,8 +61,10 @@ type ListenerPort struct {
 	Name string
 	// Protocol is the protocol that the listener port will listener for.
 	Protocol ProtocolType
-	// Port is the port number to listen on.
-	Port int32
+	// ServicePort is the port number the proxy service is listening on.
+	ServicePort int32
+	// ContainerPort is the port number the proxy container is listening on.
+	ContainerPort int32
 }
 
 // ProtocolType defines the application protocol accepted by a ListenerPort.
@@ -177,8 +179,11 @@ func (p *ProxyInfra) Validate() error {
 				if len(listener.Ports[j].Name) == 0 {
 					errs = append(errs, errors.New("listener name field required"))
 				}
-				if listener.Ports[j].Port < 1 || listener.Ports[j].Port > 65353 {
-					errs = append(errs, errors.New("listener port must be a valid port number"))
+				if listener.Ports[j].ServicePort < 1 || listener.Ports[j].ServicePort > 65353 {
+					errs = append(errs, errors.New("listener service port must be a valid port number"))
+				}
+				if listener.Ports[j].ContainerPort < 1024 || listener.Ports[j].ContainerPort > 65353 {
+					errs = append(errs, errors.New("listener container port must be a valid ephemeral port number"))
 				}
 			}
 		}

--- a/internal/ir/infra_test.go
+++ b/internal/ir/infra_test.go
@@ -63,7 +63,8 @@ func TestValidateInfra(t *testing.T) {
 						{
 							Ports: []ListenerPort{
 								{
-									Port: int32(80),
+									ServicePort:   int32(80),
+									ContainerPort: int32(8080),
 								},
 							},
 						},
@@ -73,7 +74,7 @@ func TestValidateInfra(t *testing.T) {
 			expect: false,
 		},
 		{
-			name: "no-listener-port-number",
+			name: "no-listener-service-port-number",
 			infra: &Infra{
 				Proxy: &ProxyInfra{
 					Name:  "test",
@@ -82,7 +83,8 @@ func TestValidateInfra(t *testing.T) {
 						{
 							Ports: []ListenerPort{
 								{
-									Name: "http",
+									Name:          "http",
+									ContainerPort: int32(8080),
 								},
 							},
 						},
@@ -91,6 +93,27 @@ func TestValidateInfra(t *testing.T) {
 			},
 			expect: false,
 		},
+		{
+			name: "no-listener-container-port-number",
+			infra: &Infra{
+				Proxy: &ProxyInfra{
+					Name:  "test",
+					Image: "image",
+					Listeners: []ProxyListener{
+						{
+							Ports: []ListenerPort{
+								{
+									Name:        "http",
+									ServicePort: int32(80),
+								},
+							},
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+
 		{
 			name: "no-image",
 			infra: &Infra{


### PR DESCRIPTION
* Convert gateway listner ports into service ports and ephemeral
container ports
* Pass both port mappings in the Infra IR
* Pass the container port value to the Xds IR

Fixes: https://github.com/envoyproxy/gateway/issues/192

Also fixes https://github.com/envoyproxy/gateway/issues/278

Signed-off-by: Arko Dasgupta <arko@tetrate.io>