### PR TITLE
Address comments from PR#363

### DIFF
--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.in.yaml
@@ -1,0 +1,42 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          add:
+          set:
+          remove:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -49,14 +49,9 @@ httpRoutes:
       filters:
       - type: RequestHeaderModifier
         requestHeaderModifier:
-          set: 
-          - name: "example:1"
-            value: "some-value"
-          - name: "good-header"
-            value: "some-value"
           add:
-          - name: "example/2"
-            value: "some-value"
+          set:
+          remove:
   status:
     parents:
     - parentRef:
@@ -69,10 +64,6 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
-      - type: ResolvedRefs
-        status: "False"
-        reason: UnsupportedValue
-        message: "RequestHeaderModifier Filter cannot set headers with a '/' or ':' character in them. Header: 'example:1'"
 xdsIR:
   http:
   - name: envoy-gateway-gateway-1-http
@@ -91,10 +82,6 @@ xdsIR:
       - host: 7.7.7.7
         port: 8080
         weight: 1
-      addRequestHeaders:
-      - name: "good-header"
-        value: "some-value"
-        append: false
 infraIR:
   proxy:
     metadata:

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -688,12 +688,13 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 									// try to process the rest of the headers and produce a valid config.
 									continue
 								}
+								// Per Gateway API specification on HTTPHeaderName, : and / are invalid characters in header names
 								if strings.Contains(string(addHeader.Name), "/") || strings.Contains(string(addHeader.Name), ":") {
 									parentRef.SetCondition(
 										v1beta1.RouteConditionResolvedRefs,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
-										fmt.Sprintf("RequestHeaderModifier Filter cannot set a headers with a '/' or ':' character in them. Header: %q", string(addHeader.Name)),
+										fmt.Sprintf("RequestHeaderModifier Filter cannot set headers with a '/' or ':' character in them. Header: %q", string(addHeader.Name)),
 									)
 									continue
 								}
@@ -743,12 +744,13 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 									)
 									continue
 								}
+								// Per Gateway API specification on HTTPHeaderName, : and / are invalid characters in header names
 								if strings.Contains(string(setHeader.Name), "/") || strings.Contains(string(setHeader.Name), ":") {
 									parentRef.SetCondition(
 										v1beta1.RouteConditionResolvedRefs,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
-										fmt.Sprintf("RequestHeaderModifier Filter cannot set a headers with a '/' or ':' character in them. Header: '%s'", string(setHeader.Name)),
+										fmt.Sprintf("RequestHeaderModifier Filter cannot set headers with a '/' or ':' character in them. Header: '%s'", string(setHeader.Name)),
 									)
 									continue
 								}

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -4,7 +4,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-	wrappers "github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/envoyproxy/gateway/internal/ir"
 )
@@ -192,7 +192,7 @@ func buildXdsAddedRequestHeaders(headersToAdd []ir.AddHeader) []*core.HeaderValu
 				Key:   header.Name,
 				Value: header.Value,
 			},
-			Append: &wrappers.BoolValue{Value: header.Append},
+			Append: &wrapperspb.BoolValue{Value: header.Append},
 		}
 
 		// Allow empty headers to be set, but don't add the config to do so unless necessary


### PR DESCRIPTION
There were a few outstanding comments from https://github.com/envoyproxy/gateway/pull/363 that were not addressed when it was merged. This PR adds the requested changes and resolves issue https://github.com/envoyproxy/gateway/issues/391.

Changes:
- Fixed a typo in one of the request header modifier filter error statuses.
- Reduced un-necessary indentation
- Added comments with reason behind one of the error cases (Gateway API specification)
- Replaced a deprecated dependency