### PR TITLE
Refactors Reconciler() Method for Kubernetes Provider

### DIFF
--- a/internal/provider/kubernetes/routes.go
+++ b/internal/provider/kubernetes/routes.go
@@ -53,7 +53,7 @@ func (r *gatewayAPIReconciler) processTLSRoutes(ctx context.Context, gatewayName
 					to := ObjectKindNamespacedName{kind: gatewayapi.KindService, namespace: backendNamespace, name: string(backendRef.Name)}
 					refGrant, err := r.findReferenceGrant(ctx, from, to)
 					if err != nil {
-						r.log.Error(err, "unable to find ReferenceGrant that links the Service to TLSRoute")
+						r.log.Info("failed to find referencegrant", "error", err)
 						continue
 					}
 


### PR DESCRIPTION
Refactors Kubernetes controller:
- Improves readability.
- Improves log messages.
- Updates the reconciler to continue processing a request even if dependent resources cannot be found.

Fixes #788 

Signed-off-by: danehans <daneyonhansen@gmail.com>