### PR TITLE
Fixes ResolvedRefs HTTPRoute Status Condition Calculation

### DIFF
--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
@@ -53,6 +53,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service envoy-gateway/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -58,6 +58,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
@@ -57,6 +57,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
@@ -73,6 +73,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -71,6 +71,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:
@@ -112,7 +116,7 @@ infraIR:
       listeners:
         - address: ""
           ports:
-            - name: http-1
+            - name: http-2
               protocol: "HTTP"
               servicePort: 80
               containerPort: 10080

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
@@ -53,6 +53,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -73,6 +73,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
@@ -55,6 +55,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
@@ -57,6 +57,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-3 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -60,6 +60,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-3 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -55,6 +55,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service backends/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -71,10 +71,6 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
-        status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter already configures request header: add-header-1 to be added, ignoring second entry"
 xdsIR:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -73,6 +73,10 @@ httpRoutes:
         status: "True"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter already configures request header: add-header-1 to be added, ignoring second entry"
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -84,6 +84,10 @@ httpRoutes:
         reason: UnsupportedValue
         # Currently only one invalid value status will be set. If there are multiple, then only the latest is displayed until that issue is resolved.
         message: "RequestHeaderModifier Filter already configures request header: set-header-4 to be added/set, ignoring second entry"
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -81,10 +81,6 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
-        status: "False"
         reason: UnsupportedValue
         # Currently only one invalid value status will be set. If there are multiple, then only the latest is displayed until that issue is resolved.
         message: "RequestHeaderModifier Filter already configures request header: set-header-4 to be added/set, ignoring second entry"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -69,6 +69,10 @@ httpRoutes:
         status: "True"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter already configures request header: rem-header-1 to be removed, ignoring second entry"
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -67,10 +67,6 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
-        status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter already configures request header: rem-header-1 to be removed, ignoring second entry"
 xdsIR:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -64,6 +64,10 @@ httpRoutes:
         status: "True"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter already configures request header: some-header-1 to be removed, ignoring second entry"
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -62,10 +62,6 @@ httpRoutes:
       conditions:
       - type: Accepted
         status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
-        status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter already configures request header: some-header-1 to be removed, ignoring second entry"
 xdsIR:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
@@ -67,6 +67,10 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
@@ -66,10 +66,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter cannot set a header with an empty name"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
@@ -69,6 +69,10 @@ httpRoutes:
         status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter cannot set a header with an empty name"
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
@@ -66,10 +66,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter cannot set headers with a '/' or ':' character in them. Header: 'example:1'"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
@@ -69,6 +69,10 @@ httpRoutes:
         status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter cannot set headers with a '/' or ':' character in them. Header: 'example:1'"
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -64,6 +64,10 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
@@ -61,10 +61,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter did not provide valid configuration to add/set/remove any headers"

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
@@ -64,6 +64,10 @@ httpRoutes:
         status: "False"
         reason: UnsupportedValue
         message: "RequestHeaderModifier Filter did not provide valid configuration to add/set/remove any headers"
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
@@ -65,6 +65,10 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -56,6 +56,10 @@ httpRoutes:
         status: "False"
         reason: NoMatchingListenerHostname
         message: There were no hostname intersections between the HTTPRoute and this parent ref's Listener(s).
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -66,6 +66,10 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -64,6 +64,10 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -63,6 +63,10 @@ httpRoutes:
         status: "False"
         reason: UnsupportedValue
         message: "Unknown custom filter type: UnsupportedType"
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -60,10 +60,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "Unknown custom filter type: UnsupportedType"

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -63,6 +63,10 @@ httpRoutes:
         status: "False"
         reason: UnsupportedValue
         message: "Scheme: unknown is unsupported, only 'https' and 'http' are supported"
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -60,10 +60,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "Scheme: unknown is unsupported, only 'https' and 'http' are supported"

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -63,6 +63,10 @@ httpRoutes:
         status: "False"
         reason: UnsupportedValue
         message: "Status code 666 is invalid, only 302 and 301 are supported"
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -60,10 +60,6 @@ httpRoutes:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted
-        status: "True"
-        reason: Accepted
-        message: Route is accepted
-      - type: ResolvedRefs
         status: "False"
         reason: UnsupportedValue
         message: "Status code 666 is invalid, only 302 and 301 are supported"

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -67,6 +67,10 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
@@ -54,6 +54,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
@@ -58,6 +58,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
@@ -61,7 +61,7 @@ httpRoutes:
       - type: ResolvedRefs
         status: "False"
         reason: BackendNotFound
-        message: "Service default/service-that-doesnt-exist-2 not found"
+        message: "Service default/service-that-doesnt-exist not found, Service default/service-that-doesnt-exist-2 not found"
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -56,6 +56,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -57,6 +57,10 @@ httpRoutes:
               status: "True"
               reason: Accepted
               message: Route is accepted
+            - type: ResolvedRefs
+              status: "True"
+              reason: ResolvedRefs
+              message: Service default/service-1 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
@@ -53,6 +53,10 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service envoy-gateway/service-1 found
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: HTTPRoute
   metadata:
@@ -85,6 +89,10 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service envoy-gateway/service-1 found
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: HTTPRoute
   metadata:
@@ -114,6 +122,10 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service envoy-gateway/service-2 found
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: HTTPRoute
   metadata:
@@ -146,6 +158,10 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service envoy-gateway/service-1 found
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: HTTPRoute
   metadata:
@@ -175,6 +191,10 @@ httpRoutes:
         status: "True"
         reason: Accepted
         message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Service envoy-gateway/service-2 found
 xdsIR:
   envoy-gateway-gateway-1:
     http:

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -701,7 +701,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 						// Can't have two redirects for the same route
 						if redirectResponse != nil {
 							parentRef.SetCondition(
-								v1beta1.RouteConditionResolvedRefs,
+								v1beta1.RouteConditionAccepted,
 								metav1.ConditionFalse,
 								v1beta1.RouteReasonUnsupportedValue,
 								"Cannot configure multiple requestRedirect filters for a single HTTPRouteRule",
@@ -723,7 +723,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 							} else {
 								errMsg := fmt.Sprintf("Scheme: %s is unsupported, only 'https' and 'http' are supported", *redirect.Scheme)
 								parentRef.SetCondition(
-									v1beta1.RouteConditionResolvedRefs,
+									v1beta1.RouteConditionAccepted,
 									metav1.ConditionFalse,
 									v1beta1.RouteReasonUnsupportedValue,
 									errMsg,
@@ -735,7 +735,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 						if redirect.Hostname != nil {
 							if err := isValidHostname(string(*redirect.Hostname)); err != nil {
 								parentRef.SetCondition(
-									v1beta1.RouteConditionResolvedRefs,
+									v1beta1.RouteConditionAccepted,
 									metav1.ConditionFalse,
 									v1beta1.RouteReasonUnsupportedValue,
 									err.Error(),
@@ -764,7 +764,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 							default:
 								errMsg := fmt.Sprintf("Redirect path type: %s is invalid, only \"ReplaceFullPath\" and \"ReplacePrefixMatch\" are supported", redirect.Path.Type)
 								parentRef.SetCondition(
-									v1beta1.RouteConditionResolvedRefs,
+									v1beta1.RouteConditionAccepted,
 									metav1.ConditionFalse,
 									v1beta1.RouteReasonUnsupportedValue,
 									errMsg,
@@ -781,7 +781,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 							} else {
 								errMsg := fmt.Sprintf("Status code %d is invalid, only 302 and 301 are supported", redirectCode)
 								parentRef.SetCondition(
-									v1beta1.RouteConditionResolvedRefs,
+									v1beta1.RouteConditionAccepted,
 									metav1.ConditionFalse,
 									v1beta1.RouteReasonUnsupportedValue,
 									errMsg,
@@ -813,7 +813,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 								emptyFilterConfig = false
 								if addHeader.Name == "" {
 									parentRef.SetCondition(
-										v1beta1.RouteConditionResolvedRefs,
+										v1beta1.RouteConditionAccepted,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
 										"RequestHeaderModifier Filter cannot add a header with an empty name",
@@ -824,7 +824,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 								// Per Gateway API specification on HTTPHeaderName, : and / are invalid characters in header names
 								if strings.Contains(string(addHeader.Name), "/") || strings.Contains(string(addHeader.Name), ":") {
 									parentRef.SetCondition(
-										v1beta1.RouteConditionResolvedRefs,
+										v1beta1.RouteConditionAccepted,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
 										fmt.Sprintf("RequestHeaderModifier Filter cannot set headers with a '/' or ':' character in them. Header: %q", string(addHeader.Name)),
@@ -843,8 +843,8 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 
 								if !canAddHeader {
 									parentRef.SetCondition(
-										v1beta1.RouteConditionResolvedRefs,
-										metav1.ConditionFalse,
+										v1beta1.RouteConditionAccepted,
+										metav1.ConditionTrue,
 										v1beta1.RouteReasonUnsupportedValue,
 										fmt.Sprintf("RequestHeaderModifier Filter already configures request header: %s to be added, ignoring second entry", headerKey),
 									)
@@ -870,7 +870,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 
 								if setHeader.Name == "" {
 									parentRef.SetCondition(
-										v1beta1.RouteConditionResolvedRefs,
+										v1beta1.RouteConditionAccepted,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
 										"RequestHeaderModifier Filter cannot set a header with an empty name",
@@ -880,7 +880,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 								// Per Gateway API specification on HTTPHeaderName, : and / are invalid characters in header names
 								if strings.Contains(string(setHeader.Name), "/") || strings.Contains(string(setHeader.Name), ":") {
 									parentRef.SetCondition(
-										v1beta1.RouteConditionResolvedRefs,
+										v1beta1.RouteConditionAccepted,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
 										fmt.Sprintf("RequestHeaderModifier Filter cannot set headers with a '/' or ':' character in them. Header: '%s'", string(setHeader.Name)),
@@ -899,8 +899,8 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 								}
 								if !canAddHeader {
 									parentRef.SetCondition(
-										v1beta1.RouteConditionResolvedRefs,
-										metav1.ConditionFalse,
+										v1beta1.RouteConditionAccepted,
+										metav1.ConditionTrue,
 										v1beta1.RouteReasonUnsupportedValue,
 										fmt.Sprintf("RequestHeaderModifier Filter already configures request header: %s to be added/set, ignoring second entry", headerKey),
 									)
@@ -926,7 +926,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 							for _, removedHeader := range headersToRemove {
 								if removedHeader == "" {
 									parentRef.SetCondition(
-										v1beta1.RouteConditionResolvedRefs,
+										v1beta1.RouteConditionAccepted,
 										metav1.ConditionFalse,
 										v1beta1.RouteReasonUnsupportedValue,
 										"RequestHeaderModifier Filter cannot remove a header with an empty name",
@@ -943,8 +943,8 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 								}
 								if !canRemHeader {
 									parentRef.SetCondition(
-										v1beta1.RouteConditionResolvedRefs,
-										metav1.ConditionFalse,
+										v1beta1.RouteConditionAccepted,
+										metav1.ConditionTrue,
 										v1beta1.RouteReasonUnsupportedValue,
 										fmt.Sprintf("RequestHeaderModifier Filter already configures request header: %s to be removed, ignoring second entry", removedHeader),
 									)
@@ -959,7 +959,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 						// Update the status if the filter failed to configure any valid headers to add/remove
 						if len(addRequestHeaders) == 0 && len(removeRequestHeaders) == 0 && !emptyFilterConfig {
 							parentRef.SetCondition(
-								v1beta1.RouteConditionResolvedRefs,
+								v1beta1.RouteConditionAccepted,
 								metav1.ConditionFalse,
 								v1beta1.RouteReasonUnsupportedValue,
 								"RequestHeaderModifier Filter did not provide valid configuration to add/set/remove any headers",
@@ -970,7 +970,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 						// Instead, requests that would have been processed by that filter MUST receive a HTTP error response."
 						errMsg := fmt.Sprintf("Unknown custom filter type: %s", filter.Type)
 						parentRef.SetCondition(
-							v1beta1.RouteConditionResolvedRefs,
+							v1beta1.RouteConditionAccepted,
 							metav1.ConditionFalse,
 							v1beta1.RouteReasonUnsupportedValue,
 							errMsg,
@@ -1122,13 +1122,6 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 					metav1.ConditionFalse,
 					v1beta1.RouteReasonNoMatchingListenerHostname,
 					"There were no hostname intersections between the HTTPRoute and this parent ref's Listener(s).",
-				)
-			} else {
-				parentRef.SetCondition(
-					v1beta1.RouteConditionAccepted,
-					metav1.ConditionTrue,
-					v1beta1.RouteReasonAccepted,
-					"Route is accepted",
 				)
 			}
 		}

--- a/internal/provider/kubernetes/httproute.go
+++ b/internal/provider/kubernetes/httproute.go
@@ -256,8 +256,8 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.R
 							log.Info("deleted service from resource map")
 						}
 					}
-					return reconcile.Result{}, fmt.Errorf("failed to get service %s/%s",
-						svcKey.Namespace, svcKey.Name)
+					r.log.Error(err, "failed to get service", "namespace", svcKey.Namespace, "name", svcKey.Name)
+					return reconcile.Result{}, nil
 				}
 
 				// The backendRef Service exists, so add it to the resource map.


### PR DESCRIPTION
Updates `ProcessHTTPRoutes()` to check the availability of all route backends, e.g. Services, and sets the [RouteConditionResolvedRefs](https://pkg.go.dev/sigs.k8s.io/gateway-api/apis/v1beta1@v0.5.1#RouteConditionResolvedRefs) condition accodingly.

Requires #495

Fixes #415 
