### PR TITLE
DEVELOPER.md: add envoy debugging info

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -61,5 +61,16 @@ more about the tests.
 
 **_NOTE:_**  This command is currently Work in Progress. :construction::construction::construction::construction:
 
+
+### Debugging the Envoy Config
+An easy way to view the envoy config that Envoy Gateway is using is to port-forward to the admin interface port (currently `19000`)
+on the Envoy Gateway deployment so that it can be accessed locally.
+
+`kubectl port-forward deploy/envoy-default-eg -n envoy-gateway-system 19000:19000`
+
+Now you are able to view the running Envoy configuration by navigating to `127.0.0.1:19000/config_dump`.
+
+There are many other endpoints on the [Envoy admin interface](https://www.envoyproxy.io/docs/envoy/v1.23.0/operations/admin#operations-admin-interface) that may be helpful when debugging.
+
 [make]: https://www.gnu.org/software/make/
 [gha]: https://docs.github.com/en/actions


### PR DESCRIPTION
Signed-off-by: AliceProxy <alicewasko@datawire.io>

Just adds a little info to DEVELOPER.md that might be helpful to others who want to view the envoy config or were otherwise not aware of how to access the admin interface that we setup. 