### PR TITLE
Dont store nil resources in watchable

### DIFF
--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -119,8 +119,6 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 	r.resources.DeleteGatewayClasses()
 	if acceptedGC == nil {
 		r.log.Info("failed to find an accepted gatewayclass")
-		// A nil gatewayclass removes managed proxy infra, if it exists.
-		r.resources.GatewayClasses.Store(request.Name, nil)
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
The arch has been revised to handle watchable stores and deletes

Fixes: https://github.com/envoyproxy/gateway/issues/467

Signed-off-by: Arko Dasgupta <arko@tetrate.io>