### PR TITLE
delete unneeded gatewayclass delete logic

### DIFF
--- a/internal/gatewayapi/runner/runner_test.go
+++ b/internal/gatewayapi/runner/runner_test.go
@@ -39,10 +39,9 @@ func TestRunner(t *testing.T) {
 
 	// TODO: pass valid provider resources
 
-	// Reset gateway slice and update with a nil gateway to trigger a delete.
-	pResources.DeleteGateways()
+	// Delete gateway from the map.
 	key := types.NamespacedName{Namespace: "test", Name: "test"}
-	pResources.Gateways.Store(key, nil)
+	pResources.Gateways.Delete(key)
 	require.Eventually(t, func() bool {
 		out := xdsIR.LoadAll()
 		if out == nil {

--- a/internal/message/types.go
+++ b/internal/message/types.go
@@ -22,18 +22,6 @@ type ProviderResources struct {
 	HTTPRouteStatuses watchable.Map[types.NamespacedName, *gwapiv1b1.HTTPRoute]
 }
 
-func (p *ProviderResources) DeleteGatewayClasses() {
-	for k := range p.GatewayClasses.LoadAll() {
-		p.GatewayClasses.Delete(k)
-	}
-}
-
-func (p *ProviderResources) DeleteGateways() {
-	for k := range p.Gateways.LoadAll() {
-		p.Gateways.Delete(k)
-	}
-}
-
 func (p *ProviderResources) GetGatewayClasses() []*gwapiv1b1.GatewayClass {
 	if p.GatewayClasses.Len() == 0 {
 		return nil

--- a/internal/message/types_test.go
+++ b/internal/message/types_test.go
@@ -152,8 +152,4 @@ func TestProviderResources(t *testing.T) {
 
 	svcs = resources.GetServices()
 	assert.ElementsMatch(t, svcs, []*corev1.Service{s1, s2})
-
-	// Delete gatewayclasses
-	resources.DeleteGatewayClasses()
-	assert.Nil(t, resources.GetGatewayClasses())
 }

--- a/internal/provider/kubernetes/gatewayclass.go
+++ b/internal/provider/kubernetes/gatewayclass.go
@@ -114,9 +114,6 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, request reconcil
 
 	// The gatewayclass was already deleted/finalized and there are stale queue entries.
 	acceptedGC := cc.acceptedClass()
-	// Reset gatewayclasses since this Reconcile function never performs a Delete and
-	// we are only interested in the first element.
-	r.resources.DeleteGatewayClasses()
 	if acceptedGC == nil {
 		r.log.Info("failed to find an accepted gatewayclass")
 		return reconcile.Result{}, nil


### PR DESCRIPTION
There's no need to reset the gatewayclass since we delete the gatewayclass from the watchable map when it is marked for deletion

Signed-off-by: Arko Dasgupta <arko@tetrate.io>