### PR TITLE
Fix hostname parsing for TLSRoutes

### DIFF
--- a/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.in.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.in.yaml
@@ -1,0 +1,41 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: tls
+      protocol: TLS
+      port: 91
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
+tlsRoutes:
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+services:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: default
+    name: service-1
+  spec:
+    clusterIP: 7.7.7.7
+    ports:
+    - port: 8080

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
@@ -41,17 +41,17 @@ tlsRoutes:
     - backendRefs:
       - name: service-1
         port: 8080
-    status:
-      parents:
-      - parentRef:
-          namespace: envoy-gateway
-          name: gateway-1
-        controllerName: gateway.envoyproxy.io/gatewayclass-controller
-        conditions:
-        - type: Accepted
-          status: "True"
-          reason: Accepted
-          message: Route is accepted
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
 xdsIR:
   envoy-gateway-gateway-1:
     tcp:

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
@@ -1,0 +1,83 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: tls
+      protocol: TLS
+      port: 91
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: tls
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: TLSRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
+tlsRoutes:
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+    status:
+      parents:
+      - parentRef:
+          namespace: envoy-gateway
+          name: gateway-1
+        controllerName: gateway.envoyproxy.io/gatewayclass-controller
+        conditions:
+        - type: Accepted
+          status: "True"
+          reason: Accepted
+          message: Route is accepted
+xdsIR:
+  envoy-gateway-gateway-1:
+    tcp:
+    - name: envoy-gateway-gateway-1-tls
+      address: 0.0.0.0
+      port: 10091
+      tls:
+        snis:
+        - "*" 
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+      - address: ""
+        ports:
+        - name: tls
+          protocol: "TLS"
+          servicePort: 91
+          containerPort: 10091

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.in.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.in.yaml
@@ -1,0 +1,43 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: tls
+      protocol: TLS
+      port: 91
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
+tlsRoutes:
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - "foo.com"
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+services:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    namespace: default
+    name: service-1
+  spec:
+    clusterIP: 7.7.7.7
+    ports:
+    - port: 8080

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
@@ -1,0 +1,85 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: tls
+      protocol: TLS
+      port: 91
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: tls
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: TLSRoute
+    attachedRoutes: 1
+    conditions:
+    - type: Ready
+      status: "True"
+      reason: Ready
+      message: Listener is ready
+tlsRoutes:
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    namespace: default
+    name: tlsroute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - "foo.com"        
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - parentRef:
+      namespace: envoy-gateway
+      name: gateway-1
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+xdsIR:
+  envoy-gateway-gateway-1:
+    tcp:
+    - name: envoy-gateway-gateway-1-tls
+      address: 0.0.0.0
+      port: 10091
+      tls:
+        snis:
+        - foo.com
+      destinations:
+      - host: 7.7.7.7
+        port: 8080
+        weight: 1
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+      - address: ""
+        ports:
+        - name: tls
+          protocol: "TLS"
+          servicePort: 91
+          containerPort: 10091

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
@@ -21,12 +21,12 @@ gateways:
       supportedKinds:
       - group: gateway.networking.k8s.io
         kind: TLSRoute
-    attachedRoutes: 1
-    conditions:
-    - type: Ready
-      status: "True"
-      reason: Ready
-      message: Listener is ready
+      attachedRoutes: 1
+      conditions:
+      - type: Ready
+        status: "True"
+        reason: Ready
+        message: Listener is ready
 tlsRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TLSRoute
@@ -38,7 +38,7 @@ tlsRoutes:
     - namespace: envoy-gateway
       name: gateway-1
     hostnames:
-    - "foo.com"        
+    - foo.com
     rules:
     - backendRefs:
       - name: service-1
@@ -46,8 +46,8 @@ tlsRoutes:
   status:
     parents:
     - parentRef:
-      namespace: envoy-gateway
-      name: gateway-1
+        namespace: envoy-gateway
+        name: gateway-1
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       conditions:
       - type: Accepted

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -557,7 +557,7 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR XdsIRMap
 					Port:    uint32(containerPort),
 					TLS:     irTLSConfig(listener.tlsSecret),
 				}
-				if listener.Hostname != nil {
+				if listener.Hostname != nil && *listener.Hostname != "" {
 					irListener.Hostnames = append(irListener.Hostnames, string(*listener.Hostname))
 				} else {
 					// Hostname specifies the virtual hostname to match for protocol types that define this concept.
@@ -572,19 +572,10 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR XdsIRMap
 					Address: "0.0.0.0",
 					Port:    uint32(containerPort),
 					TLS: &ir.TLSInspectorConfig{
+						// Since we need to first compute intersecting hostnames between the
+						// listener and TLS Route, populate this field after processing TLS Routes.
 						SNIs: []string{},
 					},
-				}
-				if listener.Hostname == nil || *listener.Hostname == "" {
-					listener.SetCondition(
-						v1beta1.ListenerConditionReady,
-						metav1.ConditionFalse,
-						v1beta1.ListenerReasonInvalid,
-						"Listener is invalid, see other Conditions for details.",
-					)
-				}
-				if listener.Hostname != nil && *listener.Hostname != "" {
-					irListener.TLS.SNIs = append(irListener.TLS.SNIs, string(*listener.Hostname))
 				}
 				gwXdsIR.TCP = append(gwXdsIR.TCP, irListener)
 			}
@@ -1374,13 +1365,16 @@ func (t *Translator) ProcessTLSRoutes(tlsRoutes []*v1alpha2.TLSRoute, gateways [
 				if len(hosts) == 0 {
 					continue
 				}
+
 				hasHostnameIntersection = true
 
 				irKey := irStringKey(listener.gateway)
 				irListener := xdsIR[irKey].GetTCPListener(irListenerName(listener))
 				if irListener != nil {
 					irListener.Destinations = routeDestinations
+					irListener.TLS.SNIs = hosts
 				}
+
 				// Theoretically there should only be one parent ref per
 				// Route that attaches to a given Listener, so fine to just increment here, but we
 				// might want to check to ensure we're not double-counting.

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -557,7 +557,7 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR XdsIRMap
 					Port:    uint32(containerPort),
 					TLS:     irTLSConfig(listener.tlsSecret),
 				}
-				if listener.Hostname != nil && *listener.Hostname != "" {
+				if listener.Hostname != nil {
 					irListener.Hostnames = append(irListener.Hostnames, string(*listener.Hostname))
 				} else {
 					// Hostname specifies the virtual hostname to match for protocol types that define this concept.


### PR DESCRIPTION
* use the result from `computeHosts` which returns the list of intersecting hostnames between the listener and the route to populate the SNIs field within the Xds IR TCP Listener

Fixes: https://github.com/envoyproxy/gateway/issues/661

Signed-off-by: Arko Dasgupta <arko@tetrate.io>