### PR TITLE
docs: correcting route ref, system design

### DIFF
--- a/docs/design/SYSTEM_DESIGN.md
+++ b/docs/design/SYSTEM_DESIGN.md
@@ -136,7 +136,7 @@ The draft for this document is [here][draft_design].
 [crf]: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#filters-optional
 [gwapi_conflicts]: https://gateway-api.sigs.k8s.io/concepts/guidelines/#conflicts
 [listener]: https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/listeners#config-listeners
-[route]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto#config-route-v3-routeconfiguration
+[route]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-route
 [be_ref]: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#backendrefs-optional
 [cluster]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster
 [draft_design]: https://docs.google.com/document/d/1riyTPPYuvNzIhBdrAX8dpfxTmcobWZDSYTTB5NeybuY/edit


### PR DESCRIPTION
Confused by the documented cardinality of Gateway components and their Proxy representations, I deployed the gateway with two HTTPRoutes and did a config dump of the gateway. The docs `Route` refers to the proxy `RouteConfiguration`, but it should indeed refer to `Route`.

Signed-off-by: Fredrik Geijer Haeggström <fredrik.g.haeggstrom@gmail.com>