### PR TITLE
Skip publishing xdsIR if HTTPRoutes not intialized

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -54,13 +54,11 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 		// Receive subscribed resource notifications
 		select {
 		case <-gatewayClassesCh:
-			r.waitUntilInitialized()
+			r.waitUntilGCAndGatewaysInitialized()
 		case <-gatewaysCh:
-			r.waitUntilInitialized()
+			r.waitUntilGCAndGatewaysInitialized()
 		case <-httpRoutesCh:
-			// Wait until httproute have been initialized during startup
-			r.ProviderResources.HTTPRoutesInitialized.Wait()
-			r.Logger.Info("done initializing httproute resources")
+			r.waitUntilAllGAPIInitialized()
 			// Now that the httproute resources have been initialized,
 			// allow the runner to publish the translated xdsIR.
 			xdsIRReady = true
@@ -121,9 +119,16 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 	r.Logger.Info("shutting down")
 }
 
-// WwaitUntilInitialized waits until gateway classes and
+// waitUntilGCAndGatewaysInitialized waits until gateway classes and
 // gateways have been initialized during startup
-func (r *Runner) waitUntilInitialized() {
+func (r *Runner) waitUntilGCAndGatewaysInitialized() {
 	r.ProviderResources.GatewayClassesInitialized.Wait()
 	r.ProviderResources.GatewaysInitialized.Wait()
+}
+
+// waitUntilAllGAPIInitialized waits until gateway classes,
+// gateways and httproutes have been initialized during startup
+func (r *Runner) waitUntilAllGAPIInitialized() {
+	r.waitUntilGCAndGatewaysInitialized()
+	r.ProviderResources.HTTPRoutesInitialized.Wait()
 }

--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -40,7 +40,8 @@ func (r *Runner) Start(ctx context.Context) error {
 }
 
 func (r *Runner) subscribeAndTranslate(ctx context.Context) {
-	r.Logger.Info("done initializing provider resources")
+	var xdsIRReady bool
+
 	// Subscribe to resources
 	gatewayClassesCh := r.ProviderResources.GatewayClasses.Subscribe(ctx)
 	gatewaysCh := r.ProviderResources.Gateways.Subscribe(ctx)
@@ -48,15 +49,21 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 	servicesCh := r.ProviderResources.Services.Subscribe(ctx)
 	namespacesCh := r.ProviderResources.Namespaces.Subscribe(ctx)
 
-	// Wait until provider resources have been initialized during startup
-	r.ProviderResources.Initialized.Wait()
 	for ctx.Err() == nil {
 		var in gatewayapi.Resources
 		// Receive subscribed resource notifications
 		select {
 		case <-gatewayClassesCh:
+			r.waitUntilInitialized()
 		case <-gatewaysCh:
+			r.waitUntilInitialized()
 		case <-httpRoutesCh:
+			// Wait until httproute have been initialized during startup
+			r.ProviderResources.HTTPRoutesInitialized.Wait()
+			r.Logger.Info("done initializing httproute resources")
+			// Now that the httproute resources have been initialized,
+			// allow the runner to publish the translated xdsIR.
+			xdsIRReady = true
 		case <-servicesCh:
 		case <-namespacesCh:
 		}
@@ -93,18 +100,30 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 			// Publish the IRs. Use the service name as the key
 			// to ensure there is always one element in the map.
 			// Also validate the ir before sending it.
-			if err := result.XdsIR.Validate(); err != nil {
-				r.Logger.Error(err, "unable to validate xds ir, skipped sending it")
-			} else {
-				r.XdsIR.Store(r.Name(), result.XdsIR)
-			}
-
 			if err := result.InfraIR.Validate(); err != nil {
 				r.Logger.Error(err, "unable to validate infra ir, skipped sending it")
 			} else {
 				r.InfraIR.Store(r.Name(), result.InfraIR)
 			}
+
+			// Wait until all HTTPRoutes have been reconciled , else the translation
+			// result will be incomplete, and might cause churn in the data plane.
+			if xdsIRReady {
+				if err := result.XdsIR.Validate(); err != nil {
+					r.Logger.Error(err, "unable to validate xds ir, skipped sending it")
+				} else {
+					r.XdsIR.Store(r.Name(), result.XdsIR)
+				}
+			}
+
 		}
 	}
 	r.Logger.Info("shutting down")
+}
+
+// WwaitUntilInitialized waits until gateway classes and
+// gateways have been initialized during startup
+func (r *Runner) waitUntilInitialized() {
+	r.ProviderResources.GatewayClassesInitialized.Wait()
+	r.ProviderResources.GatewaysInitialized.Wait()
 }

--- a/internal/message/types.go
+++ b/internal/message/types.go
@@ -19,9 +19,10 @@ type ProviderResources struct {
 	HTTPRoutes     watchable.Map[types.NamespacedName, *gwapiv1b1.HTTPRoute]
 	Namespaces     watchable.Map[string, *corev1.Namespace]
 	Services       watchable.Map[types.NamespacedName, *corev1.Service]
-	// Initialized.Wait() will return once each of the maps in the
-	// structure have been initialized at startup.
-	Initialized sync.WaitGroup
+
+	GatewayClassesInitialized sync.WaitGroup
+	GatewaysInitialized       sync.WaitGroup
+	HTTPRoutesInitialized     sync.WaitGroup
 }
 
 func (p *ProviderResources) DeleteGatewayClasses() {

--- a/internal/provider/kubernetes/gateway.go
+++ b/internal/provider/kubernetes/gateway.go
@@ -43,7 +43,7 @@ type gatewayReconciler struct {
 // Gateway objects across all namespaces and reconcile those that match the configured
 // gatewayclass controller name.
 func newGatewayController(mgr manager.Manager, cfg *config.Server, su status.Updater, resources *message.ProviderResources) error {
-	resources.Initialized.Add(1)
+	resources.GatewaysInitialized.Add(1)
 	r := &gatewayReconciler{
 		client:          mgr.GetClient(),
 		classController: gwapiv1b1.GatewayController(cfg.EnvoyGateway.Gateway.ControllerName),
@@ -193,7 +193,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 	}
 
 	// Once we've processed `allGateways`, record that we've fully initialized.
-	r.initializeOnce.Do(r.resources.Initialized.Done)
+	r.initializeOnce.Do(r.resources.GatewaysInitialized.Done)
 
 	r.log.WithName(request.Namespace).WithName(request.Name).Info("reconciled gateway")
 

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -38,7 +38,7 @@ type gatewayClassReconciler struct {
 // will be pre-configured to watch for cluster-scoped GatewayClass objects with
 // a controller field that matches name.
 func newGatewayClassController(mgr manager.Manager, cfg *config.Server, su status.Updater, resources *message.ProviderResources) error {
-	resources.Initialized.Add(1)
+	resources.GatewayClassesInitialized.Add(1)
 	r := &gatewayClassReconciler{
 		client:        mgr.GetClient(),
 		controller:    gwapiv1b1.GatewayController(cfg.EnvoyGateway.Gateway.ControllerName),
@@ -153,7 +153,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 		}
 	}
 	// Once we've iterated over all listed classes, mark that we've fully initialized.
-	r.initializeOnce.Do(r.resources.Initialized.Done)
+	r.initializeOnce.Do(r.resources.GatewayClassesInitialized.Done)
 
 	r.log.WithName(request.Name).Info("reconciled gatewayclass")
 	return reconcile.Result{}, nil

--- a/internal/provider/kubernetes/httproute.go
+++ b/internal/provider/kubernetes/httproute.go
@@ -41,7 +41,7 @@ type httpRouteReconciler struct {
 // newHTTPRouteController creates the httproute controller from mgr. The controller will be pre-configured
 // to watch for HTTPRoute objects across all namespaces.
 func newHTTPRouteController(mgr manager.Manager, cfg *config.Server, resources *message.ProviderResources) error {
-	resources.Initialized.Add(1)
+	resources.HTTPRoutesInitialized.Add(1)
 	r := &httpRouteReconciler{
 		client:    mgr.GetClient(),
 		log:       cfg.Logger,
@@ -212,7 +212,7 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.R
 
 	log.Info("reconciled httproute")
 
-	defer r.initializeOnce.Do(r.resources.Initialized.Done)
+	r.initializeOnce.Do(r.resources.HTTPRoutesInitialized.Done)
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
* create a seperate WaitGroup for each Gateway API resource

* allow the gateway api translator to pass the xdsIR to the next layer only when the HTTPRoutes have been initialized

Fixes: https://github.com/envoyproxy/gateway/issues/215

Signed-off-by: Arko Dasgupta <arko@tetrate.io>