### PR TITLE
provider: only store resource if spec has changed

### DIFF
--- a/internal/provider/kubernetes/gateway.go
+++ b/internal/provider/kubernetes/gateway.go
@@ -201,10 +201,15 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 		status.UpdateGatewayStatusScheduledCondition(&gw, true)
 		// update address field and ready condition
 		status.UpdateGatewayStatusReadyCondition(&gw, svc, deployment)
-		// publish status
-		key := utils.NamespacedName(&gw)
-		r.resources.GatewayStatuses.Store(key, &gw)
 
+		// publish status
+		// do it inline and not using the status updater which does not update
+		// the Status.Addresses field.
+		if err := r.client.Status().Update(ctx, &gw); err != nil {
+			r.log.Error(err, "error updating status of gateway", "name", gw.Name)
+		}
+
+		key := utils.NamespacedName(&gw)
 		// only store the resource if it does not exist or it has a newer spec.
 		if v, ok := r.resources.Gateways.Load(key); !ok || (gw.Generation > v.Generation) {
 			r.resources.Gateways.Store(key, &gw)
@@ -347,7 +352,6 @@ func (r *gatewayReconciler) subscribeAndUpdateStatus(ctx context.Context) {
 					}
 					gCopy := g.DeepCopy()
 					gCopy.Status.Conditions = status.MergeConditions(gCopy.Status.Conditions, val.Status.Conditions...)
-					gCopy.Status.Addresses = val.Status.Addresses
 					gCopy.Status.Listeners = val.Status.Listeners
 					return gCopy
 				}),

--- a/internal/provider/kubernetes/gateway.go
+++ b/internal/provider/kubernetes/gateway.go
@@ -205,7 +205,10 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 		key := utils.NamespacedName(&gw)
 		r.resources.GatewayStatuses.Store(key, &gw)
 
-		r.resources.Gateways.Store(key, &gw)
+		// only store the resource if it does not exist or it has a newer spec.
+		if v, ok := r.resources.Gateways.Load(key); !ok || (gw.Generation > v.Generation) {
+			r.resources.Gateways.Store(key, &gw)
+		}
 		if key == request.NamespacedName {
 			found = true
 		}

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -119,6 +119,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{}, nil
 	}
 
+	// Store the accepted gatewayclass in the resource map.
 	r.resources.GatewayClasses.Store(acceptedGC.GetName(), acceptedGC)
 
 	updater := func(gc *gwapiv1b1.GatewayClass, accepted bool) error {

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -119,8 +119,10 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{}, nil
 	}
 
-	// Store the accepted gatewayclass in the resource map.
-	r.resources.GatewayClasses.Store(acceptedGC.GetName(), acceptedGC)
+	// only store the resource if it does not exist or it has a newer spec.
+	if v, ok := r.resources.GatewayClasses.Load(acceptedGC.GetName()); !ok || (acceptedGC.Generation > v.Generation) {
+		r.resources.GatewayClasses.Store(acceptedGC.GetName(), acceptedGC)
+	}
 
 	updater := func(gc *gwapiv1b1.GatewayClass, accepted bool) error {
 		if r.statusUpdater != nil {

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -119,10 +119,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{}, nil
 	}
 
-	// only store the resource if it does not exist or it has a newer spec.
-	if v, ok := r.resources.GatewayClasses.Load(acceptedGC.GetName()); !ok || (acceptedGC.Generation > v.Generation) {
-		r.resources.GatewayClasses.Store(acceptedGC.GetName(), acceptedGC)
-	}
+	r.resources.GatewayClasses.Store(acceptedGC.GetName(), acceptedGC)
 
 	updater := func(gc *gwapiv1b1.GatewayClass, accepted bool) error {
 		if r.statusUpdater != nil {

--- a/internal/provider/kubernetes/httproute.go
+++ b/internal/provider/kubernetes/httproute.go
@@ -212,10 +212,11 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.R
 			return reconcile.Result{}, nil
 		}
 
-		// Store the httproute in the resource map.
-		r.resources.HTTPRoutes.Store(routeKey, &route)
-		log.Info("added httproute to resource map")
-
+		// only store the resource if it does not exist or it has a newer spec.
+		if v, ok := r.resources.HTTPRoutes.Load(routeKey); !ok || (route.Generation > v.Generation) {
+			r.resources.HTTPRoutes.Store(routeKey, &route)
+			log.Info("added httproute to resource map")
+		}
 		// Get the route's namespace from the cache.
 		nsKey := types.NamespacedName{Name: route.Namespace}
 		ns := new(corev1.Namespace)

--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -235,7 +235,12 @@ func testGatewayScheduledStatus(ctx context.Context, t *testing.T, provider *Pro
 		return cli.Get(ctx, key, gw) == nil
 	}, defaultWait, defaultTick)
 	gws, _ := resources.Gateways.Load(key)
-	assert.Equal(t, gw, gws)
+	// Only check if the spec is equal
+	// The watchable map will not store a resource
+	// with an updated status if the spec hasnt changed
+	// to eliminate this endless loop:
+	// reconcile->store->translate->update-status->reconcile
+	assert.Equal(t, gw.Spec, gws.Spec)
 }
 
 func testHTTPRoute(ctx context.Context, t *testing.T, provider *Provider, resources *message.ProviderResources) {

--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -237,7 +237,7 @@ func testGatewayScheduledStatus(ctx context.Context, t *testing.T, provider *Pro
 	gws, _ := resources.Gateways.Load(key)
 	// Only check if the spec is equal
 	// The watchable map will not store a resource
-	// with an updated status if the spec hasnt changed
+	// with an updated status if the spec has not changed
 	// to eliminate this endless loop:
 	// reconcile->store->translate->update-status->reconcile
 	assert.Equal(t, gw.Spec, gws.Spec)


### PR DESCRIPTION
Leverage the metadata.Generation field to consider whether to update the newly reconciled resource into the watchable map which will trigger translations in the backend.

Fixes: https://github.com/envoyproxy/gateway/issues/407

Signed-off-by: Arko Dasgupta <arko@tetrate.io>