### PR TITLE
Add ReferenceGrant Support for Routes

### DIFF
--- a/internal/provider/kubernetes/helpers.go
+++ b/internal/provider/kubernetes/helpers.go
@@ -209,7 +209,6 @@ func infraDeploymentName(gateway *gwapiv1b1.Gateway) string {
 //   - Validating weights.
 //   - Validating ports.
 //   - Referencing HTTPRoutes.
-//   - Referencing Services/HTTPRoutes from other namespaces using ReferenceGrant.
 func validateBackendRef(ref *gwapiv1b1.BackendRef) error {
 	switch {
 	case ref == nil:
@@ -219,8 +218,6 @@ func validateBackendRef(ref *gwapiv1b1.BackendRef) error {
 	case ref.Kind != nil && *ref.Kind != gatewayapi.KindService:
 		return fmt.Errorf("invalid kind %q; must be %q",
 			*ref.BackendObjectReference.Kind, gatewayapi.KindService)
-	case ref.Namespace != nil:
-		return fmt.Errorf("invalid namespace; must be nil")
 	}
 
 	return nil

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -79,6 +79,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		tests.GatewaySecretReferenceGrantSpecific,
 		tests.GatewaySecretMissingReferenceGrant,
 		tests.GatewaySecretInvalidReferenceGrant,
+		tests.HTTPRouteReferenceGrant,
 	}
 	cSuite.Run(t, egTests)
 


### PR DESCRIPTION
Previously, a route, e.g. HTTPRoute, could not reference a backend in a different namespace due to `validateBackendRef()` returning an error if a BackendRef included the `namespace` field.

- Updates `Reconcile()` to only add a RefereneGrant to the resource tree if the RefereneGrant can be found and only return an error if an error was received when listing RefereneGrants.
- Updates `Reconcile()` to only add s Service to the resource tree if the Service can be found and only return an error if an error was received when Getting the Service.
- Updates `validateBackendRef()` to no longer return an error if the `namespace` field is set for a backendRef.
- Adds the `HTTPRouteReferenceGrant` conformance test.

Fixes #792
Fixes #788
Fixes #545 

Signed-off-by: danehans <daneyonhansen@gmail.com>