### PR TITLE
Removes Duplicate Settings from Bootstrap Config

### DIFF
--- a/internal/infrastructure/kubernetes/bootstrap.yaml.tpl
+++ b/internal/infrastructure/kubernetes/bootstrap.yaml.tpl
@@ -23,9 +23,6 @@ dynamic_resources:
       - envoy_grpc:
           cluster_name: xds_cluster
       set_node_on_first_message_only: true
-node:
-  cluster: envoy-gateway-system
-  id: envoy-default
 static_resources:
   clusters:
   - connect_timeout: 1s


### PR DESCRIPTION
Fixes #762 

These settings are unused since they are set from [CLI args](https://github.com/envoyproxy/gateway/blob/v0.2.0/internal/infrastructure/kubernetes/deployment.go#L225-L226).

Signed-off-by: danehans <daneyonhansen@gmail.com>