### PR TITLE
release GHA: upload files in release-artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            release/gatewayapi-crds.yaml
-            release/install.yaml
+            release-artifacts/gatewayapi-crds.yaml
+            release-artifacts/install.yaml
 
         


### PR DESCRIPTION
* `release` dir was renamed to `release-artifacts`

Signed-off-by: Arko Dasgupta <arko@tetrate.io>