### PR TITLE
Add a Printable method to Xds IR

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -87,6 +87,8 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 			// Translate to IR
 			result := t.Translate(&in)
 
+			yamlXdsIR, _ := yaml.Marshal(&result.XdsIR)
+			r.Logger.WithValues("output", "xds-ir").Info(string(yamlXdsIR))
 			yamlInfraIR, _ := yaml.Marshal(&result.InfraIR)
 			r.Logger.WithValues("output", "infra-ir").Info(string(yamlInfraIR))
 

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -69,6 +69,16 @@ func (x Xds) GetTCPListener(name string) *TCPListener {
 	return nil
 }
 
+// Printable returns a deep copy of the resource that can be safely logged.
+func (x Xds) Printable() *Xds {
+	out := x.DeepCopy()
+	for _, listener := range out.HTTP {
+		// Omit field
+		listener.TLS = nil
+	}
+	return out
+}
+
 // HTTPListener holds the listener configuration.
 // +k8s:deepcopy-gen=true
 type HTTPListener struct {

--- a/internal/ir/xds_test.go
+++ b/internal/ir/xds_test.go
@@ -16,6 +16,17 @@ var (
 		Hostnames: []string{"example.com"},
 		Routes:    []*HTTPRoute{&happyHTTPRoute},
 	}
+	happyHTTPSListener = HTTPListener{
+		Name:      "happy",
+		Address:   "0.0.0.0",
+		Port:      80,
+		Hostnames: []string{"example.com"},
+		TLS: &TLSListenerConfig{
+			ServerCertificate: []byte{1, 2, 3},
+			PrivateKey:        []byte{1, 2, 3},
+		},
+		Routes: []*HTTPRoute{&happyHTTPRoute},
+	}
 	invalidAddrHTTPListener = HTTPListener{
 		Name:      "invalid-addr",
 		Address:   "1.0.0",
@@ -635,6 +646,44 @@ func TestValidateStringMatch(t *testing.T) {
 			} else {
 				require.EqualError(t, test.input.Validate(), test.want.Error())
 			}
+		})
+	}
+}
+
+func TestPrintable(t *testing.T) {
+	tests := []struct {
+		name  string
+		input Xds
+		want  *Xds
+	}{
+		{
+			name:  "empty",
+			input: Xds{},
+			want:  &Xds{},
+		},
+		{
+			name: "http",
+			input: Xds{
+				HTTP: []*HTTPListener{&happyHTTPListener},
+			},
+			want: &Xds{
+				HTTP: []*HTTPListener{&happyHTTPListener},
+			},
+		},
+		{
+			name: "https",
+			input: Xds{
+				HTTP: []*HTTPListener{&happyHTTPSListener},
+			},
+			want: &Xds{
+				HTTP: []*HTTPListener{&happyHTTPListener},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, *test.want, *test.input.Printable())
 		})
 	}
 }


### PR DESCRIPTION
* Printable returns a safe copy that can be printed/logged

* Reintroduce printing xds ir in the gateway api runner

Signed-off-by: Arko Dasgupta <arko@tetrate.io>