### PR TITLE
chore: add restrict to tag trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:        
-      - v*
+      - "v*.*.*"
 
 jobs:
   lint:


### PR DESCRIPTION
Prevent triggering release workflow from weird tags like `vxxx`, any tags with `v` as the first word will trigger the release workflow, we should add restriction to it.

`"v*.*.*"` this pattern only matches standard tag like `v0.2.0` or `v0.2.0-rc1`.

Signed-off-by: Xunzhuo <bitliu@tencent.com>