### PR TITLE
Pull Envoy and Gateway API versions out of code.

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,22 +2,52 @@ name: Docs
 on:
   push:
     branches:
-    - "main"
-    - "release-v*"
+      - "main"
+      - "release-v*"
     paths-ignore:
-    - "**/*.png"
-  pull_request:
-    branches:
-    - "main"
-    - "release-v*"
-    paths-ignore:
-    - "**/*.png"
+      - "**/*.png"
+  # pull_request:
+  #   branches:
+  #     - "main"
+  #     - "release-v*"
+  #   paths-ignore:
+  #     - "**/*.png"
 jobs:
-  docs:
+  docs-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: ./tools/github-actions/setup-deps
+      - uses: actions/checkout@v3
+      - uses: ./tools/github-actions/setup-deps
 
-    # docs
-    - run: make docs
+      # docs
+      - run: make docs
+
+      # Upload docs for GitHub Pages    
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v1.0.4
+        with:
+          # Path of the directory containing the static assets.
+          path: docs/html
+          # Duration after which artifact will expire in days.
+          # retention-days: # optional, default is 1
+
+  # This workflow contains a single job called "build"
+  docs-publish:
+    runs-on: ubuntu-latest
+    needs: docs-build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      deployments: write
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1.2.1

--- a/DOCS.md
+++ b/DOCS.md
@@ -1,0 +1,43 @@
+# Working on the Envoy Gateway Docs
+
+The documentation for the Envoy Gateway lives in the `docs/` directory. It's
+written using [reStructuredText], so you'll need a working familiarity with
+that!
+
+## Documentation Structure
+
+The root of the site is in `docs/index.rst`. This is probably where to start
+if you're trying to understand how things fit together. 
+
+It's important to note that a given document _must_ have a reference in some
+`.. toctree::` section for the document to be reachable. Not everything needs
+to be in `docs/index.rst`'s `toctree` though.
+
+## Documentation Workflow
+
+To work with the docs, just edit reStructuredText files in `docs`, then run
+
+```bash
+make docs
+```
+
+This will create `docs/html` with the built HTML pages. You can view the docs
+either simply by pointing a web browser at the `file://` path to your
+`docs/html`, or by firing up a static webserver from that directory, e.g.
+
+```
+cd docs/html ; python3 -m http.server
+```
+
+### What About Markdown Files?
+
+There are currently still some pre-RST Markdown files in the `docs/` directory.
+Those should be turned into RST files and brought into the brave new world.
+
+## Publishing Docs
+
+Whenever docs are pushed to `main`, CI will publish the built docs to GitHub
+Pages. For more details, see `.github/workflows/docs.yaml`.
+
+[reStructuredText]: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,3 +32,15 @@ project = f'Envoy Gateway {version}'
 author = 'Envoy Gateway Project Authors'
 
 copyright = '2022 Envoy Gateway Project Authors | ' + fullversion
+
+envoyVersion = os.environ["ENVOY_VERSION"]
+gatewayAPIVersion = os.environ["GATEWAYAPI_VERSION"]
+
+variables_to_export = [
+    "envoyVersion",
+    "gatewayAPIVersion",
+]
+
+frozen_locals = dict(locals())
+rst_epilog = '\n'.join(map(lambda x: f".. |{x}| replace:: {frozen_locals[x]}", variables_to_export))
+del frozen_locals

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Envoy Gateway: envoyproxy + Gateway API
 =======================================
 
-Release |version|
+Release |version| (Envoy |envoyVersion|, Gateway API |gatewayAPIVersion|)
 
 .. image:: https://img.shields.io/badge/slack-join-orange.svg
     :target: https://envoyproxy.io/slack
@@ -19,5 +19,6 @@ standalone or Kubernetes-based application gateway.
   :maxdepth: 2
 
   intro/index
+  intro/compatibility
   about_docs
   get_involved

--- a/docs/intro/compatibility.rst
+++ b/docs/intro/compatibility.rst
@@ -1,0 +1,19 @@
+Compatibility Matrix
+====================
+
+Envoy Gateway relies on the Envoy Proxy and the Gateway API, and runs
+within a Kubernetes cluster. Not all versions of each of these products
+can function together for Envoy Gateway. Supported version combinations
+are listed below; **bold** type indicates the versions of the Envoy Proxy
+and the Gateway API actually compiled into each Envoy Gateway release.
+
++--------------------------+---------------------+---------------------+----------------------------+
+| Envoy Gateway version    | Envoy Proxy version | Gateway API version | Kubernetes minimum version |
++--------------------------+---------------------+---------------------+----------------------------+
+| v0.2.0                   | **v1.23.0**         | **v0.5.0**          | v1.24                      |
++--------------------------+---------------------+---------------------+----------------------------+
+
+.. note::
+
+   This project is under active development. Many, many features are not
+   complete. We would love for you to :doc:`get involved<../get_involved>`.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -29,6 +29,7 @@ func GetRootCommand() *cobra.Command {
 	cmd.AddCommand(getServerCommand())
 	cmd.AddCommand(getxDSTestCommand())
 	cmd.AddCommand(getCertGenCommand())
+	cmd.AddCommand(getVersionsCommand())
 
 	return cmd
 }

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -9,19 +9,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	// envOutput determines whether to output as environment settings
-	envOutput bool
-)
-
 // getVersionsCommand returns the server cobra command to be executed.
 func getVersionsCommand() *cobra.Command {
+	// envOutput determines whether to output as environment settings
+	var envOutput bool
+
 	cmd := &cobra.Command{
 		Use:     "versions",
 		Aliases: []string{"version"},
 		Short:   "Show versions",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return versions()
+			return versions(envOutput)
 		},
 	}
 
@@ -32,7 +30,7 @@ func getVersionsCommand() *cobra.Command {
 }
 
 // versions shows the versions of the Envoy Gateway.
-func versions() error {
+func versions(envOutput bool) error {
 	envoyVersion := strings.Split(ir.DefaultProxyImage, ":")[1]
 
 	if envOutput {

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+
+	"github.com/envoyproxy/gateway/internal/ir"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// envOutput determines whether to output as environment settings
+	envOutput bool
+)
+
+// getVersionsCommand returns the server cobra command to be executed.
+func getVersionsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "versions",
+		Aliases: []string{"version"},
+		Short:   "Show versions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return versions()
+		},
+	}
+
+	cmd.PersistentFlags().BoolVarP(&envOutput, "env", "e", false,
+		"If set, output as environment variable settings.")
+
+	return cmd
+}
+
+// versions shows the versions of the Envoy Gateway.
+func versions() error {
+	envoyVersion := strings.Split(ir.DefaultProxyImage, ":")[1]
+
+	if envOutput {
+		fmt.Printf("ENVOY_VERSION=\"%s\"\n", envoyVersion)
+	} else {
+		fmt.Printf("Envoy:       %s\n", envoyVersion)
+	}
+
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return fmt.Errorf("could not read build info")
+	}
+
+	foundGatewayAPI := false
+
+	for _, dep := range bi.Deps {
+		if dep.Path == "sigs.k8s.io/gateway-api" {
+			if envOutput {
+				fmt.Printf("GATEWAYAPI_VERSION=\"%s\"\n", dep.Version)
+			} else {
+				fmt.Printf("Gateway API: %s\n", dep.Version)
+			}
+
+			foundGatewayAPI = true
+			break
+		}
+	}
+
+	if !foundGatewayAPI {
+		return fmt.Errorf("could not find Gateway API version")
+	}
+
+	return nil
+}

--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -3,7 +3,7 @@ DOCS_OUTPUT_DIR := docs/html
 
 .PHONY: docs
 docs: $(tools/sphinx-build) $(tools/goversion)
-	BUILD_VERSION=$(shell $(tools/goversion)) $(tools/sphinx-build) -j auto -b html $(DOCS_DIR) $(DOCS_OUTPUT_DIR)
+	env BUILD_VERSION=$(shell $(tools/goversion)) $(shell go run ./cmd/envoy-gateway versions --env) $(tools/sphinx-build) -j auto -b html $(DOCS_DIR) $(DOCS_OUTPUT_DIR)
 
 .PHONY: docs.clean
 docs.clean: ## Clean the built docs


### PR DESCRIPTION
Include them dynamically in the docs index, and manually in a barebones compatibility matrix.

Reviewers: It is very much worth discussing whether the approach here of pulling versions out
of the code is the Right Way to Do Things™.

Signed-off-by: Flynn emissary@flynn.kodachi.com
