### PR TITLE
Fixes Envoy Deployment Ref in Dev Doc

### DIFF
--- a/docs/latest/dev/README.md
+++ b/docs/latest/dev/README.md
@@ -119,7 +119,7 @@ export ENVOY_DEPLOYMENT=$(kubectl get deploy -n envoy-gateway-system --selector=
 Port forward the admin interface port:
 
 ```shell
-kubectl port-forward deploy/envoy-${ENVOY_DEPLOYMENT} -n envoy-gateway-system 19000:19000
+kubectl port-forward deploy/${ENVOY_DEPLOYMENT} -n envoy-gateway-system 19000:19000
 ```
 
 Now you are able to view the running Envoy configuration by navigating to `127.0.0.1:19000/config_dump`.

--- a/docs/v0.2.0/dev/README.md
+++ b/docs/v0.2.0/dev/README.md
@@ -119,7 +119,7 @@ export ENVOY_DEPLOYMENT=$(kubectl get deploy -n envoy-gateway-system --selector=
 Port forward the admin interface port:
 
 ```shell
-kubectl port-forward deploy/envoy-${ENVOY_DEPLOYMENT} -n envoy-gateway-system 19000:19000
+kubectl port-forward deploy/${ENVOY_DEPLOYMENT} -n envoy-gateway-system 19000:19000
 ```
 
 Now you are able to view the running Envoy configuration by navigating to `127.0.0.1:19000/config_dump`.


### PR DESCRIPTION
Previously:
```
$ export ENVOY_DEPLOYMENT=$(kubectl get deploy -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-namespace=default,gateway.envoyproxy.io/owning-gateway-name=eg -o jsonpath='{.items[0].metadata.name}')

$ echo $ENVOY_DEPLOYMENT
envoy-default-eg-64656661

$ kubectl port-forward deploy/envoy-${ENVOY_DEPLOYMENT} -n envoy-gateway-system 19000:19000

Error from server (NotFound): deployments.apps "envoy-envoy-default-eg-64656661" not found
```

After removing `envoy-`:
```
$ kubectl port-forward deploy/${ENVOY_DEPLOYMENT} -n envoy-gateway-system 19000:19000

Forwarding from 127.0.0.1:19000 -> 19000
Forwarding from [::1]:19000 -> 19000
```

Signed-off-by: danehans <daneyonhansen@gmail.com>