### PR TITLE
CODEOWNERS.md: Remove myself

### DIFF
--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,3 +1,3 @@
 # The following owners, listed in alphabetical order, own everything
 # in the repo.
-*       @AliceProxy @arkodg @danehans @LukeShu @skriss @Xunzhuo @youngnick
+*       @AliceProxy @arkodg @danehans @skriss @Xunzhuo @youngnick


### PR DESCRIPTION
As stated in last week's meeting, I'm moving on from Ambassador Labs and don't anticipate being involved with Envoy Gateway going forward.