### PR TITLE
Updates ParentRef Status Conditions

### DIFF
--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -71,10 +71,6 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
-        status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter already configures request header: add-header-1 to be added, ignoring second entry"
 xdsIR:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -71,8 +71,8 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: UnsupportedValue
-        message: "RequestHeaderModifier Filter already configures request header: add-header-1 to be added, ignoring second entry"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -81,9 +81,8 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: UnsupportedValue
-        # Currently only one invalid value status will be set. If there are multiple, then only the latest is displayed until that issue is resolved.
-        message: "RequestHeaderModifier Filter already configures request header: set-header-4 to be added/set, ignoring second entry"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -81,10 +81,6 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
-        status: "False"
         reason: UnsupportedValue
         # Currently only one invalid value status will be set. If there are multiple, then only the latest is displayed until that issue is resolved.
         message: "RequestHeaderModifier Filter already configures request header: set-header-4 to be added/set, ignoring second entry"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -67,8 +67,8 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: UnsupportedValue
-        message: "RequestHeaderModifier Filter already configures request header: rem-header-1 to be removed, ignoring second entry"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -67,10 +67,6 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
-        status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter already configures request header: rem-header-1 to be removed, ignoring second entry"
 xdsIR:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -62,8 +62,8 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: UnsupportedValue
-        message: "RequestHeaderModifier Filter already configures request header: some-header-1 to be removed, ignoring second entry"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -62,10 +62,6 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
-        status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter already configures request header: some-header-1 to be removed, ignoring second entry"
 xdsIR:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
@@ -66,10 +66,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter cannot set a header with an empty name"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
@@ -66,9 +66,9 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "False"
-        reason: UnsupportedValue
-        message: "RequestHeaderModifier Filter cannot set a header with an empty name"
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
@@ -66,10 +66,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter cannot set headers with a '/' or ':' character in them. Header: 'example:1'"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
@@ -66,9 +66,9 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "False"
-        reason: UnsupportedValue
-        message: "RequestHeaderModifier Filter cannot set headers with a '/' or ':' character in them. Header: 'example:1'"
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
@@ -61,10 +61,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter did not provide valid configuration to add/set/remove any headers"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
@@ -61,9 +61,9 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "False"
-        reason: UnsupportedValue
-        message: "RequestHeaderModifier Filter did not provide valid configuration to add/set/remove any headers"
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -60,10 +60,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "Unknown custom filter type: UnsupportedType"

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -60,9 +60,9 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "False"
-        reason: UnsupportedValue
-        message: "Unknown custom filter type: UnsupportedType"
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -60,10 +60,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "Scheme: unknown is unsupported, only 'https' and 'http' are supported"

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -60,9 +60,9 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "False"
-        reason: UnsupportedValue
-        message: "Scheme: unknown is unsupported, only 'https' and 'http' are supported"
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -60,9 +60,9 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "False"
-        reason: UnsupportedValue
-        message: "Status code 666 is invalid, only 302 and 301 are supported"
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -60,10 +60,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "Status code 666 is invalid, only 302 and 301 are supported"

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -779,7 +779,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 						// Can't have two redirects for the same route
 						if redirectResponse != nil {
 							parentRef.SetCondition(httpRoute,
-								v1beta1.RouteConditionResolvedRefs,
+								v1beta1.RouteConditionAccepted,
 								metav1.ConditionFalse,
 								v1beta1.RouteReasonUnsupportedValue,
 								"Cannot configure multiple requestRedirect filters for a single HTTPRouteRule",
@@ -801,7 +801,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 							} else {
 								errMsg := fmt.Sprintf("Scheme: %s is unsupported, only 'https' and 'http' are supported", *redirect.Scheme)
 								parentRef.SetCondition(httpRoute,
-									v1beta1.RouteConditionResolvedRefs,
+									v1beta1.RouteConditionAccepted,
 									metav1.ConditionFalse,
 									v1beta1.RouteReasonUnsupportedValue,
 									errMsg,
@@ -813,7 +813,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 						if redirect.Hostname != nil {
 							if err := isValidHostname(string(*redirect.Hostname)); err != nil {
 								parentRef.SetCondition(httpRoute,
-									v1beta1.RouteConditionResolvedRefs,
+									v1beta1.RouteConditionAccepted,
 									metav1.ConditionFalse,
 									v1beta1.RouteReasonUnsupportedValue,
 									err.Error(),
@@ -842,7 +842,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 							default:
 								errMsg := fmt.Sprintf("Redirect path type: %s is invalid, only \"ReplaceFullPath\" and \"ReplacePrefixMatch\" are supported", redirect.Path.Type)
 								parentRef.SetCondition(httpRoute,
-									v1beta1.RouteConditionResolvedRefs,
+									v1beta1.RouteConditionAccepted,
 									metav1.ConditionFalse,
 									v1beta1.RouteReasonUnsupportedValue,
 									errMsg,
@@ -859,7 +859,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 							} else {
 								errMsg := fmt.Sprintf("Status code %d is invalid, only 302 and 301 are supported", redirectCode)
 								parentRef.SetCondition(httpRoute,
-									v1beta1.RouteConditionResolvedRefs,
+									v1beta1.RouteConditionAccepted,
 									metav1.ConditionFalse,
 									v1beta1.RouteReasonUnsupportedValue,
 									errMsg,
@@ -891,7 +891,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 								emptyFilterConfig = false
 								if addHeader.Name == "" {
 									parentRef.SetCondition(httpRoute,
-										v1beta1.RouteConditionResolvedRefs,
+										v1beta1.RouteConditionAccepted,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
 										"RequestHeaderModifier Filter cannot add a header with an empty name",
@@ -902,7 +902,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 								// Per Gateway API specification on HTTPHeaderName, : and / are invalid characters in header names
 								if strings.Contains(string(addHeader.Name), "/") || strings.Contains(string(addHeader.Name), ":") {
 									parentRef.SetCondition(httpRoute,
-										v1beta1.RouteConditionResolvedRefs,
+										v1beta1.RouteConditionAccepted,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
 										fmt.Sprintf("RequestHeaderModifier Filter cannot set headers with a '/' or ':' character in them. Header: %q", string(addHeader.Name)),
@@ -921,8 +921,8 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 
 								if !canAddHeader {
 									parentRef.SetCondition(httpRoute,
-										v1beta1.RouteConditionResolvedRefs,
-										metav1.ConditionFalse,
+										v1beta1.RouteConditionAccepted,
+										metav1.ConditionTrue,
 										v1beta1.RouteReasonUnsupportedValue,
 										fmt.Sprintf("RequestHeaderModifier Filter already configures request header: %s to be added, ignoring second entry", headerKey),
 									)
@@ -948,7 +948,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 
 								if setHeader.Name == "" {
 									parentRef.SetCondition(httpRoute,
-										v1beta1.RouteConditionResolvedRefs,
+										v1beta1.RouteConditionAccepted,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
 										"RequestHeaderModifier Filter cannot set a header with an empty name",
@@ -958,7 +958,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 								// Per Gateway API specification on HTTPHeaderName, : and / are invalid characters in header names
 								if strings.Contains(string(setHeader.Name), "/") || strings.Contains(string(setHeader.Name), ":") {
 									parentRef.SetCondition(httpRoute,
-										v1beta1.RouteConditionResolvedRefs,
+										v1beta1.RouteConditionAccepted,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
 										fmt.Sprintf("RequestHeaderModifier Filter cannot set headers with a '/' or ':' character in them. Header: '%s'", string(setHeader.Name)),
@@ -977,8 +977,8 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 								}
 								if !canAddHeader {
 									parentRef.SetCondition(httpRoute,
-										v1beta1.RouteConditionResolvedRefs,
-										metav1.ConditionFalse,
+										v1beta1.RouteConditionAccepted,
+										metav1.ConditionTrue,
 										v1beta1.RouteReasonUnsupportedValue,
 										fmt.Sprintf("RequestHeaderModifier Filter already configures request header: %s to be added/set, ignoring second entry", headerKey),
 									)
@@ -1004,7 +1004,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 							for _, removedHeader := range headersToRemove {
 								if removedHeader == "" {
 									parentRef.SetCondition(httpRoute,
-										v1beta1.RouteConditionResolvedRefs,
+										v1beta1.RouteConditionAccepted,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
 										"RequestHeaderModifier Filter cannot remove a header with an empty name",
@@ -1021,8 +1021,8 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 								}
 								if !canRemHeader {
 									parentRef.SetCondition(httpRoute,
-										v1beta1.RouteConditionResolvedRefs,
-										metav1.ConditionFalse,
+										v1beta1.RouteConditionAccepted,
+										metav1.ConditionTrue,
 										v1beta1.RouteReasonUnsupportedValue,
 										fmt.Sprintf("RequestHeaderModifier Filter already configures request header: %s to be removed, ignoring second entry", removedHeader),
 									)
@@ -1037,7 +1037,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 						// Update the status if the filter failed to configure any valid headers to add/remove
 						if len(addRequestHeaders) == 0 && len(removeRequestHeaders) == 0 && !emptyFilterConfig {
 							parentRef.SetCondition(httpRoute,
-								v1beta1.RouteConditionResolvedRefs,
+								v1beta1.RouteConditionAccepted,
 								metav1.ConditionFalse,
 								v1beta1.RouteReasonUnsupportedValue,
 								"RequestHeaderModifier Filter did not provide valid configuration to add/set/remove any headers",
@@ -1048,7 +1048,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 						// Instead, requests that would have been processed by that filter MUST receive a HTTP error response."
 						errMsg := fmt.Sprintf("Unknown custom filter type: %s", filter.Type)
 						parentRef.SetCondition(httpRoute,
-							v1beta1.RouteConditionResolvedRefs,
+							v1beta1.RouteConditionAccepted,
 							metav1.ConditionFalse,
 							v1beta1.RouteReasonUnsupportedValue,
 							errMsg,

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -920,12 +920,6 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 								}
 
 								if !canAddHeader {
-									parentRef.SetCondition(httpRoute,
-										v1beta1.RouteConditionAccepted,
-										metav1.ConditionTrue,
-										v1beta1.RouteReasonUnsupportedValue,
-										fmt.Sprintf("RequestHeaderModifier Filter already configures request header: %s to be added, ignoring second entry", headerKey),
-									)
 									continue
 								}
 
@@ -976,12 +970,6 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 									}
 								}
 								if !canAddHeader {
-									parentRef.SetCondition(httpRoute,
-										v1beta1.RouteConditionAccepted,
-										metav1.ConditionTrue,
-										v1beta1.RouteReasonUnsupportedValue,
-										fmt.Sprintf("RequestHeaderModifier Filter already configures request header: %s to be added/set, ignoring second entry", headerKey),
-									)
 									continue
 								}
 								newHeader := ir.AddHeader{
@@ -1020,12 +1008,6 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 									}
 								}
 								if !canRemHeader {
-									parentRef.SetCondition(httpRoute,
-										v1beta1.RouteConditionAccepted,
-										metav1.ConditionTrue,
-										v1beta1.RouteReasonUnsupportedValue,
-										fmt.Sprintf("RequestHeaderModifier Filter already configures request header: %s to be removed, ignoring second entry", removedHeader),
-									)
 									continue
 								}
 


### PR DESCRIPTION
Updates the `Accepted` condition type to use [RouteReasonUnsupportedValue](https://pkg.go.dev/sigs.k8s.io/gateway-api/apis/v1beta1@v0.5.1#RouteReasonUnsupportedValue) instead of the `ResolvedRefs` condition type.

Fixes #494 

Signed-off-by: danehans <daneyonhansen@gmail.com>