### PR TITLE
Adds Namespace Support to Server Config Type

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -56,10 +56,14 @@ func server() error {
 // getConfig gets the Server configuration
 func getConfig() (*config.Server, error) {
 	// Initialize with default config parameters.
-	cfg, err := config.NewDefaultServer()
+	cfg, err := config.New()
 	if err != nil {
 		return nil, err
 	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	log := cfg.Logger
 
 	// Read the config file.

--- a/internal/crypto/certgen.go
+++ b/internal/crypto/certgen.go
@@ -91,13 +91,8 @@ type certificateRequest struct {
 
 // GenerateCerts generates a CA Certificate along with certificates for Envoy Gateway
 // and Envoy returning them as a *Certificates struct or error if encountered.
-func GenerateCerts(egCfg *v1alpha1.EnvoyGateway) (*Certificates, error) {
+func GenerateCerts(cfg *config.Server) (*Certificates, error) {
 	certCfg := new(Configuration)
-
-	// Check if the EG config is not provided, then default.
-	if egCfg == nil {
-		egCfg = v1alpha1.DefaultEnvoyGateway()
-	}
 
 	certCfg.getProvider()
 	switch certCfg.Provider.Type {
@@ -110,12 +105,11 @@ func GenerateCerts(egCfg *v1alpha1.EnvoyGateway) (*Certificates, error) {
 		}
 
 		var egDNSNames, envoyDNSNames []string
-		egProvider := egCfg.GetProvider().Type
+		egProvider := cfg.EnvoyGateway.GetProvider().Type
 		switch egProvider {
 		case v1alpha1.ProviderTypeKubernetes:
-			ns := config.EnvoyGatewayNamespace
-			egDNSNames = kubeServiceNames(DefaultEnvoyGatewayDNSPrefix, ns, DefaultDNSSuffix)
-			envoyDNSNames = append(envoyDNSNames, fmt.Sprintf("*.%s", ns))
+			egDNSNames = kubeServiceNames(DefaultEnvoyGatewayDNSPrefix, cfg.Namespace, DefaultDNSSuffix)
+			envoyDNSNames = append(envoyDNSNames, fmt.Sprintf("*.%s", cfg.Namespace))
 		default:
 			// Kubernetes is the only supported Envoy Gateway provider.
 			return nil, fmt.Errorf("unsupported provider type %v", egProvider)

--- a/internal/crypto/certgen_test.go
+++ b/internal/crypto/certgen_test.go
@@ -15,17 +15,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/envoyproxy/gateway/api/config/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 )
 
 func TestGenerateCerts(t *testing.T) {
 	type testcase struct {
-		envoyGateway            *v1alpha1.EnvoyGateway
 		certConfig              *Configuration
 		wantEnvoyGatewayDNSName string
 		wantEnvoyDNSName        string
 	}
+
+	cfg, err := config.New()
+	require.NoError(t, err)
 
 	run := func(t *testing.T, name string, tc testcase) {
 		t.Helper()
@@ -33,7 +34,7 @@ func TestGenerateCerts(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Helper()
 
-			got, err := GenerateCerts(tc.envoyGateway)
+			got, err := GenerateCerts(cfg)
 			require.NoError(t, err)
 
 			roots := x509.NewCertPool()
@@ -53,7 +54,7 @@ func TestGenerateCerts(t *testing.T) {
 	run(t, "no configuration - use defaults", testcase{
 		certConfig:              &Configuration{},
 		wantEnvoyGatewayDNSName: DefaultEnvoyGatewayDNSPrefix,
-		wantEnvoyDNSName:        fmt.Sprintf("*.%s", config.EnvoyGatewayNamespace),
+		wantEnvoyDNSName:        fmt.Sprintf("*.%s", config.DefaultNamespace),
 	})
 }
 

--- a/internal/envoygateway/config/config.go
+++ b/internal/envoygateway/config/config.go
@@ -6,6 +6,9 @@
 package config
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/go-logr/logr"
 
 	"github.com/envoyproxy/gateway/api/config/v1alpha1"
@@ -13,12 +16,9 @@ import (
 	"github.com/envoyproxy/gateway/internal/utils/env"
 )
 
-var (
-	// EnvoyGatewayNamespace is the namespace where envoy-gateway is running.
-	EnvoyGatewayNamespace = env.Lookup("ENVOY_GATEWAY_NAMESPACE", "envoy-gateway-system")
-)
-
 const (
+	// DefaultNamespace is the default namespace of Envoy Gateway.
+	DefaultNamespace = "envoy-gateway-system"
 	// EnvoyGatewayServiceName is the name of the Envoy Gateway service.
 	EnvoyGatewayServiceName = "envoy-gateway"
 	// EnvoyPrefix is the prefix applied to the Envoy ConfigMap, Service, Deployment, and ServiceAccount.
@@ -30,18 +30,43 @@ const (
 type Server struct {
 	// EnvoyGateway is the configuration used to startup Envoy Gateway.
 	EnvoyGateway *v1alpha1.EnvoyGateway
+	// Namespace is the namespace that Envoy Gateway runs in.
+	Namespace string
 	// Logger is the logr implementation used by Envoy Gateway.
 	Logger logr.Logger
 }
 
-// NewDefaultServer returns a Server with default parameters.
-func NewDefaultServer() (*Server, error) {
+// New returns a Server with default parameters.
+func New() (*Server, error) {
 	logger, err := log.NewLogger()
 	if err != nil {
 		return nil, err
 	}
 	return &Server{
 		EnvoyGateway: v1alpha1.DefaultEnvoyGateway(),
+		Namespace:    env.Lookup("ENVOY_GATEWAY_NAMESPACE", DefaultNamespace),
 		Logger:       logger,
 	}, nil
+}
+
+// Validate validates a Server config.
+func (s *Server) Validate() error {
+	switch {
+	case s == nil:
+		return errors.New("server config is unspecified")
+	case s.EnvoyGateway == nil:
+		return errors.New("envoy gateway config is unspecified")
+	case s.EnvoyGateway.EnvoyGatewaySpec.Gateway == nil:
+		return errors.New("gateway is unspecified")
+	case len(s.EnvoyGateway.EnvoyGatewaySpec.Gateway.ControllerName) == 0:
+		return errors.New("gateway controllerName is unspecified")
+	case s.EnvoyGateway.EnvoyGatewaySpec.Provider == nil:
+		return errors.New("provider is unspecified")
+	case s.EnvoyGateway.EnvoyGatewaySpec.Provider.Type != v1alpha1.ProviderTypeKubernetes:
+		return fmt.Errorf("unsupported provider %v", s.EnvoyGateway.EnvoyGatewaySpec.Provider.Type)
+	case len(s.Namespace) == 0:
+		return errors.New("namespace is empty string")
+	}
+
+	return nil
 }

--- a/internal/envoygateway/config/config_test.go
+++ b/internal/envoygateway/config/config_test.go
@@ -1,0 +1,115 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/gateway/api/config/v1alpha1"
+)
+
+func TestValidate(t *testing.T) {
+	cfg, err := New()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name   string
+		cfg    *Server
+		expect bool
+	}{
+		{
+			name:   "default",
+			cfg:    cfg,
+			expect: true,
+		},
+		{
+			name: "empty namespace",
+			cfg: &Server{
+				EnvoyGateway: &v1alpha1.EnvoyGateway{
+					EnvoyGatewaySpec: v1alpha1.EnvoyGatewaySpec{
+						Gateway:  v1alpha1.DefaultGateway(),
+						Provider: v1alpha1.DefaultProvider(),
+					},
+				},
+				Namespace: "",
+			},
+			expect: false,
+		},
+		{
+			name: "unspecified envoy gateway",
+			cfg: &Server{
+				Namespace: "test-ns",
+				Logger:    logr.Logger{},
+			},
+			expect: false,
+		},
+		{
+			name: "unspecified gateway",
+			cfg: &Server{
+				EnvoyGateway: &v1alpha1.EnvoyGateway{
+					EnvoyGatewaySpec: v1alpha1.EnvoyGatewaySpec{
+						Provider: v1alpha1.DefaultProvider(),
+					},
+				},
+				Namespace: "test-ns",
+			},
+			expect: false,
+		},
+		{
+			name: "unspecified provider",
+			cfg: &Server{
+				EnvoyGateway: &v1alpha1.EnvoyGateway{
+					EnvoyGatewaySpec: v1alpha1.EnvoyGatewaySpec{
+						Gateway: v1alpha1.DefaultGateway(),
+					},
+				},
+				Namespace: "test-ns",
+			},
+			expect: false,
+		},
+		{
+			name: "empty gateway controllerName",
+			cfg: &Server{
+				EnvoyGateway: &v1alpha1.EnvoyGateway{
+					EnvoyGatewaySpec: v1alpha1.EnvoyGatewaySpec{
+						Gateway:  &v1alpha1.Gateway{ControllerName: ""},
+						Provider: v1alpha1.DefaultProvider(),
+					},
+				},
+				Namespace: "test-ns",
+			},
+			expect: false,
+		},
+		{
+			name: "unsupported provider",
+			cfg: &Server{
+				EnvoyGateway: &v1alpha1.EnvoyGateway{
+					EnvoyGatewaySpec: v1alpha1.EnvoyGatewaySpec{
+						Gateway:  v1alpha1.DefaultGateway(),
+						Provider: &v1alpha1.Provider{Type: v1alpha1.ProviderTypeFile},
+					},
+				},
+				Namespace: "test-ns",
+			},
+			expect: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if !tc.expect {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/gatewayapi/runner/runner_test.go
+++ b/internal/gatewayapi/runner/runner_test.go
@@ -24,7 +24,7 @@ func TestRunner(t *testing.T) {
 	pResources := new(message.ProviderResources)
 	xdsIR := new(message.XdsIR)
 	infraIR := new(message.InfraIR)
-	cfg, err := config.NewDefaultServer()
+	cfg, err := config.New()
 	require.NoError(t, err)
 	r := New(&Config{
 		Server:            *cfg,

--- a/internal/infrastructure/kubernetes/deployment_test.go
+++ b/internal/infrastructure/kubernetes/deployment_test.go
@@ -20,6 +20,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway"
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
 	"github.com/envoyproxy/gateway/internal/ir"
 	xdsrunner "github.com/envoyproxy/gateway/internal/xds/server/runner"
@@ -107,8 +108,10 @@ func checkContainerImage(t *testing.T, container *corev1.Container, image string
 }
 
 func TestExpectedDeployment(t *testing.T) {
+	svrCfg, err := config.New()
+	require.NoError(t, err)
 	cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects().Build()
-	kube := NewInfra(cli)
+	kube := NewInfra(cli, svrCfg)
 	infra := ir.NewInfra()
 
 	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
@@ -163,7 +166,10 @@ func deploymentWithImage(deploy *appsv1.Deployment, image string) *appsv1.Deploy
 }
 
 func TestCreateOrUpdateDeployment(t *testing.T) {
-	kube := NewInfra(nil)
+	cfg, err := config.New()
+	require.NoError(t, err)
+
+	kube := NewInfra(nil, cfg)
 	infra := ir.NewInfra()
 
 	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"

--- a/internal/infrastructure/kubernetes/infra.go
+++ b/internal/infrastructure/kubernetes/infra.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/ir"
-	"github.com/envoyproxy/gateway/internal/utils/env"
 )
 
 // Infra manages the creation and deletion of Kubernetes infrastructure
@@ -26,10 +25,10 @@ type Infra struct {
 }
 
 // NewInfra returns a new Infra.
-func NewInfra(cli client.Client) *Infra {
+func NewInfra(cli client.Client, cfg *config.Server) *Infra {
 	return &Infra{
 		Client:    cli,
-		Namespace: env.Lookup("ENVOY_GATEWAY_NAMESPACE", config.EnvoyGatewayNamespace),
+		Namespace: cfg.Namespace,
 	}
 }
 

--- a/internal/infrastructure/kubernetes/service_test.go
+++ b/internal/infrastructure/kubernetes/service_test.go
@@ -17,6 +17,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway"
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
 	"github.com/envoyproxy/gateway/internal/ir"
 )
@@ -66,8 +67,10 @@ func checkServiceHasLabels(t *testing.T, svc *corev1.Service, expected map[strin
 }
 
 func TestDesiredService(t *testing.T) {
+	cfg, err := config.New()
+	require.NoError(t, err)
 	cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects().Build()
-	kube := NewInfra(cli)
+	kube := NewInfra(cli, cfg)
 	infra := ir.NewInfra()
 	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
 	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = infra.Proxy.Name

--- a/internal/infrastructure/kubernetes/serviceaccount_test.go
+++ b/internal/infrastructure/kubernetes/serviceaccount_test.go
@@ -20,18 +20,21 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway"
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
 	"github.com/envoyproxy/gateway/internal/ir"
 )
 
 func TestExpectedServiceAccount(t *testing.T) {
+	cfg, err := config.New()
+	require.NoError(t, err)
 	cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects().Build()
-	kube := NewInfra(cli)
+	kube := NewInfra(cli, cfg)
 	infra := ir.NewInfra()
 
 	// An infra without Gateway owner labels should trigger
 	// an error.
-	_, err := kube.expectedServiceAccount(infra)
+	_, err = kube.expectedServiceAccount(infra)
 	require.NotNil(t, err)
 
 	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"

--- a/internal/infrastructure/manager.go
+++ b/internal/infrastructure/manager.go
@@ -37,7 +37,7 @@ func NewManager(cfg *config.Server) (Manager, error) {
 		if err != nil {
 			return nil, err
 		}
-		mgr = kubernetes.NewInfra(cli)
+		mgr = kubernetes.NewInfra(cli, cfg)
 	} else {
 		// Kube is the only supported provider type for now.
 		return nil, fmt.Errorf("unsupported provider type %v", cfg.EnvoyGateway.Provider.Type)

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -49,6 +49,7 @@ type gatewayAPIReconciler struct {
 	log             logr.Logger
 	statusUpdater   status.Updater
 	classController gwapiv1b1.GatewayController
+	namespace       string
 
 	resources *message.ProviderResources
 }
@@ -61,6 +62,7 @@ func newGatewayAPIController(mgr manager.Manager, cfg *config.Server, su status.
 		client:          mgr.GetClient(),
 		log:             cfg.Logger,
 		classController: gwapiv1b1.GatewayController(cfg.EnvoyGateway.Gateway.ControllerName),
+		namespace:       cfg.Namespace,
 		statusUpdater:   su,
 		resources:       resources,
 	}

--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -48,7 +48,7 @@ func TestProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	// Setup and start the kube provider.
-	svr, err := config.NewDefaultServer()
+	svr, err := config.New()
 	require.NoError(t, err)
 	resources := new(message.ProviderResources)
 	provider, err := New(cliCfg, svr, resources)

--- a/internal/xds/translator/runner/runner_test.go
+++ b/internal/xds/translator/runner/runner_test.go
@@ -22,7 +22,7 @@ func TestRunner(t *testing.T) {
 	// Setup
 	xdsIR := new(message.XdsIR)
 	xds := new(message.Xds)
-	cfg, err := config.NewDefaultServer()
+	cfg, err := config.New()
 	require.NoError(t, err)
 	r := New(&Config{
 		Server: *cfg,


### PR DESCRIPTION
Adds `Namespace` field to the server config API type. This allows the namespace that EG runs in to be consumed by different types, e.g. Kube controllers to filter watches.

Fixes #777

Signed-off-by: danehans <daneyonhansen@gmail.com>