### PR TITLE
Fix Secrets deletion logic in gateway reconcile method

### DIFF
--- a/internal/provider/kubernetes/gateway.go
+++ b/internal/provider/kubernetes/gateway.go
@@ -385,13 +385,13 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 			switch {
 			case err != nil:
 				r.log.Error(err, "failed to verify if other gateways reference secret")
-			case referenced:
+			case !referenced:
 				r.log.Info("no other gateways reference secret; deleting from resource map",
 					"namespace", secret.Namespace, "name", secret.Name)
 				key := utils.NamespacedName(&secret)
 				r.resources.Secrets.Delete(key)
 			default:
-				r.log.Info("no other gateways reference secret; deleting from resource map",
+				r.log.Info("other gateways reference secret; keeping the secret in the resource map",
 					"namespace", secret.Namespace, "name", secret.Name)
 			}
 		}

--- a/internal/provider/kubernetes/gateway.go
+++ b/internal/provider/kubernetes/gateway.go
@@ -290,7 +290,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 	}
 
 	found := false
-	var matchedGwSecrets []corev1.Secret
+	var secrets []corev1.Secret
 	// Set status conditions for all accepted gateways.
 	for i := range acceptedGateways {
 		gw := acceptedGateways[i]
@@ -372,7 +372,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 		}
 		if key == request.NamespacedName {
 			found = true
-			matchedGwSecrets = secrets
 		}
 	}
 
@@ -380,8 +379,8 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 		r.resources.Gateways.Delete(request.NamespacedName)
 		// Delete the TLS secrets from the resource map if no other managed
 		// Gateways reference them.
-		for i := range matchedGwSecrets {
-			secret := matchedGwSecrets[i]
+		for i := range secrets {
+			secret := secrets[i]
 			referenced, err := r.gatewaysRefSecret(ctx, &secret)
 			switch {
 			case err != nil:

--- a/internal/provider/kubernetes/gateway.go
+++ b/internal/provider/kubernetes/gateway.go
@@ -290,7 +290,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 	}
 
 	found := false
-	var secrets []corev1.Secret
+	var matchedGwSecrets []corev1.Secret
 	// Set status conditions for all accepted gateways.
 	for i := range acceptedGateways {
 		gw := acceptedGateways[i]
@@ -372,6 +372,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 		}
 		if key == request.NamespacedName {
 			found = true
+			matchedGwSecrets = secrets
 		}
 	}
 
@@ -379,8 +380,8 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, request reconcile.Req
 		r.resources.Gateways.Delete(request.NamespacedName)
 		// Delete the TLS secrets from the resource map if no other managed
 		// Gateways reference them.
-		for i := range secrets {
-			secret := secrets[i]
+		for i := range matchedGwSecrets {
+			secret := matchedGwSecrets[i]
 			referenced, err := r.gatewaysRefSecret(ctx, &secret)
 			switch {
 			case err != nil:


### PR DESCRIPTION
When a Gateway resource is deleted, its Secrets in resource map which are not referenced from other Gateways should be deleted. It was in the other way around and this  PR is to fix it.