### PR TITLE
Fixes Translation Test Case Failure

### DIFF
--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -58,7 +58,7 @@ httpRoutes:
         namespace: envoy-gateway
         name: gateway-1
         sectionName: http
-      # controllerName: envoyproxy.io/gateway-controller
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
         status: "True"


### PR DESCRIPTION
https://github.com/envoyproxy/gateway/pull/395 added `controllerName: gateway.envoyproxy.io/gatewayclass-controller` to translation test cases. https://github.com/envoyproxy/gateway/pull/399 was merged shortly after and didn't include this update, causing CI to fail.

Signed-off-by: danehans <daneyonhansen@gmail.com>