### PR TITLE
set Gateway namespace and name labels on dependent resources

### DIFF
--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
@@ -74,7 +74,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
@@ -66,7 +66,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
@@ -66,7 +66,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
@@ -64,7 +64,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
@@ -64,7 +64,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
@@ -64,7 +64,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
@@ -62,7 +62,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
@@ -68,7 +68,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
@@ -69,7 +69,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
@@ -68,7 +68,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
@@ -60,7 +60,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -82,7 +82,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
@@ -61,7 +61,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
@@ -81,7 +81,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
@@ -84,7 +84,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
@@ -84,7 +84,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -105,7 +105,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
@@ -74,7 +74,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -99,7 +99,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
@@ -76,7 +76,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
@@ -84,7 +84,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -87,7 +87,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -76,7 +76,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -111,7 +111,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -128,7 +128,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -101,7 +101,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -94,7 +94,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
@@ -98,7 +98,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
@@ -101,7 +101,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
@@ -101,7 +101,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -88,7 +88,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
@@ -92,7 +92,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
@@ -93,7 +93,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
@@ -79,7 +79,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
@@ -81,7 +81,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
@@ -80,7 +80,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
@@ -78,7 +78,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
@@ -79,7 +79,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -80,7 +80,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -69,7 +69,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -91,7 +91,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -88,7 +88,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -92,7 +92,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -93,7 +93,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -93,7 +93,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -93,7 +93,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
@@ -75,7 +75,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
@@ -84,7 +84,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
@@ -86,7 +86,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -80,7 +80,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -91,7 +91,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -23,9 +23,13 @@ const (
 	KindService   = "Service"
 	KindSecret    = "Secret"
 
-	// OwningGatewayLabel is the owner reference label used for managed infra.
+	// OwningGatewayNamespaceLabel is the owner reference label used for managed infra.
+	// The value should be the namespace of the accepted Envoy Gateway.
+	OwningGatewayNamespaceLabel = "gateway.envoyproxy.io/owning-gateway-namespace"
+
+	// OwningGatewayNameLabel is the owner reference label used for managed infra.
 	// The value should be the name of the accepted Envoy Gateway.
-	OwningGatewayLabel = "gateway.envoyproxy.io/owning-gateway"
+	OwningGatewayNameLabel = "gateway.envoyproxy.io/owning-gateway-name"
 
 	// minEphemeralPort is the first port in the ephemeral port range.
 	minEphemeralPort = 1024
@@ -227,7 +231,7 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR XdsIRMap
 		gwXdsIR := &ir.Xds{}
 		gwInfraIR := ir.NewInfra()
 		gwInfraIR.Proxy.Name = irKey
-		gwInfraIR.Proxy.GetProxyMetadata().Labels = GatewayOwnerLabel(gateway.Name)
+		gwInfraIR.Proxy.GetProxyMetadata().Labels = GatewayOwnerLabels(gateway.Namespace, gateway.Name)
 		// save the IR references in the map before the translation starts
 		xdsIR[irKey] = gwXdsIR
 		infraIR[irKey] = gwInfraIR
@@ -1240,8 +1244,11 @@ func irTLSConfig(tlsSecret *v1.Secret) *ir.TLSListenerConfig {
 	}
 }
 
-// GatewayOwnerLabel returns the Gateway Owner label using
-// the provided name as the value.
-func GatewayOwnerLabel(name string) map[string]string {
-	return map[string]string{OwningGatewayLabel: name}
+// GatewayOwnerLabels returns the Gateway Owner labels using
+// the provided namespace and name as the values.
+func GatewayOwnerLabels(namespace, name string) map[string]string {
+	return map[string]string{
+		OwningGatewayNamespaceLabel: namespace,
+		OwningGatewayNameLabel:      name,
+	}
 }

--- a/internal/infrastructure/kubernetes/deployment.go
+++ b/internal/infrastructure/kubernetes/deployment.go
@@ -104,10 +104,10 @@ func (i *Infra) expectedDeployment(infra *ir.Infra) (*appsv1.Deployment, error) 
 		return nil, err
 	}
 
-	// Set the labels based on the owning gatewayclass name.
+	// Set the labels based on the owning gateway name.
 	labels := envoyLabels(infra.GetProxyInfra().GetProxyMetadata().Labels)
-	if _, ok := labels[gatewayapi.OwningGatewayLabel]; !ok {
-		return nil, fmt.Errorf("missing owning gateway label")
+	if len(labels[gatewayapi.OwningGatewayNamespaceLabel]) == 0 || len(labels[gatewayapi.OwningGatewayNameLabel]) == 0 {
+		return nil, fmt.Errorf("missing owning gateway labels")
 	}
 
 	deployment := &appsv1.Deployment{

--- a/internal/infrastructure/kubernetes/deployment_test.go
+++ b/internal/infrastructure/kubernetes/deployment_test.go
@@ -104,7 +104,10 @@ func TestExpectedDeployment(t *testing.T) {
 	cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects().Build()
 	kube := NewInfra(cli)
 	infra := ir.NewInfra()
-	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayLabel] = infra.Proxy.Name
+
+	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
+	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = infra.Proxy.Name
+
 	deploy, err := kube.expectedDeployment(infra)
 	require.NoError(t, err)
 
@@ -156,7 +159,10 @@ func deploymentWithImage(deploy *appsv1.Deployment, image string) *appsv1.Deploy
 func TestCreateOrUpdateDeployment(t *testing.T) {
 	kube := NewInfra(nil)
 	infra := ir.NewInfra()
-	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayLabel] = infra.Proxy.Name
+
+	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
+	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = infra.Proxy.Name
+
 	deploy, err := kube.expectedDeployment(infra)
 	require.NoError(t, err)
 
@@ -186,7 +192,10 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 			in: &ir.Infra{
 				Proxy: &ir.ProxyInfra{
 					Metadata: &ir.InfraMetadata{
-						Labels: map[string]string{gatewayapi.OwningGatewayLabel: infra.Proxy.Name},
+						Labels: map[string]string{
+							gatewayapi.OwningGatewayNamespaceLabel: "default",
+							gatewayapi.OwningGatewayNameLabel:      infra.Proxy.Name,
+						},
 					},
 					Name:      ir.DefaultProxyName,
 					Image:     "envoyproxy/gateway-dev:v1.2.3",

--- a/internal/infrastructure/kubernetes/infra_test.go
+++ b/internal/infrastructure/kubernetes/infra_test.go
@@ -20,7 +20,8 @@ func TestCreateInfra(t *testing.T) {
 	expected := ir.NewInfra()
 	// Apply the expected labels to the proxy infra.
 	expected.GetProxyInfra().GetProxyMetadata().Labels = envoyAppLabel()
-	expected.GetProxyInfra().GetProxyMetadata().Labels[gatewayapi.OwningGatewayLabel] = "test-gw"
+	expected.GetProxyInfra().GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
+	expected.GetProxyInfra().GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = "test-gw"
 
 	testCases := []struct {
 		name   string

--- a/internal/infrastructure/kubernetes/service.go
+++ b/internal/infrastructure/kubernetes/service.go
@@ -38,8 +38,8 @@ func (i *Infra) expectedService(infra *ir.Infra) (*corev1.Service, error) {
 
 	// Set the labels based on the owning gatewayclass name.
 	labels := envoyLabels(infra.GetProxyInfra().GetProxyMetadata().Labels)
-	if _, ok := labels[gatewayapi.OwningGatewayLabel]; !ok {
-		return nil, fmt.Errorf("missing owning gateway label")
+	if len(labels[gatewayapi.OwningGatewayNamespaceLabel]) == 0 || len(labels[gatewayapi.OwningGatewayNameLabel]) == 0 {
+		return nil, fmt.Errorf("missing owning gateway labels")
 	}
 
 	svc := &corev1.Service{

--- a/internal/infrastructure/kubernetes/service_test.go
+++ b/internal/infrastructure/kubernetes/service_test.go
@@ -65,7 +65,8 @@ func TestDesiredService(t *testing.T) {
 	cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects().Build()
 	kube := NewInfra(cli)
 	infra := ir.NewInfra()
-	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayLabel] = infra.Proxy.Name
+	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
+	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = infra.Proxy.Name
 	infra.Proxy.Listeners[0].Ports = []ir.ListenerPort{
 		{
 			Name:          "gateway-system-gateway-1",
@@ -93,7 +94,8 @@ func TestDesiredService(t *testing.T) {
 
 	// Ensure the Envoy service has the expected labels.
 	lbls := envoyAppLabel()
-	lbls[gatewayapi.OwningGatewayLabel] = infra.Proxy.Name
+	lbls[gatewayapi.OwningGatewayNamespaceLabel] = "default"
+	lbls[gatewayapi.OwningGatewayNameLabel] = infra.Proxy.Name
 	checkServiceHasLabels(t, svc, lbls)
 
 	for _, port := range infra.Proxy.Listeners[0].Ports {

--- a/internal/infrastructure/kubernetes/serviceaccount_test.go
+++ b/internal/infrastructure/kubernetes/serviceaccount_test.go
@@ -22,7 +22,10 @@ func TestExpectedServiceAccount(t *testing.T) {
 	cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects().Build()
 	kube := NewInfra(cli)
 	infra := ir.NewInfra()
-	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayLabel] = infra.Proxy.Name
+
+	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
+	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = infra.Proxy.Name
+
 	sa := kube.expectedServiceAccount(infra)
 
 	// Check the serviceaccount name is as expected.


### PR DESCRIPTION
Switches from a single label that only specifies
the Gateway name to two labels, one for namespace
and one for name, on Gateway dependent resources.
This avoids conflicts between Gateways in different 
namespaces with the same names.

Also fixes mapping from dependent resources to
the owning Gateway in the Gateway reconciler.

Closes #452.
Closes #453.

Signed-off-by: Steve Kriss <krisss@vmware.com>

Note, I'll tackle labeling the ServiceAccount and ConfigMap in a separate PR.