### PR TITLE
use RefNotPermitted reason for invalid cross-namespace TLS cert ref

### DIFF
--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
@@ -28,7 +28,7 @@ gateways:
           conditions:
             - type: ResolvedRefs
               status: "False"
-              reason: InvalidCertificateRef
+              reason: RefNotPermitted
               message: Certificate ref to secret default/tls-secret-1 not permitted by any ReferenceGrant
             - type: Ready
               status: "False"

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -431,7 +431,7 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR XdsIRMap
 						listener.SetCondition(
 							v1beta1.ListenerConditionResolvedRefs,
 							metav1.ConditionFalse,
-							v1beta1.ListenerReasonInvalidCertificateRef,
+							v1beta1.ListenerReasonRefNotPermitted,
 							fmt.Sprintf("Certificate ref to secret %s/%s not permitted by any ReferenceGrant", *certificateRef.Namespace, certificateRef.Name),
 						)
 						break

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -46,7 +46,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		Debug:                    *flags.ShowDebug,
 		CleanupBaseResources:     *flags.CleanupBaseResources,
 		ValidUniqueListenerPorts: validUniqueListenerPorts,
-		SupportedFeatures: []suite.SupportedFeature{suite.SupportReferenceGrant},
+		SupportedFeatures:        []suite.SupportedFeature{suite.SupportReferenceGrant},
 	})
 	cSuite.Setup(t)
 	egTests := []suite.ConformanceTest{
@@ -63,9 +63,8 @@ func TestGatewayAPIConformance(t *testing.T) {
 		tests.HTTPRouteInvalidCrossNamespaceBackendRef,
 		tests.GatewaySecretReferenceGrantAllInNamespace,
 		tests.GatewaySecretReferenceGrantSpecific,
-		// Uncomment when https://github.com/envoyproxy/gateway/issues/538 is fixed.
-		/*tests.GatewaySecretMissingReferenceGrant,
-		tests.GatewaySecretInvalidReferenceGrant,*/
+		tests.GatewaySecretMissingReferenceGrant,
+		tests.GatewaySecretInvalidReferenceGrant,
 	}
 	cSuite.Run(t, egTests)
 


### PR DESCRIPTION
Closes #538.

Signed-off-by: Steve Kriss <krisss@vmware.com>

Leaving as draft for now since #441 is also a blocker for this issue.