### PR TITLE
Add Gateway condition based on Envoy deployment status

### DIFF
--- a/internal/envoygateway/config/config.go
+++ b/internal/envoygateway/config/config.go
@@ -12,6 +12,8 @@ const (
 	EnvoyGatewayNamespace = "envoy-gateway-system"
 	// EnvoyServiceName is the name of the Envoy Service.
 	EnvoyServiceName = "envoy"
+	// EnvoyDeploymentName is the name of the Envoy Deployment.
+	EnvoyDeploymentName = "envoy"
 )
 
 // Server wraps the EnvoyGateway configuration and additional parameters

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -258,7 +258,10 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR *ir.Xds,
 			}
 
 			// Validate allowed namespaces
-			if listener.AllowedRoutes != nil && listener.AllowedRoutes.Namespaces != nil && listener.AllowedRoutes.Namespaces.From != nil && *listener.AllowedRoutes.Namespaces.From == v1beta1.NamespacesFromSelector {
+			if listener.AllowedRoutes != nil &&
+				listener.AllowedRoutes.Namespaces != nil &&
+				listener.AllowedRoutes.Namespaces.From != nil &&
+				*listener.AllowedRoutes.Namespaces.From == v1beta1.NamespacesFromSelector {
 				if listener.AllowedRoutes.Namespaces.Selector == nil {
 					listener.SetCondition(
 						v1beta1.ListenerConditionReady,

--- a/internal/infrastructure/kubernetes/deployment.go
+++ b/internal/infrastructure/kubernetes/deployment.go
@@ -15,14 +15,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
 	"github.com/envoyproxy/gateway/internal/ir"
 	xdsrunner "github.com/envoyproxy/gateway/internal/xds/server/runner"
 )
 
 const (
-	// envoyDeploymentName is the name of the Envoy Deployment resource.
-	envoyDeploymentName = "envoy"
 	// envoyContainerName is the name of the Envoy container.
 	envoyContainerName = "envoy"
 	// envoyNsEnvVar is the name of the Envoy Gateway namespace environment variable.
@@ -114,7 +113,7 @@ func (i *Infra) expectedDeployment(infra *ir.Infra) (*appsv1.Deployment, error) 
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: i.Namespace,
-			Name:      envoyDeploymentName,
+			Name:      config.EnvoyDeploymentName,
 			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -225,7 +224,7 @@ func (i *Infra) createOrUpdateDeployment(ctx context.Context, infra *ir.Infra) e
 	current := &appsv1.Deployment{}
 	key := types.NamespacedName{
 		Namespace: i.Namespace,
-		Name:      envoyDeploymentName,
+		Name:      config.EnvoyDeploymentName,
 	}
 
 	if err := i.Client.Get(ctx, key, current); err != nil {
@@ -258,7 +257,7 @@ func (i *Infra) deleteDeployment(ctx context.Context) error {
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: i.Namespace,
-			Name:      envoyDeploymentName,
+			Name:      config.EnvoyDeploymentName,
 		},
 	}
 

--- a/internal/provider/kubernetes/gateway.go
+++ b/internal/provider/kubernetes/gateway.go
@@ -195,7 +195,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 		// Get the status of the Gateway's associated Envoy Deployment.
 		deployment, err := r.envoyDeploymentForGateway(ctx)
 		if err != nil {
-			r.log.Info("failed to get deployment for gatteway",
+			r.log.Info("failed to get deployment for gateway",
 				"namespace", gw.Namespace, "name", gw.Name)
 		}
 
@@ -312,7 +312,7 @@ func (r *gatewayReconciler) removeFinalizer(ctx context.Context, gc *gwapiv1b1.G
 	return nil
 }
 
-// envoyDeploymentForGateway returns the Envoy service, returning nil if the service doesn't exist.
+// envoyDeploymentForGateway returns the Envoy Deployment, returning nil if the Deployment doesn't exist.
 func (r *gatewayReconciler) envoyDeploymentForGateway(ctx context.Context) (*appsv1.Deployment, error) {
 	key := types.NamespacedName{
 		Namespace: config.EnvoyGatewayNamespace,

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -60,7 +60,7 @@ func computeGatewayReadyCondition(gw *gwapiv1b1.Gateway, deployment *appsv1.Depl
 			"No addresses have been assigned to the Gateway", time.Now(), gw.Generation)
 	}
 
-	// If there are any unavailable replicas for the Envoy Deployment, donot
+	// If there are any unavailable replicas for the Envoy Deployment, don't
 	// mark the Gateway as ready yet.
 	if deployment.Status.UnavailableReplicas > 0 {
 		return newCondition(string(gwapiv1b1.GatewayConditionReady), metav1.ConditionFalse,

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -4,6 +4,7 @@
 package status
 
 import (
+	"fmt"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -68,9 +69,10 @@ func computeGatewayReadyCondition(gw *gwapiv1b1.Gateway, deployment *appsv1.Depl
 			"Deployment replicas unavailable", time.Now(), gw.Generation)
 	}
 
+	message := fmt.Sprintf("Address assigned to the Gateway, %d/%d envoy Deployment replicas available",
+		deployment.Status.AvailableReplicas, deployment.Status.Replicas)
 	return newCondition(string(gwapiv1b1.GatewayConditionReady), metav1.ConditionTrue,
-		string(gwapiv1b1.GatewayReasonReady),
-		"Address assigned to the Gateway", time.Now(), gw.Generation)
+		string(gwapiv1b1.GatewayReasonReady), message, time.Now(), gw.Generation)
 }
 
 // mergeConditions adds or updates matching conditions, and updates the transition

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -60,9 +60,9 @@ func computeGatewayReadyCondition(gw *gwapiv1b1.Gateway, deployment *appsv1.Depl
 			"No addresses have been assigned to the Gateway", time.Now(), gw.Generation)
 	}
 
-	// If there are any unavailable replicas for the Envoy Deployment, don't
+	// If there are no available replicas for the Envoy Deployment, don't
 	// mark the Gateway as ready yet.
-	if deployment.Status.UnavailableReplicas > 0 {
+	if deployment.Status.AvailableReplicas == 0 {
 		return newCondition(string(gwapiv1b1.GatewayConditionReady), metav1.ConditionFalse,
 			string(gwapiv1b1.GatewayReasonNoResources),
 			"Deployment replicas unavailable", time.Now(), gw.Generation)

--- a/internal/status/conditions_test.go
+++ b/internal/status/conditions_test.go
@@ -272,6 +272,7 @@ func TestGatewayReadyCondition(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			gtw := &gwapiv1b1.Gateway{}

--- a/internal/status/conditions_test.go
+++ b/internal/status/conditions_test.go
@@ -245,7 +245,7 @@ func TestGatewayReadyCondition(t *testing.T) {
 		{
 			name:             "ready gateway",
 			serviceAddress:   true,
-			deploymentStatus: appsv1.DeploymentStatus{UnavailableReplicas: 0},
+			deploymentStatus: appsv1.DeploymentStatus{AvailableReplicas: 1},
 			expect: metav1.Condition{
 				Status: metav1.ConditionTrue,
 				Reason: string(gwapiv1b1.GatewayReasonReady),
@@ -254,7 +254,7 @@ func TestGatewayReadyCondition(t *testing.T) {
 		{
 			name:             "not ready gateway without address",
 			serviceAddress:   false,
-			deploymentStatus: appsv1.DeploymentStatus{UnavailableReplicas: 0},
+			deploymentStatus: appsv1.DeploymentStatus{AvailableReplicas: 1},
 			expect: metav1.Condition{
 				Status: metav1.ConditionFalse,
 				Reason: string(gwapiv1b1.GatewayReasonAddressNotAssigned),
@@ -263,7 +263,7 @@ func TestGatewayReadyCondition(t *testing.T) {
 		{
 			name:             "not ready gateway with address unavailable pods",
 			serviceAddress:   true,
-			deploymentStatus: appsv1.DeploymentStatus{UnavailableReplicas: 1},
+			deploymentStatus: appsv1.DeploymentStatus{AvailableReplicas: 0},
 			expect: metav1.Condition{
 				Status: metav1.ConditionFalse,
 				Reason: string(gwapiv1b1.GatewayReasonNoResources),

--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -8,10 +9,13 @@ import (
 )
 
 // SetGatewayStatus adds or updates status for the provided Gateway.
-func SetGatewayStatus(gw *gwapiv1b1.Gateway, scheduled bool, svc *corev1.Service) *gwapiv1b1.Gateway {
+func SetGatewayStatus(gw *gwapiv1b1.Gateway, scheduled bool, svc *corev1.Service, deployment *appsv1.Deployment) *gwapiv1b1.Gateway {
 	computeGatewayStatusAddrs(gw, svc)
-	gw.Status.Conditions = mergeConditions(gw.Status.Conditions,
-		computeGatewayScheduledCondition(gw, scheduled), computeGatewayReadyCondition(gw))
+	gw.Status.Conditions = mergeConditions(
+		gw.Status.Conditions,
+		computeGatewayScheduledCondition(gw, scheduled),
+		computeGatewayReadyCondition(gw, deployment),
+	)
 	return gw
 }
 


### PR DESCRIPTION
This commit adds support for watching over envoy deployment updates, 
and capture the deployment status to eventually determine the gateway 
status condition. We mark the gateway as ready, if the envoy deployment
has no unavailable replicas.
Resolves #345 

Signed-off-by: Shubham Chauhan <shubham@tetrate.io>