### PR TITLE
Support suffix matches for headers

### DIFF
--- a/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.in.yaml
@@ -1,0 +1,34 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:
+        - "*.envoyproxy.io"
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
@@ -1,0 +1,92 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 1
+          conditions:
+            - type: Ready
+              status: "True"
+              reason: Ready
+              message: Listener is ready
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      hostnames:
+        - "*.envoyproxy.io"
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080
+    status:
+      parents:
+        - parentRef:
+            namespace: envoy-gateway
+            name: gateway-1
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
+          conditions:
+            - type: Accepted
+              status: "True"
+              reason: Accepted
+              message: Route is accepted
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+      - name: envoy-gateway-gateway-1-http
+        address: 0.0.0.0
+        port: 10080
+        hostnames:
+          - "*"
+        routes:
+          - name: default-httproute-1-rule-0-match-0-*.envoyproxy.io
+            pathMatch:
+              prefix: "/"
+            headerMatches:
+              - name: ":authority"
+                suffix: envoyproxy.io
+            destinations:
+              - host: 7.7.7.7
+                port: 8080
+                weight: 1
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+        - address: ""
+          ports:
+            - name: http
+              protocol: "HTTP"
+              servicePort: 80
+              containerPort: 10080

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -410,6 +410,8 @@ type StringMatch struct {
 	Exact *string
 	// Prefix match condition.
 	Prefix *string
+	// Suffix match condition.
+	Suffix *string
 	// SafeRegex match condition.
 	SafeRegex *string
 }
@@ -422,6 +424,9 @@ func (s StringMatch) Validate() error {
 		matchCount++
 	}
 	if s.Prefix != nil {
+		matchCount++
+	}
+	if s.Suffix != nil {
 		matchCount++
 	}
 	if s.SafeRegex != nil {

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -121,6 +121,12 @@ func buildXdsStringMatcher(irMatch *ir.StringMatch) *matcher.StringMatcher {
 				Prefix: *irMatch.Prefix,
 			},
 		}
+	} else if irMatch.Suffix != nil {
+		stringMatcher = &matcher.StringMatcher{
+			MatchPattern: &matcher.StringMatcher_Suffix{
+				Suffix: *irMatch.Suffix,
+			},
+		}
 	} else if irMatch.SafeRegex != nil {
 		stringMatcher = &matcher.StringMatcher{
 			MatchPattern: &matcher.StringMatcher_SafeRegex{

--- a/internal/xds/translator/testdata/in/xds-ir/http-route.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route.yaml
@@ -7,12 +7,14 @@ http:
   routes:
   - name: "first-route"
     pathMatch:
-      name: "test"
       exact: "foo/bar"
     headerMatches:
     - name: user
       stringMatch:
       exact: "jason"
+    - name: test 
+      stringMatch:
+      suffix: "end"     
     queryParamMatches:
     - name: "debug"
       exact: "yes"

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
@@ -9,6 +9,9 @@
         - name: user
           stringMatch:
             exact: jason
+        - name: test
+          stringMatch:
+            suffix: end            
         path: foo/bar
         queryParameters:
         - name: debug


### PR DESCRIPTION
* The gateway API allows wildcard hostnames such as `*.example.com` to be used in HTTPRoutes https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.Listener

* Added a suffix match in the Xds IR as well as the xds matcher translation to support this case

Fixes: https://github.com/envoyproxy/gateway/issues/738

Signed-off-by: Arko Dasgupta <arko@tetrate.io>