### PR TITLE
fix port for curl command example

### DIFF
--- a/docs/user/QUICKSTART.md
+++ b/docs/user/QUICKSTART.md
@@ -62,7 +62,7 @@ In certain environments, the load balancer may be exposed using a hostname, inst
 
 Curl the example app through Envoy proxy:
 ```shell
-curl --verbose --header "Host: www.example.com" http://$GATEWAY_HOST:8888/get
+curl --verbose --header "Host: www.example.com" http://$GATEWAY_HOST:8080/get
 ```
 You can replace `get` with any of the supported [httpbin methods][httpbin_methods].
 


### PR DESCRIPTION
* port should be the service port `8080`

Signed-off-by: Arko Dasgupta <arko@tetrate.io>