### PR TITLE
Sort match conditions based on Gateway API Spec

### DIFF
--- a/internal/gatewayapi/sort.go
+++ b/internal/gatewayapi/sort.go
@@ -6,11 +6,11 @@ import (
 	"github.com/envoyproxy/gateway/internal/ir"
 )
 
-type XdsIRRoutesSlice []*ir.HTTPRoute
+type XdsIRRoutes []*ir.HTTPRoute
 
-func (x XdsIRRoutesSlice) Len() int      { return len(x) }
-func (x XdsIRRoutesSlice) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
-func (x XdsIRRoutesSlice) Less(i, j int) bool {
+func (x XdsIRRoutes) Len() int      { return len(x) }
+func (x XdsIRRoutes) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+func (x XdsIRRoutes) Less(i, j int) bool {
 	// 1. Sort based on characters in a matching path.
 	pCountI := pathMatchCount(x[i].PathMatch)
 	pCountJ := pathMatchCount(x[j].PathMatch)
@@ -48,7 +48,7 @@ func sortXdsIRMap(xdsIR XdsIRMap) {
 		sort.SliceStable(ir.HTTP, func(i, j int) bool { return ir.HTTP[i].Name < ir.HTTP[j].Name })
 		for _, http := range ir.HTTP {
 			// descending order
-			sort.Sort(sort.Reverse(XdsIRRoutesSlice(http.Routes)))
+			sort.Sort(sort.Reverse(XdsIRRoutes(http.Routes)))
 		}
 	}
 }

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.in.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.in.yaml
@@ -1,129 +1,129 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http
-          protocol: HTTP
-          port: 80
-          allowedRoutes:
-            namespaces:
-              from: Same
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: envoy-gateway
-      name: httproute-1
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: envoy-gateway
-      name: httproute-2
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      hostnames:    
-      - example.com    
-      rules:
-        - matches:
-            - path:
-                value: "/v1/example"
-              queryParams:
-              - name: "debug"
-                value: "yes"               
-          backendRefs:
-            - name: service-1
-              port: 8080
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: envoy-gateway
-      name: httproute-3
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      hostnames:    
-      - example.com    
-      rules:
-        - matches:
-            - path:
-                value: "/v1/example"
-          backendRefs:
-            - name: service-2
-              port: 8080             
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: envoy-gateway
-      name: httproute-4
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      hostnames:
-      - example.net        
-      rules:
-        - matches:
-            - path:
-                value: "/v1/status"
-              headers:
-              - name: "version"
-                value: "one"
-          backendRefs:
-            - name: service-1
-              port: 8080
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: envoy-gateway
-      name: httproute-5
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      hostnames:    
-      - example.net    
-      rules:
-        - matches:
-            - path:
-                value: "/v1/status"
-          backendRefs:
-            - name: service-2
-              port: 8080               
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-2
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - example.com
+    rules:
+    - matches:
+      - path:
+          value: "/v1/example"
+        queryParams:
+        - name: "debug"
+          value: "yes"
+      backendRefs:
+      - name: service-1
+        port: 8080
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-3
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - example.com
+    rules:
+    - matches:
+      - path:
+          value: "/v1/example"
+      backendRefs:
+      - name: service-2
+        port: 8080
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-4
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - example.net
+    rules:
+    - matches:
+      - path:
+          value: "/v1/status"
+        headers:
+        - name: "version"
+          value: "one"
+      backendRefs:
+      - name: service-1
+        port: 8080
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-5
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - example.net
+    rules:
+    - matches:
+      - path:
+          value: "/v1/status"
+      backendRefs:
+      - name: service-2
+        port: 8080
 services:
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      namespace: envoy-gateway
-      name: service-1
-    spec:
-      clusterIP: 7.7.7.7
-      ports:
-        - port: 8080
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      namespace: envoy-gateway
-      name: service-2
-    spec:
-      clusterIP: 8.8.8.8
-      ports:
-        - port: 8080
+- apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: envoy-gateway
+    name: service-1
+  spec:
+    clusterIP: 7.7.7.7
+    ports:
+    - port: 8080
+- apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: envoy-gateway
+    name: service-2
+  spec:
+    clusterIP: 8.8.8.8
+    ports:
+    - port: 8080

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.in.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.in.yaml
@@ -1,0 +1,129 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: Same
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: envoy-gateway
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: envoy-gateway
+      name: httproute-2
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:    
+      - example.com    
+      rules:
+        - matches:
+            - path:
+                value: "/v1/example"
+              queryParams:
+              - name: "debug"
+                value: "yes"               
+          backendRefs:
+            - name: service-1
+              port: 8080
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: envoy-gateway
+      name: httproute-3
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:    
+      - example.com    
+      rules:
+        - matches:
+            - path:
+                value: "/v1/example"
+          backendRefs:
+            - name: service-2
+              port: 8080             
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: envoy-gateway
+      name: httproute-4
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:
+      - example.net        
+      rules:
+        - matches:
+            - path:
+                value: "/v1/status"
+              headers:
+              - name: "version"
+                value: "one"
+          backendRefs:
+            - name: service-1
+              port: 8080
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: envoy-gateway
+      name: httproute-5
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:    
+      - example.net    
+      rules:
+        - matches:
+            - path:
+                value: "/v1/status"
+          backendRefs:
+            - name: service-2
+              port: 8080               
+services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      namespace: envoy-gateway
+      name: service-1
+    spec:
+      clusterIP: 7.7.7.7
+      ports:
+        - port: 8080
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      namespace: envoy-gateway
+      name: service-2
+    spec:
+      clusterIP: 8.8.8.8
+      ports:
+        - port: 8080

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
@@ -1,0 +1,256 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: Same
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 5 
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: envoy-gateway
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted             
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: envoy-gateway
+      name: httproute-2
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:    
+      - example.com    
+      rules:
+        - matches:
+            - path:
+                value: "/v1/example"
+              queryParams:
+              - name: "debug"
+                value: "yes"               
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted             
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: envoy-gateway
+      name: httproute-3
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:    
+      - example.com    
+      rules:
+        - matches:
+            - path:
+                value: "/v1/example"
+          backendRefs:
+            - name: service-2
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted              
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: envoy-gateway
+      name: httproute-4
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:
+      - example.net        
+      rules:
+        - matches:
+            - path:
+                value: "/v1/status"
+              headers:
+              - name: "version"
+                value: "one"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted             
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: envoy-gateway
+      name: httproute-5
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:    
+      - example.net    
+      rules:
+        - matches:
+            - path:
+                value: "/v1/status"
+          backendRefs:
+            - name: service-2
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted             
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+      - name: envoy-gateway-gateway-1-http
+        address: 0.0.0.0
+        port: 10080
+        hostnames:
+          - "*"
+        routes:
+          - name: envoy-gateway-httproute-2-rule-0-match-0-example.com
+            pathMatch:
+              prefix: "/v1/example"
+            # Remove comments once https://github.com/envoyproxy/gateway/issues/512 is fixed  
+            # queryParamMatches:
+            # - name: "debug"
+            #   exact: "yes"
+            headerMatches:
+            - name: :authority 
+              exact: example.com
+            destinations:
+              - host: 7.7.7.7
+                port: 8080
+                weight: 1
+          - name: envoy-gateway-httproute-3-rule-0-match-0-example.com
+            pathMatch:
+              prefix: "/v1/example"
+            headerMatches:
+            - name: :authority 
+              exact: example.com             
+            destinations:
+              - host: 8.8.8.8
+                port: 8080
+                weight: 1
+          - name: envoy-gateway-httproute-4-rule-0-match-0-example.net
+            pathMatch:
+              prefix: "/v1/status"
+            headerMatches:
+            - name: :authority 
+              exact: example.net                   
+            - name: "version"
+              exact: "one"
+            destinations:
+              - host: 7.7.7.7
+                port: 8080
+                weight: 1
+          - name: envoy-gateway-httproute-5-rule-0-match-0-example.net
+            pathMatch:
+              prefix: "/v1/status"
+            headerMatches:
+            - name: :authority 
+              exact: example.net             
+            destinations:
+              - host: 8.8.8.8
+                port: 8080
+                weight: 1
+          - name: envoy-gateway-httproute-1-rule-0-match-0-*
+            pathMatch:
+              prefix: "/"
+            destinations:
+              - host: 7.7.7.7
+                port: 8080
+                weight: 1
+               
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:v1.23-latest
+      listeners:
+        - address: ""
+          ports:
+            - name: envoy-gateway-gateway-1
+              protocol: "HTTP"
+              servicePort: 80
+              containerPort: 10080

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
@@ -1,243 +1,242 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: Gateway
-    metadata:
-      namespace: envoy-gateway
-      name: gateway-1
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - name: http
-          protocol: HTTP
-          port: 80
-          allowedRoutes:
-            namespaces:
-              from: Same
-    status:
-      listeners:
-        - name: http
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-          attachedRoutes: 5 
-          conditions:
-            - type: Ready
-              status: "True"
-              reason: Ready
-              message: Listener is ready
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 5
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
 httpRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: envoy-gateway
-      name: httproute-1
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      rules:
-        - matches:
-            - path:
-                value: "/"
-          backendRefs:
-            - name: service-1
-              port: 8080
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-          controllerName: gateway.envoyproxy.io/gatewayclass-controller
-          conditions:
-            - type: Accepted
-              status: "True"
-              reason: Accepted
-              message: Route is accepted             
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: envoy-gateway
-      name: httproute-2
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      hostnames:    
-      - example.com    
-      rules:
-        - matches:
-            - path:
-                value: "/v1/example"
-              queryParams:
-              - name: "debug"
-                value: "yes"               
-          backendRefs:
-            - name: service-1
-              port: 8080
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-          controllerName: gateway.envoyproxy.io/gatewayclass-controller
-          conditions:
-            - type: Accepted
-              status: "True"
-              reason: Accepted
-              message: Route is accepted             
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: envoy-gateway
-      name: httproute-3
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      hostnames:    
-      - example.com    
-      rules:
-        - matches:
-            - path:
-                value: "/v1/example"
-          backendRefs:
-            - name: service-2
-              port: 8080
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-          controllerName: gateway.envoyproxy.io/gatewayclass-controller
-          conditions:
-            - type: Accepted
-              status: "True"
-              reason: Accepted
-              message: Route is accepted              
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: envoy-gateway
-      name: httproute-4
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      hostnames:
-      - example.net        
-      rules:
-        - matches:
-            - path:
-                value: "/v1/status"
-              headers:
-              - name: "version"
-                value: "one"
-          backendRefs:
-            - name: service-1
-              port: 8080
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-          controllerName: gateway.envoyproxy.io/gatewayclass-controller
-          conditions:
-            - type: Accepted
-              status: "True"
-              reason: Accepted
-              message: Route is accepted             
-  - apiVersion: gateway.networking.k8s.io/v1beta1
-    kind: HTTPRoute
-    metadata:
-      namespace: envoy-gateway
-      name: httproute-5
-    spec:
-      parentRefs:
-        - namespace: envoy-gateway
-          name: gateway-1
-      hostnames:    
-      - example.net    
-      rules:
-        - matches:
-            - path:
-                value: "/v1/status"
-          backendRefs:
-            - name: service-2
-              port: 8080
-    status:
-      parents:
-        - parentRef:
-            namespace: envoy-gateway
-            name: gateway-1
-          controllerName: gateway.envoyproxy.io/gatewayclass-controller
-          conditions:
-            - type: Accepted
-              status: "True"
-              reason: Accepted
-              message: Route is accepted             
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-2
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - example.com
+    rules:
+    - matches:
+      - path:
+          value: "/v1/example"
+        queryParams:
+        - name: "debug"
+          value: "yes"
+      backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-3
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - example.com
+    rules:
+    - matches:
+      - path:
+          value: "/v1/example"
+      backendRefs:
+      - name: service-2
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-4
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - example.net
+    rules:
+    - matches:
+      - path:
+          value: "/v1/status"
+        headers:
+        - name: "version"
+          value: "one"
+      backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
+    name: httproute-5
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - example.net
+    rules:
+    - matches:
+      - path:
+          value: "/v1/status"
+      backendRefs:
+      - name: service-2
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     http:
-      - name: envoy-gateway-gateway-1-http
-        address: 0.0.0.0
-        port: 10080
-        hostnames:
-          - "*"
-        routes:
-          - name: envoy-gateway-httproute-2-rule-0-match-0-example.com
-            pathMatch:
-              prefix: "/v1/example"
-            # Remove comments once https://github.com/envoyproxy/gateway/issues/512 is fixed  
-            # queryParamMatches:
-            # - name: "debug"
-            #   exact: "yes"
-            headerMatches:
-            - name: :authority 
-              exact: example.com
-            destinations:
-              - host: 7.7.7.7
-                port: 8080
-                weight: 1
-          - name: envoy-gateway-httproute-3-rule-0-match-0-example.com
-            pathMatch:
-              prefix: "/v1/example"
-            headerMatches:
-            - name: :authority 
-              exact: example.com             
-            destinations:
-              - host: 8.8.8.8
-                port: 8080
-                weight: 1
-          - name: envoy-gateway-httproute-4-rule-0-match-0-example.net
-            pathMatch:
-              prefix: "/v1/status"
-            headerMatches:
-            - name: :authority 
-              exact: example.net                   
-            - name: "version"
-              exact: "one"
-            destinations:
-              - host: 7.7.7.7
-                port: 8080
-                weight: 1
-          - name: envoy-gateway-httproute-5-rule-0-match-0-example.net
-            pathMatch:
-              prefix: "/v1/status"
-            headerMatches:
-            - name: :authority 
-              exact: example.net             
-            destinations:
-              - host: 8.8.8.8
-                port: 8080
-                weight: 1
-          - name: envoy-gateway-httproute-1-rule-0-match-0-*
-            pathMatch:
-              prefix: "/"
-            destinations:
-              - host: 7.7.7.7
-                port: 8080
-                weight: 1
-               
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*"
+      routes:
+      - name: envoy-gateway-httproute-2-rule-0-match-0-example.com
+        pathMatch:
+          prefix: "/v1/example"
+        # Remove comments once https://github.com/envoyproxy/gateway/issues/512 is fixed
+        # queryParamMatches:
+        # - name: "debug"
+        #   exact: "yes"
+        headerMatches:
+        - name: :authority
+          exact: example.com
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+      - name: envoy-gateway-httproute-3-rule-0-match-0-example.com
+        pathMatch:
+          prefix: "/v1/example"
+        headerMatches:
+        - name: :authority
+          exact: example.com
+        destinations:
+        - host: 8.8.8.8
+          port: 8080
+          weight: 1
+      - name: envoy-gateway-httproute-4-rule-0-match-0-example.net
+        pathMatch:
+          prefix: "/v1/status"
+        headerMatches:
+        - name: :authority
+          exact: example.net
+        - name: "version"
+          exact: "one"
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+      - name: envoy-gateway-httproute-5-rule-0-match-0-example.net
+        pathMatch:
+          prefix: "/v1/status"
+        headerMatches:
+        - name: :authority
+          exact: example.net
+        destinations:
+        - host: 8.8.8.8
+          port: 8080
+          weight: 1
+      - name: envoy-gateway-httproute-1-rule-0-match-0-*
+        pathMatch:
+          prefix: "/"
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
 infraIR:
   envoy-gateway-gateway-1:
     proxy:
@@ -248,9 +247,9 @@ infraIR:
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:v1.23-latest
       listeners:
-        - address: ""
-          ports:
-            - name: envoy-gateway-gateway-1
-              protocol: "HTTP"
-              servicePort: 80
-              containerPort: 10080
+      - address: ""
+        ports:
+        - name: envoy-gateway-gateway-1
+          protocol: "HTTP"
+          servicePort: 80
+          containerPort: 10080

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -45,6 +45,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		tests.HTTPRouteInvalidCrossNamespaceParentRef,
 		tests.HTTPExactPathMatching,
 		tests.HTTPRouteCrossNamespace,
+		tests.HTTPRouteHeaderMatching,
 		tests.HTTPRouteMatchingAcrossRoutes,
 		tests.HTTPRouteInvalidNonExistentBackendRef,
 		tests.HTTPRouteInvalidBackendRefUnknownKind,


### PR DESCRIPTION
Sort based on the match precedence defined in
https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRouteRule

Fixes: https://github.com/envoyproxy/gateway/issues/436 Fixes: https://github.com/envoyproxy/gateway/issues/483

Signed-off-by: Arko Dasgupta <arko@tetrate.io>