### PR TITLE
Fix flow for gatewayclass deletes

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
-	"github.com/envoyproxy/gateway/internal/ir"
 	"github.com/envoyproxy/gateway/internal/message"
 	"github.com/envoyproxy/gateway/internal/provider/utils"
 )
@@ -71,11 +70,6 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 		case gatewayClasses == nil:
 			// Envoy Gateway startup.
 			continue
-		case gatewayClasses[0] == nil:
-			// No need to translate, publish empty IRs to trigger a delete operation.
-			r.XdsIR.Store(r.Name(), &ir.Xds{})
-			// A nil ProxyInfra tells the Infra Manager to delete the managed proxy infra.
-			r.InfraIR.Store(r.Name(), &ir.Infra{Proxy: nil})
 		default:
 			// Translate and publish IRs.
 			t := &gatewayapi.Translator{

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -103,8 +103,8 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 				!slice.ContainsString(gatewayClasses.Items[i].Finalizers, gatewayClassFinalizer) {
 				r.log.Info("gatewayclass marked for deletion")
 				cc.removeMatch(&gatewayClasses.Items[i])
-				// A nil gatewayclass removes managed proxy infra, if it exists.
-				r.resources.GatewayClasses.Store(request.Name, nil)
+				// Delete the gatewayclass from the watchable map.
+				r.resources.GatewayClasses.Delete(request.Name)
 				continue
 			}
 


### PR DESCRIPTION
* Delete the gatewayclass from the watchable map if it has been scheduled for deletion

* We always end up storing the accepted gatewayclass in the same controller in the same function

* Clean up the gateway-api runner code which earlier expected a gatewayclass slice with a `nil` element

Signed-off-by: Arko Dasgupta <arko@tetrate.io>