### PR TITLE
reset watchable map when gatewayclass is empty

### DIFF
--- a/internal/gatewayapi/runner/runner_test.go
+++ b/internal/gatewayapi/runner/runner_test.go
@@ -1,0 +1,52 @@
+package runner
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	"github.com/envoyproxy/gateway/internal/ir"
+	"github.com/envoyproxy/gateway/internal/message"
+)
+
+func TestRunner(t *testing.T) {
+	// Setup
+	pResources := new(message.ProviderResources)
+	xdsIR := new(message.XdsIR)
+	infraIR := new(message.InfraIR)
+	cfg, err := config.NewDefaultServer()
+	require.NoError(t, err)
+	r := New(&Config{
+		Server:            *cfg,
+		ProviderResources: pResources,
+		XdsIR:             xdsIR,
+		InfraIR:           infraIR,
+	})
+	ctx := context.Background()
+	// Start
+	err = r.Start(ctx)
+	require.NoError(t, err)
+
+	// IR is nil at start
+	require.Equal(t, (*ir.Xds)(nil), xdsIR.Get())
+	require.Equal(t, (*ir.Infra)(nil), infraIR.Get())
+
+	// TODO: pass valid provider resources
+
+	// Reset gatewayclass slice and update with a nil gatewayclass to trigger a delete
+	pResources.DeleteGatewayClasses()
+	pResources.GatewayClasses.Store("test", nil)
+	require.Eventually(t, func() bool {
+		out := xdsIR.Get()
+		if out == nil {
+			return false
+		}
+		// Ensure ir is empty
+		return (reflect.DeepEqual(*xdsIR.Get(), ir.Xds{})) && (reflect.DeepEqual(*infraIR.Get(), ir.Infra{Proxy: nil}))
+	}, time.Second*1, time.Millisecond*20)
+
+}

--- a/internal/message/types.go
+++ b/internal/message/types.go
@@ -24,6 +24,13 @@ type ProviderResources struct {
 	Initialized sync.WaitGroup
 }
 
+func (p *ProviderResources) DeleteGatewayClasses() {
+	for k, _ := range p.GatewayClasses.LoadAll() {
+		p.GatewayClasses.Delete(k)
+	}
+	return
+}
+
 func (p *ProviderResources) GetGatewayClasses() []*gwapiv1b1.GatewayClass {
 	if p.GatewayClasses.Len() == 0 {
 		return nil

--- a/internal/message/types.go
+++ b/internal/message/types.go
@@ -25,10 +25,9 @@ type ProviderResources struct {
 }
 
 func (p *ProviderResources) DeleteGatewayClasses() {
-	for k, _ := range p.GatewayClasses.LoadAll() {
+	for k := range p.GatewayClasses.LoadAll() {
 		p.GatewayClasses.Delete(k)
 	}
-	return
 }
 
 func (p *ProviderResources) GetGatewayClasses() []*gwapiv1b1.GatewayClass {

--- a/internal/message/types_test.go
+++ b/internal/message/types_test.go
@@ -161,6 +161,10 @@ func TestProviderResources(t *testing.T) {
 
 	svcs = resources.GetServices()
 	assert.ElementsMatch(t, svcs, []*corev1.Service{s1, s2})
+
+	// Delete gatewayclasses
+	resources.DeleteGatewayClasses()
+	assert.Nil(t, resources.GetGatewayClasses())
 }
 
 func TestXdsIR(t *testing.T) {

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -104,14 +104,15 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 	}
 
 	acceptedGC := cc.acceptedClass()
+	// Reset gatewayclasses since this Reconcile function never performs a Delete and
+	// we are only interested in the first element.
+	r.resources.DeleteGatewayClasses()
 	if acceptedGC == nil {
 		// A nil gatewayclass removes managed proxy infra, if it exists.
 		r.log.Info("failed to find an accepted gatewayclass")
-		r.resources.DeleteGatewayClasses()
 		r.resources.GatewayClasses.Store(request.Name, nil)
 		return reconcile.Result{}, nil
 	}
-
 	// Store the accepted gatewayclass in the resource map.
 	r.resources.GatewayClasses.Store(acceptedGC.GetName(), acceptedGC)
 

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -107,6 +107,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 	if acceptedGC == nil {
 		// A nil gatewayclass removes managed proxy infra, if it exists.
 		r.log.Info("failed to find an accepted gatewayclass")
+		pResources.DeleteGatewayClasses()
 		r.resources.GatewayClasses.Store(request.Name, nil)
 		return reconcile.Result{}, nil
 	}

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -107,7 +107,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 	if acceptedGC == nil {
 		// A nil gatewayclass removes managed proxy infra, if it exists.
 		r.log.Info("failed to find an accepted gatewayclass")
-		pResources.DeleteGatewayClasses()
+		r.resources.DeleteGatewayClasses()
 		r.resources.GatewayClasses.Store(request.Name, nil)
 		return reconcile.Result{}, nil
 	}


### PR DESCRIPTION
Also fixes: https://github.com/envoyproxy/gateway/issues/228

Signed-off-by: Arko Dasgupta <arko@tetrate.io>