### PR TITLE
send resource statuses using watchable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ bin/
 release-artifacts/
 
 # Outputs
-cover.out
+coverage.xml

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -149,6 +149,8 @@ func setupRunners(cfg *config.Server) error {
 	pResources.GatewayClasses.Close()
 	pResources.Gateways.Close()
 	pResources.HTTPRoutes.Close()
+	pResources.GatewayStatuses.Close()
+	pResources.HTTPRouteStatuses.Close()
 	xdsIR.Close()
 	infraIR.Close()
 	xds.Close()

--- a/internal/gatewayapi/contexts.go
+++ b/internal/gatewayapi/contexts.go
@@ -32,7 +32,13 @@ func (g *GatewayContext) SetCondition(conditionType v1beta1.GatewayConditionType
 
 	idx := -1
 	for i, existing := range g.Status.Conditions {
-		if existing.Type == string(conditionType) {
+		if existing.Type == cond.Type {
+			// return early if the condition is unchanged
+			if existing.Status == cond.Status &&
+				existing.Reason == cond.Reason &&
+				existing.Message == cond.Message {
+				return
+			}
 			idx = i
 			break
 		}
@@ -110,7 +116,13 @@ func (l *ListenerContext) SetCondition(conditionType v1beta1.ListenerConditionTy
 
 	idx := -1
 	for i, existing := range l.gateway.Status.Listeners[l.listenerStatusIdx].Conditions {
-		if existing.Type == string(conditionType) {
+		if existing.Type == cond.Type {
+			// return early if the condition is unchanged
+			if existing.Status == cond.Status &&
+				existing.Reason == cond.Reason &&
+				existing.Message == cond.Message {
+				return
+			}
 			idx = i
 			break
 		}
@@ -125,6 +137,11 @@ func (l *ListenerContext) SetCondition(conditionType v1beta1.ListenerConditionTy
 
 func (l *ListenerContext) SetSupportedKinds(kinds ...v1beta1.RouteGroupKind) {
 	l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds = kinds
+}
+
+func (l *ListenerContext) ResetAttachedRoutes() {
+	// Reset attached route count since it will be recomputed during translation.
+	l.gateway.Status.Listeners[l.listenerStatusIdx].AttachedRoutes = 0
 }
 
 func (l *ListenerContext) IncrementAttachedRoutes() {
@@ -259,7 +276,13 @@ func (r *RouteParentContext) SetCondition(conditionType v1beta1.RouteConditionTy
 
 	idx := -1
 	for i, existing := range r.route.Status.Parents[r.routeParentStatusIdx].Conditions {
-		if existing.Type == string(conditionType) {
+		if existing.Type == cond.Type {
+			// return early if the condition is unchanged
+			if existing.Status == cond.Status &&
+				existing.Reason == cond.Reason &&
+				existing.Message == cond.Message {
+				return
+			}
 			idx = i
 			break
 		}

--- a/internal/gatewayapi/contexts.go
+++ b/internal/gatewayapi/contexts.go
@@ -1,6 +1,8 @@
 package gatewayapi
 
 import (
+	"time"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -17,10 +19,12 @@ type GatewayContext struct {
 
 func (g *GatewayContext) SetCondition(conditionType v1beta1.GatewayConditionType, status metav1.ConditionStatus, reason v1beta1.GatewayConditionReason, message string) {
 	cond := metav1.Condition{
-		Type:    string(conditionType),
-		Status:  status,
-		Reason:  string(reason),
-		Message: message,
+		Type:               string(conditionType),
+		Status:             status,
+		Reason:             string(reason),
+		Message:            message,
+		ObservedGeneration: g.Generation,
+		LastTransitionTime: metav1.NewTime(time.Now()),
 	}
 
 	idx := -1
@@ -93,10 +97,12 @@ type ListenerContext struct {
 
 func (l *ListenerContext) SetCondition(conditionType v1beta1.ListenerConditionType, status metav1.ConditionStatus, reason v1beta1.ListenerConditionReason, message string) {
 	cond := metav1.Condition{
-		Type:    string(conditionType),
-		Status:  status,
-		Reason:  string(reason),
-		Message: message,
+		Type:               string(conditionType),
+		Status:             status,
+		Reason:             string(reason),
+		Message:            message,
+		ObservedGeneration: l.gateway.Generation,
+		LastTransitionTime: metav1.NewTime(time.Now()),
 	}
 
 	idx := -1
@@ -232,10 +238,12 @@ func (r *RouteParentContext) SetListeners(listeners ...*ListenerContext) {
 
 func (r *RouteParentContext) SetCondition(conditionType v1beta1.RouteConditionType, status metav1.ConditionStatus, reason v1beta1.RouteConditionReason, message string) {
 	cond := metav1.Condition{
-		Type:    string(conditionType),
-		Status:  status,
-		Reason:  string(reason),
-		Message: message,
+		Type:               string(conditionType),
+		Status:             status,
+		Reason:             string(reason),
+		Message:            message,
+		ObservedGeneration: r.route.Generation,
+		LastTransitionTime: metav1.NewTime(time.Now()),
 	}
 
 	idx := -1

--- a/internal/gatewayapi/contexts.go
+++ b/internal/gatewayapi/contexts.go
@@ -149,6 +149,9 @@ func (l *ListenerContext) AllowsNamespace(namespace *v1.Namespace) bool {
 	case v1beta1.NamespacesFromAll:
 		return true
 	case v1beta1.NamespacesFromSelector:
+		if l.namespaceSelector == nil {
+			return false
+		}
 		return l.namespaceSelector.Matches(labels.Set(namespace.Labels))
 	default:
 		// NamespacesFromSame is the default

--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -91,10 +91,11 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 			}
 			// Translate to IR
 			result := t.Translate(&in)
+
 			yamlXdsIR, _ := yaml.Marshal(&result.XdsIR)
-			r.Logger.Info(string(yamlXdsIR))
+			r.Logger.WithValues("output", "xds-ir").Info(string(yamlXdsIR))
 			yamlInfraIR, _ := yaml.Marshal(&result.InfraIR)
-			r.Logger.Info(string(yamlInfraIR))
+			r.Logger.WithValues("output", "infra-ir").Info(string(yamlInfraIR))
 
 			// Publish the IRs. Use the service name as the key
 			// to ensure there is always one element in the map.
@@ -124,7 +125,6 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 				key := utils.NamespacedName(httpRoute)
 				r.ProviderResources.HTTPRouteStatuses.Store(key, httpRoute)
 			}
-
 		}
 	}
 	r.Logger.Info("shutting down")

--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
 	"github.com/envoyproxy/gateway/internal/ir"
 	"github.com/envoyproxy/gateway/internal/message"
+	"github.com/envoyproxy/gateway/internal/provider/utils"
 )
 
 type Config struct {
@@ -112,6 +113,16 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 				} else {
 					r.XdsIR.Store(r.Name(), result.XdsIR)
 				}
+			}
+
+			// Update Status
+			for _, gateway := range result.Gateways {
+				key := utils.NamespacedName(gateway)
+				r.ProviderResources.GatewayStatuses.Store(key, gateway)
+			}
+			for _, httpRoute := range result.HTTPRoutes {
+				key := utils.NamespacedName(httpRoute)
+				r.ProviderResources.HTTPRouteStatuses.Store(key, httpRoute)
 			}
 
 		}

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
@@ -47,7 +47,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
@@ -47,7 +47,7 @@ httpRoutes:
     - parentRef:
         namespace: envoy-gateway
         name: gateway-1
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
@@ -53,7 +53,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
@@ -51,7 +51,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
@@ -51,7 +51,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
@@ -51,7 +51,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
@@ -49,7 +49,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
@@ -55,7 +55,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
@@ -56,7 +56,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
@@ -55,7 +55,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
@@ -47,7 +47,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -52,7 +52,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
@@ -48,7 +48,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
@@ -51,7 +51,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
@@ -71,7 +71,7 @@ httpRoutes:
     - parentRef:
         namespace: envoy-gateway
         name: gateway-1
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "False"

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
@@ -71,7 +71,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "False"

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -65,7 +65,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
@@ -47,7 +47,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -67,7 +67,7 @@ httpRoutes:
             namespace: envoy-gateway
             name: gateway-1
             sectionName: http-2
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
@@ -49,7 +49,7 @@ httpRoutes:
             namespace: envoy-gateway
             name: gateway-1
             sectionName: http
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
@@ -51,7 +51,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -54,7 +54,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -49,7 +49,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -67,7 +67,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -77,7 +77,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -63,7 +63,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -58,7 +58,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
@@ -61,7 +61,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
@@ -63,7 +63,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
@@ -63,7 +63,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
@@ -58,7 +58,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
@@ -59,7 +59,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -49,7 +49,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -50,7 +50,7 @@ httpRoutes:
     - parentRef:
         namespace: envoy-gateway
         name: gateway-1
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "False"

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -60,7 +60,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -58,7 +58,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -57,7 +57,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -57,7 +57,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -57,7 +57,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -61,7 +61,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
@@ -48,7 +48,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
@@ -52,7 +52,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -50,7 +50,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -51,7 +51,7 @@ httpRoutes:
         - parentRef:
             namespace: envoy-gateway
             name: gateway-1
-          # controllerName: envoyproxy.io/gateway-controller
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
           conditions:
             - type: Accepted
               status: "True"

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -135,7 +135,9 @@ func (t *Translator) GetRelevantGateways(gateways []*v1beta1.Gateway) []*Gateway
 			}
 
 			for _, listener := range gateway.Spec.Listeners {
-				gc.GetListenerContext(listener.Name)
+				l := gc.GetListenerContext(listener.Name)
+				// Reset attached route count since it will be recomputed during translation.
+				l.ResetAttachedRoutes()
 			}
 
 			relevant = append(relevant, gc)

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -415,28 +415,26 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR *ir.Xds,
 			lConditions := listener.GetConditions()
 			if len(lConditions) == 0 {
 				listener.SetCondition(v1beta1.ListenerConditionReady, metav1.ConditionTrue, v1beta1.ListenerReasonReady, "Listener is ready")
-			} else {
 				// Any condition on the listener apart from Ready=true indicates an error.
-				if !(lConditions[0].Type == string(v1beta1.ListenerConditionReady) && lConditions[0].Status == metav1.ConditionTrue) {
-					// set "Ready: false" if it's not set already.
-					var hasReadyCond bool
-					for _, existing := range lConditions {
-						if existing.Type == string(v1beta1.ListenerConditionReady) {
-							hasReadyCond = true
-							break
-						}
+			} else if !(lConditions[0].Type == string(v1beta1.ListenerConditionReady) && lConditions[0].Status == metav1.ConditionTrue) {
+				// set "Ready: false" if it's not set already.
+				var hasReadyCond bool
+				for _, existing := range lConditions {
+					if existing.Type == string(v1beta1.ListenerConditionReady) {
+						hasReadyCond = true
+						break
 					}
-					if !hasReadyCond {
-						listener.SetCondition(
-							v1beta1.ListenerConditionReady,
-							metav1.ConditionFalse,
-							v1beta1.ListenerReasonInvalid,
-							"Listener is invalid, see other Conditions for details.",
-						)
-					}
-					// skip computing IR
-					continue
 				}
+				if !hasReadyCond {
+					listener.SetCondition(
+						v1beta1.ListenerConditionReady,
+						metav1.ConditionFalse,
+						v1beta1.ListenerReasonInvalid,
+						"Listener is invalid, see other Conditions for details.",
+					)
+				}
+				// skip computing IR
+				continue
 			}
 
 			servicePort := int32(listener.Port)

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -429,11 +429,9 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR *ir.Xds,
 						v1beta1.ListenerReasonInvalid,
 						"Listener is invalid, see other Conditions for details.",
 					)
+					continue
 				}
-
-				continue
 			}
-
 			listener.SetCondition(v1beta1.ListenerConditionReady, metav1.ConditionTrue, v1beta1.ListenerReasonReady, "Listener is ready")
 
 			servicePort := int32(listener.Port)
@@ -1024,8 +1022,9 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 				}
 
 				irListener := xdsIR.GetListener(irListenerName(listener))
-				irListener.Routes = append(irListener.Routes, perHostRoutes...)
-
+				if irListener != nil {
+					irListener.Routes = append(irListener.Routes, perHostRoutes...)
+				}
 				// Theoretically there should only be one parent ref per
 				// Route that attaches to a given Listener, so fine to just increment here, but we
 				// might want to check to ensure we're not double-counting.

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -76,8 +78,8 @@ func TestTranslate(t *testing.T) {
 			got := translator.Translate(resources)
 
 			sort.Slice(got.XdsIR.HTTP, func(i, j int) bool { return got.XdsIR.HTTP[i].Name < got.XdsIR.HTTP[j].Name })
-
-			assert.EqualValues(t, want, got)
+			opts := cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")
+			assert.Equal(t, true, cmp.Equal(want, got, opts))
 		})
 	}
 }

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -79,7 +79,7 @@ func TestTranslate(t *testing.T) {
 
 			sort.Slice(got.XdsIR.HTTP, func(i, j int) bool { return got.XdsIR.HTTP[i].Name < got.XdsIR.HTTP[j].Name })
 			opts := cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")
-			assert.Equal(t, true, cmp.Equal(want, got, opts))
+			require.Empty(t, cmp.Diff(want, got, opts))
 		})
 	}
 }

--- a/internal/message/types.go
+++ b/internal/message/types.go
@@ -20,6 +20,9 @@ type ProviderResources struct {
 	Namespaces     watchable.Map[string, *corev1.Namespace]
 	Services       watchable.Map[types.NamespacedName, *corev1.Service]
 
+	GatewayStatuses   watchable.Map[types.NamespacedName, *gwapiv1b1.Gateway]
+	HTTPRouteStatuses watchable.Map[types.NamespacedName, *gwapiv1b1.HTTPRoute]
+
 	GatewayClassesInitialized sync.WaitGroup
 	GatewaysInitialized       sync.WaitGroup
 	HTTPRoutesInitialized     sync.WaitGroup

--- a/internal/provider/kubernetes/gateway.go
+++ b/internal/provider/kubernetes/gateway.go
@@ -348,7 +348,7 @@ func (r *gatewayReconciler) subscribeAndUpdateStatus(ctx context.Context) {
 					if _, ok := obj.(*gwapiv1b1.Gateway); !ok {
 						panic(fmt.Sprintf("unsupported object type %T", obj))
 					}
-					return val
+					return val.DeepCopy()
 				}),
 			})
 		}

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -91,6 +91,9 @@ func (r *gatewayClassReconciler) hasMatchingController(obj client.Object) bool {
 func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	r.log.WithName(request.Name).Info("reconciling gatewayclass")
 
+	// Once we've iterated over all listed classes, mark that we've fully initialized.
+	defer r.initializeOnce.Do(r.resources.GatewayClassesInitialized.Done)
+
 	var gatewayClasses gwapiv1b1.GatewayClassList
 	if err := r.client.List(ctx, &gatewayClasses); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error listing gatewayclasses: %v", err)
@@ -163,8 +166,6 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 			return reconcile.Result{}, err
 		}
 	}
-	// Once we've iterated over all listed classes, mark that we've fully initialized.
-	r.initializeOnce.Do(r.resources.GatewayClassesInitialized.Done)
 
 	r.log.WithName(request.Name).Info("reconciled gatewayclass")
 	return reconcile.Result{}, nil

--- a/internal/provider/kubernetes/httproute.go
+++ b/internal/provider/kubernetes/httproute.go
@@ -130,6 +130,8 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.R
 
 	log.Info("reconciling httproute")
 
+	defer r.initializeOnce.Do(r.resources.HTTPRoutesInitialized.Done)
+
 	// Fetch all HTTPRoutes from the cache.
 	routeList := &gwapiv1b1.HTTPRouteList{}
 	if err := r.client.List(ctx, routeList); err != nil {
@@ -221,7 +223,6 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.R
 
 	log.Info("reconciled httproute")
 
-	r.initializeOnce.Do(r.resources.HTTPRoutesInitialized.Done)
 	return reconcile.Result{}, nil
 }
 

--- a/internal/provider/kubernetes/httproute.go
+++ b/internal/provider/kubernetes/httproute.go
@@ -269,7 +269,7 @@ func (r *httpRouteReconciler) subscribeAndUpdateStatus(ctx context.Context) {
 					if _, ok := obj.(*gwapiv1b1.HTTPRoute); !ok {
 						panic(fmt.Sprintf("unsupported object type %T", obj))
 					}
-					return value
+					return value.DeepCopy()
 				}),
 			})
 		}

--- a/internal/provider/kubernetes/httproute.go
+++ b/internal/provider/kubernetes/httproute.go
@@ -24,6 +24,8 @@ import (
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
 	"github.com/envoyproxy/gateway/internal/message"
+	"github.com/envoyproxy/gateway/internal/provider/utils"
+	"github.com/envoyproxy/gateway/internal/status"
 )
 
 const (
@@ -31,8 +33,9 @@ const (
 )
 
 type httpRouteReconciler struct {
-	client client.Client
-	log    logr.Logger
+	client        client.Client
+	log           logr.Logger
+	statusUpdater status.Updater
 
 	initializeOnce sync.Once
 	resources      *message.ProviderResources
@@ -40,12 +43,13 @@ type httpRouteReconciler struct {
 
 // newHTTPRouteController creates the httproute controller from mgr. The controller will be pre-configured
 // to watch for HTTPRoute objects across all namespaces.
-func newHTTPRouteController(mgr manager.Manager, cfg *config.Server, resources *message.ProviderResources) error {
+func newHTTPRouteController(mgr manager.Manager, cfg *config.Server, su status.Updater, resources *message.ProviderResources) error {
 	resources.HTTPRoutesInitialized.Add(1)
 	r := &httpRouteReconciler{
-		client:    mgr.GetClient(),
-		log:       cfg.Logger,
-		resources: resources,
+		client:        mgr.GetClient(),
+		log:           cfg.Logger,
+		statusUpdater: su,
+		resources:     resources,
 	}
 
 	c, err := controller.New("httproute", mgr, controller.Options{Reconciler: r})
@@ -57,6 +61,10 @@ func newHTTPRouteController(mgr manager.Manager, cfg *config.Server, resources *
 	if err := c.Watch(&source.Kind{Type: &gwapiv1b1.HTTPRoute{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return err
 	}
+
+	// Subscribe to status updates
+	go r.subscribeAndUpdateStatus(context.Background())
+
 	// Add indexing on HTTPRoute, for Service objects that are referenced in HTTPRoute objects
 	// via `.spec.rules.backendRefs`. This helps in querying for HTTPRoutes that are affected by
 	// a particular Service CRUD.
@@ -101,15 +109,16 @@ func (r *httpRouteReconciler) getHTTPRoutesForService(obj client.Object) []recon
 	affectedHTTPRouteList := &gwapiv1b1.HTTPRouteList{}
 
 	if err := r.client.List(context.Background(), affectedHTTPRouteList, &client.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector(serviceHTTPRouteIndex, NamespacedName(obj).String()),
+		FieldSelector: fields.OneTermEqualSelector(serviceHTTPRouteIndex, utils.NamespacedName(obj).String()),
 	}); err != nil {
 		return []reconcile.Request{}
 	}
 
 	requests := make([]reconcile.Request, len(affectedHTTPRouteList.Items))
 	for i, item := range affectedHTTPRouteList.Items {
+		item := item
 		requests[i] = reconcile.Request{
-			NamespacedName: NamespacedName(item.DeepCopy()),
+			NamespacedName: utils.NamespacedName(&item),
 		}
 	}
 
@@ -131,7 +140,7 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.R
 	for i := range routeList.Items {
 		// See if this route from the list matched the reconciled route.
 		route := routeList.Items[i]
-		routeKey := NamespacedName(&route)
+		routeKey := utils.NamespacedName(&route)
 		if routeKey == request.NamespacedName {
 			found = true
 		}
@@ -236,4 +245,30 @@ func validateBackendRef(ref *gwapiv1b1.HTTPBackendRef) error {
 	}
 
 	return nil
+}
+
+// subscribeAndUpdateStatus subscribes to httproute status updates and writes it into the
+// Kubernetes API Server
+func (r *httpRouteReconciler) subscribeAndUpdateStatus(ctx context.Context) {
+	// Subscribe to resources
+	for snapshot := range r.resources.HTTPRouteStatuses.Subscribe(ctx) {
+		r.log.Info("received a status notification")
+		statuses := snapshot.State
+		for key, o := range statuses {
+			o := o
+			r.statusUpdater.Send(status.Update{
+				NamespacedName: key,
+				Resource:       new(gwapiv1b1.HTTPRoute),
+				Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+					if _, ok := obj.(*gwapiv1b1.HTTPRoute); !ok {
+						panic(fmt.Sprintf("unsupported object type %T", obj))
+					}
+					return o
+				}),
+			})
+			// Delete to prevent multiple rewrites
+			r.resources.HTTPRouteStatuses.Delete(key)
+		}
+	}
+	r.log.Info("status subscriber shutting down")
 }

--- a/internal/provider/kubernetes/kubernetes.go
+++ b/internal/provider/kubernetes/kubernetes.go
@@ -50,7 +50,7 @@ func New(cfg *rest.Config, svr *config.Server, resources *message.ProviderResour
 	if err := newGatewayController(mgr, svr, updateHandler.Writer(), resources); err != nil {
 		return nil, fmt.Errorf("failed to create gateway controller: %w", err)
 	}
-	if err := newHTTPRouteController(mgr, svr, resources); err != nil {
+	if err := newHTTPRouteController(mgr, svr, updateHandler.Writer(), resources); err != nil {
 		return nil, fmt.Errorf("failed to create httproute controller: %w", err)
 	}
 

--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
 	"github.com/envoyproxy/gateway/internal/message"
+	"github.com/envoyproxy/gateway/internal/provider/utils"
 )
 
 const (
@@ -569,7 +570,7 @@ func testHTTPRoute(ctx context.Context, t *testing.T, provider *Provider, resour
 			}, defaultWait, defaultTick)
 
 			// Ensure the Service is in the resource map.
-			svcKey := NamespacedName(svc)
+			svcKey := utils.NamespacedName(svc)
 			require.Eventually(t, func() bool {
 				_, ok := resources.Services.Load(svcKey)
 				return ok

--- a/internal/provider/utils/utils.go
+++ b/internal/provider/utils/utils.go
@@ -1,4 +1,4 @@
-package kubernetes
+package utils
 
 import (
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -63,7 +63,8 @@ func computeGatewayReadyCondition(gw *gwapiv1b1.Gateway, deployment *appsv1.Depl
 
 	// If there are no available replicas for the Envoy Deployment, don't
 	// mark the Gateway as ready yet.
-	if deployment.Status.AvailableReplicas == 0 {
+
+	if deployment == nil || deployment.Status.AvailableReplicas == 0 {
 		return newCondition(string(gwapiv1b1.GatewayConditionReady), metav1.ConditionFalse,
 			string(gwapiv1b1.GatewayReasonNoResources),
 			"Deployment replicas unavailable", time.Now(), gw.Generation)

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -142,6 +142,7 @@ func (u *UpdateWriter) Send(update Update) {
 // Supported objects:
 //  GatewayClasses
 //  Gateway
+//  HTTPRoute
 func isStatusEqual(objA, objB interface{}) bool {
 	opts := cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")
 	switch a := objA.(type) {
@@ -153,6 +154,12 @@ func isStatusEqual(objA, objB interface{}) bool {
 		}
 	case *gwapiv1b1.Gateway:
 		if b, ok := objB.(*gwapiv1b1.Gateway); ok {
+			if cmp.Equal(a.Status, b.Status, opts) {
+				return true
+			}
+		}
+	case *gwapiv1b1.HTTPRoute:
+		if b, ok := objB.(*gwapiv1b1.HTTPRoute); ok {
 			if cmp.Equal(a.Status, b.Status, opts) {
 				return true
 			}

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -69,5 +69,5 @@ delete-cluster: $(tools/kind) ## Delete kind cluster.
 	$(tools/kind) delete cluster --name envoy-gateway
 
 .PHONY: release-manifests
-release-manifests: $(tools/kustomize)
+release-manifests: $(tools/kustomize) ## Generate Kubernetes release manifests.
 	tools/hack/release-manifests.sh $(GATEWAY_API_VERSION) $(TAG)


### PR DESCRIPTION
* Allow multiple runners (such as gatewayapi) to update the status of resources such as gateway and httproute by publishing the updated status of the resource on a watchable map.
* The provider runner subscribes to these status updates and updates the resource status in the API Server

Signed-off-by: Arko Dasgupta <arko@tetrate.io>