### PR TITLE
internal/gatewayapi: support HTTP method matching

### DIFF
--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.in.yaml
@@ -1,0 +1,31 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - method: POST
+          backendRefs:
+            - name: service-1
+              port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
@@ -1,0 +1,87 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - method: POST
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+      - name: envoy-gateway-gateway-1-http
+        address: 0.0.0.0
+        port: 10080
+        hostnames:
+          - "*"
+        routes:
+          - name: default-httproute-1-rule-0-match-0-*
+            headerMatches:
+              - name: ":method"
+                exact: POST
+            destinations:
+              - host: 7.7.7.7
+                port: 8080
+                weight: 1
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+        - address: ""
+          ports:
+            - name: http
+              protocol: "HTTP"
+              servicePort: 80
+              containerPort: 10080

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -1095,6 +1095,13 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*v1beta1.HTTPRoute, gateways
 						}
 					}
 
+					if match.Method != nil {
+						irRoute.HeaderMatches = append(irRoute.HeaderMatches, &ir.StringMatch{
+							Name:  ":method",
+							Exact: StringPtr(string(*match.Method)),
+						})
+					}
+
 					// Add the redirect filter or direct response that were created earlier to all the irRoutes
 					if redirectResponse != nil {
 						irRoute.Redirect = redirectResponse


### PR DESCRIPTION
Closes #655.

Signed-off-by: Steve Kriss <krisss@vmware.com>

Note, the conformance test for this was added after Gateway API v0.5.1 so we can't run it until we pick up v0.6.0, but here are the results from running it manually from `main`:

```shell
--- PASS: TestConformance (17.18s)
    --- PASS: TestConformance/HTTPRouteMethodMatching (1.04s)
        --- PASS: TestConformance/HTTPRouteMethodMatching/2_request_to_'/'_should_receive_a_404 (4.04s)
        --- PASS: TestConformance/HTTPRouteMethodMatching/0_request_to_'/'_should_go_to_infra-backend-v1 (4.04s)
        --- PASS: TestConformance/HTTPRouteMethodMatching/1_request_to_'/'_should_go_to_infra-backend-v2 (4.05s)
```

I'll file another issue to remind us to enable the test down the road.