### PR TITLE
docs: nits for `kube-deploy` docs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -48,16 +48,11 @@ Envoy Gateway is built using a [make][make]-based build system. Our CI is based 
 it into the Kind cluster.
 
 ### Deploying Envoy Gateway in Kubernetes
-* Run `make kube-deploy TAG=latest` to deploy Envoy Gateway resources with the latest Envoy Gateway Dev Image
-as well as the Gateway API CRDs into a Kubernetes cluster (linked to the current kube context).
-* Run `make kube-deploy IMAGE=envoyproxy/gateway TAG=xxx`, like `make kube-deploy IMAGE=envoyproxy/gateway TAG=v0.2.0-rc1`, 
-to deploy Envoy Gateway resources with the Released Envoy Gateway Image 
-as well as the Gateway API CRDs into a Kubernetes cluster (linked to the current kube context).
-* Run `make kube-deploy IMAGE=xxx TAG=xxx`, like `make kube-deploy IMAGE=foo/bar TAG=my-feature`, 
-to deploy Envoy Gateway resources with your custom image into the cluster 
-as well as the Gateway API CRDs into a Kubernetes cluster (linked to the current kube context).
+* Run `IMAGE=envoyproxy/gateway-dev TAG=latest make kube-deploy` to deploy Envoy Gateway resources, including the Gateway API CRDs,
+with the `envoyproxy/gateway-dev:latest` Envoy Gateway image into a Kubernetes cluster (linked to the current kube context).
 * Run `make kube-undeploy` to delete the resources from the cluster created using `kube-deploy`.
 
+**_NOTE:_**  Replace `IMAGE` with your registry's image name.
 
 ### Run Gateway API Conformance Tests
 * Run `make conformance` to run Gateway API Conformance tests using `envoy-gateway` in a

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -36,10 +36,10 @@ endif
 
 .PHONY: kube-install
 kube-install: manifests $(tools/kustomize) ## Install Envoy Gateway CRDs into the Kubernetes cluster specified in ~/.kube/config.
-	@mkdir -pv $(OUTPUT_DIR)/manifests/provider
-	@cp -r $(KUBE_PROVIDER_DIR) $(OUTPUT_DIR)/manifests/provider
-	@mkdir -pv $(OUTPUT_DIR)/manifests/infra
-	@cp -r $(KUBE_INFRA_DIR) $(OUTPUT_DIR)/manifests/infra
+	mkdir -pv $(OUTPUT_DIR)/manifests/provider
+	cp -r $(KUBE_PROVIDER_DIR) $(OUTPUT_DIR)/manifests/provider
+	mkdir -pv $(OUTPUT_DIR)/manifests/infra
+	cp -r $(KUBE_INFRA_DIR) $(OUTPUT_DIR)/manifests/infra
 	$(tools/kustomize) build $(OUTPUT_DIR)/manifests/provider/config/crd | kubectl apply -f -
 	kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/experimental-install.yaml
 
@@ -49,15 +49,15 @@ kube-uninstall: manifests $(tools/kustomize) ## Uninstall Envoy Gateway CRDs fro
 
 .PHONY: kube-deploy
 kube-deploy: kube-install ## Install Envoy Gateway controller into the Kubernetes cluster specified in ~/.kube/config.
-	@cd $(OUTPUT_DIR)/manifests/provider/config/envoy-gateway && $(ROOT_DIR)/$(tools/kustomize) edit set image envoyproxy/gateway-dev=$(IMAGE):$(TAG)
+	cd $(OUTPUT_DIR)/manifests/provider/config/envoy-gateway && $(ROOT_DIR)/$(tools/kustomize) edit set image envoyproxy/gateway-dev=$(IMAGE):$(TAG)
 	$(tools/kustomize) build $(OUTPUT_DIR)/manifests/provider/config/default | kubectl apply -f -
 	$(tools/kustomize) build $(OUTPUT_DIR)/manifests/infra/config/rbac | kubectl apply -f -
 
 .PHONY: kube-undeploy
 kube-undeploy: kube-uninstall ## Uninstall the Envoy Gateway controller into the Kubernetes cluster specified in ~/.kube/config.
 	$(tools/kustomize) build $(OUTPUT_DIR)/manifests/provider/config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f - 
-	@rm -rf $(OUTPUT_DIR)/manifests/provider
-	@rm -rf $(OUTPUT_DIR)/manifests/infra
+	rm -rf $(OUTPUT_DIR)/manifests/provider
+	rm -rf $(OUTPUT_DIR)/manifests/infra
 
 .PHONY: run-kube-local
 run-kube-local: build kube-install ## Run Envoy Gateway locally.


### PR DESCRIPTION
* match the examples to previous `build-multiarch` section

* rm `@` from make target to expose cmds running / improve debuggability

Signed-off-by: Arko Dasgupta <arko@tetrate.io>