### PR TITLE
[provider] Remove gateway class from controlledClasses on Delete

### DIFF
--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -103,7 +103,11 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 
 	for i := range gatewayClasses.Items {
 		if gatewayClasses.Items[i].Spec.ControllerName == r.controller {
-			cc.addMatch(&gatewayClasses.Items[i])
+			if !gatewayClasses.Items[i].DeletionTimestamp.IsZero() {
+				cc.removeMatch(&gatewayClasses.Items[i])
+			} else {
+				cc.addMatch(&gatewayClasses.Items[i])
+			}
 		}
 	}
 
@@ -172,8 +176,13 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 }
 
 type controlledClasses struct {
+	// matchedClasses holds all GatewayClass objects with matching controllerName.
 	matchedClasses []*gwapiv1b1.GatewayClass
-	oldestClass    *gwapiv1b1.GatewayClass
+
+	// oldestClass stores the first GatewayClass encountered with matching
+	// controllerName. This is maintained so that the oldestClass does not change
+	// during reboots.
+	oldestClass *gwapiv1b1.GatewayClass
 }
 
 func (cc *controlledClasses) addMatch(gc *gwapiv1b1.GatewayClass) {
@@ -187,6 +196,37 @@ func (cc *controlledClasses) addMatch(gc *gwapiv1b1.GatewayClass) {
 	case gc.CreationTimestamp.Time.Equal(cc.oldestClass.CreationTimestamp.Time) && gc.Name < cc.oldestClass.Name:
 		// tie-breaker: first one in alphabetical order is considered oldest/accepted
 		cc.oldestClass = gc
+	}
+}
+
+func (cc *controlledClasses) removeMatch(gc *gwapiv1b1.GatewayClass) {
+	// First remove gc from matchedClasses.
+	for i, matchedGC := range cc.matchedClasses {
+		if matchedGC.Name == gc.Name {
+			cc.matchedClasses[i] = cc.matchedClasses[len(cc.matchedClasses)-1]
+			cc.matchedClasses = cc.matchedClasses[:len(cc.matchedClasses)-1]
+			break
+		}
+	}
+
+	// If the oldestClass is removed, find the new oldestClass candidate
+	// from matchedClasses.
+	if cc.oldestClass.Name == gc.Name {
+		if len(cc.matchedClasses) == 0 {
+			cc.oldestClass = nil
+			return
+		}
+
+		cc.oldestClass = cc.matchedClasses[0]
+		for i := 1; i < len(cc.matchedClasses); i++ {
+			current := cc.matchedClasses[i]
+			if current.CreationTimestamp.Time.Before(cc.oldestClass.CreationTimestamp.Time) ||
+				(current.CreationTimestamp.Time.Equal(cc.oldestClass.CreationTimestamp.Time) &&
+					current.Name < cc.oldestClass.Name) {
+				cc.oldestClass = current
+				return
+			}
+		}
 	}
 }
 

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -211,7 +211,7 @@ func (cc *controlledClasses) removeMatch(gc *gwapiv1b1.GatewayClass) {
 
 	// If the oldestClass is removed, find the new oldestClass candidate
 	// from matchedClasses.
-	if cc.oldestClass.Name == gc.Name {
+	if cc.oldestClass != nil && cc.oldestClass.Name == gc.Name {
 		if len(cc.matchedClasses) == 0 {
 			cc.oldestClass = nil
 			return

--- a/internal/provider/kubernetes/gatewayclass_test.go
+++ b/internal/provider/kubernetes/gatewayclass_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,5 +59,99 @@ func TestGatewayClassHasMatchingController(t *testing.T) {
 			res := r.hasMatchingController(tc.obj)
 			require.Equal(t, tc.expect, res)
 		})
+	}
+}
+
+func TestGatewayOldestClass(t *testing.T) {
+	createGatewayClass := func(name string, creationTime time.Time) *gwapiv1b1.GatewayClass {
+		return &gwapiv1b1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				CreationTimestamp: metav1.NewTime(creationTime),
+			},
+			Spec: gwapiv1b1.GatewayClassSpec{
+				ControllerName: v1alpha1.GatewayControllerName,
+			},
+		}
+	}
+
+	currentTime := metav1.Now()
+	addDuration := time.Duration(10)
+	testCases := []struct {
+		name    string
+		classes map[string]time.Time
+		remove  map[string]time.Time
+		oldest  string
+	}{
+		{
+			name: "normal",
+			classes: map[string]time.Time{
+				"class-b": currentTime.Time,
+				"class-a": currentTime.Add(1 * addDuration),
+			},
+			remove: nil,
+			oldest: "class-b",
+		},
+		{
+			name: "tie breaker",
+			classes: map[string]time.Time{
+				"class-aa": currentTime.Time,
+				"class-ab": currentTime.Time,
+			},
+			remove: nil,
+			oldest: "class-aa",
+		},
+		{
+			name: "remove from matched",
+			classes: map[string]time.Time{
+				"class-a": currentTime.Time,
+				"class-b": currentTime.Add(1 * addDuration),
+				"class-c": currentTime.Add(2 * addDuration),
+			},
+			remove: map[string]time.Time{
+				"class-b": currentTime.Add(1 * addDuration),
+			},
+			oldest: "class-a",
+		},
+		{
+			name: "remove oldest",
+			classes: map[string]time.Time{
+				"class-a": currentTime.Time,
+				"class-b": currentTime.Add(1 * addDuration),
+				"class-c": currentTime.Add(2 * addDuration),
+			},
+			remove: map[string]time.Time{
+				"class-a": currentTime.Time,
+			},
+			oldest: "class-b",
+		},
+		{
+			name: "remove oldest last",
+			classes: map[string]time.Time{
+				"class-a": currentTime.Time,
+			},
+			remove: map[string]time.Time{
+				"class-a": currentTime.Time,
+			},
+			oldest: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		var cc controlledClasses
+		for name, timestamp := range tc.classes {
+			cc.addMatch(createGatewayClass(name, timestamp))
+		}
+
+		for name, timestamp := range tc.remove {
+			cc.removeMatch(createGatewayClass(name, timestamp))
+		}
+
+		if tc.oldest == "" {
+			require.Nil(t, cc.oldestClass)
+			return
+		}
+
+		require.Equal(t, tc.oldest, cc.oldestClass.Name)
 	}
 }


### PR DESCRIPTION
This commit removes a gatewayclass object from controllerClasses when a object Deletion is triggered. This also maintains the oldest class in controlledClasses.
Fixes #222

Signed-off-by: Shubham Chauhan <shubham@tetrate.io>