### PR TITLE
fix merging https and http listeners on same port

### DIFF
--- a/internal/xds/translator/testdata/in/xds-ir/multiple-listeners-same-port.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/multiple-listeners-same-port.yaml
@@ -3,7 +3,10 @@ http:
   address: "0.0.0.0"
   port: 10080
   hostnames:
-  - "example.com"
+  - "foo.com"
+  tls:
+    serverCertificate: [99, 101, 114, 116, 45, 100, 97, 116, 97] # byte slice representation of "cert-data"
+    privateKey: [107, 101, 121, 45, 100, 97, 116, 97] # byte slice representation of "key-data"
   routes:
   - name: "first-route" 
     destinations:
@@ -13,7 +16,10 @@ http:
   address: "0.0.0.0"
   port: 10080
   hostnames:
-  - "example.net"
+  - "foo.net"
+  tls:
+    serverCertificate: [99, 101, 114, 116, 45, 100, 97, 116, 97] # byte slice representation of "cert-data"
+    privateKey: [107, 101, 121, 45, 100, 97, 116, 97] # byte slice representation of "key-data"
   routes:
   - name: "second-route" 
     destinations:
@@ -23,10 +29,7 @@ http:
   address: "0.0.0.0"
   port: 10080
   hostnames:
-  - "foo.com"
-  tls:
-    serverCertificate: [99, 101, 114, 116, 45, 100, 97, 116, 97] # byte slice representation of "cert-data"
-    privateKey: [107, 101, 121, 45, 100, 97, 116, 97] # byte slice representation of "key-data"
+  - "example.com"
   routes:
   - name: "third-route" 
     destinations:
@@ -36,10 +39,7 @@ http:
   address: "0.0.0.0"
   port: 10080
   hostnames:
-  - "foo.net"
-  tls:
-    serverCertificate: [99, 101, 114, 116, 45, 100, 97, 116, 97] # byte slice representation of "cert-data"
-    privateKey: [107, 101, 121, 45, 100, 97, 116, 97] # byte slice representation of "key-data"
+  - "example.net"
   routes:
   - name: "fourth-route" 
     destinations:

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
@@ -21,7 +21,7 @@
               setNodeOnFirstMessageOnly: true
               transportApiVersion: V3
             resourceApiVersion: V3
-          routeConfigName: first-listener
+          routeConfigName: third-listener
         statPrefix: http
   filterChains:
   - filterChainMatch:
@@ -45,7 +45,7 @@
               setNodeOnFirstMessageOnly: true
               transportApiVersion: V3
             resourceApiVersion: V3
-          routeConfigName: third-listener
+          routeConfigName: first-listener
         statPrefix: https
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -53,7 +53,7 @@
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
         commonTlsContext:
           tlsCertificateSdsSecretConfigs:
-          - name: third-listener
+          - name: first-listener
             sdsConfig:
               apiConfigSource:
                 apiType: DELTA_GRPC
@@ -84,7 +84,7 @@
               setNodeOnFirstMessageOnly: true
               transportApiVersion: V3
             resourceApiVersion: V3
-          routeConfigName: fourth-listener
+          routeConfigName: second-listener
         statPrefix: https
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -92,7 +92,7 @@
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
         commonTlsContext:
           tlsCertificateSdsSecretConfigs:
-          - name: fourth-listener
+          - name: second-listener
             sdsConfig:
               apiConfigSource:
                 apiType: DELTA_GRPC

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.routes.yaml
@@ -1,15 +1,17 @@
 - name: first-listener
   virtualHosts:
   - domains:
-    - example.com
+    - foo.com
     name: first-listener
     routes:
     - match:
         prefix: /
       route:
         cluster: first-route
+- name: second-listener
+  virtualHosts:
   - domains:
-    - example.net
+    - foo.net
     name: second-listener
     routes:
     - match:
@@ -19,17 +21,15 @@
 - name: third-listener
   virtualHosts:
   - domains:
-    - foo.com
+    - example.com
     name: third-listener
     routes:
     - match:
         prefix: /
       route:
         cluster: third-route
-- name: fourth-listener
-  virtualHosts:
   - domains:
-    - foo.net
+    - example.net
     name: fourth-listener
     routes:
     - match:

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.secrets.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.secrets.yaml
@@ -1,10 +1,10 @@
-- name: third-listener
+- name: first-listener
   tlsCertificate:
     certificateChain:
       inlineBytes: Y2VydC1kYXRh
     privateKey:
       inlineBytes: a2V5LWRhdGE=
-- name: fourth-listener
+- name: second-listener
   tlsCertificate:
     certificateChain:
       inlineBytes: Y2VydC1kYXRh


### PR DESCRIPTION
Gracefully handle the case when an https listener is first created, and then an http one is added later. In such a case the route config within the default filter chain wouldnt exist

Signed-off-by: Arko Dasgupta <arko@tetrate.io>