### PR TITLE
Fix Merge for HTTPS listeners

### DIFF
--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -36,17 +36,17 @@ func Translate(ir *ir.Xds) (*types.ResourceVersionTable, error) {
 			// within the same RouteConfiguration instead
 			if httpListener.TLS == nil {
 				addFilterChain = false
-			}
-			// Find the route config associated with this listener that
-			// maps to the filter chain for http traffic
-			// There should only be one of these per xds listener
-			routeName, err := findXdsHTTPRouteConfigName(xdsListener)
-			if err != nil {
-				return nil, err
-			}
-			xdsRouteCfg = findXdsRouteConfig(tCtx, routeName)
-			if xdsRouteCfg == nil {
-				return nil, errors.New("unable to find xds route config")
+				// Find the route config associated with this listener that
+				// maps to the filter chain for http traffic
+				// There should only be one of these per xds listener
+				routeName, err := findXdsHTTPRouteConfigName(xdsListener)
+				if err != nil {
+					return nil, err
+				}
+				xdsRouteCfg = findXdsRouteConfig(tCtx, routeName)
+				if xdsRouteCfg == nil {
+					return nil, errors.New("unable to find xds route config")
+				}
 			}
 		}
 

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -30,23 +30,21 @@ func Translate(ir *ir.Xds) (*types.ResourceVersionTable, error) {
 		if xdsListener == nil {
 			xdsListener = buildXdsListener(httpListener.Name, httpListener.Address, httpListener.Port)
 			tCtx.AddXdsResource(resource.ListenerType, xdsListener)
-		} else {
+		} else if httpListener.TLS == nil {
 			// If an existing listener exists, dont create a new filter chain
 			// for HTTP traffic, match on the Domains field within VirtualHosts
 			// within the same RouteConfiguration instead
-			if httpListener.TLS == nil {
-				addFilterChain = false
-				// Find the route config associated with this listener that
-				// maps to the filter chain for http traffic
-				// There should only be one of these per xds listener
-				routeName, err := findXdsHTTPRouteConfigName(xdsListener)
-				if err != nil {
-					return nil, err
-				}
-				xdsRouteCfg = findXdsRouteConfig(tCtx, routeName)
-				if xdsRouteCfg == nil {
-					return nil, errors.New("unable to find xds route config")
-				}
+			addFilterChain = false
+			// Find the route config associated with this listener that
+			// maps to the filter chain for http traffic
+			// There should only be one of these per xds listener
+			routeName, err := findXdsHTTPRouteConfigName(xdsListener)
+			if err != nil {
+				return nil, err
+			}
+			xdsRouteCfg = findXdsRouteConfig(tCtx, routeName)
+			if xdsRouteCfg == nil {
+				return nil, errors.New("unable to find xds route config")
 			}
 		}
 


### PR DESCRIPTION
* findXdsHTTPRouteConfigName should only be executed for HTTP listeners, not for HTTPS since we create a new filterChain for them.

Fixes: https://github.com/envoyproxy/gateway/issues/520#issuecomment-1283089969

Signed-off-by: Arko Dasgupta <arko@tetrate.io>