### PR TITLE
run invalid cross namespace backend conformance test

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -48,6 +48,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		tests.HTTPRouteMatchingAcrossRoutes,
 		tests.HTTPRouteInvalidNonExistentBackendRef,
 		tests.HTTPRouteInvalidBackendRefUnknownKind,
+		tests.HTTPRouteInvalidCrossNamespaceBackendRef,
 	}
 	cSuite.Run(t, egTests)
 


### PR DESCRIPTION
Signed-off-by: AliceProxy <alicewasko@datawire.io>

Adds HTTPRouteInvalidCrossNamespaceBackendRef to the active conformance tests, should have been fixed by  https://github.com/envoyproxy/gateway/pull/443 and resolves issue https://github.com/envoyproxy/gateway/issues/433