### PR TITLE
Stall ns notifications until gws have inited

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -62,7 +62,7 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 		case <-servicesCh:
 			r.waitUntilAllGAPIInitialized()
 		case <-namespacesCh:
-			r.waitUntilAllGAPIInitialized()
+			r.waitUntilGCAndGatewaysInitialized()
 		}
 		r.Logger.Info("received a notification")
 		// Load all resources required for translation


### PR DESCRIPTION
* Fixes a regression caused by https://github.com/envoyproxy/gateway/pull/420 which stalled namespace notifications until the httproute resource were initialized, but the namespaces are required to be populated to built listener context which affects infra IR creation.

Signed-off-by: Arko Dasgupta <arko@tetrate.io>