### PR TITLE
fix service cleanup in resource map add tests

### DIFF
--- a/internal/provider/kubernetes/httproute.go
+++ b/internal/provider/kubernetes/httproute.go
@@ -303,7 +303,7 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.R
 			r.referenceStore.removeRouteToServicesMapping(ObjectKindNamespacedName{kindHTTPRoute, request.Namespace, request.Name}, svc)
 			if !r.referenceStore.isServiceReferredByRoutes(svc) {
 				r.resources.Services.Delete(svc)
-				log.Info("deleted service from resource map", "service", svc)
+				log.Info("deleted service from resource map", "namespace", svc.Namespace, "name", svc.Name)
 			}
 		}
 	}

--- a/internal/provider/kubernetes/httproute.go
+++ b/internal/provider/kubernetes/httproute.go
@@ -302,8 +302,8 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.R
 		for svc := range routeServices {
 			r.referenceStore.removeRouteToServicesMapping(ObjectKindNamespacedName{kindHTTPRoute, request.Namespace, request.Name}, svc)
 			if !r.referenceStore.isServiceReferredByRoutes(svc) {
-				r.resources.Services.Delete(request.NamespacedName)
-				log.Info("deleted service from resource map")
+				r.resources.Services.Delete(svc)
+				log.Info("deleted service from resource map", "service", svc)
 			}
 		}
 	}

--- a/internal/provider/kubernetes/httproute.go
+++ b/internal/provider/kubernetes/httproute.go
@@ -301,7 +301,7 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.R
 		routeServices := r.referenceStore.getRouteToServicesMapping(ObjectKindNamespacedName{kindHTTPRoute, request.Namespace, request.Name})
 		for svc := range routeServices {
 			r.referenceStore.removeRouteToServicesMapping(ObjectKindNamespacedName{kindHTTPRoute, request.Namespace, request.Name}, svc)
-			if r.referenceStore.isServiceReferredByRoutes(svc) {
+			if !r.referenceStore.isServiceReferredByRoutes(svc) {
 				r.resources.Services.Delete(request.NamespacedName)
 				log.Info("deleted service from resource map")
 			}

--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -907,16 +907,16 @@ func testServiceCleanupForMultipleRoutes(ctx context.Context, t *testing.T, prov
 		Name:      svc.Name,
 	}
 
-	_, ok := resources.Services.Load(key)
-	assert.Equal(t, true, ok)
+	rSvc, _ := resources.Services.Load(key)
+	assert.NotNil(t, rSvc)
 
 	// Delete the TLSRoute, and check if the Service is still present
 	require.NoError(t, cli.Delete(ctx, &tlsRoute))
-	_, ok = resources.Services.Load(key)
-	assert.Equal(t, true, ok)
+	rSvc, _ = resources.Services.Load(key)
+	assert.NotNil(t, rSvc)
 
 	// Delete the HTTPRoute, and check if the Service is also removed
 	require.NoError(t, cli.Delete(ctx, &httpRoute))
-	_, ok = resources.Services.Load(key)
-	assert.Equal(t, false, ok)
+	rSvc, _ = resources.Services.Load(key)
+	assert.Nil(t, rSvc)
 }

--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	defaultWait = time.Second * 20
+	defaultWait = time.Second * 60
 	defaultTick = time.Millisecond * 20
 )
 
@@ -59,11 +59,11 @@ func TestProvider(t *testing.T) {
 	}()
 
 	testcases := map[string]func(context.Context, *testing.T, *Provider, *message.ProviderResources){
-		// "gatewayclass controller name":         testGatewayClassController,
-		// "gatewayclass accepted status":         testGatewayClassAcceptedStatus,
-		// "gateway scheduled status":             testGatewayScheduledStatus,
-		// "httproute":                            testHTTPRoute,
-		// "tlsroute":                             testTLSRoute,
+		"gatewayclass controller name":         testGatewayClassController,
+		"gatewayclass accepted status":         testGatewayClassAcceptedStatus,
+		"gateway scheduled status":             testGatewayScheduledStatus,
+		"httproute":                            testHTTPRoute,
+		"tlsroute":                             testTLSRoute,
 		"stale service cleanup route deletion": testServiceCleanupForMultipleRoutes,
 	}
 	for name, tc := range testcases {

--- a/internal/provider/kubernetes/store_test.go
+++ b/internal/provider/kubernetes/store_test.go
@@ -57,6 +57,6 @@ func testRouteToServicesMappings(t *testing.T, cache *providerReferenceStore) {
 	// Verify that ns1svc2 is still referred by another route (HTTPRoute/ns1/r1)
 	require.Equal(t, true, cache.isServiceReferredByRoutes(ns1svc2))
 
-	// Verify that ns1svc1 is not referred by anu other route
+	// Verify that ns1svc1 is not referred by any other route
 	require.Equal(t, false, cache.isServiceReferredByRoutes(ns1svc1))
 }

--- a/internal/provider/kubernetes/tlsroute.go
+++ b/internal/provider/kubernetes/tlsroute.go
@@ -284,8 +284,8 @@ func (r *tlsRouteReconciler) Reconcile(ctx context.Context, request reconcile.Re
 		for svc := range routeServices {
 			r.referenceStore.removeRouteToServicesMapping(ObjectKindNamespacedName{kindTLSRoute, request.Namespace, request.Name}, svc)
 			if !r.referenceStore.isServiceReferredByRoutes(svc) {
-				r.resources.Services.Delete(request.NamespacedName)
-				log.Info("deleted service from resource map")
+				r.resources.Services.Delete(svc)
+				log.Info("deleted service from resource map", "service", svc)
 			}
 		}
 	}

--- a/internal/provider/kubernetes/tlsroute.go
+++ b/internal/provider/kubernetes/tlsroute.go
@@ -285,7 +285,7 @@ func (r *tlsRouteReconciler) Reconcile(ctx context.Context, request reconcile.Re
 			r.referenceStore.removeRouteToServicesMapping(ObjectKindNamespacedName{kindTLSRoute, request.Namespace, request.Name}, svc)
 			if !r.referenceStore.isServiceReferredByRoutes(svc) {
 				r.resources.Services.Delete(svc)
-				log.Info("deleted service from resource map", "service", svc)
+				log.Info("deleted service from resource map", "namespace", svc.Namespace, "name", svc.Name)
 			}
 		}
 	}

--- a/internal/provider/kubernetes/tlsroute.go
+++ b/internal/provider/kubernetes/tlsroute.go
@@ -283,7 +283,7 @@ func (r *tlsRouteReconciler) Reconcile(ctx context.Context, request reconcile.Re
 		routeServices := r.referenceStore.getRouteToServicesMapping(ObjectKindNamespacedName{kindTLSRoute, request.Namespace, request.Name})
 		for svc := range routeServices {
 			r.referenceStore.removeRouteToServicesMapping(ObjectKindNamespacedName{kindTLSRoute, request.Namespace, request.Name}, svc)
-			if r.referenceStore.isServiceReferredByRoutes(svc) {
+			if !r.referenceStore.isServiceReferredByRoutes(svc) {
 				r.resources.Services.Delete(request.NamespacedName)
 				log.Info("deleted service from resource map")
 			}


### PR DESCRIPTION
This commit adds tests related to cleaning up of
stale Services from the resource map, and fixes issues around it.

Signed-off-by: Shubham Chauhan <shubham@tetrate.io>