### PR TITLE
Enable remaining refgrant conformance test

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -80,6 +80,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		tests.GatewaySecretMissingReferenceGrant,
 		tests.GatewaySecretInvalidReferenceGrant,
 		tests.HTTPRouteReferenceGrant,
+		tests.HTTPRoutePartiallyInvalidViaInvalidReferenceGrant,
 	}
 	cSuite.Run(t, egTests)
 


### PR DESCRIPTION
Enables `HTTPRoutePartiallyInvalidViaInvalidReferenceGrant`

Fixed by https://github.com/envoyproxy/gateway/pull/793

Closes https://github.com/envoyproxy/gateway/issues/781

Signed-off-by: Arko Dasgupta <arko@tetrate.io>