### PR TITLE
fix: update build-and-test workflow to match the latest branch pattern

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -3,13 +3,13 @@ on:
   push:
     branches:
     - "main"
-    - "release-v*"
+    - "release/v*"
     paths-ignore:
     - "**/*.png"
   pull_request:
     branches:
     - "main"
-    - "release-v*"
+    - "release/v*"
     paths-ignore:
     - "**/*.png"
 jobs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,13 +3,13 @@ on:
   push:
     branches:
       - "main"
-      - "release-v*"
+      - "release/v*"
     paths-ignore:
       - "**/*.png"
   pull_request:
     branches:
       - "main"
-      - "release-v*"
+      - "release/v*"
     paths-ignore:
       - "**/*.png"
 


### PR DESCRIPTION
Fixes: https://github.com/envoyproxy/gateway/issues/629

Signed-off-by: bitliu <bitliu@tencent.com>

We should be careful about changing the branch naming pattern, if we did change, do not forget to sync to build-and-test and doc workflow, since they should be triggered to run and build the last commit merged into release branch,