### PR TITLE
add make demo to deploy example resources

### DIFF
--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -59,6 +59,17 @@ kube-undeploy: kube-uninstall ## Uninstall the Envoy Gateway controller into the
 	rm -rf $(OUTPUT_DIR)/manifests/provider
 	rm -rf $(OUTPUT_DIR)/manifests/infra
 
+.PHONY: kube-demo
+kube-demo: ## Deploy a demo backend service, gatewayclass, gateway and httproute resource and test the configuration.
+	kubectl apply -f examples/kubernetes/httpbin.yaml
+	kubectl apply -f examples/kubernetes/gatewayclass.yaml
+	kubectl apply -f examples/kubernetes/gateway.yaml
+	kubectl apply -f examples/kubernetes/httproute.yaml
+	@echo "\nPort forward to the Envoy service using the commane below"
+	@echo "kubectl -n envoy-gateway-system port-forward service/envoy-default-eg 8888:8080 &"
+	@echo "\nCurl the app through Envoy proxy using the command below"
+	@echo "curl --verbose --header \"Host: www.example.com\" http://localhost:8888/get\n"
+
 .PHONY: run-kube-local
 run-kube-local: build kube-install ## Run Envoy Gateway locally.
 	tools/hack/run-kube-local.sh

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -65,7 +65,7 @@ kube-demo: ## Deploy a demo backend service, gatewayclass, gateway and httproute
 	kubectl apply -f examples/kubernetes/gatewayclass.yaml
 	kubectl apply -f examples/kubernetes/gateway.yaml
 	kubectl apply -f examples/kubernetes/httproute.yaml
-	@echo "\nPort forward to the Envoy service using the commane below"
+	@echo "\nPort forward to the Envoy service using the command below"
 	@echo "kubectl -n envoy-gateway-system port-forward service/envoy-default-eg 8888:8080 &"
 	@echo "\nCurl the app through Envoy proxy using the command below"
 	@echo "curl --verbose --header \"Host: www.example.com\" http://localhost:8888/get\n"

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -70,6 +70,13 @@ kube-demo: ## Deploy a demo backend service, gatewayclass, gateway and httproute
 	@echo "\nCurl the app through Envoy proxy using the command below"
 	@echo "curl --verbose --header \"Host: www.example.com\" http://localhost:8888/get\n"
 
+.PHONY: kube-demo-undeploy
+kube-demo-undeploy: ## Uninstall the Kubernetes resources installed from the `make kub-demo` command.
+	kubectl delete -f examples/kubernetes/httproute.yaml
+	kubectl delete -f examples/kubernetes/gateway.yaml
+	kubectl delete -f examples/kubernetes/gatewayclass.yaml
+	kubectl delete -f examples/kubernetes/httpbin.yaml
+
 .PHONY: run-kube-local
 run-kube-local: build kube-install ## Run Envoy Gateway locally.
 	tools/hack/run-kube-local.sh

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -71,7 +71,7 @@ kube-demo: ## Deploy a demo backend service, gatewayclass, gateway and httproute
 	@echo "curl --verbose --header \"Host: www.example.com\" http://localhost:8888/get\n"
 
 .PHONY: kube-demo-undeploy
-kube-demo-undeploy: ## Uninstall the Kubernetes resources installed from the `make kub-demo` command.
+kube-demo-undeploy: ## Uninstall the Kubernetes resources installed from the `make kube-demo` command.
 	kubectl delete -f examples/kubernetes/httproute.yaml
 	kubectl delete -f examples/kubernetes/gateway.yaml
 	kubectl delete -f examples/kubernetes/gatewayclass.yaml


### PR DESCRIPTION
```
make kube-demo
kubectl apply -f examples/kubernetes/httpbin.yaml
serviceaccount/httpbin unchanged
service/httpbin unchanged
deployment.apps/httpbin unchanged
kubectl apply -f examples/kubernetes/gatewayclass.yaml
gatewayclass.gateway.networking.k8s.io/eg unchanged
kubectl apply -f examples/kubernetes/gateway.yaml
gateway.gateway.networking.k8s.io/eg configured
kubectl apply -f examples/kubernetes/httproute.yaml
httproute.gateway.networking.k8s.io/httpbin configured

Port forward to the Envoy service using the command below
kubectl -n envoy-gateway-system port-forward service/envoy-default-eg 8888:8080 &

Curl the app through Envoy proxy using the command below
curl --verbose --header "Host: www.example.com" http://localhost:8888/get

```

Signed-off-by: Arko Dasgupta <arko@tetrate.io>