### PR TITLE
Updates Infra IR to Support Multiple Envoy Services

### DIFF
--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
@@ -76,9 +76,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
@@ -68,9 +68,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-    - address: ""
+    - name: envoy-gateway-gateway-1
+      address: ""
       ports:
-      - name: envoy-gateway-gateway-1
+      - name: http
         protocol: "HTTP"
         servicePort: 80
         containerPort: 10080

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
@@ -68,4 +68,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
@@ -66,4 +66,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
@@ -66,4 +66,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
@@ -66,4 +66,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
@@ -64,4 +64,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
@@ -70,4 +70,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
@@ -71,4 +71,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
@@ -70,4 +70,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
@@ -62,4 +62,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -84,9 +84,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: tls
             protocol: "HTTPS"
             servicePort: 443
             containerPort: 10443

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
@@ -63,4 +63,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
@@ -83,9 +83,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: tls
             protocol: "HTTPS"
             servicePort: 443
             containerPort: 10443

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-different-port-and-hostname.in.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-different-port-and-hostname.in.yaml
@@ -1,0 +1,50 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http-1
+      protocol: HTTP
+      port: 80
+      hostname: foo.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: http-2
+      protocol: HTTP
+      port: 81
+      hostname: bar.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+services:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: envoy-gateway
+    name: service-1
+  spec:
+    clusterIP: 7.7.7.7
+    ports:
+      - port: 8080

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-different-port-and-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-different-port-and-hostname.out.yaml
@@ -1,0 +1,119 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http-1
+      protocol: HTTP
+      port: 80
+      hostname: foo.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: http-2
+      protocol: HTTP
+      port: 81
+      hostname: bar.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+  status:
+    listeners:
+      - name: http-1
+        supportedKinds:
+          - group: gateway.networking.k8s.io
+            kind: HTTPRoute
+        attachedRoutes: 1
+        conditions:
+          - type: Ready
+            status: "True"
+            reason: Ready
+            message: Listener is ready
+      - name: http-2
+        supportedKinds:
+          - group: gateway.networking.k8s.io
+            kind: HTTPRoute
+        attachedRoutes: 1
+        conditions:
+          - type: Ready
+            status: "True"
+            reason: Ready
+            message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+  status:
+    parents:
+      - parentRef:
+          namespace: envoy-gateway
+          name: gateway-1
+        conditions:
+          - type: Accepted
+            status: "True"
+            reason: Accepted
+            message: Route is accepted
+xdsIR:
+  http:
+    - name: envoy-gateway-gateway-1-http-1
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+        - "foo.com"
+      routes:
+        - name: envoy-gateway-httproute-1-rule-0-match-0-foo.com
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+    - name: envoy-gateway-gateway-1-http-2
+      address: 0.0.0.0
+      port: 10081
+      hostnames:
+        - "bar.com"
+      routes:
+        - name: envoy-gateway-httproute-1-rule-0-match-0-bar.com
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+infraIR:
+  proxy:
+    metadata:
+      labels:
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
+    name: envoy-gateway-class
+    image: envoyproxy/envoy:v1.23-latest
+    listeners:
+    - name: envoy-gateway-gateway-1
+      address: ""
+      ports:
+        - name: http-1
+          protocol: "HTTP"
+          servicePort: 80
+          containerPort: 10080
+        - name: http-2
+          protocol: "HTTP"
+          servicePort: 81
+          containerPort: 10081

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
@@ -86,4 +86,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-    - address: ""
+    - name: envoy-gateway-gateway-1
+      address: ""

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
@@ -86,4 +86,5 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -107,9 +107,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http-1
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
@@ -76,9 +76,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -101,9 +101,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http-1
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
@@ -78,9 +78,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
@@ -86,9 +86,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -89,9 +89,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -78,9 +78,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -80,9 +80,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -71,9 +71,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-    - address: ""
+    - name: envoy-gateway-gateway-1
+      address: ""
       ports:
-      - name: envoy-gateway-gateway-1
+      - name: http
         protocol: "HTTP"
         containerPort: 10080
         servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -97,9 +97,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-    - address: ""
+    - name: envoy-gateway-gateway-1
+      address: ""
       ports:
-      - name: envoy-gateway-gateway-1
+      - name: http
         protocol: "HTTP"
         containerPort: 10080
         servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -94,9 +94,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-    - address: ""
+    - name: envoy-gateway-gateway-1
+      address: ""
       ports:
-      - name: envoy-gateway-gateway-1
+      - name: http
         protocol: "HTTP"
         containerPort: 10080
         servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -98,9 +98,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-    - address: ""
+    - name: envoy-gateway-gateway-1
+      address: ""
       ports:
-      - name: envoy-gateway-gateway-1
+      - name: http
         protocol: "HTTP"
         containerPort: 10080
         servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -95,9 +95,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-    - address: ""
+    - name: envoy-gateway-gateway-1
+      address: ""
       ports:
-      - name: envoy-gateway-gateway-1
+      - name: http
         protocol: "HTTP"
         containerPort: 10080
         servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -95,9 +95,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-    - address: ""
+    - name: envoy-gateway-gateway-1
+      address: ""
       ports:
-      - name: envoy-gateway-gateway-1
+      - name: http
         protocol: "HTTP"
         containerPort: 10080
         servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -99,9 +99,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-    - address: ""
+    - name: envoy-gateway-gateway-1
+      address: ""
       ports:
-      - name: envoy-gateway-gateway-1
+      - name: http
         protocol: "HTTP"
         containerPort: 10080
         servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
@@ -77,9 +77,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
@@ -86,9 +86,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http
             protocol: "HTTP"
             serviceport: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -82,9 +82,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -93,9 +93,10 @@ infraIR:
     name: envoy-gateway-class
     image: envoyproxy/envoy:v1.23-latest
     listeners:
-      - address: ""
+      - name: envoy-gateway-gateway-1
+        address: ""
         ports:
-          - name: envoy-gateway-gateway-1
+          - name: http
             protocol: "HTTP"
             servicePort: 80
             containerPort: 10080

--- a/internal/gatewayapi/testdata/two-gateways-with-two-listeners-with-different-port-and-hostname.in.yaml
+++ b/internal/gatewayapi/testdata/two-gateways-with-two-listeners-with-different-port-and-hostname.in.yaml
@@ -1,0 +1,74 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http-1
+      protocol: HTTP
+      port: 80
+      hostname: foo.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: http-2
+      protocol: HTTP
+      port: 81
+      hostname: bar.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-2
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http-1
+        protocol: HTTP
+        port: 82
+        hostname: foobar.com
+        allowedRoutes:
+          namespaces:
+            from: Same
+      - name: http-2
+        protocol: HTTP
+        port: 83
+        hostname: barfoo.com
+        allowedRoutes:
+          namespaces:
+            from: Same
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    - namespace: envoy-gateway
+      name: gateway-2
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+services:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: envoy-gateway
+    name: service-1
+  spec:
+    clusterIP: 7.7.7.7
+    ports:
+      - port: 8080

--- a/internal/gatewayapi/testdata/two-gateways-with-two-listeners-with-different-port-and-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/two-gateways-with-two-listeners-with-different-port-and-hostname.out.yaml
@@ -1,0 +1,210 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http-1
+      protocol: HTTP
+      port: 80
+      hostname: foo.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: http-2
+      protocol: HTTP
+      port: 81
+      hostname: bar.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+  status:
+    listeners:
+      - name: http-1
+        supportedKinds:
+          - group: gateway.networking.k8s.io
+            kind: HTTPRoute
+        attachedRoutes: 1
+        conditions:
+          - type: Ready
+            status: "True"
+            reason: Ready
+            message: Listener is ready
+      - name: http-2
+        supportedKinds:
+          - group: gateway.networking.k8s.io
+            kind: HTTPRoute
+        attachedRoutes: 1
+        conditions:
+          - type: Ready
+            status: "True"
+            reason: Ready
+            message: Listener is ready
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-2
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+      - name: http-1
+        protocol: HTTP
+        port: 82
+        hostname: foobar.com
+        allowedRoutes:
+          namespaces:
+            from: Same
+      - name: http-2
+        protocol: HTTP
+        port: 83
+        hostname: barfoo.com
+        allowedRoutes:
+          namespaces:
+            from: Same
+  status:
+    listeners:
+      - name: http-1
+        supportedKinds:
+          - group: gateway.networking.k8s.io
+            kind: HTTPRoute
+        attachedRoutes: 1
+        conditions:
+          - type: Ready
+            status: "True"
+            reason: Ready
+            message: Listener is ready
+      - name: http-2
+        supportedKinds:
+          - group: gateway.networking.k8s.io
+            kind: HTTPRoute
+        attachedRoutes: 1
+        conditions:
+          - type: Ready
+            status: "True"
+            reason: Ready
+            message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-1
+  spec:
+    parentRefs:
+      - namespace: envoy-gateway
+        name: gateway-1
+      - namespace: envoy-gateway
+        name: gateway-2
+    rules:
+      - matches:
+          - path:
+              value: "/"
+        backendRefs:
+          - name: service-1
+            port: 8080
+  status:
+    parents:
+      - parentRef:
+          namespace: envoy-gateway
+          name: gateway-1
+        conditions:
+          - type: Accepted
+            status: "True"
+            reason: Accepted
+            message: Route is accepted
+      - parentRef:
+          namespace: envoy-gateway
+          name: gateway-2
+        conditions:
+          - type: Accepted
+            status: "True"
+            reason: Accepted
+            message: Route is accepted
+xdsIR:
+  http:
+    - name: envoy-gateway-gateway-1-http-1
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+        - "foo.com"
+      routes:
+        - name: envoy-gateway-httproute-1-rule-0-match-0-foo.com
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+    - name: envoy-gateway-gateway-1-http-2
+      address: 0.0.0.0
+      port: 10081
+      hostnames:
+        - "bar.com"
+      routes:
+        - name: envoy-gateway-httproute-1-rule-0-match-0-bar.com
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+    - name: envoy-gateway-gateway-2-http-1
+      address: 0.0.0.0
+      port: 10082
+      hostnames:
+        - "foobar.com"
+      routes:
+        - name: envoy-gateway-httproute-1-rule-0-match-0-foobar.com
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+    - name: envoy-gateway-gateway-2-http-2
+      address: 0.0.0.0
+      port: 10083
+      hostnames:
+        - "barfoo.com"
+      routes:
+        - name: envoy-gateway-httproute-1-rule-0-match-0-barfoo.com
+          pathMatch:
+            prefix: "/"
+          destinations:
+            - host: 7.7.7.7
+              port: 8080
+              weight: 1
+infraIR:
+  proxy:
+    metadata:
+      labels:
+        gateway.envoyproxy.io/owning-gatewayclass: envoy-gateway-class
+    name: envoy-gateway-class
+    image: envoyproxy/envoy:v1.23-latest
+    listeners:
+    - name: envoy-gateway-gateway-1
+      address: ""
+      ports:
+        - name: http-1
+          protocol: "HTTP"
+          servicePort: 80
+          containerPort: 10080
+        - name: http-2
+          protocol: "HTTP"
+          servicePort: 81
+          containerPort: 10081
+    - name: envoy-gateway-gateway-2
+      address: ""
+      ports:
+        - name: http-1
+          protocol: "HTTP"
+          servicePort: 82
+          containerPort: 10082
+        - name: http-2
+          protocol: "HTTP"
+          servicePort: 83
+          containerPort: 10083

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -76,6 +76,15 @@ func TestTranslate(t *testing.T) {
 			got := translator.Translate(resources)
 
 			sort.Slice(got.XdsIR.HTTP, func(i, j int) bool { return got.XdsIR.HTTP[i].Name < got.XdsIR.HTTP[j].Name })
+			sort.Slice(got.InfraIR.Proxy.Listeners, func(i, j int) bool {
+				return got.InfraIR.Proxy.Listeners[i].Name < got.InfraIR.Proxy.Listeners[j].Name
+			})
+			for i := range got.InfraIR.Proxy.Listeners {
+				listener := got.InfraIR.Proxy.Listeners[i]
+				sort.Slice(listener.Ports, func(j, k int) bool {
+					return listener.Ports[j].Name < listener.Ports[k].Name
+				})
+			}
 
 			assert.EqualValues(t, want, got)
 		})

--- a/internal/ir/infra_test.go
+++ b/internal/ir/infra_test.go
@@ -18,7 +18,7 @@ func TestValidateInfra(t *testing.T) {
 			expect: false,
 		},
 		{
-			name: "no-name",
+			name: "no-proxy-infra-name",
 			infra: &Infra{
 				Proxy: &ProxyInfra{
 					Name:      "",
@@ -46,12 +46,94 @@ func TestValidateInfra(t *testing.T) {
 					Image: "image",
 					Listeners: []ProxyListener{
 						{
-							Ports: []ListenerPort{},
+							Name:    "test",
+							Ports:   []ListenerPort{},
+							Address: "1.2.3.4",
 						},
 					},
 				},
 			},
 			expect: false,
+		},
+		{
+			name: "no-listener-name",
+			infra: &Infra{
+				Proxy: &ProxyInfra{
+					Name:  "test",
+					Image: "image",
+					Listeners: []ProxyListener{
+						{
+							Ports: []ListenerPort{
+								{
+									ServicePort:   int32(80),
+									ContainerPort: int32(8080),
+								},
+							},
+							Address: "1.2.3.4",
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "one-listener-two-ports",
+			infra: &Infra{
+				Proxy: &ProxyInfra{
+					Name:  "test",
+					Image: "image",
+					Listeners: []ProxyListener{
+						{
+							Name: "gateway-1",
+							Ports: []ListenerPort{
+								{
+									Name:          "http-1",
+									ServicePort:   int32(80),
+									ContainerPort: int32(8080),
+								},
+								{
+									Name:          "http-2",
+									ServicePort:   int32(81),
+									ContainerPort: int32(8081),
+								},
+							},
+						},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "two-listeners",
+			infra: &Infra{
+				Proxy: &ProxyInfra{
+					Name:  "test",
+					Image: "image",
+					Listeners: []ProxyListener{
+						{
+							Name: "gateway-1",
+							Ports: []ListenerPort{
+								{
+									Name:          "http-1",
+									ServicePort:   int32(80),
+									ContainerPort: int32(8080),
+								},
+							},
+						},
+						{
+							Name: "gateway-2",
+							Ports: []ListenerPort{
+								{
+									Name:          "http-1",
+									ServicePort:   int32(81),
+									ContainerPort: int32(8081),
+								},
+							},
+						},
+					},
+				},
+			},
+			expect: true,
 		},
 		{
 			name: "no-listener-port-name",


### PR DESCRIPTION
Currently, EG creates a single Kube Service regardless of the number of Gateways. This causes issues with running conformance tests since the base manifests create three Gateways that cannot be collapsed into one. This PR updates the Infra IR to support managing multiple Kube Services by mapping a Gateway to Infra IR Listener and mapping a Gateway listener to Infra IR ListenerPort.

Partially fixes:
https://github.com/envoyproxy/gateway/issues/349
https://github.com/envoyproxy/gateway/issues/380
https://github.com/envoyproxy/gateway/issues/382

Signed-off-by: danehans <daneyonhansen@gmail.com>