### PR TITLE
retag gateway-dev image in release GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "##[set-output name=release_tag;]$(echo ${GITHUB_REF##*/})"
+          echo "::set-output name=release_tag::$(echo ${GITHUB_REF##*/})"
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
       - name: Login to DockerHub
@@ -23,21 +23,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      # pull, retag gateway-dev image and push
-      - name: Pull gateway-dev image
+      - name: Retag and push existing gateway-dev image
         run: |
-          docker pull envoyproxy/gateway-dev:${{ steps.vars.outputs.sha_short }}
-      - name: Retag image
-        run: |
-          docker tag envoyproxy/gateway-dev:${{ steps.vars.outputs.sha_short }} envoyproxy/gateway:${{ steps.vars.outputs.release_tag }}
-      - name: Push image to envoyproxy/gateway
-        run: |
-          docker push envoyproxy/gateway:${{ steps.vars.outputs.release_tag }}
+          skopeo copy --all docker://docker.io/envoyproxy/gateway-dev:${{ steps.vars.outputs.sha_short }} docker://docker.io/envoyproxy/gateway:${{ steps.vars.outputs.release_tag }}
 
       - name: Generate Release Manifests
-        env:
-          EG_TAG_VERSION: ${{ steps.tag_env.outputs.version}}
-        run: make release-manifests TAG=${EG_TAG_VERSION}
+        run: make release-manifests TAG=${{ steps.tag_env.outputs.version}}
 
       - name: Upload Release Manifests
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,45 +5,34 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:        
       - "v*.*.*"
-
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./tools/github-actions/setup-deps
-
-      # lint
-      - run: make lint-deps
-      - run: make -k lint
-
   release:
     runs-on: ubuntu-latest
-    needs: [ lint ]
     steps:
       - uses: actions/checkout@v3
-      - uses: ./tools/github-actions/setup-deps
 
-      - name: Extract Tag value
-        id: tag_env
+      - name: Extract Release Tag and Commit SHA
+        id: vars
         shell: bash
         run: |
-          echo "##[set-output name=version;]$(echo ${GITHUB_REF##*/})"
+          echo "##[set-output name=release_tag;]$(echo ${GITHUB_REF##*/})"
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
-      # test
-      - run: make go.test.unit
-
-      # build and push image
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Build and Push EG Image
-        env:
-          EG_TAG_VERSION: ${{ steps.tag_env.outputs.version}}
-        run: make image.push.multiarch TAG=${EG_TAG_VERSION} IMAGE_NAME=gateway PLATFORMS="linux_amd64 linux_arm64"
+      # pull, retag gateway-dev image and push
+      - name: Pull gateway-dev image
+        run: |
+          docker pull envoyproxy/gateway-dev:${{ steps.vars.outputs.sha_short }}
+      - name: Retag image
+        run: |
+          docker tag envoyproxy/gateway-dev:${{ steps.vars.outputs.sha_short }} envoyproxy/gateway:${{ steps.vars.outputs.release_tag }}
+      - name: Push image to envoyproxy/gateway
+        run: |
+          docker push envoyproxy/gateway:${{ steps.vars.outputs.release_tag }}
 
       - name: Generate Release Manifests
         env:


### PR DESCRIPTION
* instead of rebuilding and retesting the image,
reuse/retag the envoyproxy/gateway-dev with the matching commit SHA

Addresses https://github.com/envoyproxy/gateway/pull/299#discussion_r959118354

Signed-off-by: Arko Dasgupta <arko@tetrate.io>