### PR TITLE
fix:solve the warnings in 'make doc'

### DIFF
--- a/docs/latest/design/gatewayapi-translator.md
+++ b/docs/latest/design/gatewayapi-translator.md
@@ -48,7 +48,7 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-      hostname: *.envoygateway.io
+      hostname: "*.envoygateway.io"
     - name: http
       protocol: HTTP
       port: 80
@@ -75,7 +75,7 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-      hostname: *.envoygateway.io
+      hostname: "*.envoygateway.io"
     - name: http
       protocol: HTTP
       port: 80

--- a/docs/latest/dev/CODE_OF_CONDUCT.md
+++ b/docs/latest/dev/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
-## Community Code of Conduct
+# Community Code of Conduct
 
 Gateway follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/docs/latest/index.rst
+++ b/docs/latest/index.rst
@@ -1,5 +1,5 @@
 `Envoy Gateway </>`_
-=============
+====================
 
 Release: |version|
 

--- a/docs/latest/user/tls-passthrough.md
+++ b/docs/latest/user/tls-passthrough.md
@@ -51,7 +51,7 @@ kubectl apply -f https://raw.githubusercontent.com/envoyproxy/gateway/latest/exa
 Patch the Gateway from the Quickstart guide to include a TLS listener that listens on port `6443` and is configured for TLS mode Passthrough:
 
 ```console
-$ kubectl patch gateway eg --type=json --patch '[{
+kubectl patch gateway eg --type=json --patch '[{
    "op": "add",
    "path": "/spec/listeners/-",
    "value": {

--- a/docs/latest/user/tls-passthrough.md
+++ b/docs/latest/user/tls-passthrough.md
@@ -50,7 +50,7 @@ kubectl apply -f https://raw.githubusercontent.com/envoyproxy/gateway/latest/exa
 
 Patch the Gateway from the Quickstart guide to include a TLS listener that listens on port `6443` and is configured for TLS mode Passthrough:
 
-```console
+```shell
 kubectl patch gateway eg --type=json --patch '[{
    "op": "add",
    "path": "/spec/listeners/-",

--- a/docs/v0.2.0/design/gatewayapi-translator.md
+++ b/docs/v0.2.0/design/gatewayapi-translator.md
@@ -48,7 +48,7 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-      hostname: *.envoygateway.io
+      hostname: "*.envoygateway.io"
     - name: http
       protocol: HTTP
       port: 80
@@ -75,7 +75,7 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-      hostname: *.envoygateway.io
+      hostname: "*.envoygateway.io"
     - name: http
       protocol: HTTP
       port: 80

--- a/docs/v0.2.0/dev/CODE_OF_CONDUCT.md
+++ b/docs/v0.2.0/dev/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
-## Community Code of Conduct
+# Community Code of Conduct
 
 Gateway follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/docs/v0.2.0/index.rst
+++ b/docs/v0.2.0/index.rst
@@ -1,5 +1,5 @@
 `Envoy Gateway </>`_
-=============
+====================
 
 Release: |version|
 

--- a/docs/v0.2.0/user/tls-passthrough.md
+++ b/docs/v0.2.0/user/tls-passthrough.md
@@ -51,7 +51,7 @@ kubectl apply -f https://raw.githubusercontent.com/envoyproxy/gateway/v0.2.0/exa
 Patch the Gateway from the Quickstart guide to include a TLS listener that listens on port `6443` and is configured for TLS mode Passthrough:
 
 ```console
-$ kubectl patch gateway eg --type=json --patch '[{
+kubectl patch gateway eg --type=json --patch '[{
    "op": "add",
    "path": "/spec/listeners/-",
    "value": {

--- a/docs/v0.2.0/user/tls-passthrough.md
+++ b/docs/v0.2.0/user/tls-passthrough.md
@@ -50,7 +50,7 @@ kubectl apply -f https://raw.githubusercontent.com/envoyproxy/gateway/v0.2.0/exa
 
 Patch the Gateway from the Quickstart guide to include a TLS listener that listens on port `6443` and is configured for TLS mode Passthrough:
 
-```console
+```shell
 kubectl patch gateway eg --type=json --patch '[{
    "op": "add",
    "path": "/spec/listeners/-",


### PR DESCRIPTION
`make doc` command generates six warnings：
- [ ] `WARNING: duplicate label prerequisites`, `WARNING: 'myst' reference target not found:`
- [ ] `WARNING: document isn't included in any toctree`
- [x] `index.rst:2: WARNING: Title underline too short.`
- [x] `CODE_OF_CONDUCT.md:1: WARNING: Document headings start at H2, not H1 [myst.header]`
- [x] `WARNING: Could not lex literal_block as "yaml". Highlighting skipped.`
- [x] `WARNING: Could not lex literal_block as "console". Highlighting skipped.`

I have solved the last four warnings, but the first two "warnings" have not been solved

The `warning1` is because there are many subtitles with the same name, the file link is invalid

The `warning2` is that several files have not been determined and added to the directory

The last two warnings cause code block highlighting failure，I'm not sure if my changes are appropriate


Signed-off-by: thredreams <1220474743@qq.com>