### PR TITLE
fix `make gen-check` error msg

### DIFF
--- a/tools/make/lint.mk
+++ b/tools/make/lint.mk
@@ -68,6 +68,6 @@ lint.shellcheck:
 .PHONY: gen-check
 gen-check: generate manifests
 	@if [ ! -z "`git status --porcelain`" ]; then \
-		@echo "ERROR: Some files need to be updated, please run 'make generate' and `make manifests` to include any changed files to your PR"; \
+		echo "\nERROR: Some files need to be updated, please run 'make generate' and 'make manifests' to include any changed files to your PR\n"; \
 		git diff --exit-code; \
 	fi


### PR DESCRIPTION
* replace `` with '' to skip executing 'make manifests'

* rm @ in indented echo cmd within if statement

Signed-off-by: Arko Dasgupta <arko@tetrate.io>