### PR TITLE
Adds Docs Site CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+gateway.envoyproxy.io


### PR DESCRIPTION
Adds the CNAME record for GitHub Pages to resolve the docs site.

Signed-off-by: danehans <daneyonhansen@gmail.com>