### PR TITLE
Merges Release Manifests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            release-artifacts/gatewayapi-crds.yaml
             release-artifacts/install.yaml
 
         

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
+  - release-artifacts/gatewayapi-crds.yaml
   - release-artifacts/envoy-gateway.yaml
   - release-artifacts/infra-manager-rbac.yaml


### PR DESCRIPTION
Merges the Gateway API install manifest into the EG install manifest. Now, only the EG install manifest will be produced as a release artifact. Users will only need a single `kubectl apply` command to install EG and dependent resources, e.g. Gateway API CRDs.

Fixes: #485 

Signed-off-by: danehans <daneyonhansen@gmail.com>