### PR TITLE
fix: remove deprecated set-output in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,8 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=release_tag::$(echo ${GITHUB_REF##*/})"
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "release_tag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -25,10 +25,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Retag and push existing gateway-dev image
         run: |
-          skopeo copy --all docker://docker.io/envoyproxy/gateway-dev:${{ steps.vars.outputs.sha_short }} docker://docker.io/envoyproxy/gateway:${{ steps.vars.outputs.release_tag }}
+          skopeo copy --all docker://docker.io/envoyproxy/gateway-dev:${{ env.sha_short }} docker://docker.io/envoyproxy/gateway:${{ env.release_tag }}
 
       - name: Generate Release Manifests
-        run: make generate-manifests IMAGE=envoyproxy/gateway TAG=${{ steps.vars.outputs.release_tag}} OUTPUT_DIR=release-artifacts
+        run: make generate-manifests IMAGE=envoyproxy/gateway TAG=${{ env.release_tag}} OUTPUT_DIR=release-artifacts
 
       - name: Upload Release Manifests
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: bitliu <bitliu@tencent.com>