### PR TITLE
Updates Spellcheck Ignore

### DIFF
--- a/tools/linter/codespell/.codespell.skip
+++ b/tools/linter/codespell/.codespell.skip
@@ -8,6 +8,8 @@
 *.jpg
 *.ico
 *.svg
+*.js
+*.css
 go.mod
 go.sum
 bin

--- a/tools/linter/codespell/.codespell.skip
+++ b/tools/linter/codespell/.codespell.skip
@@ -8,8 +8,7 @@
 *.jpg
 *.ico
 *.svg
-*.js
-*.css
+./docs/html/*
 go.mod
 go.sum
 bin


### PR DESCRIPTION
Update spellcheck linter to ignore `./docs/html` docs generated by our docs workflow.

Signed-off-by: danehans <daneyonhansen@gmail.com>