### PR TITLE
Adds Support for Managing Gateway Status Addresses

### DIFF
--- a/internal/envoygateway/config/config.go
+++ b/internal/envoygateway/config/config.go
@@ -7,6 +7,13 @@ import (
 	"github.com/envoyproxy/gateway/internal/log"
 )
 
+const (
+	// EnvoyGatewayNamespace is the namespace where envoy-gateway is running.
+	EnvoyGatewayNamespace = "envoy-gateway-system"
+	// EnvoyServiceName is the name of the Envoy Service.
+	EnvoyServiceName = "envoy"
+)
+
 // Server wraps the EnvoyGateway configuration and additional parameters
 // used by Envoy Gateway server.
 type Server struct {

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -49,6 +49,10 @@ func PathMatchTypePtr(pType v1beta1.PathMatchType) *v1beta1.PathMatchType {
 	return &pType
 }
 
+func GatewayAddressTypePtr(addr v1beta1.AddressType) *v1beta1.AddressType {
+	return &addr
+}
+
 func PathMatchTypeDerefOr(matchType *v1beta1.PathMatchType, defaultType v1beta1.PathMatchType) v1beta1.PathMatchType {
 	if matchType != nil {
 		return *matchType

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
@@ -72,8 +72,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
@@ -64,8 +64,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
@@ -64,8 +64,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
@@ -62,8 +62,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
@@ -62,8 +62,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
@@ -62,8 +62,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
@@ -60,8 +60,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
@@ -66,8 +66,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
@@ -67,8 +67,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
@@ -66,8 +66,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
@@ -58,8 +58,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -80,8 +80,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
@@ -59,8 +59,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
@@ -79,8 +79,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
@@ -82,8 +82,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
@@ -82,8 +82,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -103,8 +103,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
@@ -72,8 +72,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -97,8 +97,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
@@ -74,8 +74,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
@@ -82,8 +82,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -85,8 +85,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -74,8 +74,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -76,8 +76,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -67,8 +67,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -93,8 +93,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -90,8 +90,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -94,8 +94,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -91,8 +91,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -91,8 +91,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -95,8 +95,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
@@ -73,8 +73,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
@@ -82,8 +82,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -78,8 +78,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -89,8 +89,7 @@ infraIR:
   proxy:
     metadata:
       labels:
-        gateway.envoyproxy.io/owning-gateway-name: gateway-1
-        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -21,12 +21,9 @@ const (
 	KindService   = "Service"
 	KindSecret    = "Secret"
 
-	// OwningGatewayNameLabel is the owner reference label used for managed infra.
-	// The value should be the name of the Gateway used to CRUD the Service.
-	OwningGatewayNameLabel = "gateway.envoyproxy.io/owning-gateway-name"
-	// OwningGatewayNamespaceLabel is the owner reference label used for managed infra.
-	// The value should be the namespace of the Gateway used to CRUD the Service.
-	OwningGatewayNamespaceLabel = "gateway.envoyproxy.io/owning-gateway-namespace"
+	// OwningGatewayClassLabel is the owner reference label used for managed infra.
+	// The value should be the name of the accepted Envoy GatewayClass.
+	OwningGatewayClassLabel = "gateway.envoyproxy.io/owning-gatewayclass"
 
 	// minEphemeralPort is the first port in the ephemeral port range.
 	minEphemeralPort = 1024
@@ -110,15 +107,7 @@ func (t *Translator) Translate(resources *Resources) *TranslateResult {
 
 	infraIR := ir.NewInfra()
 	infraIR.Proxy.Name = string(t.GatewayClassName)
-
-	// Apply Infra IR metadata.
-	if resources != nil {
-		for i := range resources.Gateways {
-			if resources.Gateways[i] != nil {
-				infraIR.Proxy.Metadata.Labels = GatewayOwnerLabels(resources.Gateways[i])
-			}
-		}
-	}
+	infraIR.Proxy.GetProxyMetadata().Labels = GatewayClassOwnerLabel(string(t.GatewayClassName))
 
 	// Get Gateways belonging to our GatewayClass.
 	gateways := t.GetRelevantGateways(resources.Gateways)
@@ -1005,10 +994,8 @@ func irTLSConfig(tlsSecret *v1.Secret) *ir.TLSListenerConfig {
 	}
 }
 
-// GatewayOwnerLabels returns owner labels for the provided Gateway.
-func GatewayOwnerLabels(gw *v1beta1.Gateway) map[string]string {
-	return map[string]string{
-		OwningGatewayNameLabel:      gw.Name,
-		OwningGatewayNamespaceLabel: gw.Namespace,
-	}
+// GatewayClassOwnerLabel returns the GatewayCLass Owner label using
+// the provided name as the value.
+func GatewayClassOwnerLabel(name string) map[string]string {
+	return map[string]string{OwningGatewayClassLabel: name}
 }

--- a/internal/infrastructure/kubernetes/deployment.go
+++ b/internal/infrastructure/kubernetes/deployment.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 
+	"github.com/envoyproxy/gateway/internal/gatewayapi"
 	"github.com/envoyproxy/gateway/internal/ir"
 	xdsrunner "github.com/envoyproxy/gateway/internal/xds/server/runner"
 )
@@ -100,7 +101,11 @@ func (i *Infra) expectedDeployment(infra *ir.Infra) (*appsv1.Deployment, error) 
 		return nil, err
 	}
 
-	podSelector := envoyPodSelector(infra.GetProxyInfra().Name)
+	// Set the labels based on the owning gatewayclass name.
+	labels := envoyLabels(infra.GetProxyInfra().GetProxyMetadata().Labels)
+	if _, ok := labels[gatewayapi.OwningGatewayClassLabel]; !ok {
+		return nil, fmt.Errorf("missing owning gatewayclass label")
+	}
 
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -110,14 +115,14 @@ func (i *Infra) expectedDeployment(infra *ir.Infra) (*appsv1.Deployment, error) 
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: i.Namespace,
 			Name:      envoyDeploymentName,
-			Labels:    podSelector.MatchLabels,
+			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: pointer.Int32(1),
-			Selector: podSelector,
+			Selector: envoySelector(infra.GetProxyInfra().GetProxyMetadata().Labels),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: podSelector.MatchLabels,
+					Labels: envoySelector(infra.GetProxyInfra().GetProxyMetadata().Labels).MatchLabels,
 				},
 				Spec: corev1.PodSpec{
 					Containers:                    containers,

--- a/internal/infrastructure/kubernetes/deployment.go
+++ b/internal/infrastructure/kubernetes/deployment.go
@@ -100,7 +100,7 @@ func (i *Infra) expectedDeployment(infra *ir.Infra) (*appsv1.Deployment, error) 
 		return nil, err
 	}
 
-	podSelector := EnvoyPodSelector(infra.GetProxyInfra().Name)
+	podSelector := envoyPodSelector(infra.GetProxyInfra().Name)
 
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -265,23 +265,4 @@ func (i *Infra) deleteDeployment(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-// EnvoyPodSelector returns a label selector using "control-plane: envoy-gateway" as the
-// key/value pair.
-//
-// TODO: Update k/v pair to use gatewayclass controller name to distinguish between
-//       multiple Envoy Gateways.
-func EnvoyPodSelector(gcName string) *metav1.LabelSelector {
-	return &metav1.LabelSelector{
-		MatchLabels: envoyLabels(gcName),
-	}
-}
-
-// envoyLabels returns the labels used for Envoy.
-func envoyLabels(gcName string) map[string]string {
-	return map[string]string{
-		"gatewayClass": gcName,
-		"app":          "envoy",
-	}
 }

--- a/internal/infrastructure/kubernetes/deployment_test.go
+++ b/internal/infrastructure/kubernetes/deployment_test.go
@@ -205,31 +205,6 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 	}
 }
 
-func TestEnvoyPodSelector(t *testing.T) {
-	cases := []struct {
-		name     string
-		gcName   string
-		expected map[string]string
-	}{
-		{
-			name:   "default",
-			gcName: "eg",
-			expected: map[string]string{
-				"gatewayClass": "eg",
-				"app":          "envoy",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		tc := tc
-		t.Run("", func(t *testing.T) {
-			got := EnvoyPodSelector(tc.gcName)
-			require.Equal(t, tc.expected, got.MatchLabels)
-		})
-	}
-}
-
 func TestDeleteDeployment(t *testing.T) {
 	testCases := []struct {
 		name   string

--- a/internal/infrastructure/kubernetes/infra.go
+++ b/internal/infrastructure/kubernetes/infra.go
@@ -10,13 +10,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/ir"
 	"github.com/envoyproxy/gateway/internal/utils/env"
-)
-
-const (
-	// envoyGatewayNamespace is the namespace where envoy-gateway is running.
-	envoyGatewayNamespace = "envoy-gateway-system"
 )
 
 // Infra holds all the translated Infra IR resources and provides
@@ -45,7 +41,7 @@ func NewInfra(cli client.Client) *Infra {
 	}
 
 	// Set the namespace used for the managed infra.
-	infra.Namespace = env.Lookup("ENVOY_GATEWAY_NAMESPACE", envoyGatewayNamespace)
+	infra.Namespace = env.Lookup("ENVOY_GATEWAY_NAMESPACE", config.EnvoyGatewayNamespace)
 
 	return infra
 }

--- a/internal/infrastructure/kubernetes/infra_test.go
+++ b/internal/infrastructure/kubernetes/infra_test.go
@@ -19,9 +19,8 @@ import (
 func TestCreateInfra(t *testing.T) {
 	expected := ir.NewInfra()
 	// Apply the expected labels to the proxy infra.
-	expected.GetProxyInfra().GetProxyMetadata().Labels = envoyLabels()
-	expected.GetProxyInfra().GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "test-ns"
-	expected.GetProxyInfra().GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = "test-gw"
+	expected.GetProxyInfra().GetProxyMetadata().Labels = envoyAppLabel()
+	expected.GetProxyInfra().GetProxyMetadata().Labels[gatewayapi.OwningGatewayClassLabel] = "test-gc"
 
 	testCases := []struct {
 		name   string

--- a/internal/infrastructure/kubernetes/labels.go
+++ b/internal/infrastructure/kubernetes/labels.go
@@ -1,0 +1,29 @@
+package kubernetes
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// envoyLabels returns the labels used for all Envoy resources.
+func envoyLabels() map[string]string {
+	return map[string]string{
+		"app.gateway.envoyproxy.io/name": "envoy",
+	}
+}
+
+// envoyPodSelector returns a label selector used to select Envoy pods.
+//
+// TODO: Update k/v pair to use gatewayclass controller name to distinguish between
+//       multiple Envoy Gateways.
+func envoyPodSelector(gcName string) *metav1.LabelSelector {
+	return &metav1.LabelSelector{
+		MatchLabels: envoyPodLabels(gcName),
+	}
+}
+
+// envoyPodLabels returns the labels used for Envoy pods.
+func envoyPodLabels(gcName string) map[string]string {
+	lbls := envoyLabels()
+	lbls["gatewayClass"] = gcName
+	return lbls
+}

--- a/internal/infrastructure/kubernetes/labels.go
+++ b/internal/infrastructure/kubernetes/labels.go
@@ -4,26 +4,27 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// envoyLabels returns the labels used for all Envoy resources.
-func envoyLabels() map[string]string {
+// envoyAppLabel returns the labels used for all Envoy resources.
+func envoyAppLabel() map[string]string {
 	return map[string]string{
 		"app.gateway.envoyproxy.io/name": "envoy",
 	}
 }
 
-// envoyPodSelector returns a label selector used to select Envoy pods.
-//
-// TODO: Update k/v pair to use gatewayclass controller name to distinguish between
-//       multiple Envoy Gateways.
-func envoyPodSelector(gcName string) *metav1.LabelSelector {
+// envoySelector returns a label selector used to select resources
+// based on the provided lbls.
+func envoySelector(extraLbls map[string]string) *metav1.LabelSelector {
 	return &metav1.LabelSelector{
-		MatchLabels: envoyPodLabels(gcName),
+		MatchLabels: envoyLabels(extraLbls),
 	}
 }
 
-// envoyPodLabels returns the labels used for Envoy pods.
-func envoyPodLabels(gcName string) map[string]string {
-	lbls := envoyLabels()
-	lbls["gatewayClass"] = gcName
+// envoyLabels returns the labels, including extraLbls, used for Envoy resources.
+func envoyLabels(extraLbls map[string]string) map[string]string {
+	lbls := envoyAppLabel()
+	for k, v := range extraLbls {
+		lbls[k] = v
+	}
+
 	return lbls
 }

--- a/internal/infrastructure/kubernetes/labels_test.go
+++ b/internal/infrastructure/kubernetes/labels_test.go
@@ -1,0 +1,32 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvoyPodSelector(t *testing.T) {
+	cases := []struct {
+		name     string
+		gcName   string
+		expected map[string]string
+	}{
+		{
+			name:   "default",
+			gcName: "eg",
+			expected: map[string]string{
+				"gatewayClass":                   "eg",
+				"app.gateway.envoyproxy.io/name": "envoy",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("", func(t *testing.T) {
+			got := envoyPodSelector(tc.gcName)
+			require.Equal(t, tc.expected, got.MatchLabels)
+		})
+	}
+}

--- a/internal/infrastructure/kubernetes/labels_test.go
+++ b/internal/infrastructure/kubernetes/labels_test.go
@@ -9,14 +9,14 @@ import (
 func TestEnvoyPodSelector(t *testing.T) {
 	cases := []struct {
 		name     string
-		gcName   string
+		in       map[string]string
 		expected map[string]string
 	}{
 		{
-			name:   "default",
-			gcName: "eg",
+			name: "default",
+			in:   map[string]string{"foo": "bar"},
 			expected: map[string]string{
-				"gatewayClass":                   "eg",
+				"foo":                            "bar",
 				"app.gateway.envoyproxy.io/name": "envoy",
 			},
 		},
@@ -25,7 +25,7 @@ func TestEnvoyPodSelector(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run("", func(t *testing.T) {
-			got := envoyPodSelector(tc.gcName)
+			got := envoySelector(tc.in)
 			require.Equal(t, tc.expected, got.MatchLabels)
 		})
 	}

--- a/internal/infrastructure/kubernetes/service_test.go
+++ b/internal/infrastructure/kubernetes/service_test.go
@@ -64,8 +64,7 @@ func TestDesiredService(t *testing.T) {
 	cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects().Build()
 	kube := NewInfra(cli)
 	infra := ir.NewInfra()
-	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "test-ns"
-	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = "test-gw"
+	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayClassLabel] = "test-gc"
 	infra.Proxy.Listeners[0].Ports = []ir.ListenerPort{
 		{
 			Name:          "gateway-system-gateway-1",
@@ -89,9 +88,8 @@ func TestDesiredService(t *testing.T) {
 	checkServiceHasTargetPort(t, svc, 2443)
 
 	// Ensure the Envoy service has the expected labels.
-	lbls := envoyLabels()
-	lbls[gatewayapi.OwningGatewayNamespaceLabel] = "test-ns"
-	lbls[gatewayapi.OwningGatewayNameLabel] = "test-gw"
+	lbls := envoyAppLabel()
+	lbls[gatewayapi.OwningGatewayClassLabel] = "test-gc"
 	checkServiceHasLabels(t, svc, lbls)
 
 	for _, port := range infra.Proxy.Listeners[0].Ports {

--- a/internal/ir/infra.go
+++ b/internal/ir/infra.go
@@ -136,6 +136,15 @@ func (i *Infra) GetProxyInfra() *ProxyInfra {
 	return i.Proxy
 }
 
+// GetProxyMetadata returns the InfraMetadata.
+func (p *ProxyInfra) GetProxyMetadata() *InfraMetadata {
+	if p.Metadata == nil {
+		p.Metadata = NewInfraMetadata()
+	}
+
+	return p.Metadata
+}
+
 // Validate validates the provided Infra.
 func (i *Infra) Validate() error {
 	if i == nil {

--- a/internal/provider/kubernetes/gateway.go
+++ b/internal/provider/kubernetes/gateway.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,6 +23,7 @@ import (
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	"github.com/envoyproxy/gateway/internal/gatewayapi"
 	"github.com/envoyproxy/gateway/internal/message"
 	"github.com/envoyproxy/gateway/internal/status"
 )
@@ -65,6 +68,12 @@ func newGatewayController(mgr manager.Manager, cfg *config.Server, su status.Upd
 	}
 	r.log.Info("watching gateway objects")
 
+	// Trigger gateway reconciliation when the Envoy service,
+	// managed by Infra Manager, has changed.
+	if err := c.Watch(&source.Kind{Type: &corev1.Service{}}, r.enqueueRequestForOwningGateway()); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -91,6 +100,28 @@ func (r *gatewayReconciler) hasMatchingController(obj client.Object) bool {
 	}
 
 	return true
+}
+
+// enqueueRequestForOwningGateway returns an event handler that maps events to
+// objects containing Gateway ns/name owner labels.
+func (r *gatewayReconciler) enqueueRequestForOwningGateway() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
+		labels := a.GetLabels()
+		ns, nsFound := labels[gatewayapi.OwningGatewayNamespaceLabel]
+		name, nameFound := labels[gatewayapi.OwningGatewayNameLabel]
+		if nsFound && nameFound {
+			r.log.Info("queueing gateway", "namespace", ns, "name", name)
+			return []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Namespace: ns,
+						Name:      name,
+					},
+				},
+			}
+		}
+		return []reconcile.Request{}
+	})
 }
 
 // Reconcile finds all the Gateways for the GatewayClass with an "Accepted: true" condition
@@ -135,24 +166,30 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 		r.resources.Gateways.Delete(request.NamespacedName)
 	}
 
-	// Set the "Scheduled" condition to true for all accepted gateways.
-	for _, gw := range acceptedGateways {
+	// Set status conditions for all accepted gateways.
+	for i := range acceptedGateways {
+		gw := acceptedGateways[i]
+		// Get the status address of the Gateway's associated Service.
+		svc, err := r.serviceForGateway(ctx, &gw)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		r.statusUpdater.Send(status.Update{
 			NamespacedName: types.NamespacedName{Namespace: gw.Namespace, Name: gw.Name},
-			Resource:       &gwapiv1b1.Gateway{},
+			Resource:       new(gwapiv1b1.Gateway),
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				gw, ok := obj.(*gwapiv1b1.Gateway)
 				if !ok {
 					panic(fmt.Sprintf("unsupported object type %T", obj))
 				}
 
-				return status.SetGatewayScheduled(gw.DeepCopy(), true)
+				return status.SetGatewayStatus(gw.DeepCopy(), true, svc)
 			}),
 		})
 	}
 
 	// Once we've processed `allGateways`, record that we've fully initialized.
-	defer r.initializeOnce.Do(r.resources.Initialized.Done)
+	r.initializeOnce.Do(r.resources.Initialized.Done)
 
 	r.log.WithName(request.Namespace).WithName(request.Name).Info("reconciled gateway")
 
@@ -201,4 +238,21 @@ func gatewaysOfClass(gc *gwapiv1b1.GatewayClass, gwList *gwapiv1b1.GatewayList) 
 		}
 	}
 	return ret
+}
+
+// serviceForGateway returns the service for the provided gateway, returning nil if
+// the service doesn't exist.
+func (r *gatewayReconciler) serviceForGateway(ctx context.Context, gw *gwapiv1b1.Gateway) (*corev1.Service, error) {
+	key := types.NamespacedName{
+		Namespace: config.EnvoyGatewayNamespace,
+		Name:      config.EnvoyServiceName,
+	}
+	svc := new(corev1.Service)
+	if err := r.client.Get(ctx, key, svc); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return svc, nil
 }

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -50,6 +50,22 @@ func computeGatewayScheduledCondition(gw *gwapiv1b1.Gateway, scheduled bool) met
 	}
 }
 
+// computeGatewayReadyCondition computes the Gateway Ready status condition.
+// TODO: Ready condition should surface true when the Envoy Deployment status is ready.
+//       xref: https://github.com/envoyproxy/gateway/issues/345.
+func computeGatewayReadyCondition(gw *gwapiv1b1.Gateway) metav1.Condition {
+	switch len(gw.Status.Addresses) {
+	case 0:
+		return newCondition(string(gwapiv1b1.GatewayConditionReady), metav1.ConditionFalse,
+			string(gwapiv1b1.GatewayReasonAddressNotAssigned),
+			"No addresses have been assigned to the Gateway", time.Now(), gw.Generation)
+	default:
+		return newCondition(string(gwapiv1b1.GatewayConditionReady), metav1.ConditionTrue,
+			string(gwapiv1b1.GatewayReasonReady),
+			"Address assigned to the Gateway", time.Now(), gw.Generation)
+	}
+}
+
 // mergeConditions adds or updates matching conditions, and updates the transition
 // time if details of a condition have changed. Returns the updated condition array.
 func mergeConditions(conditions []metav1.Condition, updates ...metav1.Condition) []metav1.Condition {

--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -1,9 +1,51 @@
 package status
 
-import gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+import (
+	corev1 "k8s.io/api/core/v1"
+	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-// SetGatewayScheduled adds or updates the Scheduled condition for the provided Gateway.
-func SetGatewayScheduled(gw *gwapiv1b1.Gateway, scheduled bool) *gwapiv1b1.Gateway {
-	gw.Status.Conditions = mergeConditions(gw.Status.Conditions, computeGatewayScheduledCondition(gw, scheduled))
+	"github.com/envoyproxy/gateway/internal/gatewayapi"
+)
+
+// SetGatewayStatus adds or updates status for the provided Gateway.
+func SetGatewayStatus(gw *gwapiv1b1.Gateway, scheduled bool, svc *corev1.Service) *gwapiv1b1.Gateway {
+	computeGatewayStatusAddrs(gw, svc)
+	gw.Status.Conditions = mergeConditions(gw.Status.Conditions,
+		computeGatewayScheduledCondition(gw, scheduled), computeGatewayReadyCondition(gw))
 	return gw
+}
+
+// computeGatewayStatusAddrs computes status addresses for the provided gateway
+// based on the status IP/Hostname of svc.
+func computeGatewayStatusAddrs(gw *gwapiv1b1.Gateway, svc *corev1.Service) {
+	var addrs, hostnames []string
+	if svc != nil {
+		for i := range svc.Status.LoadBalancer.Ingress {
+			switch {
+			case len(svc.Status.LoadBalancer.Ingress[i].IP) > 0:
+				addrs = append(addrs, svc.Status.LoadBalancer.Ingress[i].IP)
+			case len(svc.Status.LoadBalancer.Ingress[i].Hostname) > 0:
+				hostnames = append(hostnames, svc.Status.LoadBalancer.Ingress[i].Hostname)
+			}
+		}
+	}
+
+	var gwAddrs []gwapiv1b1.GatewayAddress
+	for i := range addrs {
+		addr := gwapiv1b1.GatewayAddress{
+			Type:  gatewayapi.GatewayAddressTypePtr(gwapiv1b1.IPAddressType),
+			Value: addrs[i],
+		}
+		gwAddrs = append(gwAddrs, addr)
+	}
+
+	for i := range hostnames {
+		addr := gwapiv1b1.GatewayAddress{
+			Type:  gatewayapi.GatewayAddressTypePtr(gwapiv1b1.HostnameAddressType),
+			Value: hostnames[i],
+		}
+		gwAddrs = append(gwAddrs, addr)
+	}
+
+	gw.Status.Addresses = gwAddrs
 }


### PR DESCRIPTION
- Updates gateway controller to watch services and trigger a reconciliation for those with the EG Gateway owning labels.
- Moves label and label selector funcs to a common file, `labels.go`.
- Updates status manager to manage the Gateway "Ready" condition based on the availability of Gateway status addresses.
- Applies Gateway ns/name owning labels to the Envoy service.
- Updates the quickstart guide to use the Gateway status address instead of the Envoy service address.

Requires #350

Fixes #330 