### PR TITLE
Makes Codecov CI Job Optional

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         files: ./coverage.xml
         name: codecov-envoy-gateway
         verbose: true


### PR DESCRIPTION
PRs required for RC2 are failing due to [Codecov GKE issues](https://status.codecov.com/#). This removes codecov as a required CI job.

Signed-off-by: danehans <daneyonhansen@gmail.com>