### PR TITLE
Update Conformance Tests

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -47,6 +47,10 @@ jobs:
     # build
     - run: make build-multiarch
 
+    # conformance
+    - name: Run Conformance Tests
+      run: make conformance
+
     # build and push image
     - name: Login to DockerHub
       if: github.event_name == 'push'

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -29,8 +29,16 @@ func TestGatewayAPIConformance(t *testing.T) {
 		GatewayClassName:     *flags.GatewayClassName,
 		Debug:                *flags.ShowDebug,
 		CleanupBaseResources: *flags.CleanupBaseResources,
+		ValidUniqueListenerPorts: []v1alpha2.PortNumber{
+			v1alpha2.PortNumber(int32(80)),
+			v1alpha2.PortNumber(int32(81)),
+			v1alpha2.PortNumber(int32(82)),
+			v1alpha2.PortNumber(int32(83)),
+			v1alpha2.PortNumber(int32(84)),
+		},
 	})
 	cSuite.Setup(t)
-	cSuite.Run(t, tests.ConformanceTests)
+	egTests := []suite.ConformanceTest{tests.HTTPRouteSimpleSameNamespace}
+	cSuite.Run(t, egTests)
 
 }

--- a/tools/hack/kind-load-image.sh
+++ b/tools/hack/kind-load-image.sh
@@ -39,16 +39,20 @@ fi
 
 # Update the image pull policy in the Envoy Gateway deployment manifest so
 # the image is served by the kind cluster.
-echo "setting \"imagePullPolicy: IfNotPresent\" for Envoy Gateway deployment"
-run::sed \
-  "-es|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|" \
-  "./internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml"
+for file in internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml internal/provider/kubernetes/config/envoy-gateway/certgen-job.yaml ; do
+  echo "setting \"imagePullPolicy: IfNotPresent\" for $file"
+  run::sed \
+    "-es|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|" \
+    "$file"
+done
 
 # Update the image in the Envoy Gateway deployment manifest.
-echo "setting \"image: ${IMAGE}:${TAG}\" for Envoy Gateway deployment"
-run::sed \
-  "-es|image: envoyproxy/gateway-dev:.*$|image: ${IMAGE}:${TAG}|" \
-  "./internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml"
+for file in internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml internal/provider/kubernetes/config/envoy-gateway/certgen-job.yaml ; do
+  echo "setting \"image: ${IMAGE}:${TAG}\" for $file"
+  run::sed \
+    "-es|image: envoyproxy/gateway-dev:.*$|image: ${IMAGE}:${TAG}|" \
+    "$file"
+done
 
 # Push the Envoy Gateway image to the kind cluster.
 echo "Loading image ${IMAGE}:${TAG} to kind cluster ${CLUSTER_NAME}..."

--- a/tools/hack/kind-load-image.sh
+++ b/tools/hack/kind-load-image.sh
@@ -37,9 +37,11 @@ if ! kind::cluster::exists "$CLUSTER_NAME" ; then
     exit 2
 fi
 
+files=(internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml internal/provider/kubernetes/config/envoy-gateway/certgen-job.yaml)
+
 # Update the image pull policy in the Envoy Gateway deployment manifest so
 # the image is served by the kind cluster.
-for file in internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml internal/provider/kubernetes/config/envoy-gateway/certgen-job.yaml ; do
+for file in "${files[@]}" ; do
   echo "setting \"imagePullPolicy: IfNotPresent\" for $file"
   run::sed \
     "-es|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|" \
@@ -47,7 +49,7 @@ for file in internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml
 done
 
 # Update the image in the Envoy Gateway deployment manifest.
-for file in internal/provider/kubernetes/config/envoy-gateway/deploy_and_ns.yaml internal/provider/kubernetes/config/envoy-gateway/certgen-job.yaml ; do
+for file in "${files[@]}" ; do
   echo "setting \"image: ${IMAGE}:${TAG}\" for $file"
   run::sed \
     "-es|image: envoyproxy/gateway-dev:.*$|image: ${IMAGE}:${TAG}|" \

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -79,7 +79,7 @@ run-conformance: ## Run Gateway API conformance.
 	kubectl wait --timeout=5m -n gateway-system deployment/gateway-api-admission-server --for=condition=Available
 	kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
 	kubectl apply -f internal/provider/kubernetes/config/samples/gatewayclass.yaml
-	go test -tags conformance ./test/conformance --gateway-class=envoy-gateway --debug=true --cleanup-base-resources=false
+	go test -v -tags conformance ./test/conformance --gateway-class=envoy-gateway --debug=true
 
 .PHONY: delete-cluster
 delete-cluster: $(tools/kind) ## Delete kind cluster.

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -64,7 +64,7 @@ run-kube-local: build kube-install ## Run Envoy Gateway locally.
 	tools/hack/run-kube-local.sh
 
 .PHONY: conformance 
-conformance: create-cluster kube-deploy run-conformance delete-cluster ## Create a kind cluster, deploy EG into it, run Gateway API conformance, and clean up.
+conformance: create-cluster kube-install-image kube-deploy run-conformance delete-cluster ## Create a kind cluster, deploy EG into it, run Gateway API conformance, and clean up.
 
 .PHONY: create-cluster
 create-cluster: $(tools/kind) ## Create a kind cluster suitable for running Gateway API conformance.
@@ -79,7 +79,7 @@ run-conformance: ## Run Gateway API conformance.
 	kubectl wait --timeout=5m -n gateway-system deployment/gateway-api-admission-server --for=condition=Available
 	kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
 	kubectl apply -f internal/provider/kubernetes/config/samples/gatewayclass.yaml
-	go test -tags conformance ./test/conformance --gateway-class=envoy-gateway
+	go test -tags conformance ./test/conformance --gateway-class=envoy-gateway --debug=true --cleanup-base-resources=false
 
 .PHONY: delete-cluster
 delete-cluster: $(tools/kind) ## Delete kind cluster.


### PR DESCRIPTION
Updates conformance tests to:
- Run in CI
- Run one test, `HTTPRouteSimpleSameNamespace` instead of the entire suite.
- Update Gateways to use different port numbers.
- Adds sets additional test flags to make target.