### PR TITLE
Adds HTTPRoute ParentRef Validation

### DIFF
--- a/internal/provider/kubernetes/httproute.go
+++ b/internal/provider/kubernetes/httproute.go
@@ -33,9 +33,10 @@ const (
 )
 
 type httpRouteReconciler struct {
-	client        client.Client
-	log           logr.Logger
-	statusUpdater status.Updater
+	client          client.Client
+	log             logr.Logger
+	statusUpdater   status.Updater
+	classController gwapiv1b1.GatewayController
 
 	initializeOnce sync.Once
 	resources      *message.ProviderResources
@@ -46,10 +47,11 @@ type httpRouteReconciler struct {
 func newHTTPRouteController(mgr manager.Manager, cfg *config.Server, su status.Updater, resources *message.ProviderResources) error {
 	resources.HTTPRoutesInitialized.Add(1)
 	r := &httpRouteReconciler{
-		client:        mgr.GetClient(),
-		log:           cfg.Logger,
-		statusUpdater: su,
-		resources:     resources,
+		client:          mgr.GetClient(),
+		log:             cfg.Logger,
+		classController: gwapiv1b1.GatewayController(cfg.EnvoyGateway.Gateway.ControllerName),
+		statusUpdater:   su,
+		resources:       resources,
 	}
 
 	c, err := controller.New("httproute", mgr, controller.Options{Reconciler: r})
@@ -145,6 +147,24 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.R
 		routeKey := utils.NamespacedName(&route)
 		if routeKey == request.NamespacedName {
 			found = true
+		}
+
+		// Validate the route.
+		gws, err := r.validateParentRefs(ctx, &route)
+		if err != nil {
+			// Remove the route from the watchable map since it's invalid.
+			r.resources.HTTPRoutes.Delete(routeKey)
+			r.log.Error(err, "invalid parentRefs for httproute")
+			return reconcile.Result{}, nil
+		}
+		log.Info("validated httproute parentRefs")
+
+		if len(gws) == 0 {
+			// Remove the route from the watchable map since it doesn't reference
+			// a managed Gateway.
+			log.Info("httproute doesn't reference any managed gateways")
+			r.resources.HTTPRoutes.Delete(routeKey)
+			return reconcile.Result{}, nil
 		}
 
 		// Store the httproute in the resource map.
@@ -275,4 +295,47 @@ func (r *httpRouteReconciler) subscribeAndUpdateStatus(ctx context.Context) {
 		}
 	}
 	r.log.Info("status subscriber shutting down")
+}
+
+// validateParentRefs validates parentRefs for the provided route, returning the referenced Gateways
+// managed by Envoy Gateway. The only supported parentRef is a Gateway.
+func (r *httpRouteReconciler) validateParentRefs(ctx context.Context, route *gwapiv1b1.HTTPRoute) ([]gwapiv1b1.Gateway, error) {
+	if route == nil {
+		return nil, fmt.Errorf("httproute is nil")
+	}
+
+	var ret []gwapiv1b1.Gateway
+	for i := range route.Spec.ParentRefs {
+		ref := route.Spec.ParentRefs[i]
+		if ref.Kind != nil && *ref.Kind != "Gateway" {
+			return nil, fmt.Errorf("invalid Kind %q", *ref.Kind)
+		}
+		if ref.Group != nil && *ref.Group != gwapiv1b1.GroupName {
+			return nil, fmt.Errorf("invalid Group %q", *ref.Group)
+		}
+		// Ensure the referenced Gateway exists, using the route's namespace unless
+		// specified by the parentRef.
+		ns := route.Namespace
+		if ref.Namespace != nil {
+			ns = string(*ref.Namespace)
+		}
+		gwKey := types.NamespacedName{
+			Namespace: ns,
+			Name:      string(ref.Name),
+		}
+		gw := new(gwapiv1b1.Gateway)
+		if err := r.client.Get(ctx, gwKey, gw); err != nil {
+			return nil, fmt.Errorf("failed to get gateway %s/%s: %v", gwKey.Namespace, gwKey.Name, err)
+		}
+		gcKey := types.NamespacedName{Name: string(gw.Spec.GatewayClassName)}
+		gc := new(gwapiv1b1.GatewayClass)
+		if err := r.client.Get(ctx, gcKey, gc); err != nil {
+			return nil, fmt.Errorf("failed to get gatewayclass %s: %v", gcKey.Name, err)
+		}
+		if gc.Spec.ControllerName == r.classController {
+			ret = append(ret, *gw)
+		}
+	}
+
+	return ret, nil
 }

--- a/internal/provider/kubernetes/httproute_test.go
+++ b/internal/provider/kubernetes/httproute_test.go
@@ -1,0 +1,367 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/envoyproxy/gateway/api/config/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/envoygateway"
+	"github.com/envoyproxy/gateway/internal/gatewayapi"
+)
+
+func TestValidateParentRefs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		route    *gwapiv1b1.HTTPRoute
+		gateways []*gwapiv1b1.Gateway
+		classes  []*gwapiv1b1.GatewayClass
+		expect   []gwapiv1b1.Gateway
+		expected bool
+	}{
+		{
+			name: "valid parentRef",
+			route: &gwapiv1b1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+				Spec: gwapiv1b1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1b1.CommonRouteSpec{
+						ParentRefs: []gwapiv1b1.ParentReference{
+							{
+								Group: gatewayapi.GroupPtr(gwapiv1b1.GroupName),
+								Kind:  gatewayapi.KindPtr("Gateway"),
+								Name:  "test",
+							},
+						},
+					},
+				},
+			},
+			gateways: []*gwapiv1b1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+					},
+					Spec: gwapiv1b1.GatewaySpec{
+						GatewayClassName: "gc1",
+					},
+				},
+			},
+			classes: []*gwapiv1b1.GatewayClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gc1",
+					},
+					Spec: gwapiv1b1.GatewayClassSpec{
+						ControllerName: gwapiv1b1.GatewayController(v1alpha1.GatewayControllerName),
+					},
+				},
+			},
+			expect: []gwapiv1b1.Gateway{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Gateway",
+						APIVersion: gwapiv1b1.GroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       "test",
+						Name:            "test",
+						ResourceVersion: "999",
+					},
+					Spec: gwapiv1b1.GatewaySpec{
+						GatewayClassName: "gc1",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "invalid parentRef group",
+			route: &gwapiv1b1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+				Spec: gwapiv1b1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1b1.CommonRouteSpec{
+						ParentRefs: []gwapiv1b1.ParentReference{
+							{
+								Group: gatewayapi.GroupPtr("unsupported.group"),
+								Kind:  gatewayapi.KindPtr("Gateway"),
+								Name:  "test",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "invalid parentRef kind",
+			route: &gwapiv1b1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+				Spec: gwapiv1b1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1b1.CommonRouteSpec{
+						ParentRefs: []gwapiv1b1.ParentReference{
+							{
+								Group: gatewayapi.GroupPtr(gwapiv1b1.GroupName),
+								Kind:  gatewayapi.KindPtr("UnsupportedKind"),
+								Name:  "test",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "non-existent parentRef name",
+			route: &gwapiv1b1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+				Spec: gwapiv1b1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1b1.CommonRouteSpec{
+						ParentRefs: []gwapiv1b1.ParentReference{
+							{
+								Group: gatewayapi.GroupPtr(gwapiv1b1.GroupName),
+								Kind:  gatewayapi.KindPtr("Gateway"),
+								Name:  "no-existent",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "valid parentRefs",
+			route: &gwapiv1b1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+				Spec: gwapiv1b1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1b1.CommonRouteSpec{
+						ParentRefs: []gwapiv1b1.ParentReference{
+							{
+								Group: gatewayapi.GroupPtr(gwapiv1b1.GroupName),
+								Kind:  gatewayapi.KindPtr("Gateway"),
+								Name:  "test",
+							},
+							{
+								Group: gatewayapi.GroupPtr(gwapiv1b1.GroupName),
+								Kind:  gatewayapi.KindPtr("Gateway"),
+								Name:  "test2",
+							},
+						},
+					},
+				},
+			},
+			gateways: []*gwapiv1b1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+					},
+					Spec: gwapiv1b1.GatewaySpec{
+						GatewayClassName: "gc1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test2",
+					},
+					Spec: gwapiv1b1.GatewaySpec{
+						GatewayClassName: "gc1",
+					},
+				},
+			},
+			classes: []*gwapiv1b1.GatewayClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gc1",
+					},
+					Spec: gwapiv1b1.GatewayClassSpec{
+						ControllerName: gwapiv1b1.GatewayController(v1alpha1.GatewayControllerName),
+					},
+				},
+			},
+			expect: []gwapiv1b1.Gateway{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Gateway",
+						APIVersion: gwapiv1b1.GroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       "test",
+						Name:            "test",
+						ResourceVersion: "999",
+					},
+					Spec: gwapiv1b1.GatewaySpec{
+						GatewayClassName: "gc1",
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Gateway",
+						APIVersion: gwapiv1b1.GroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       "test",
+						Name:            "test2",
+						ResourceVersion: "999",
+					},
+					Spec: gwapiv1b1.GatewaySpec{
+						GatewayClassName: "gc1",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "one of two parentRefs are managed",
+			route: &gwapiv1b1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+				Spec: gwapiv1b1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1b1.CommonRouteSpec{
+						ParentRefs: []gwapiv1b1.ParentReference{
+							{
+								Group: gatewayapi.GroupPtr(gwapiv1b1.GroupName),
+								Kind:  gatewayapi.KindPtr("Gateway"),
+								Name:  "test",
+							},
+							{
+								Group: gatewayapi.GroupPtr(gwapiv1b1.GroupName),
+								Kind:  gatewayapi.KindPtr("Gateway"),
+								Name:  "test2",
+							},
+						},
+					},
+				},
+			},
+			gateways: []*gwapiv1b1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+					},
+					Spec: gwapiv1b1.GatewaySpec{
+						GatewayClassName: "gc1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test2",
+					},
+					Spec: gwapiv1b1.GatewaySpec{
+						GatewayClassName: "gc2",
+					},
+				},
+			},
+			classes: []*gwapiv1b1.GatewayClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gc1",
+					},
+					Spec: gwapiv1b1.GatewayClassSpec{
+						ControllerName: gwapiv1b1.GatewayController(v1alpha1.GatewayControllerName),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gc2",
+					},
+					Spec: gwapiv1b1.GatewayClassSpec{
+						ControllerName: gwapiv1b1.GatewayController("unmanaged.controller"),
+					},
+				},
+			},
+			expect: []gwapiv1b1.Gateway{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Gateway",
+						APIVersion: gwapiv1b1.GroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       "test",
+						Name:            "test",
+						ResourceVersion: "999",
+					},
+					Spec: gwapiv1b1.GatewaySpec{
+						GatewayClassName: "gc1",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "one of two valid parentRefs kind",
+			route: &gwapiv1b1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+				Spec: gwapiv1b1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1b1.CommonRouteSpec{
+						ParentRefs: []gwapiv1b1.ParentReference{
+							{
+								Group: gatewayapi.GroupPtr(gwapiv1b1.GroupName),
+								Kind:  gatewayapi.KindPtr("Gateway"),
+								Name:  "test",
+							},
+							{
+								Group: gatewayapi.GroupPtr(gwapiv1b1.GroupName),
+								Kind:  gatewayapi.KindPtr("Unsupported"),
+								Name:  "test2",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	// Create the reconciler.
+	r := &httpRouteReconciler{classController: gwapiv1b1.GatewayController(v1alpha1.GatewayControllerName)}
+	ctx := context.Background()
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var objs []client.Object
+			for i := range tc.classes {
+				objs = append(objs, tc.classes[i])
+			}
+			for i := range tc.gateways {
+				objs = append(objs, tc.gateways[i])
+			}
+			r.client = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects(objs...).Build()
+			gws, err := r.validateParentRefs(ctx, tc.route)
+			if tc.expected {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			assert.Equal(t, tc.expect, gws)
+		})
+	}
+}


### PR DESCRIPTION
Adds support for validating `parentRefs` of an HTTPRoute. Previously, the httproute controller would process an HTTPRoute even if it references a gateway that doesn't. This causes EG to perform unnecessary processing. An HTTPRoute does not contain `status` so an error is surfaced.

Partially Fixes: #301

Signed-off-by: danehans <daneyonhansen@gmail.com>