### PR TITLE
rm docker buildx action setup

### DIFF
--- a/tools/github-actions/setup-deps/action.yaml
+++ b/tools/github-actions/setup-deps/action.yaml
@@ -8,5 +8,3 @@ runs:
       with:
         go-version: 1.18.2
         cache: true
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
no longer needed after https://github.com/envoyproxy/gateway/pull/305
was merged

Signed-off-by: Arko Dasgupta <arko@tetrate.io>