### PR TITLE
ci: build image once in GHA

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -44,10 +44,7 @@ jobs:
         name: codecov-envoy-gateway
         verbose: true
 
-    # build
-    - run: make build-multiarch
-
-    # conformance
+    # build image and run conformance
     - name: Run Conformance Tests
       run: CONFORMANCE_UNIQUE_PORTS=false make conformance
 

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -79,14 +79,14 @@ kube-demo-undeploy: ## Uninstall the Kubernetes resources installed from the `ma
 #	tools/hack/run-kube-local.sh
 
 .PHONY: conformance 
-conformance: create-cluster kube-install-image kube-deploy run-conformance delete-cluster ## Create a kind cluster, deploy EG into it, run Gateway API conformance, and clean up.
+conformance: create-cluster build-multiarch kube-install-image kube-deploy run-conformance delete-cluster ## Create a kind cluster, deploy EG into it, run Gateway API conformance, and clean up.
 
 .PHONY: create-cluster
 create-cluster: $(tools/kind) ## Create a kind cluster suitable for running Gateway API conformance.
 	tools/hack/create-cluster.sh
 
 .PHONY: kube-install-image
-kube-install-image: image.build $(tools/kind) ## Install the EG image to a kind cluster using the provided $IMAGE and $TAG.
+kube-install-image: $(tools/kind) ## Install the EG image to a kind cluster using the provided $IMAGE and $TAG.
 	tools/hack/kind-load-image.sh $(IMAGE) $(TAG)
 
 .PHONY: run-conformance


### PR DESCRIPTION
* Previously, the image was being explicitly built in the GHA using `build-multiarch` and then again in the `kube-install-image` command.
* Now, just build it once as a `conformance` target dependancy.

Signed-off-by: Arko Dasgupta <arko@tetrate.io>