### PR TITLE
fix: wrong image name in release manifests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,9 @@ jobs:
         run: make image.push.multiarch TAG=${EG_TAG_VERSION} IMAGE_NAME=gateway PLATFORMS="linux_amd64 linux_arm64"
 
       - name: Generate Release Manifests
-        run: make release-manifests
+        env:
+          EG_TAG_VERSION: ${{ steps.tag_env.outputs.version}}
+        run: make release-manifests TAG=${EG_TAG_VERSION}
 
       - name: Upload Release Manifests
         uses: softprops/action-gh-release@v1

--- a/tools/make/common.mk
+++ b/tools/make/common.mk
@@ -30,12 +30,6 @@ ifeq ($(origin OUTPUT_DIR),undefined)
 OUTPUT_DIR := $(ROOT_DIR)/bin
 endif
 
-# Set the version number. you should not need to do this
-# for the majority of scenarios.
-ifeq ($(origin VERSION), undefined)
-VERSION := $(shell git describe --abbrev=0 --dirty --always --tags | sed 's/-/./g')
-endif
-
 # REV is the short git sha of latest commit.
 REV=$(shell git rev-parse --short HEAD)
 

--- a/tools/make/golang.mk
+++ b/tools/make/golang.mk
@@ -19,7 +19,7 @@ go.build.%:
 	$(eval PLATFORM := $(word 1,$(subst ., ,$*)))
 	$(eval OS := $(word 1,$(subst _, ,$(PLATFORM))))
 	$(eval ARCH := $(word 2,$(subst _, ,$(PLATFORM))))
-	@$(call log, "Building binary $(COMMAND) with commit $(REV) in version $(VERSION) for $(OS) $(ARCH)")
+	@$(call log, "Building binary $(COMMAND) with commit $(REV) for $(OS) $(ARCH)")
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o $(OUTPUT_DIR)/$(OS)/$(ARCH)/$(COMMAND) $(ROOT_PACKAGE)/cmd/$(COMMAND)
 
 # Build the envoy-gateway binaries in the hosted platforms.

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -69,4 +69,4 @@ delete-cluster: $(tools/kind) ## Delete kind cluster.
 
 .PHONY: release-manifests
 release-manifests: $(tools/kustomize)
-	tools/hack/release-manifests.sh $(GATEWAY_API_VERSION) $(VERSION)
+	tools/hack/release-manifests.sh $(GATEWAY_API_VERSION) $(TAG)


### PR DESCRIPTION
<img width="567" alt="image" src="https://user-images.githubusercontent.com/48784001/187757937-3beaffa5-1176-4bb4-a590-cf185d6e3b58.png">

Fixed:

<img width="939" alt="image" src="https://user-images.githubusercontent.com/48784001/187759810-7ab72b8c-20f0-4aca-99cc-bab58df5c099.png">


image tag of EG in release manifests is incorrect 😢, let us fix it.

Signed-off-by: Xunzhuo <bitliu@tencent.com>