### PR TITLE
Merge ir listeners into single xds listener

### DIFF
--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -23,7 +23,7 @@ func buildXdsCluster(routeName string, destinations []*ir.RouteDestination) (*cl
 		// load balancers need the value to be set.
 		LoadBalancingWeight: &wrapperspb.UInt32Value{Value: 1}}
 	localities = append(localities, locality)
-	clusterName := getXdsClusterName(routeName)
+	clusterName := routeName
 	return &cluster.Cluster{
 		Name:                 clusterName,
 		ConnectTimeout:       durationpb.New(5 * time.Second),

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -135,7 +135,7 @@ func buildXdsStringMatcher(irMatch *ir.StringMatch) *matcher.StringMatcher {
 func buildXdsRouteAction(routeName string) *route.RouteAction {
 	return &route.RouteAction{
 		ClusterSpecifier: &route.RouteAction_Cluster{
-			Cluster: getXdsClusterName(routeName),
+			Cluster: routeName,
 		},
 	}
 }
@@ -148,7 +148,7 @@ func buildXdsWeightedRouteAction(httpRoute *ir.HTTPRoute) *route.RouteAction {
 			Weight: &wrapperspb.UInt32Value{Value: httpRoute.BackendWeights.Invalid},
 		},
 		{
-			Name:   getXdsClusterName(httpRoute.Name),
+			Name:   httpRoute.Name,
 			Weight: &wrapperspb.UInt32Value{Value: httpRoute.BackendWeights.Valid},
 		},
 	}

--- a/internal/xds/translator/testdata/in/xds-ir/multiple-listeners-same-port.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/multiple-listeners-same-port.yaml
@@ -1,0 +1,66 @@
+http:
+- name: "first-listener"
+  address: "0.0.0.0"
+  port: 10080
+  hostnames:
+  - "example.com"
+  routes:
+  - name: "first-route" 
+    destinations:
+    - host: "1.2.3.4"
+      port: 50000
+- name: "second-listener"
+  address: "0.0.0.0"
+  port: 10080
+  hostnames:
+  - "example.net"
+  routes:
+  - name: "second-route" 
+    destinations:
+    - host: "1.2.3.4"
+      port: 50000
+- name: "third-listener"
+  address: "0.0.0.0"
+  port: 10080
+  hostnames:
+  - "foo.com"
+  tls:
+    serverCertificate: [99, 101, 114, 116, 45, 100, 97, 116, 97] # byte slice representation of "cert-data"
+    privateKey: [107, 101, 121, 45, 100, 97, 116, 97] # byte slice representation of "key-data"
+  routes:
+  - name: "third-route" 
+    destinations:
+    - host: "1.2.3.4"
+      port: 50000
+- name: "fourth-listener"
+  address: "0.0.0.0"
+  port: 10080
+  hostnames:
+  - "foo.net"
+  tls:
+    serverCertificate: [99, 101, 114, 116, 45, 100, 97, 116, 97] # byte slice representation of "cert-data"
+    privateKey: [107, 101, 121, 45, 100, 97, 116, 97] # byte slice representation of "key-data"
+  routes:
+  - name: "fourth-route" 
+    destinations:
+    - host: "1.2.3.4"
+      port: 50000
+tcp:
+- name: "fifth-listener"
+  address: "0.0.0.0"
+  port: 10080
+  tls:
+    snis:
+    - bar.com
+  destinations:
+  - host: "1.2.3.4"
+    port: 50000
+- name: "sixth-listener"
+  address: "0.0.0.0"
+  port: 10080
+  tls:
+    snis:
+    - bar.net 
+    destinations:
+    - host: "1.2.3.4"
+      port: 50000

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
@@ -3,7 +3,7 @@
   connectTimeout: 5s
   dnsLookupFamily: V4_ONLY
   loadAssignment:
-    clusterName: cluster_direct-route
+    clusterName: direct-route
     endpoints:
     - lbEndpoints:
       - endpoint:
@@ -13,6 +13,6 @@
               portValue: 50000
       loadBalancingWeight: 1
       locality: {}
-  name: cluster_direct-route
+  name: direct-route
   outlierDetection: {}
   type: STATIC

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.listeners.yaml
@@ -2,8 +2,8 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  filterChains:
-  - filters:
+  defaultFilterChain:
+    filters:
     - name: envoy.filters.network.http_connection_manager
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -21,6 +21,6 @@
               setNodeOnFirstMessageOnly: true
               transportApiVersion: V3
             resourceApiVersion: V3
-          routeConfigName: route_first-listener
+          routeConfigName: first-listener
         statPrefix: http
-  name: listener_first-listener_10080
+  name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.routes.yaml
@@ -1,8 +1,8 @@
-- name: route_first-listener
+- name: first-listener
   virtualHosts:
   - domains:
     - '*'
-    name: route_first-listener
+    name: first-listener
     routes:
     - directResponse:
         body:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
@@ -3,7 +3,7 @@
   connectTimeout: 5s
   dnsLookupFamily: V4_ONLY
   loadAssignment:
-    clusterName: cluster_redirect-route
+    clusterName: redirect-route
     endpoints:
     - lbEndpoints:
       - endpoint:
@@ -13,6 +13,6 @@
               portValue: 50000
       loadBalancingWeight: 1
       locality: {}
-  name: cluster_redirect-route
+  name: redirect-route
   outlierDetection: {}
   type: STATIC

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.listeners.yaml
@@ -2,8 +2,8 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  filterChains:
-  - filters:
+  defaultFilterChain:
+    filters:
     - name: envoy.filters.network.http_connection_manager
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -21,6 +21,6 @@
               setNodeOnFirstMessageOnly: true
               transportApiVersion: V3
             resourceApiVersion: V3
-          routeConfigName: route_first-listener
+          routeConfigName: first-listener
         statPrefix: http
-  name: listener_first-listener_10080
+  name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.routes.yaml
@@ -1,8 +1,8 @@
-- name: route_first-listener
+- name: first-listener
   virtualHosts:
   - domains:
     - '*'
-    name: route_first-listener
+    name: first-listener
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
@@ -3,7 +3,7 @@
   connectTimeout: 5s
   dnsLookupFamily: V4_ONLY
   loadAssignment:
-    clusterName: cluster_request-header-route
+    clusterName: request-header-route
     endpoints:
     - lbEndpoints:
       - endpoint:
@@ -13,6 +13,6 @@
               portValue: 50000
       loadBalancingWeight: 1
       locality: {}
-  name: cluster_request-header-route
+  name: request-header-route
   outlierDetection: {}
   type: STATIC

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.listeners.yaml
@@ -2,8 +2,8 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  filterChains:
-  - filters:
+  defaultFilterChain:
+    filters:
     - name: envoy.filters.network.http_connection_manager
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -21,6 +21,6 @@
               setNodeOnFirstMessageOnly: true
               transportApiVersion: V3
             resourceApiVersion: V3
-          routeConfigName: route_first-listener
+          routeConfigName: first-listener
         statPrefix: http
-  name: listener_first-listener_10080
+  name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
@@ -1,8 +1,8 @@
-- name: route_first-listener
+- name: first-listener
   virtualHosts:
   - domains:
     - '*'
-    name: route_first-listener
+    name: first-listener
     routes:
     - match:
         prefix: /
@@ -31,4 +31,4 @@
       - some-header5
       - some-header6
       route:
-        cluster: cluster_request-header-route
+        cluster: request-header-route

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
@@ -3,7 +3,7 @@
   connectTimeout: 5s
   dnsLookupFamily: V4_ONLY
   loadAssignment:
-    clusterName: cluster_first-route
+    clusterName: first-route
     endpoints:
     - lbEndpoints:
       - endpoint:
@@ -13,6 +13,6 @@
               portValue: 50000
       loadBalancingWeight: 1
       locality: {}
-  name: cluster_first-route
+  name: first-route
   outlierDetection: {}
   type: STATIC

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
@@ -2,8 +2,8 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  filterChains:
-  - filters:
+  defaultFilterChain:
+    filters:
     - name: envoy.filters.network.http_connection_manager
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -21,6 +21,6 @@
               setNodeOnFirstMessageOnly: true
               transportApiVersion: V3
             resourceApiVersion: V3
-          routeConfigName: route_first-listener
+          routeConfigName: first-listener
         statPrefix: http
-  name: listener_first-listener_10080
+  name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.routes.yaml
@@ -1,8 +1,8 @@
-- name: route_first-listener
+- name: first-listener
   virtualHosts:
   - domains:
     - '*'
-    name: route_first-listener
+    name: first-listener
     routes:
     - match:
         prefix: /
@@ -12,6 +12,6 @@
           clusters:
           - name: invalid-backend-cluster
             weight: 1
-          - name: cluster_first-route
+          - name: first-route
             weight: 1
           totalWeight: 2

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
@@ -3,7 +3,7 @@
   connectTimeout: 5s
   dnsLookupFamily: V4_ONLY
   loadAssignment:
-    clusterName: cluster_first-route
+    clusterName: first-route
     endpoints:
     - lbEndpoints:
       - endpoint:
@@ -13,6 +13,6 @@
               portValue: 50000
       loadBalancingWeight: 1
       locality: {}
-  name: cluster_first-route
+  name: first-route
   outlierDetection: {}
   type: STATIC

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.listeners.yaml
@@ -2,8 +2,8 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  filterChains:
-  - filters:
+  defaultFilterChain:
+    filters:
     - name: envoy.filters.network.http_connection_manager
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -21,6 +21,6 @@
               setNodeOnFirstMessageOnly: true
               transportApiVersion: V3
             resourceApiVersion: V3
-          routeConfigName: route_first-listener
+          routeConfigName: first-listener
         statPrefix: http
-  name: listener_first-listener_10080
+  name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
@@ -1,10 +1,10 @@
-- name: route_first-listener
+- name: first-listener
   virtualHosts:
   - domains:
     - '*'
-    name: route_first-listener
+    name: first-listener
     routes:
     - match:
         prefix: /
       route:
-        cluster: cluster_first-route
+        cluster: first-route

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
@@ -1,0 +1,102 @@
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  dnsLookupFamily: V4_ONLY
+  loadAssignment:
+    clusterName: first-route
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 1.2.3.4
+              portValue: 50000
+      loadBalancingWeight: 1
+      locality: {}
+  name: first-route
+  outlierDetection: {}
+  type: STATIC
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  dnsLookupFamily: V4_ONLY
+  loadAssignment:
+    clusterName: second-route
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 1.2.3.4
+              portValue: 50000
+      loadBalancingWeight: 1
+      locality: {}
+  name: second-route
+  outlierDetection: {}
+  type: STATIC
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  dnsLookupFamily: V4_ONLY
+  loadAssignment:
+    clusterName: third-route
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 1.2.3.4
+              portValue: 50000
+      loadBalancingWeight: 1
+      locality: {}
+  name: third-route
+  outlierDetection: {}
+  type: STATIC
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  dnsLookupFamily: V4_ONLY
+  loadAssignment:
+    clusterName: fourth-route
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 1.2.3.4
+              portValue: 50000
+      loadBalancingWeight: 1
+      locality: {}
+  name: fourth-route
+  outlierDetection: {}
+  type: STATIC
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  dnsLookupFamily: V4_ONLY
+  loadAssignment:
+    clusterName: fifth-listener
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 1.2.3.4
+              portValue: 50000
+      loadBalancingWeight: 1
+      locality: {}
+  name: fifth-listener
+  outlierDetection: {}
+  type: STATIC
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  dnsLookupFamily: V4_ONLY
+  loadAssignment:
+    clusterName: sixth-listener
+    endpoints:
+    - loadBalancingWeight: 1
+      locality: {}
+  name: sixth-listener
+  outlierDetection: {}
+  type: STATIC

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
@@ -1,0 +1,127 @@
+- address:
+    socketAddress:
+      address: 0.0.0.0
+      portValue: 10080
+  defaultFilterChain:
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        rds:
+          configSource:
+            apiConfigSource:
+              apiType: DELTA_GRPC
+              grpcServices:
+              - envoyGrpc:
+                  clusterName: xds_cluster
+              setNodeOnFirstMessageOnly: true
+              transportApiVersion: V3
+            resourceApiVersion: V3
+          routeConfigName: first-listener
+        statPrefix: http
+  filterChains:
+  - filterChainMatch:
+      serverNames:
+      - foo.com
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        rds:
+          configSource:
+            apiConfigSource:
+              apiType: DELTA_GRPC
+              grpcServices:
+              - envoyGrpc:
+                  clusterName: xds_cluster
+              setNodeOnFirstMessageOnly: true
+              transportApiVersion: V3
+            resourceApiVersion: V3
+          routeConfigName: third-listener
+        statPrefix: https
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        commonTlsContext:
+          tlsCertificateSdsSecretConfigs:
+          - name: third-listener
+            sdsConfig:
+              apiConfigSource:
+                apiType: DELTA_GRPC
+                grpcServices:
+                - envoyGrpc:
+                    clusterName: xds_cluster
+                setNodeOnFirstMessageOnly: true
+                transportApiVersion: V3
+              resourceApiVersion: V3
+  - filterChainMatch:
+      serverNames:
+      - foo.net
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        rds:
+          configSource:
+            apiConfigSource:
+              apiType: DELTA_GRPC
+              grpcServices:
+              - envoyGrpc:
+                  clusterName: xds_cluster
+              setNodeOnFirstMessageOnly: true
+              transportApiVersion: V3
+            resourceApiVersion: V3
+          routeConfigName: fourth-listener
+        statPrefix: https
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        commonTlsContext:
+          tlsCertificateSdsSecretConfigs:
+          - name: fourth-listener
+            sdsConfig:
+              apiConfigSource:
+                apiType: DELTA_GRPC
+                grpcServices:
+                - envoyGrpc:
+                    clusterName: xds_cluster
+                setNodeOnFirstMessageOnly: true
+                transportApiVersion: V3
+              resourceApiVersion: V3
+  - filterChainMatch:
+      serverNames:
+      - bar.com
+    filters:
+    - name: envoy.filters.network.tcp_proxy
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+        cluster: fifth-listener
+        statPrefix: passthrough
+  - filterChainMatch:
+      serverNames:
+      - bar.net
+    filters:
+    - name: envoy.filters.network.tcp_proxy
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+        cluster: sixth-listener
+        statPrefix: passthrough
+  listenerFilters:
+  - name: envoy.filters.listener.tls_inspector
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+  name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.routes.yaml
@@ -1,0 +1,38 @@
+- name: first-listener
+  virtualHosts:
+  - domains:
+    - example.com
+    name: first-listener
+    routes:
+    - match:
+        prefix: /
+      route:
+        cluster: first-route
+  - domains:
+    - example.net
+    name: second-listener
+    routes:
+    - match:
+        prefix: /
+      route:
+        cluster: second-route
+- name: third-listener
+  virtualHosts:
+  - domains:
+    - foo.com
+    name: third-listener
+    routes:
+    - match:
+        prefix: /
+      route:
+        cluster: third-route
+- name: fourth-listener
+  virtualHosts:
+  - domains:
+    - foo.net
+    name: fourth-listener
+    routes:
+    - match:
+        prefix: /
+      route:
+        cluster: fourth-route

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.secrets.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.secrets.yaml
@@ -1,0 +1,12 @@
+- name: third-listener
+  tlsCertificate:
+    certificateChain:
+      inlineBytes: Y2VydC1kYXRh
+    privateKey:
+      inlineBytes: a2V5LWRhdGE=
+- name: fourth-listener
+  tlsCertificate:
+    certificateChain:
+      inlineBytes: Y2VydC1kYXRh
+    privateKey:
+      inlineBytes: a2V5LWRhdGE=

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
@@ -3,7 +3,7 @@
   connectTimeout: 5s
   dnsLookupFamily: V4_ONLY
   loadAssignment:
-    clusterName: cluster_first-route
+    clusterName: first-route
     endpoints:
     - lbEndpoints:
       - endpoint:
@@ -13,6 +13,6 @@
               portValue: 50000
       loadBalancingWeight: 1
       locality: {}
-  name: cluster_first-route
+  name: first-route
   outlierDetection: {}
   type: STATIC

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
@@ -3,7 +3,10 @@
       address: 0.0.0.0
       portValue: 10080
   filterChains:
-  - filters:
+  - filterChainMatch:
+      serverNames:
+      - '*'
+    filters:
     - name: envoy.filters.network.http_connection_manager
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -21,15 +24,15 @@
               setNodeOnFirstMessageOnly: true
               transportApiVersion: V3
             resourceApiVersion: V3
-          routeConfigName: route_first-listener
-        statPrefix: http
+          routeConfigName: first-listener
+        statPrefix: https
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
         commonTlsContext:
           tlsCertificateSdsSecretConfigs:
-          - name: secret_first-listener
+          - name: first-listener
             sdsConfig:
               apiConfigSource:
                 apiType: DELTA_GRPC
@@ -39,4 +42,8 @@
                 setNodeOnFirstMessageOnly: true
                 transportApiVersion: V3
               resourceApiVersion: V3
-  name: listener_first-listener_10080
+  listenerFilters:
+  - name: envoy.filters.listener.tls_inspector
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+  name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.routes.yaml
@@ -1,10 +1,10 @@
-- name: route_first-listener
+- name: first-listener
   virtualHosts:
   - domains:
     - '*'
-    name: route_first-listener
+    name: first-listener
     routes:
     - match:
         prefix: /
       route:
-        cluster: cluster_first-route
+        cluster: first-route

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.secrets.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.secrets.yaml
@@ -1,4 +1,4 @@
-- name: secret_first-listener
+- name: first-listener
   tlsCertificate:
     certificateChain:
       inlineBytes: Y2VydC1kYXRh

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
@@ -3,7 +3,7 @@
   connectTimeout: 5s
   dnsLookupFamily: V4_ONLY
   loadAssignment:
-    clusterName: cluster_tls-passthrough
+    clusterName: tls-passthrough
     endpoints:
     - lbEndpoints:
       - endpoint:
@@ -18,6 +18,6 @@
               portValue: 50001
       loadBalancingWeight: 1
       locality: {}
-  name: cluster_tls-passthrough
+  name: tls-passthrough
   outlierDetection: {}
   type: STATIC

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.listeners.yaml
@@ -10,10 +10,10 @@
     - name: envoy.filters.network.tcp_proxy
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-        cluster: cluster_tls-passthrough
+        cluster: tls-passthrough
         statPrefix: passthrough
   listenerFilters:
   - name: envoy.filters.listener.tls_inspector
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-  name: listener_tls-passthrough_10080
+  name: tls-passthrough

--- a/internal/xds/translator/translator_test.go
+++ b/internal/xds/translator/translator_test.go
@@ -53,6 +53,10 @@ func TestTranslate(t *testing.T) {
 		{
 			name: "tls-route-passthrough",
 		},
+		{
+			name:           "multiple-listeners-same-port",
+			requireSecrets: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -46,7 +46,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		Debug:                    *flags.ShowDebug,
 		CleanupBaseResources:     *flags.CleanupBaseResources,
 		ValidUniqueListenerPorts: validUniqueListenerPorts,
-		SupportedFeatures: []suite.SupportedFeature{suite.SupportReferenceGrant},
+		SupportedFeatures:        []suite.SupportedFeature{suite.SupportReferenceGrant},
 	})
 	cSuite.Setup(t)
 	egTests := []suite.ConformanceTest{
@@ -58,6 +58,8 @@ func TestGatewayAPIConformance(t *testing.T) {
 		tests.HTTPRouteCrossNamespace,
 		tests.HTTPRouteHeaderMatching,
 		tests.HTTPRouteMatchingAcrossRoutes,
+		tests.HTTPRouteHostnameIntersection,
+		tests.HTTPRouteListenerHostnameMatching,
 		tests.HTTPRouteInvalidNonExistentBackendRef,
 		tests.HTTPRouteInvalidBackendRefUnknownKind,
 		tests.HTTPRouteInvalidCrossNamespaceBackendRef,


### PR DESCRIPTION
* Reuse an xds listener if one already exists for the same addr:port
* Add filter chain matches with a unique filter chain and route config for each of these ir listeners, except for http listeners which share the same DefaultFilterChain and the same route config
* removed the xds resource naming for now since it wasnt adding much value

Fixes: https://github.com/envoyproxy/gateway/issues/437
Fixes: https://github.com/envoyproxy/gateway/issues/434

Signed-off-by: Arko Dasgupta <arko@tetrate.io>