### PR TITLE
internal/infrastructure/kubernetes: drop Resources struct

### DIFF
--- a/internal/infrastructure/kubernetes/deployment.go
+++ b/internal/infrastructure/kubernetes/deployment.go
@@ -292,10 +292,6 @@ func (i *Infra) createOrUpdateDeployment(ctx context.Context, infra *ir.Infra) e
 		}
 	}
 
-	if err := i.updateResource(deploy); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/internal/infrastructure/kubernetes/infra.go
+++ b/internal/infrastructure/kubernetes/infra.go
@@ -3,11 +3,7 @@ package kubernetes
 import (
 	"context"
 	"errors"
-	"fmt"
-	"sync"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
@@ -15,67 +11,21 @@ import (
 	"github.com/envoyproxy/gateway/internal/utils/env"
 )
 
-// Infra holds all the translated Infra IR resources and provides
-// the scaffolding for the managing Kubernetes infrastructure.
+// Infra manages the creation and deletion of Kubernetes infrastructure
+// based on Infra IR resources.
 type Infra struct {
-	mu     sync.Mutex
 	Client client.Client
+
 	// Namespace is the Namespace used for managed infra.
 	Namespace string
-	Resources *Resources
-}
-
-// Resources are managed Kubernetes resources.
-type Resources struct {
-	ServiceAccount *corev1.ServiceAccount
-	Deployment     *appsv1.Deployment
-	Service        *corev1.Service
 }
 
 // NewInfra returns a new Infra.
 func NewInfra(cli client.Client) *Infra {
-	infra := &Infra{
-		mu:        sync.Mutex{},
+	return &Infra{
 		Client:    cli,
-		Resources: newResources(),
+		Namespace: env.Lookup("ENVOY_GATEWAY_NAMESPACE", config.EnvoyGatewayNamespace),
 	}
-
-	// Set the namespace used for the managed infra.
-	infra.Namespace = env.Lookup("ENVOY_GATEWAY_NAMESPACE", config.EnvoyGatewayNamespace)
-
-	return infra
-}
-
-// newResources returns a new Resources.
-func newResources() *Resources {
-	return &Resources{
-		ServiceAccount: new(corev1.ServiceAccount),
-		Deployment:     new(appsv1.Deployment),
-		Service:        new(corev1.Service),
-	}
-}
-
-// updateResource updates the obj to the infra resources, using the object type
-// to identify the object kind to add.
-func (i *Infra) updateResource(obj client.Object) error {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	if i.Resources == nil {
-		i.Resources = new(Resources)
-	}
-
-	switch o := obj.(type) {
-	case *corev1.ServiceAccount:
-		i.Resources.ServiceAccount = o
-	case *appsv1.Deployment:
-		i.Resources.Deployment = o
-	case *corev1.Service:
-		i.Resources.Service = o
-	default:
-		return fmt.Errorf("unexpected object kind %s", obj.GetObjectKind())
-	}
-
-	return nil
 }
 
 // CreateInfra creates the managed kube infra, if it doesn't exist.
@@ -86,10 +36,6 @@ func (i *Infra) CreateInfra(ctx context.Context, infra *ir.Infra) error {
 
 	if infra.Proxy == nil {
 		return errors.New("infra proxy ir is nil")
-	}
-
-	if i.Resources == nil {
-		i.Resources = newResources()
 	}
 
 	if err := i.createOrUpdateServiceAccount(ctx, infra); err != nil {

--- a/internal/infrastructure/kubernetes/service.go
+++ b/internal/infrastructure/kubernetes/service.go
@@ -93,10 +93,6 @@ func (i *Infra) createOrUpdateService(ctx context.Context, infra *ir.Infra) erro
 		}
 	}
 
-	if err := i.updateResource(svc); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/internal/infrastructure/kubernetes/service_test.go
+++ b/internal/infrastructure/kubernetes/service_test.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,7 +116,6 @@ func TestDeleteService(t *testing.T) {
 			t.Parallel()
 			kube := &Infra{
 				Client:    fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build(),
-				mu:        sync.Mutex{},
 				Namespace: "test",
 			}
 			infra := ir.NewInfra()

--- a/internal/infrastructure/kubernetes/serviceaccount.go
+++ b/internal/infrastructure/kubernetes/serviceaccount.go
@@ -62,10 +62,6 @@ func (i *Infra) createOrUpdateServiceAccount(ctx context.Context, infra *ir.Infr
 		}
 	}
 
-	if err := i.updateResource(sa); err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Drops the Resources struct as it was only
being used to record state of the created
Kubernetes resources for testing purposes.
Replaces it with calls to the fake kube
client to fetch the resources.

Closes #370.

This will make implementing #457 easier.

Signed-off-by: Steve Kriss <krisss@vmware.com>

cc @danehans - let me know if I misunderstood the purpose of the existing structure.