### PR TITLE
chore: restrict make build-multiarch to pull_request only

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -39,6 +39,10 @@ jobs:
           name: codecov-envoy-gateway
           verbose: true
 
+      # build
+      - run: make build-multiarch
+        if: github.event_name == 'pull_request'
+
       # build and push image
       - name: Login to DockerHub
         if: github.event_name == 'push'

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -29,9 +29,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./tools/github-actions/setup-deps
 
-      # build
-      - run: make build-multiarch
-
       # test
       - run: make go.test.coverage
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Restrict make build-multiarch to pull_request only, since `make image.push.multiarch` will excute it again.

Signed-off-by: Xunzhuo <bitliu@tencent.com>