### PR TITLE
Fixes Release Workflow Artifacts Directory

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            release/gatewayapi-crds.yaml
-            release/install.yaml
-
-        
+            release-artifacts/gatewayapi-crds.yaml
+            release-artifacts/install.yaml


### PR DESCRIPTION
https://github.com/envoyproxy/gateway/pull/300 stores release manifests in `release-artifacts` and not `release`. This PR updates the release workflow from https://github.com/envoyproxy/gateway/pull/312 accordingly.

Signed-off-by: danehans <daneyonhansen@gmail.com>