### PR TITLE
opt: run conformance test concurrently in multi-kube-version

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -35,9 +35,8 @@ jobs:
     - uses: ./tools/github-actions/setup-deps
     - run: make -k licensecheck
 
-  build-and-test:
+  coverage-test:
     runs-on: ubuntu-latest
-    needs: [lint, gen-check, license-check]
     steps:
     - uses: actions/checkout@v3
     - uses: ./tools/github-actions/setup-deps
@@ -53,28 +52,67 @@ jobs:
         name: codecov-envoy-gateway
         verbose: true
 
-    # build
-    - name: Build Multiarch EG Binaries
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, gen-check, license-check, coverage-test]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./tools/github-actions/setup-deps
+
+    - name: Build EG Multiarch Binaries
       run: make build-multiarch PLATFORMS="linux_amd64 linux_arm64"
 
+    - name: Upload EG Binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: envoy-gateway
+        path: bin/
+
+  conformance-test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    strategy:
+      matrix:
+        version: [ v1.22.9, v1.23.6, v1.24.0 ]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./tools/github-actions/setup-deps
+
+    - name: Download EG Binaries
+      uses: actions/download-artifact@v3
+      with:
+        name: envoy-gateway
+        path: bin/
+    
+    - name: Give Privileges To EG Binaries
+      run: |
+        chmod +x bin/linux/amd64/envoy-gateway
+        chmod +x bin/linux/arm64/envoy-gateway
+
     # conformance
-    - name: Run Conformance Tests (v1.24.0)
+    - name: Run Conformance Tests 
       env:
-        KIND_NODE_TAG: v1.24.0
+        KIND_NODE_TAG: ${{ matrix.version }}
         CONFORMANCE_UNIQUE_PORTS: false
       run: make conformance
-    
-    - name: Run Conformance Tests (v1.23.6)
-      env:
-        KIND_NODE_TAG: v1.23.6
-        CONFORMANCE_UNIQUE_PORTS: false
-      run: make conformance
-    
-    - name: Run Conformance Tests (v1.22.9)
-      env:
-        KIND_NODE_TAG: v1.22.9
-        CONFORMANCE_UNIQUE_PORTS: false
-      run: make conformance
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [conformance-test]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./tools/github-actions/setup-deps
+
+    - name: Download EG Binaries
+      uses: actions/download-artifact@v3
+      with:
+        name: envoy-gateway
+        path: bin/
+
+    - name: Give Privileges To EG Binaries
+      run: |
+        chmod +x bin/linux/amd64/envoy-gateway
+        chmod +x bin/linux/arm64/envoy-gateway
 
     # build and push image
     - name: Login to DockerHub
@@ -85,6 +123,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: Setup Multiarch Environment
+      if: github.event_name == 'push'
       run: make image.multiarch.setup
 
     - name: Build and Push EG Commit Image

--- a/tools/make/image.mk
+++ b/tools/make/image.mk
@@ -47,7 +47,8 @@ image.verify:
 image.build: $(addprefix image.build.$(IMAGE_PLAT)., $(IMAGES))
 
 .PHONY: image.build.%
-image.build.%: go.build.% image.verify
+image.build.%: image.verify
+	$(eval COMMAND := $(word 2,$(subst ., ,$*)))
 	$(eval IMAGES := $(COMMAND))
 	$(eval IMAGE_PLAT := $(subst _,/,$(PLATFORM)))
 	@$(call log, "Building image $(IMAGES) in tag $(TAG) for $(IMAGE_PLAT)")
@@ -100,7 +101,7 @@ image.push.multiarch:
 
 .PHONY: image
 image: ## Build docker images for host platform. See Option PLATFORM and BINS.
-image: image.build
+image: go.build image.build
 
 .PHONY: image-multiarch
 image-multiarch: ## Build docker images for multiple platforms. See Option PLATFORMS and IMAGES.

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -67,7 +67,7 @@ kube-demo-undeploy: ## Uninstall the Kubernetes resources installed from the `ma
 #run-kube-local: build kube-install ## Run Envoy Gateway locally.
 #	tools/hack/run-kube-local.sh
 
-.PHONY: conformance 
+.PHONY: conformance
 conformance: create-cluster kube-install-image kube-deploy run-conformance delete-cluster ## Create a kind cluster, deploy EG into it, run Gateway API conformance, and clean up.
 
 .PHONY: create-cluster


### PR DESCRIPTION
Run conformance test concurrently in multi kube-version.

Roughly calculated that the new mode will save about half the time compared to the previous one.

As we add more kube versions to run conformance tests, the running time of build-and-test workflow will nearly not increase. But the former way will cause the time to grow exponentially.

https://github.com/envoyproxy/gateway/actions/runs/3425534566

Signed-off-by: bitliu <bitliu@tencent.com>