### PR TITLE
Convert Status Updater process into a lib

### DIFF
--- a/internal/provider/kubernetes/kubernetes.go
+++ b/internal/provider/kubernetes/kubernetes.go
@@ -12,7 +12,6 @@ import (
 	"github.com/envoyproxy/gateway/internal/envoygateway"
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/message"
-	"github.com/envoyproxy/gateway/internal/status"
 )
 
 // Provider is the scaffolding for the Kubernetes provider. It sets up dependencies
@@ -38,19 +37,14 @@ func New(cfg *rest.Config, svr *config.Server, resources *message.ProviderResour
 		return nil, fmt.Errorf("failed to create manager: %w", err)
 	}
 
-	updateHandler := status.NewUpdateHandler(mgr.GetLogger(), mgr.GetClient())
-	if err := mgr.Add(updateHandler); err != nil {
-		return nil, fmt.Errorf("failed to add status update handler %v", err)
-	}
-
 	// Create and register the controllers with the manager.
-	if err := newGatewayClassController(mgr, svr, updateHandler.Writer(), resources); err != nil {
+	if err := newGatewayClassController(mgr, svr, resources); err != nil {
 		return nil, fmt.Errorf("failed to create gatewayclass controller: %w", err)
 	}
-	if err := newGatewayController(mgr, svr, updateHandler.Writer(), resources); err != nil {
+	if err := newGatewayController(mgr, svr, resources); err != nil {
 		return nil, fmt.Errorf("failed to create gateway controller: %w", err)
 	}
-	if err := newHTTPRouteController(mgr, svr, updateHandler.Writer(), resources); err != nil {
+	if err := newHTTPRouteController(mgr, svr, resources); err != nil {
 		return nil, fmt.Errorf("failed to create httproute controller: %w", err)
 	}
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -5,136 +5,37 @@ package status
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/envoyproxy/gateway/internal/provider/utils"
 )
 
-// Update contains an all the information needed to update an object's status.
-// Send down a channel to the goroutine that actually writes the changes back.
-type Update struct {
-	NamespacedName types.NamespacedName
-	Resource       client.Object
-	Mutator        Mutator
-}
-
-// Mutator is an interface to hold mutator functions for status updates.
-type Mutator interface {
-	Mutate(obj client.Object) client.Object
-}
-
-// MutatorFunc is a function adaptor for Mutators.
-type MutatorFunc func(client.Object) client.Object
-
-// Mutate adapts the MutatorFunc to fit through the Mutator interface.
-func (m MutatorFunc) Mutate(old client.Object) client.Object {
-	if m == nil {
-		return nil
-	}
-
-	return m(old)
-}
-
-// UpdateHandler holds the details required to actually write an Update back to the referenced object.
-type UpdateHandler struct {
-	log           logr.Logger
-	client        client.Client
-	sendUpdates   chan struct{}
-	updateChannel chan Update
-}
-
-func NewUpdateHandler(log logr.Logger, client client.Client) *UpdateHandler {
-	return &UpdateHandler{
-		log:           log,
-		client:        client,
-		sendUpdates:   make(chan struct{}),
-		updateChannel: make(chan Update, 100),
-	}
-}
-
-func (u *UpdateHandler) apply(update Update) {
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		obj := update.Resource
-
+func UpdateStatus(c client.Client, newObj client.Object) error {
+	name := utils.NamespacedName(newObj)
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Get the resource.
-		if err := u.client.Get(context.Background(), update.NamespacedName, obj); err != nil {
+		var obj client.Object
+		if err := c.Get(context.Background(), name, obj); err != nil {
 			return err
 		}
 
-		newObj := update.Mutator.Mutate(obj)
-
 		if isStatusEqual(obj, newObj) {
-			u.log.WithName(update.NamespacedName.Name).
-				WithName(update.NamespacedName.Namespace).
-				Info("status unchanged, bypassing update")
 			return nil
 		}
 
-		return u.client.Status().Update(context.Background(), newObj)
+		return c.Status().Update(context.Background(), newObj)
 	}); err != nil {
-		u.log.Error(err, "unable to update status", "name", update.NamespacedName.Name,
-			"namespace", update.NamespacedName.Namespace)
+		return fmt.Errorf("unable to update status for %s: %w", name, err)
 	}
-}
 
-func (u *UpdateHandler) NeedLeaderElection() bool {
-	return true
-}
-
-// Start runs the goroutine to perform status writes.
-func (u *UpdateHandler) Start(ctx context.Context) error {
-	u.log.Info("started status update handler")
-	defer u.log.Info("stopped status update handler")
-
-	// Enable Updaters to start sending updates to this handler.
-	close(u.sendUpdates)
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case update := <-u.updateChannel:
-			u.log.Info("received a status update", "namespace", update.NamespacedName.Namespace,
-				"name", update.NamespacedName.Name)
-
-			u.apply(update)
-		}
-	}
-}
-
-// Writer retrieves the interface that should be used to write to the UpdateHandler.
-func (u *UpdateHandler) Writer() Updater {
-	return &UpdateWriter{
-		enabled:       u.sendUpdates,
-		updateChannel: u.updateChannel,
-	}
-}
-
-// Updater describes an interface to send status updates somewhere.
-type Updater interface {
-	Send(u Update)
-}
-
-// UpdateWriter takes status updates and sends these to the UpdateHandler via a channel.
-type UpdateWriter struct {
-	enabled       <-chan struct{}
-	updateChannel chan<- Update
-}
-
-// Send sends the given Update off to the update channel for writing by the UpdateHandler.
-func (u *UpdateWriter) Send(update Update) {
-	// Non-blocking receive to see if we should pass along update.
-	select {
-	case <-u.enabled:
-		u.updateChannel <- update
-	default:
-	}
+	return nil
 }
 
 // isStatusEqual checks if two objects have equivalent status.


### PR DESCRIPTION
* Since the status update logic lives in its own go routine, make status updates within the status subscriber synchronous by converting the status updater into a library rather than a go routine

Fixes: https://github.com/envoyproxy/gateway/issues/414

Signed-off-by: Arko Dasgupta <arko@tetrate.io>