### PR TITLE
Return 500 responses for invalid backends

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/envoyproxy/gateway
 go 1.18
 
 require (
-	github.com/envoyproxy/go-control-plane v0.10.3
+	github.com/envoyproxy/go-control-plane v0.10.3-0.20220719090109-b024c36d9935
 	github.com/go-logr/zapr v1.2.0
 	github.com/google/go-cmp v0.5.8
 	github.com/spf13/cobra v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
+github.com/envoyproxy/go-control-plane v0.10.3-0.20220719090109-b024c36d9935 h1:1P6HktLf+VNpEwASft2E0KU7ddeuu73UMnFpawKuD58=
+github.com/envoyproxy/go-control-plane v0.10.3-0.20220719090109-b024c36d9935/go.mod h1:fJJn/j26vwOu972OllsvAgJJM//w9BV6Fxbg2LuVd34=
 github.com/envoyproxy/go-control-plane v0.10.3 h1:xdCVXxEe0Y3FQith+0cj2irwZudqGYvecuLB1HtdexY=
 github.com/envoyproxy/go-control-plane v0.10.3/go.mod h1:fJJn/j26vwOu972OllsvAgJJM//w9BV6Fxbg2LuVd34=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.in.yaml
@@ -1,0 +1,42 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          type: Exact
+          value: "/exact"
+      backendRefs:
+      - name: service-1
+        port: 8888
+services:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-1
+  spec:
+    clusterIP: 7.7.7.7
+    ports:
+    - port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
@@ -1,0 +1,91 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          type: Exact
+          value: "/exact"
+      backendRefs:
+      - name: service-1
+        port: 8888
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "False"
+        reason: PortNotFound
+        message: "Port 8888 not found on service default/service-1"
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-*
+        pathMatch:
+          exact: "/exact"
+        backendWeights: 
+          invalid: 1
+        directResponse:
+          statusCode: 500
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:v1.23-latest
+      listeners:
+      - address: ""
+        ports:
+        - name: envoy-gateway-gateway-1
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.in.yaml
@@ -1,0 +1,45 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                type: Exact
+                value: "/exact"
+          backendRefs:
+            - name: service-1
+              group: "invalid"
+              namespace: backends
+              port: 8080
+services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      namespace: backends
+      name: service-1
+    spec:
+      clusterIP: 7.7.7.7
+      ports:
+        - port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
@@ -1,0 +1,93 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          type: Exact
+          value: "/exact"
+      backendRefs:
+      - name: service-1
+        group: "invalid"
+        namespace: backends
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "False"
+        reason: InvalidKind
+        message: Group is invalid, only the core API group (specified by omitting the group field or setting it to an empty string) is supported
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-*
+        pathMatch:
+          exact: "/exact"
+        backendWeights: 
+          invalid: 1
+        directResponse:
+          statusCode: 500
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:v1.23-latest
+      listeners:
+      - address: ""
+        ports:
+        - name: envoy-gateway-gateway-1
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.in.yaml
@@ -1,0 +1,35 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                type: Exact
+                value: "/exact"
+          backendRefs:
+            - name: service-1
+              kind: "URL"
+              port: 8080
+

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
@@ -1,0 +1,93 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          type: Exact
+          value: "/exact"
+      backendRefs:
+      - name: service-1
+        kind: "URL"
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "False"
+        reason: InvalidKind
+        message: Kind is invalid, only Service is supported
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-*
+        pathMatch:
+          exact: "/exact"
+        backendWeights: 
+          invalid: 1
+        directResponse:
+          statusCode: 500
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:v1.23-latest
+      listeners:
+      - address: ""
+        ports:
+        - name: envoy-gateway-gateway-1
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80
+

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.in.yaml
@@ -1,0 +1,41 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                type: Exact
+                value: "/exact"
+          backendRefs:
+            - name: service-1
+services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: service-1
+    spec:
+      clusterIP: 7.7.7.7
+      ports:
+        - port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
@@ -1,0 +1,91 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          type: Exact
+          value: "/exact"
+      backendRefs:
+      - name: service-1
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "False"
+        reason: PortNotSpecified
+        message: "A valid port number corresponding to a port on the Service must be specified"
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-*
+        pathMatch:
+          exact: "/exact"
+        backendWeights: 
+          invalid: 1
+        directResponse:
+          statusCode: 500
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:v1.23-latest
+      listeners:
+      - address: ""
+        ports:
+        - name: envoy-gateway-gateway-1
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80
+

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.in.yaml
@@ -1,0 +1,33 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                type: Exact
+                value: "/exact"
+          backendRefs:
+            - name: service-that-doesnt-exist
+              port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
@@ -1,0 +1,92 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          type: Exact
+          value: "/exact"
+      backendRefs:
+      - name: service-that-doesnt-exist
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "False"
+        reason: BackendNotFound
+        message: "Service default/service-that-doesnt-exist not found"
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-*
+        pathMatch:
+          exact: "/exact"
+        backendWeights: 
+          invalid: 1
+        directResponse:
+          statusCode: 500
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:v1.23-latest
+      listeners:
+      - address: ""
+        ports:
+        - name: envoy-gateway-gateway-1
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80
+

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -58,7 +58,7 @@ httpRoutes:
             - type: ResolvedRefs
               status: "False"
               reason: RefNotPermitted
-              message: Backend ref to service backends/service-1 not permitted by any ReferenceGrant
+              message: "Backend ref to service backends/service-1 not permitted by any ReferenceGrant"
 xdsIR:
   envoy-gateway-gateway-1:
     http:
@@ -71,9 +71,10 @@ xdsIR:
           - name: default-httproute-1-rule-0-match-0-*
             pathMatch:
               exact: "/exact"
-          InvalidBackends: 1
-          DirectResponse:
-            StatusCode: 500
+            backendWeights: 
+              invalid: 1
+            directResponse:
+              statusCode: 500
 infraIR:
   envoy-gateway-gateway-1:
     proxy:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -71,8 +71,9 @@ xdsIR:
           - name: default-httproute-1-rule-0-match-0-*
             pathMatch:
               exact: "/exact"
-            # TODO this should change when the correct behavior for invalid backend refs is implemented
-            destinations:
+          InvalidBackends: 1
+          DirectResponse:
+            StatusCode: 500
 infraIR:
   envoy-gateway-gateway-1:
     proxy:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -81,10 +81,6 @@ xdsIR:
         headerMatches:
         - name: ":authority"
           exact: gateway.envoyproxy.io
-        destinations:
-        - host: 7.7.7.7
-          port: 8080
-          weight: 1
         redirect:
           scheme: https
           statusCode: 301

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -79,10 +79,6 @@ xdsIR:
         headerMatches:
         - name: ":authority"
           exact: gateway.envoyproxy.io
-        destinations:
-        - host: 7.7.7.7
-          port: 8080
-          weight: 1
         redirect:
           scheme: https
           statusCode: 301

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -84,10 +84,6 @@ xdsIR:
           exact: gateway.envoyproxy.io
         # I believe the correct way to handle an invalid filter should be to allow the HTTPRoute to function
         # normally but leave out the filter config and set the status, but this behaviour can be changed.
-        destinations:
-        - host: 7.7.7.7
-          port: 8080
-          weight: 1
         directResponse:
           body: "Unknown custom filter type: UnsupportedType"
           statusCode: 500

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -82,10 +82,6 @@ xdsIR:
         headerMatches:
         - name: ":authority"
           exact: gateway.envoyproxy.io
-        destinations:
-        - host: 7.7.7.7
-          port: 8080
-          weight: 1
         redirect:
           scheme: http
           statusCode: 302

--- a/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.in.yaml
@@ -1,0 +1,46 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                type: Exact
+                value: "/exact"
+          backendRefs:
+            - name: service-that-doesnt-exist
+              port: 8080
+            - name: service-that-doesnt-exist-2
+              port: 8080
+            - name: service-1
+              port: 8080
+services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: service-1
+    spec:
+      clusterIP: 7.7.7.7
+      ports:
+        - port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
@@ -1,0 +1,99 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          type: Exact
+          value: "/exact"
+      backendRefs:
+      - name: service-that-doesnt-exist
+        port: 8080
+      - name: service-that-doesnt-exist-2
+        port: 8080
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "False"
+        reason: BackendNotFound
+        message: "Service default/service-that-doesnt-exist-2 not found"
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-*
+        pathMatch:
+          exact: "/exact"
+        backendWeights: 
+          invalid: 2  # The weighted clusters for invalid backend refs aren't part of the IR
+          valid: 1
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:v1.23-latest
+      listeners:
+      - address: ""
+        ports:
+        - name: envoy-gateway-gateway-1
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80
+

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -126,6 +126,12 @@ func (t TLSListenerConfig) Validate() error {
 	return errs
 }
 
+// DestinationWeights stores the weights of valid and invalid backends for the route so that 500 error responses can be returned in the same proportions
+type BackendWeights struct {
+	Valid   uint32
+	Invalid uint32
+}
+
 // HTTPRoute holds the route information associated with the HTTP Route
 // +k8s:deepcopy-gen=true
 type HTTPRoute struct {
@@ -137,6 +143,8 @@ type HTTPRoute struct {
 	HeaderMatches []*StringMatch
 	// QueryParamMatches define the match conditions on the query parameters.
 	QueryParamMatches []*StringMatch
+	// DestinationWeights stores the weights of valid and invalid backends for the route so that 500 error responses can be returned in the same proportions
+	BackendWeights BackendWeights
 	// AddRequestHeaders defines header/value sets to be added to the headers of requests.
 	AddRequestHeaders []AddHeader
 	// RemoveRequestHeaders defines a list of headers to be removed from requests.

--- a/internal/ir/xds_test.go
+++ b/internal/ir/xds_test.go
@@ -30,6 +30,20 @@ var (
 		Hostnames: []string{"example.com"},
 		Routes:    []*HTTPRoute{&emptyMatchHTTPRoute},
 	}
+	invalidBackendHTTPListener = HTTPListener{
+		Name:      "invalid-backend-match",
+		Address:   "0.0.0.0",
+		Port:      80,
+		Hostnames: []string{"example.com"},
+		Routes:    []*HTTPRoute{&invalidBackendHTTPRoute},
+	}
+	weightedInvalidBackendsHTTPListener = HTTPListener{
+		Name:      "weighted-invalid-backends-match",
+		Address:   "0.0.0.0",
+		Port:      80,
+		Hostnames: []string{"example.com"},
+		Routes:    []*HTTPRoute{&weightedInvalidBackendsHTTPRoute},
+	}
 
 	// HTTPRoute
 	happyHTTPRoute = HTTPRoute{
@@ -42,6 +56,21 @@ var (
 	emptyMatchHTTPRoute = HTTPRoute{
 		Name:         "empty-match",
 		Destinations: []*RouteDestination{&happyRouteDestination},
+	}
+	invalidBackendHTTPRoute = HTTPRoute{
+		Name: "invalid-backend",
+		PathMatch: &StringMatch{
+			Exact: ptrTo("invalid-backend"),
+		},
+		InvalidBackends: 1,
+	}
+	weightedInvalidBackendsHTTPRoute = HTTPRoute{
+		Name: "weighted-invalid-backends",
+		PathMatch: &StringMatch{
+			Exact: ptrTo("invalid-backends"),
+		},
+		Destinations:    []*RouteDestination{&happyRouteDestination},
+		InvalidBackends: 1,
 	}
 
 	redirectHTTPRoute = HTTPRoute{
@@ -356,6 +385,16 @@ func TestValidateHTTPRoute(t *testing.T) {
 			name:  "empty match",
 			input: emptyMatchHTTPRoute,
 			want:  []error{ErrHTTPRouteMatchEmpty},
+		},
+		{
+			name:  "invalid backend",
+			input: invalidBackendHTTPRoute,
+			want:  nil,
+		},
+		{
+			name:  "weighted invalid backends",
+			input: weightedInvalidBackendsHTTPRoute,
+			want:  nil,
 		},
 		{
 			name: "empty name and invalid match",

--- a/internal/ir/xds_test.go
+++ b/internal/ir/xds_test.go
@@ -62,15 +62,20 @@ var (
 		PathMatch: &StringMatch{
 			Exact: ptrTo("invalid-backend"),
 		},
-		InvalidBackends: 1,
+		BackendWeights: BackendWeights{
+			Invalid: 1,
+		},
 	}
 	weightedInvalidBackendsHTTPRoute = HTTPRoute{
 		Name: "weighted-invalid-backends",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("invalid-backends"),
 		},
-		Destinations:    []*RouteDestination{&happyRouteDestination},
-		InvalidBackends: 1,
+		Destinations: []*RouteDestination{&happyRouteDestination},
+		BackendWeights: BackendWeights{
+			Invalid: 1,
+			Valid:   1,
+		},
 	}
 
 	redirectHTTPRoute = HTTPRoute{
@@ -245,6 +250,20 @@ func TestValidateXds(t *testing.T) {
 				HTTP: []*HTTPListener{&happyHTTPListener, &invalidAddrHTTPListener, &invalidRouteMatchHTTPListener},
 			},
 			want: []error{ErrHTTPListenerAddressInvalid, ErrHTTPRouteMatchEmpty},
+		},
+		{
+			name: "invalid backend",
+			input: Xds{
+				HTTP: []*HTTPListener{&happyHTTPListener, &invalidBackendHTTPListener},
+			},
+			want: nil,
+		},
+		{
+			name: "weighted invalid backend",
+			input: Xds{
+				HTTP: []*HTTPListener{&happyHTTPListener, &weightedInvalidBackendsHTTPListener},
+			},
+			want: nil,
 		},
 	}
 	for _, test := range tests {

--- a/internal/ir/zz_generated.deepcopy.go
+++ b/internal/ir/zz_generated.deepcopy.go
@@ -135,6 +135,7 @@ func (in *HTTPRoute) DeepCopyInto(out *HTTPRoute) {
 			}
 		}
 	}
+	out.BackendWeights = in.BackendWeights
 	if in.AddRequestHeaders != nil {
 		in, out := &in.AddRequestHeaders, &out.AddRequestHeaders
 		*out = make([]AddHeader, len(*in))

--- a/internal/xds/cache/snapshotcache.go
+++ b/internal/xds/cache/snapshotcache.go
@@ -135,8 +135,9 @@ func (s *snapshotcache) OnStreamOpen(ctx context.Context, streamID int64, typeUR
 	return nil
 }
 
-func (s *snapshotcache) OnStreamClosed(streamID int64) {
+func (s *snapshotcache) OnStreamClosed(streamID int64, node *envoy_config_core_v3.Node) {
 
+	// TODO: something with the node?
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -231,8 +232,9 @@ func (s *snapshotcache) OnDeltaStreamOpen(ctx context.Context, streamID int64, t
 	return nil
 }
 
-func (s *snapshotcache) OnDeltaStreamClosed(streamID int64) {
+func (s *snapshotcache) OnDeltaStreamClosed(streamID int64, node *envoy_config_core_v3.Node) {
 
+	// TODO: something with the node?
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-request-headers.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-request-headers.yaml
@@ -27,6 +27,5 @@ http:
       value: ""
       append: false
     removeRequestHeaders:
-      remove:
-      - "some-header5"
-      - "some-header6"
+    - "some-header5"
+    - "some-header6"

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-weighted-invalid-backend.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-weighted-invalid-backend.yaml
@@ -1,0 +1,14 @@
+http:
+- name: "first-listener"
+  address: "0.0.0.0"
+  port: 10080
+  hostnames:
+  - "*"
+  routes:
+  - name: "first-route" 
+    destinations:
+    - host: "1.2.3.4"
+      port: 50000
+    backendWeights: 
+      invalid: 1
+      valid: 1

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
@@ -3,7 +3,7 @@
   connectTimeout: 5s
   dnsLookupFamily: V4_ONLY
   loadAssignment:
-    clusterName: cluster_request-headers-route
+    clusterName: cluster_request-header-route
     endpoints:
     - lbEndpoints:
       - endpoint:
@@ -13,6 +13,6 @@
               portValue: 50000
       loadBalancingWeight: 1
       locality: {}
-  name: cluster_request-headers-route
+  name: cluster_request-header-route
   outlierDetection: {}
   type: STATIC

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
@@ -6,35 +6,29 @@
     routes:
     - match:
         prefix: /
+      requestHeadersToAdd:
+      - append: true
+        header:
+          key: some-header
+          value: some-value
+      - append: true
+        header:
+          key: some-header-2
+          value: some-value
+      - append: false
+        header:
+          key: some-header3
+          value: some-value
+      - append: false
+        header:
+          key: some-header4
+          value: some-value
+      - append: false
+        header:
+          key: empty-header
+        keepEmptyValue: true
+      requestHeadersToRemove:
+      - some-header5
+      - some-header6
       route:
         cluster: cluster_request-header-route
-    request_headers_to_add:
-    - header:
-        key: "some-header"
-        value: "some-value"
-      append: true
-      keep_empty_value: false
-    - header:
-        key: "some-header-2"
-        value: "some-value"
-      append: true
-      keep_empty_value: false
-    - header:
-        key: "some-header-3"
-        value: "some-value"
-      append: false
-      keep_empty_value: false
-    - header:
-        key: "some-header-4"
-        value: "some-value"
-      append: false
-      keep_empty_value: false
-    - header:
-        key: "empty-header"
-        value: ""
-      append: false
-      keep_empty_value: true
-    request_headers_to_remove:
-    - "some-header5"
-    - "some-header6"
-

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
@@ -1,0 +1,18 @@
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  dnsLookupFamily: V4_ONLY
+  loadAssignment:
+    clusterName: cluster_first-route
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 1.2.3.4
+              portValue: 50000
+      loadBalancingWeight: 1
+      locality: {}
+  name: cluster_first-route
+  outlierDetection: {}
+  type: STATIC

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
@@ -1,0 +1,26 @@
+- address:
+    socketAddress:
+      address: 0.0.0.0
+      portValue: 10080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        rds:
+          configSource:
+            apiConfigSource:
+              apiType: GRPC
+              grpcServices:
+              - envoyGrpc:
+                  clusterName: xds_cluster
+              setNodeOnFirstMessageOnly: true
+              transportApiVersion: V3
+            resourceApiVersion: V3
+          routeConfigName: route_first-listener
+        statPrefix: http
+  name: listener_first-listener_10080

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.routes.yaml
@@ -1,0 +1,17 @@
+- name: route_first-listener
+  virtualHosts:
+  - domains:
+    - '*'
+    name: route_first-listener
+    routes:
+    - match:
+        prefix: /
+      route:
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+        weightedClusters:
+          clusters:
+          - name: invalid-backend-cluster
+            weight: 1
+          - name: cluster_first-route
+            weight: 1
+          totalWeight: 2

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -60,7 +60,10 @@ func Translate(ir *ir.Xds) (*types.ResourceVersionTable, error) {
 			}
 			vHost.Routes = append(vHost.Routes, xdsRoute)
 
-			// 1:1 between IR HTTPRoute and xDS Cluster
+			// Skip trying to build an IR cluster if the httpRoute only has invalid backends
+			if len(httpRoute.Destinations) == 0 && httpRoute.BackendWeights.Invalid > 0 {
+				continue
+			}
 			xdsCluster, err := buildXdsCluster(httpRoute)
 			if err != nil {
 				return nil, multierror.Append(err, errors.New("error building xds cluster"))

--- a/internal/xds/translator/translator_test.go
+++ b/internal/xds/translator/translator_test.go
@@ -39,6 +39,9 @@ func TestTranslate(t *testing.T) {
 		{
 			name: "http-route-direct-response",
 		},
+		{
+			name: "http-route-weighted-invalid-backend",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/xds/translator/translator_test.go
+++ b/internal/xds/translator/translator_test.go
@@ -40,6 +40,9 @@ func TestTranslate(t *testing.T) {
 			name: "http-route-direct-response",
 		},
 		{
+			name: "http-route-request-headers",
+		},
+		{
 			name: "http-route-weighted-invalid-backend",
 		},
 	}

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -46,6 +46,8 @@ func TestGatewayAPIConformance(t *testing.T) {
 		tests.HTTPExactPathMatching,
 		tests.HTTPRouteCrossNamespace,
 		tests.HTTPRouteMatchingAcrossRoutes,
+		tests.HTTPRouteInvalidNonExistentBackendRef,
+		tests.HTTPRouteInvalidBackendRefUnknownKind,
 	}
 	cSuite.Run(t, egTests)
 


### PR DESCRIPTION
When a HTTPRoute has invalid backends we need to return 500 responses for gateway API conformance. If there are no valid backends at all then a direct response is issued with status 500, if there is a mix of valid and invalid backends then a weighted cluster is used. 

resolves https://github.com/envoyproxy/gateway/issues/162