### PR TITLE
chore: split up `push-multiarch` and make dev images manifests matched

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -41,7 +41,6 @@ jobs:
 
       # build
       - run: make build-multiarch
-        if: github.event_name == 'pull_request'
 
       # build and push image
       - name: Login to DockerHub
@@ -50,6 +49,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - run: make image.multiarch.setup
 
       - name: Build and Push EG Commit Image
         if: github.event_name == 'push'

--- a/tools/make/image.mk
+++ b/tools/make/image.mk
@@ -88,13 +88,12 @@ image.multiarch.setup: image.verify image.multiarch.verify image.multiarch.emula
 	docker buildx rm $(BUILDX_CONTEXT) || :
 	docker buildx create --use --name $(BUILDX_CONTEXT) --platform "${BUILDX_PLATFORMS}"
 
-
 .PHONY: image.build.multiarch
-image.build.multiarch: image.multiarch.setup go.build.multiarch
+image.build.multiarch:
 	docker buildx build bin -f "$(ROOT_DIR)/tools/docker/$(IMAGES)/Dockerfile" -t "${IMAGE}:${TAG}" --platform "${BUILDX_PLATFORMS}"
 
 .PHONY: image.push.multiarch
-image.push.multiarch: image.multiarch.setup go.build.multiarch
+image.push.multiarch:
 	docker buildx build bin -f "$(ROOT_DIR)/tools/docker/$(IMAGES)/Dockerfile" -t "${IMAGE}:${TAG}" --platform "${BUILDX_PLATFORMS}" --push
 
 ##@ Image
@@ -105,7 +104,7 @@ image: image.build
 
 .PHONY: image-multiarch
 image-multiarch: ## Build docker images for multiple platforms. See Option PLATFORMS and IMAGES.
-image-multiarch: image.build.multiarch
+image-multiarch: image.multiarch.setup go.build.multiarch image.build.multiarch
 
 .PHONY: push
 push: ## Push docker images to registry.
@@ -113,5 +112,5 @@ push: image.push
 
 .PHONY: push-multiarch
 push-multiarch: ## Push docker images for multiple platforms to registry.
-push-multiarch: image.push.multiarch
+push-multiarch: image.multiarch.setup go.build.multiarch image.push.multiarch
 


### PR DESCRIPTION
Fix #342 

Tested in: https://github.com/Xunzhuo/gateway/runs/8215648214?check_suite_focus=true

<img width="1429" alt="image" src="https://user-images.githubusercontent.com/48784001/188732915-dacba7ca-9266-4044-8839-1dd874a86c9b.png">

Signed-off-by: Xunzhuo <bitliu@tencent.com>