### PR TITLE
Fix merge-conflict-caused CI breakage

### DIFF
--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.in.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.in.yaml
@@ -1,40 +1,40 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http-1
-          protocol: HTTP
-          port: 80
-          hostname: foo.com
-          allowedRoutes:
-            namespaces:
-              from: All
-        - name: http-2
-          protocol: HTTP
-          port: 80
-          hostname: foo.com
-          allowedRoutes:
-            namespaces:
-              from: All
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http-1
+      protocol: HTTP
+      port: 80
+      hostname: foo.com
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: http-2
+      protocol: HTTP
+      port: 80
+      hostname: foo.com
+      allowedRoutes:
+        namespaces:
+          from: All
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: default
-      name: httproute-1
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
@@ -1,82 +1,82 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http-1
-          protocol: HTTP
-          port: 80
-          hostname: foo.com
-          allowedRoutes:
-            namespaces:
-              from: All
-        - name: http-2
-          protocol: HTTP
-          port: 80
-          hostname: foo.com
-          allowedRoutes:
-            namespaces:
-              from: All
-    status:
-      listeners:
-        - name: http-1
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-          conditions:
-            - type: Conflicted
-              status: "True"
-              reason: HostnameConflict
-              message: All listeners for a given port must use a unique hostname
-            - type: Ready
-              status: "False"
-              reason: Invalid
-              message: Listener is invalid, see other Conditions for details.
-        - name: http-2
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-          conditions:
-            - type: Conflicted
-              status: "True"
-              reason: HostnameConflict
-              message: All listeners for a given port must use a unique hostname
-            - type: Ready
-              status: "False"
-              reason: Invalid
-              message: Listener is invalid, see other Conditions for details.
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http-1
+      protocol: HTTP
+      port: 80
+      hostname: foo.com
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: http-2
+      protocol: HTTP
+      port: 80
+      hostname: foo.com
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http-1
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      conditions:
+      - type: Conflicted
+        status: "True"
+        reason: HostnameConflict
+        message: All listeners for a given port must use a unique hostname
+      - type: Ready
+        status: "False"
+        reason: Invalid
+        message: Listener is invalid, see other Conditions for details.
+    - name: http-2
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      conditions:
+      - type: Conflicted
+        status: "True"
+        reason: HostnameConflict
+        message: All listeners for a given port must use a unique hostname
+      - type: Ready
+        status: "False"
+        reason: Invalid
+        message: Listener is invalid, see other Conditions for details.
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: default
-      name: httproute-1
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
-          conditions:
-            - type: Accepted
-              status: "False"
-              reason: NoReadyListeners
-              message: There are no ready listeners for this parent ref
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      # controllerName: envoyproxy.io/gateway-controller
+      conditions:
+      - type: Accepted
+        status: "False"
+        reason: NoReadyListeners
+        message: There are no ready listeners for this parent ref
 xdsIR: {}
 infraIR:
   proxy:
@@ -87,4 +87,4 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+    - address: ""

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -1,68 +1,68 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http
-          protocol: HTTP
-          port: 80
-          hostname: "*.envoyproxy.io"
-          allowedRoutes:
-            namespaces:
-              from: All
-    status:
-      listeners:
-        - name: http
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-          attachedRoutes: 0
-          conditions:
-            - type: Ready
-              status: "True"
-              reason: Ready
-              message: Listener is ready
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 0
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: default
-      name: httproute-1
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      hostnames:
-        - whales.kubernetes.io
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
-          conditions:
-            - type: Accepted
-              status: "False"
-              reason: NoMatchingListenerHostname
-              message: There were no hostname intersections between the HTTPRoute and this parent ref's Listener(s).
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - whales.kubernetes.io
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      # controllerName: envoyproxy.io/gateway-controller
+      conditions:
+      - type: Accepted
+        status: "False"
+        reason: NoMatchingListenerHostname
+        message: There were no hostname intersections between the HTTPRoute and this parent ref's Listener(s).
 xdsIR:
   http:
-    - name: envoy-gateway-gateway-1-http
-      address: 0.0.0.0
-      port: 80
-      hostnames:
-        - "*.envoyproxy.io"
+  - name: envoy-gateway-gateway-1-http
+    address: 0.0.0.0
+    port: 80
+    hostnames:
+    - "*.envoyproxy.io"
 infraIR:
   proxy:
     metadata:
@@ -72,8 +72,8 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
-        ports:
-          - name: envoy-gateway-gateway-1
-            protocol: "HTTP"
-            port: 80
+    - address: ""
+      ports:
+      - name: envoy-gateway-gateway-1
+        protocol: "HTTP"
+        port: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.in.yaml
@@ -7,13 +7,13 @@ gateways:
   spec:
     gatewayClassName: envoy-gateway-class
     listeners:
-      - name: http
-        protocol: HTTP
-        port: 80
-        hostname: "*.envoyproxy.io"
-        allowedRoutes:
-          namespaces:
-            from: All
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
 httpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: HTTPRoute
@@ -22,24 +22,24 @@ httpRoutes:
     name: httproute-1
   spec:
     hostnames:
-      - gateway.envoyproxy.io
+    - gateway.envoyproxy.io
     parentRefs:
-      - namespace: envoy-gateway
-        name: gateway-1
-        sectionName: http
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
     rules:
-      - matches:
-          - path:
-              value: "/"
-        backendRefs:
-          - name: service-1
-            port: 8080
-        filters:
-        - type: RequestRedirect
-          requestRedirect:
-            scheme: https
-            statusCode: 301
-            path:
-              type: ReplaceFullPath
-              replaceFullPath: /redirected
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: https
+          statusCode: 301
+          path:
+            type: ReplaceFullPath
+            replaceFullPath: /redirected
 

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -91,6 +91,10 @@ xdsIR:
           fullReplace: /redirected
 infraIR:
   proxy:
+    metadata:
+      labels:
+        gateway.envoyproxy.io/owning-gateway-name: gateway-1
+        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -1,101 +1,101 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http
-          protocol: HTTP
-          port: 80
-          hostname: "*.envoyproxy.io"
-          allowedRoutes:
-            namespaces:
-              from: All
-    status:
-      listeners:
-        - name: http
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-          attachedRoutes: 1
-          conditions:
-            - type: Ready
-              status: "True"
-              reason: Ready
-              message: Listener is ready
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: default
-      name: httproute-1
-    spec:
-      hostnames:
-      - gateway.envoyproxy.io
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-          sectionName: http
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
-          filters:
-          - type: RequestRedirect
-            requestRedirect:
-              scheme: https
-              statusCode: 301
-              path:
-                type: ReplaceFullPath
-                replaceFullPath: /redirected
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-            sectionName: http
-          # controllerName: envoyproxy.io/gateway-controller
-          conditions:
-            - type: Accepted
-              status: "True"
-              reason: Accepted
-              message: Route is accepted
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: https
+          statusCode: 301
+          path:
+            type: ReplaceFullPath
+            replaceFullPath: /redirected
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      # controllerName: envoyproxy.io/gateway-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   http:
-    - name: envoy-gateway-gateway-1-http
-      address: 0.0.0.0
-      port: 80
-      hostnames:
-      - "*.envoyproxy.io"
-      routes:
-        - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
-          pathMatch:
-            prefix: "/"
-          headerMatches:
-            - name: ":authority"
-              exact: gateway.envoyproxy.io
-          destinations:
-            - host: 7.7.7.7
-              port: 8080
-              weight: 1
-          redirect:
-            scheme: https
-            statusCode: 301
-            path:
-              fullReplace: /redirected
+  - name: envoy-gateway-gateway-1-http
+    address: 0.0.0.0
+    port: 80
+    hostnames:
+    - "*.envoyproxy.io"
+    routes:
+    - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+      pathMatch:
+        prefix: "/"
+      headerMatches:
+      - name: ":authority"
+        exact: gateway.envoyproxy.io
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1
+      redirect:
+        scheme: https
+        statusCode: 301
+        path:
+          fullReplace: /redirected
 infraIR:
   proxy:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
-        ports:
-          - name: envoy-gateway-gateway-1
-            protocol: "HTTP"
-            port: 80
+    - address: ""
+      ports:
+      - name: envoy-gateway-gateway-1
+        protocol: "HTTP"
+        port: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.in.yaml
@@ -7,13 +7,13 @@ gateways:
   spec:
     gatewayClassName: envoy-gateway-class
     listeners:
-      - name: http
-        protocol: HTTP
-        port: 80
-        hostname: "*.envoyproxy.io"
-        allowedRoutes:
-          namespaces:
-            from: All
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
 httpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: HTTPRoute
@@ -22,22 +22,22 @@ httpRoutes:
     name: httproute-1
   spec:
     hostnames:
-      - gateway.envoyproxy.io
+    - gateway.envoyproxy.io
     parentRefs:
-      - namespace: envoy-gateway
-        name: gateway-1
-        sectionName: http
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
     rules:
-      - matches:
-          - path:
-              value: "/"
-        backendRefs:
-          - name: service-1
-            port: 8080
-        filters:
-        - type: RequestRedirect
-          requestRedirect:
-            scheme: https
-            statusCode: 301
-            hostname: "redirected.com"
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: https
+          statusCode: 301
+          hostname: "redirected.com"
 

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -1,98 +1,98 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http
-          protocol: HTTP
-          port: 80
-          hostname: "*.envoyproxy.io"
-          allowedRoutes:
-            namespaces:
-              from: All
-    status:
-      listeners:
-        - name: http
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-          attachedRoutes: 1
-          conditions:
-            - type: Ready
-              status: "True"
-              reason: Ready
-              message: Listener is ready
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: default
-      name: httproute-1
-    spec:
-      hostnames:
-      - gateway.envoyproxy.io
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-          sectionName: http
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
-          filters:
-          - type: RequestRedirect
-            requestRedirect:
-              scheme: https
-              statusCode: 301
-              hostname: "redirected.com"
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-            sectionName: http
-          # controllerName: envoyproxy.io/gateway-controller
-          conditions:
-            - type: Accepted
-              status: "True"
-              reason: Accepted
-              message: Route is accepted
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: https
+          statusCode: 301
+          hostname: "redirected.com"
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      # controllerName: envoyproxy.io/gateway-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   http:
-    - name: envoy-gateway-gateway-1-http
-      address: 0.0.0.0
-      port: 80
-      hostnames:
-      - "*.envoyproxy.io"
-      routes:
-        - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
-          pathMatch:
-            prefix: "/"
-          headerMatches:
-            - name: ":authority"
-              exact: gateway.envoyproxy.io
-          destinations:
-            - host: 7.7.7.7
-              port: 8080
-              weight: 1
-          redirect:
-            scheme: https
-            statusCode: 301
-            hostname: "redirected.com"
+  - name: envoy-gateway-gateway-1-http
+    address: 0.0.0.0
+    port: 80
+    hostnames:
+    - "*.envoyproxy.io"
+    routes:
+    - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+      pathMatch:
+        prefix: "/"
+      headerMatches:
+      - name: ":authority"
+        exact: gateway.envoyproxy.io
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1
+      redirect:
+        scheme: https
+        statusCode: 301
+        hostname: "redirected.com"
 infraIR:
   proxy:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
-        ports:
-          - name: envoy-gateway-gateway-1
-            protocol: "HTTP"
-            port: 80
+    - address: ""
+      ports:
+      - name: envoy-gateway-gateway-1
+        protocol: "HTTP"
+        port: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -88,6 +88,10 @@ xdsIR:
         hostname: "redirected.com"
 infraIR:
   proxy:
+    metadata:
+      labels:
+        gateway.envoyproxy.io/owning-gateway-name: gateway-1
+        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.in.yaml
@@ -7,13 +7,13 @@ gateways:
   spec:
     gatewayClassName: envoy-gateway-class
     listeners:
-      - name: http
-        protocol: HTTP
-        port: 80
-        hostname: "*.envoyproxy.io"
-        allowedRoutes:
-          namespaces:
-            from: All
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
 httpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: HTTPRoute
@@ -22,21 +22,21 @@ httpRoutes:
     name: httproute-1
   spec:
     hostnames:
-      - gateway.envoyproxy.io
+    - gateway.envoyproxy.io
     parentRefs:
-      - namespace: envoy-gateway
-        name: gateway-1
-        sectionName: http
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
     rules:
-      - matches:
-          - path:
-              value: "/"
-        backendRefs:
-          - name: service-1
-            port: 8080
-        filters:
-        - type: UnsupportedType
-          requestRedirect:
-            scheme: https
-            statusCode: 301
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: UnsupportedType
+        requestRedirect:
+          scheme: https
+          statusCode: 301
 

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -1,102 +1,102 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http
-          protocol: HTTP
-          port: 80
-          hostname: "*.envoyproxy.io"
-          allowedRoutes:
-            namespaces:
-              from: All
-    status:
-      listeners:
-        - name: http
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-          attachedRoutes: 1
-          conditions:
-            - type: Ready
-              status: "True"
-              reason: Ready
-              message: Listener is ready
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: default
-      name: httproute-1
-    spec:
-      hostnames:
-      - gateway.envoyproxy.io
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-          sectionName: http
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
-          filters:
-          - type: UnsupportedType
-            requestRedirect:
-              scheme: https
-              statusCode: 301
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-            sectionName: http
-          # controllerName: envoyproxy.io/gateway-controller
-          conditions:
-            - type: Accepted
-              status: "True"
-              reason: Accepted
-              message: Route is accepted
-            - type: ResolvedRefs
-              status: "False"
-              reason: UnsupportedValue
-              message: "Unknown custom filter type: UnsupportedType"
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: UnsupportedType
+        requestRedirect:
+          scheme: https
+          statusCode: 301
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      # controllerName: envoyproxy.io/gateway-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "False"
+        reason: UnsupportedValue
+        message: "Unknown custom filter type: UnsupportedType"
 xdsIR:
   http:
-    - name: envoy-gateway-gateway-1-http
-      address: 0.0.0.0
-      port: 80
-      hostnames:
-      - "*.envoyproxy.io"
-      routes:
-        - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
-          pathMatch:
-            prefix: "/"
-          headerMatches:
-            - name: ":authority"
-              exact: gateway.envoyproxy.io
-          # I believe the correct way to handle an invalid filter should be to allow the HTTPRoute to function
-          # normally but leave out the filter config and set the status, but this behaviour can be changed.
-          destinations:
-            - host: 7.7.7.7
-              port: 8080
-              weight: 1
-          directResponse:
-            body: "Unknown custom filter type: UnsupportedType"
-            statusCode: 500
+  - name: envoy-gateway-gateway-1-http
+    address: 0.0.0.0
+    port: 80
+    hostnames:
+    - "*.envoyproxy.io"
+    routes:
+    - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+      pathMatch:
+        prefix: "/"
+      headerMatches:
+      - name: ":authority"
+        exact: gateway.envoyproxy.io
+      # I believe the correct way to handle an invalid filter should be to allow the HTTPRoute to function
+      # normally but leave out the filter config and set the status, but this behaviour can be changed.
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1
+      directResponse:
+        body: "Unknown custom filter type: UnsupportedType"
+        statusCode: 500
 infraIR:
   proxy:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
-        ports:
-          - name: envoy-gateway-gateway-1
-            protocol: "HTTP"
-            port: 80
+    - address: ""
+      ports:
+      - name: envoy-gateway-gateway-1
+        protocol: "HTTP"
+        port: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -92,6 +92,10 @@ xdsIR:
         statusCode: 500
 infraIR:
   proxy:
+    metadata:
+      labels:
+        gateway.envoyproxy.io/owning-gateway-name: gateway-1
+        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.in.yaml
@@ -7,13 +7,13 @@ gateways:
   spec:
     gatewayClassName: envoy-gateway-class
     listeners:
-      - name: http
-        protocol: HTTP
-        port: 80
-        hostname: "*.envoyproxy.io"
-        allowedRoutes:
-          namespaces:
-            from: All
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
 httpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: HTTPRoute
@@ -22,21 +22,21 @@ httpRoutes:
     name: httproute-1
   spec:
     hostnames:
-      - gateway.envoyproxy.io
+    - gateway.envoyproxy.io
     parentRefs:
-      - namespace: envoy-gateway
-        name: gateway-1
-        sectionName: http
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
     rules:
-      - matches:
-          - path:
-              value: "/"
-        backendRefs:
-          - name: service-1
-            port: 8080
-        filters:
-        - type: RequestRedirect
-          requestRedirect:
-            scheme: unknown
-            statusCode: 301
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: unknown
+          statusCode: 301
 

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -1,99 +1,99 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http
-          protocol: HTTP
-          port: 80
-          hostname: "*.envoyproxy.io"
-          allowedRoutes:
-            namespaces:
-              from: All
-    status:
-      listeners:
-        - name: http
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-          attachedRoutes: 1
-          conditions:
-            - type: Ready
-              status: "True"
-              reason: Ready
-              message: Listener is ready
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: default
-      name: httproute-1
-    spec:
-      hostnames:
-      - gateway.envoyproxy.io
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-          sectionName: http
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
-          filters:
-          - type: RequestRedirect
-            requestRedirect:
-              scheme: unknown
-              statusCode: 301
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-            sectionName: http
-          # controllerName: envoyproxy.io/gateway-controller
-          conditions:
-            - type: Accepted
-              status: "True"
-              reason: Accepted
-              message: Route is accepted
-            - type: ResolvedRefs
-              status: "False"
-              reason: UnsupportedValue
-              message: "Scheme: unknown is unsupported, only 'https' and 'http' are supported"
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: unknown
+          statusCode: 301
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      # controllerName: envoyproxy.io/gateway-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "False"
+        reason: UnsupportedValue
+        message: "Scheme: unknown is unsupported, only 'https' and 'http' are supported"
 xdsIR:
   http:
-    - name: envoy-gateway-gateway-1-http
-      address: 0.0.0.0
-      port: 80
-      hostnames:
-      - "*.envoyproxy.io"
-      routes:
-        - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
-          pathMatch:
-            prefix: "/"
-          headerMatches:
-            - name: ":authority"
-              exact: gateway.envoyproxy.io
-          # I believe the correct way to handle an invalid filter should be to allow the HTTPRoute to function
-          # normally but leave out the filter config and set the status, but this behaviour can be changed.
-          destinations:
-            - host: 7.7.7.7
-              port: 8080
-              weight: 1
+  - name: envoy-gateway-gateway-1-http
+    address: 0.0.0.0
+    port: 80
+    hostnames:
+    - "*.envoyproxy.io"
+    routes:
+    - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+      pathMatch:
+        prefix: "/"
+      headerMatches:
+      - name: ":authority"
+        exact: gateway.envoyproxy.io
+      # I believe the correct way to handle an invalid filter should be to allow the HTTPRoute to function
+      # normally but leave out the filter config and set the status, but this behaviour can be changed.
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1
 infraIR:
   proxy:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
-        ports:
-          - name: envoy-gateway-gateway-1
-            protocol: "HTTP"
-            port: 80
+    - address: ""
+      ports:
+      - name: envoy-gateway-gateway-1
+        protocol: "HTTP"
+        port: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -89,6 +89,10 @@ xdsIR:
         weight: 1
 infraIR:
   proxy:
+    metadata:
+      labels:
+        gateway.envoyproxy.io/owning-gateway-name: gateway-1
+        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.in.yaml
@@ -7,13 +7,13 @@ gateways:
   spec:
     gatewayClassName: envoy-gateway-class
     listeners:
-      - name: http
-        protocol: HTTP
-        port: 80
-        hostname: "*.envoyproxy.io"
-        allowedRoutes:
-          namespaces:
-            from: All
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
 httpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: HTTPRoute
@@ -22,21 +22,21 @@ httpRoutes:
     name: httproute-1
   spec:
     hostnames:
-      - gateway.envoyproxy.io
+    - gateway.envoyproxy.io
     parentRefs:
-      - namespace: envoy-gateway
-        name: gateway-1
-        sectionName: http
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
     rules:
-      - matches:
-          - path:
-              value: "/"
-        backendRefs:
-          - name: service-1
-            port: 8080
-        filters:
-        - type: RequestRedirect
-          requestRedirect:
-            scheme: https
-            statusCode: 666
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: https
+          statusCode: 666
 

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -1,99 +1,99 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http
-          protocol: HTTP
-          port: 80
-          hostname: "*.envoyproxy.io"
-          allowedRoutes:
-            namespaces:
-              from: All
-    status:
-      listeners:
-        - name: http
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-          attachedRoutes: 1
-          conditions:
-            - type: Ready
-              status: "True"
-              reason: Ready
-              message: Listener is ready
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: default
-      name: httproute-1
-    spec:
-      hostnames:
-      - gateway.envoyproxy.io
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-          sectionName: http
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
-          filters:
-          - type: RequestRedirect
-            requestRedirect:
-              scheme: https
-              statusCode: 666
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-            sectionName: http
-          # controllerName: envoyproxy.io/gateway-controller
-          conditions:
-            - type: Accepted
-              status: "True"
-              reason: Accepted
-              message: Route is accepted
-            - type: ResolvedRefs
-              status: "False"
-              reason: UnsupportedValue
-              message: "Status code 666 is invalid, only 302 and 301 are supported"
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: https
+          statusCode: 666
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      # controllerName: envoyproxy.io/gateway-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "False"
+        reason: UnsupportedValue
+        message: "Status code 666 is invalid, only 302 and 301 are supported"
 xdsIR:
   http:
-    - name: envoy-gateway-gateway-1-http
-      address: 0.0.0.0
-      port: 80
-      hostnames:
-      - "*.envoyproxy.io"
-      routes:
-        - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
-          pathMatch:
-            prefix: "/"
-          headerMatches:
-            - name: ":authority"
-              exact: gateway.envoyproxy.io
-          # I believe the correct way to handle an invalid filter should be to allow the HTTPRoute to function
-          # normally but leave out the filter config and set the status, but this behaviour can be changed.
-          destinations:
-            - host: 7.7.7.7
-              port: 8080
-              weight: 1
+  - name: envoy-gateway-gateway-1-http
+    address: 0.0.0.0
+    port: 80
+    hostnames:
+    - "*.envoyproxy.io"
+    routes:
+    - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+      pathMatch:
+        prefix: "/"
+      headerMatches:
+      - name: ":authority"
+        exact: gateway.envoyproxy.io
+      # I believe the correct way to handle an invalid filter should be to allow the HTTPRoute to function
+      # normally but leave out the filter config and set the status, but this behaviour can be changed.
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1
 infraIR:
   proxy:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
-        ports:
-          - name: envoy-gateway-gateway-1
-            protocol: "HTTP"
-            port: 80
+    - address: ""
+      ports:
+      - name: envoy-gateway-gateway-1
+        protocol: "HTTP"
+        port: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -89,6 +89,10 @@ xdsIR:
         weight: 1
 infraIR:
   proxy:
+    metadata:
+      labels:
+        gateway.envoyproxy.io/owning-gateway-name: gateway-1
+        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.in.yaml
@@ -7,13 +7,13 @@ gateways:
   spec:
     gatewayClassName: envoy-gateway-class
     listeners:
-      - name: http
-        protocol: HTTP
-        port: 80
-        hostname: "*.envoyproxy.io"
-        allowedRoutes:
-          namespaces:
-            from: All
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
 httpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: HTTPRoute
@@ -22,25 +22,25 @@ httpRoutes:
     name: httproute-1
   spec:
     hostnames:
-      - gateway.envoyproxy.io
+    - gateway.envoyproxy.io
     parentRefs:
-      - namespace: envoy-gateway
-        name: gateway-1
-        sectionName: http
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
     rules:
-      - matches:
-          - path:
-              value: "/"
-        backendRefs:
-          - name: service-1
-            port: 8080
-        filters:
-        - type: RequestRedirect
-          requestRedirect:
-            scheme: http
-            statusCode: 302
-            port: 8080
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: /redirected
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: http
+          statusCode: 302
+          port: 8080
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /redirected
 

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -1,103 +1,103 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http
-          protocol: HTTP
-          port: 80
-          hostname: "*.envoyproxy.io"
-          allowedRoutes:
-            namespaces:
-              from: All
-    status:
-      listeners:
-        - name: http
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-          attachedRoutes: 1
-          conditions:
-            - type: Ready
-              status: "True"
-              reason: Ready
-              message: Listener is ready
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: default
-      name: httproute-1
-    spec:
-      hostnames:
-      - gateway.envoyproxy.io
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-          sectionName: http
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
-          filters:
-          - type: RequestRedirect
-            requestRedirect:
-              scheme: http
-              statusCode: 302
-              port: 8080
-              path:
-                type: ReplacePrefixMatch
-                replacePrefixMatch: /redirected
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-            sectionName: http
-          # controllerName: envoyproxy.io/gateway-controller
-          conditions:
-            - type: Accepted
-              status: "True"
-              reason: Accepted
-              message: Route is accepted
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: http
+          statusCode: 302
+          port: 8080
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /redirected
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      # controllerName: envoyproxy.io/gateway-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   http:
-    - name: envoy-gateway-gateway-1-http
-      address: 0.0.0.0
-      port: 80
-      hostnames:
-      - "*.envoyproxy.io"
-      routes:
-        - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
-          pathMatch:
-            prefix: "/"
-          headerMatches:
-            - name: ":authority"
-              exact: gateway.envoyproxy.io
-          destinations:
-            - host: 7.7.7.7
-              port: 8080
-              weight: 1
-          redirect:
-            scheme: http
-            statusCode: 302
-            port: 8080
-            path:
-              prefixMatchReplace: /redirected
+  - name: envoy-gateway-gateway-1-http
+    address: 0.0.0.0
+    port: 80
+    hostnames:
+    - "*.envoyproxy.io"
+    routes:
+    - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+      pathMatch:
+        prefix: "/"
+      headerMatches:
+      - name: ":authority"
+        exact: gateway.envoyproxy.io
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1
+      redirect:
+        scheme: http
+        statusCode: 302
+        port: 8080
+        path:
+          prefixMatchReplace: /redirected
 infraIR:
   proxy:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
-        ports:
-          - name: envoy-gateway-gateway-1
-            protocol: "HTTP"
-            port: 80
+    - address: ""
+      ports:
+      - name: envoy-gateway-gateway-1
+        protocol: "HTTP"
+        port: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -93,6 +93,10 @@ xdsIR:
           prefixMatchReplace: /redirected
 infraIR:
   proxy:
+    metadata:
+      labels:
+        gateway.envoyproxy.io/owning-gateway-name: gateway-1
+        gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:


### PR DESCRIPTION
Both the linter and the tests are broken on `main`. A PR that tightens up the `yamllint` config was merged concurrently with several PRs that add YAML that the new config complains about. A PR that adds a field to testdata output files was merged concurrently with PRs that add new testdata output files (and so don't have that new field). These are merge conflicts, but Git wasn't able to recognize them as such; fix those conflicts.