### PR TITLE
Handle IR Deletes

### DIFF
--- a/internal/envoygateway/config/config.go
+++ b/internal/envoygateway/config/config.go
@@ -12,8 +12,8 @@ const (
 	EnvoyGatewayNamespace = "envoy-gateway-system"
 	// EnvoyGatewayServiceName is the name of the Envoy Gateway service.
 	EnvoyGatewayServiceName = "envoy-gateway"
-	// EnvoyConfigMapName is the name of the Envoy ConfigMap.
-	EnvoyConfigMapName = "envoy"
+	// EnvoyConfigMapPrefix is the prefix applied to the Envoy ConfigMap.
+	EnvoyConfigMapPrefix = "envoy"
 	// EnvoyServicePrefix is the prefix applied to the Envoy Service.
 	EnvoyServicePrefix = "envoy"
 	// EnvoyDeploymentPrefix is the prefix applied to the Envoy Deployment.

--- a/internal/gatewayapi/runner/runner_test.go
+++ b/internal/gatewayapi/runner/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -51,4 +52,50 @@ func TestRunner(t *testing.T) {
 		return (reflect.DeepEqual(xdsIR.LoadAll(), map[string]*ir.Xds{})) && (reflect.DeepEqual(infraIR.LoadAll(), map[string]*ir.Infra{}))
 	}, time.Second*1, time.Millisecond*20)
 
+}
+
+func TestGetIRKeysToDelete(t *testing.T) {
+	testCases := []struct {
+		name    string
+		curKeys []string
+		newKeys []string
+		delKeys []string
+	}{
+		{
+			name:    "empty",
+			curKeys: []string{},
+			newKeys: []string{},
+			delKeys: []string{},
+		},
+		{name: "no new keys",
+			curKeys: []string{"one", "two"},
+			newKeys: []string{},
+			delKeys: []string{"one", "two"},
+		},
+		{
+			name:    "no cur keys",
+			curKeys: []string{},
+			newKeys: []string{"one", "two"},
+			delKeys: []string{},
+		},
+		{
+			name:    "equal",
+			curKeys: []string{"one", "two"},
+			newKeys: []string{"two", "one"},
+			delKeys: []string{},
+		},
+		{
+			name:    "mix",
+			curKeys: []string{"one", "two"},
+			newKeys: []string{"two", "three"},
+			delKeys: []string{"one"},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tc.delKeys, getIRKeysToDelete(tc.curKeys, tc.newKeys))
+		})
+	}
 }

--- a/internal/infrastructure/kubernetes/deployment.go
+++ b/internal/infrastructure/kubernetes/deployment.go
@@ -149,7 +149,7 @@ func (i *Infra) expectedDeployment(infra *ir.Infra) (*appsv1.Deployment, error) 
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: config.EnvoyConfigMapName,
+										Name: expectedConfigMapName(infra.Proxy.Name),
 									},
 									Items: []corev1.KeyToPath{
 										{

--- a/internal/infrastructure/kubernetes/infra.go
+++ b/internal/infrastructure/kubernetes/infra.go
@@ -96,7 +96,7 @@ func (i *Infra) CreateInfra(ctx context.Context, infra *ir.Infra) error {
 		return err
 	}
 
-	if _, err := i.createOrUpdateConfigMap(ctx); err != nil {
+	if _, err := i.createOrUpdateConfigMap(ctx, infra); err != nil {
 		return err
 	}
 
@@ -125,7 +125,7 @@ func (i *Infra) DeleteInfra(ctx context.Context, infra *ir.Infra) error {
 		return err
 	}
 
-	if err := i.deleteConfigMap(ctx); err != nil {
+	if err := i.deleteConfigMap(ctx, infra); err != nil {
 		return err
 	}
 

--- a/internal/xds/translator/runner/runner_test.go
+++ b/internal/xds/translator/runner/runner_test.go
@@ -70,7 +70,7 @@ func TestRunner(t *testing.T) {
 		}
 		// Ensure an xds listener is created
 		return len(out["test"].XdsResources[resourcev3.ListenerType]) == 1
-	}, time.Second*2, time.Millisecond*20)
+	}, time.Second*3, time.Millisecond*50)
 
 	// Delete the IR triggering an xds delete
 	xdsIR.Delete("test")
@@ -78,6 +78,6 @@ func TestRunner(t *testing.T) {
 		out := xds.LoadAll()
 		// Ensure that xds has no key, value pairs
 		return len(out) == 0
-	}, time.Second*2, time.Millisecond*20)
+	}, time.Second*3, time.Millisecond*50)
 
 }

--- a/internal/xds/translator/runner/runner_test.go
+++ b/internal/xds/translator/runner/runner_test.go
@@ -65,6 +65,9 @@ func TestRunner(t *testing.T) {
 		if out == nil {
 			return false
 		}
+		if out["test"] == nil {
+			return false
+		}
 		// Ensure an xds listener is created
 		return len(out["test"].XdsResources[resourcev3.ListenerType]) == 1
 	}, time.Second*1, time.Millisecond*20)

--- a/internal/xds/translator/runner/runner_test.go
+++ b/internal/xds/translator/runner/runner_test.go
@@ -76,11 +76,8 @@ func TestRunner(t *testing.T) {
 	xdsIR.Delete("test")
 	require.Eventually(t, func() bool {
 		out := xds.LoadAll()
-		if len(out) != 0 {
-			return false
-		}
 		// Ensure that xds has no key, value pairs
-		return true
+		return len(out) == 0
 	}, time.Second*2, time.Millisecond*20)
 
 }

--- a/internal/xds/translator/runner/runner_test.go
+++ b/internal/xds/translator/runner/runner_test.go
@@ -70,17 +70,17 @@ func TestRunner(t *testing.T) {
 		}
 		// Ensure an xds listener is created
 		return len(out["test"].XdsResources[resourcev3.ListenerType]) == 1
-	}, time.Second*1, time.Millisecond*20)
+	}, time.Second*2, time.Millisecond*20)
 
-	// Update with an empty IR triggering a delete
-	xdsIR.Store("test", &ir.Xds{})
+	// Delete the IR triggering an xds delete
+	xdsIR.Delete("test")
 	require.Eventually(t, func() bool {
 		out := xds.LoadAll()
-		if out == nil {
+		if len(out) != 0 {
 			return false
 		}
-		// Ensure no xds listener exists
-		return len(out["test"].XdsResources[resourcev3.ListenerType]) == 0
-	}, time.Second*1, time.Millisecond*20)
+		// Ensure that xds has no key, value pairs
+		return true
+	}, time.Second*2, time.Millisecond*20)
 
 }


### PR DESCRIPTION
* Add a function that computes which keys to delete in the gateway-api runner

* Delete above keys from the Infra and Xds IR maps

* Update infra and xds runners to trigger deletes when a delete notification is recieved.

Fixes: https://github.com/envoyproxy/gateway/issues/423

Signed-off-by: Arko Dasgupta <arko@tetrate.io>