### PR TITLE
Switching codeowners

### DIFF
--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,3 +1,3 @@
 # The following owners, listed in alphabetical order, own everything
 # in the repo.
-*       @alexgervais @arkodg @danehans @LukeShu @skriss @youngnick
+*       @AliceProxy @arkodg @danehans @LukeShu @skriss @youngnick


### PR DESCRIPTION
Signed-off-by: alex <alex@datawire.io>

Replacing myself as codeowner given my lack of involvement in the project lately with @AliceProxy who has been much more active and contributing. 