### PR TITLE
rm provider resource wait during init logic

### DIFF
--- a/internal/message/types.go
+++ b/internal/message/types.go
@@ -1,8 +1,6 @@
 package message
 
 import (
-	"sync"
-
 	"github.com/telepresenceio/watchable"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,10 +20,6 @@ type ProviderResources struct {
 
 	GatewayStatuses   watchable.Map[types.NamespacedName, *gwapiv1b1.Gateway]
 	HTTPRouteStatuses watchable.Map[types.NamespacedName, *gwapiv1b1.HTTPRoute]
-
-	GatewayClassesInitialized sync.WaitGroup
-	GatewaysInitialized       sync.WaitGroup
-	HTTPRoutesInitialized     sync.WaitGroup
 }
 
 func (p *ProviderResources) DeleteGatewayClasses() {


### PR DESCRIPTION
* removes all the waitgroup logic associated with the provider resources (gatewayclass, gateway, httproute) that was added to ensure that all resources within the watchable map was comepletely initialized before the gateway api translated the resources

* this logic is being removed because the individual waitgroups for each resource are causing a sort of deadlock within the gateway-api runner and not allowing it to process new notifications

* removing this logic does mean that there might some churn in the dataplane during EG reboots. This should get fixed with https://github.com/envoyproxy/gateway/issues/413 which plans on reconciling all resources within a single controller so we cont need to synchonize across multiple controllers using multiple waitgroups

Signed-off-by: Arko Dasgupta <arko@tetrate.io>