### PR TITLE
Set missing controller name in test manifest

### DIFF
--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -58,7 +58,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"


### PR DESCRIPTION
Signed-off-by: AliceProxy <alicewasko@datawire.io>

Adds the `controllerName: gateway.envoyproxy.io/gatewayclass-controller` in the expected output from one of the test manifests. 