### PR TITLE
update codecov action to v3

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Run Coverage Tests
       run: make go.test.coverage
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
         files: ./coverage.xml


### PR DESCRIPTION
Addresses deprecations, possibly
helps with the upload flake.

Signed-off-by: Steve Kriss <krisss@vmware.com>

(See e.g. https://github.com/envoyproxy/gateway/actions/runs/3379855695 for the deprecation warning)