### PR TITLE
Fix package import for HTTPRouteFilterExtensionRef

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -550,7 +550,7 @@ func addHTTPRouteIndexers(ctx context.Context, mgr manager.Manager) error {
 		for _, rule := range httproute.Spec.Rules {
 			for i := range rule.Filters {
 				filter := rule.Filters[i]
-				if filter.Type == gwapiv1a2.HTTPRouteFilterExtensionRef {
+				if filter.Type == gwapiv1b1.HTTPRouteFilterExtensionRef {
 					if err := gatewayapi.ValidateHTTPRouteFilter(&filter); err != nil {
 						filters = append(filters,
 							types.NamespacedName{

--- a/internal/provider/kubernetes/routes_test.go
+++ b/internal/provider/kubernetes/routes_test.go
@@ -211,7 +211,11 @@ func TestProcessHTTPRoutes(t *testing.T) {
 			for _, filter := range tc.filters {
 				objs = append(objs, filter)
 			}
-			r.client = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects(objs...).Build()
+			r.client = fakeclient.NewClientBuilder().
+				WithScheme(envoygateway.GetScheme()).
+				WithObjects(objs...).
+				WithIndex(&gwapiv1b1.HTTPRoute{}, gatewayHTTPRouteIndex, gatewayHTTPRouteIndexFunc).
+				Build()
 
 			// Process the test case httproutes.
 			resourceTree := gatewayapi.NewResources()


### PR DESCRIPTION
Caused by merging https://github.com/envoyproxy/gateway/pull/791 without rebasing https://github.com/envoyproxy/gateway/pull/816

Signed-off-by: Arko Dasgupta <arko@tetrate.io>