### PR TITLE
Order gateway resource updates in provider

### DIFF
--- a/internal/provider/kubernetes/gateway.go
+++ b/internal/provider/kubernetes/gateway.go
@@ -179,17 +179,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 	}
 
 	found := false
-	for i := range acceptedGateways {
-		key := utils.NamespacedName(&acceptedGateways[i])
-		r.resources.Gateways.Store(key, &acceptedGateways[i])
-		if key == request.NamespacedName {
-			found = true
-		}
-	}
-	if !found {
-		r.resources.Gateways.Delete(request.NamespacedName)
-	}
-
 	// Set status conditions for all accepted gateways.
 	for i := range acceptedGateways {
 		gw := acceptedGateways[i]
@@ -215,6 +204,15 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 		// publish status
 		key := utils.NamespacedName(&gw)
 		r.resources.GatewayStatuses.Store(key, &gw)
+
+		r.resources.Gateways.Store(key, &gw)
+		if key == request.NamespacedName {
+			found = true
+		}
+	}
+
+	if !found {
+		r.resources.Gateways.Delete(request.NamespacedName)
 	}
 
 	r.log.WithName(request.Namespace).WithName(request.Name).Info("reconciled gateway")


### PR DESCRIPTION
1) update the reconciled gateway resource with a newer status in the provider
2) pass that updated resource to the status update goroutine
3) store the updated resource in the watchable map so the gateway api translator performs status updates on the newer resource

Fixes: https://github.com/envoyproxy/gateway/issues/459
Fixes: https://github.com/envoyproxy/gateway/issues/464

Signed-off-by: Arko Dasgupta <arko@tetrate.io>