### PR TITLE
Fixes Supported Kube Version

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -47,6 +47,8 @@ Envoy Gateway is built using a [make][make]-based build system. Our CI is based 
 * Run `make create-cluster` to create a Kind cluster and `make kube-install-image` to build a image and load
 it into the Kind cluster.
 
+**_NOTE:_** Envoy Gateway is tested against Kubernetes v1.24.0.
+
 ### Deploying Envoy Gateway in Kubernetes
 * Run `IMAGE=envoyproxy/gateway-dev TAG=latest make kube-deploy` to deploy Envoy Gateway resources, including the Gateway API CRDs,
 with the `envoyproxy/gateway-dev:latest` Envoy Gateway image into a Kubernetes cluster (linked to the current kube context).

--- a/docs/user/QUICKSTART.md
+++ b/docs/user/QUICKSTART.md
@@ -4,7 +4,7 @@ This guide will help you get started with Envoy Gateway in a few simple steps.
 ## Prerequisites
 A Kubernetes cluster.
 
-__Note:__ Envoy Gateway is tested against Kubernetes v1.24.1.
+__Note:__ Envoy Gateway is tested against Kubernetes v1.24.0.
 
 ## Installation
 Install the Gateway API CRDs:


### PR DESCRIPTION
Updates the supported Kube version to `v1.24.0` based on the [create-cluster](https://github.com/envoyproxy/gateway/blob/v0.2.0-rc2/tools/hack/create-cluster.sh#L8) target.

Signed-off-by: danehans <daneyonhansen@gmail.com>