### PR TITLE
Dont close stale Issues or PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,23 +21,14 @@ jobs:
         # Different amounts of days for issues/PRs are not currently supported but there is a PR
         # open for it: https://github.com/actions/stale/issues/214
         days-before-stale: 30
-        days-before-close: 7
+        days-before-close: -1
         stale-issue-message: >
           This issue has been automatically marked as stale because it has not had activity in the
-          last 30 days. It will be closed in the next 7 days unless it is tagged "help wanted" or "no stalebot" or other activity
-          occurs. Thank you for your contributions.
-        close-issue-message: >
-          This issue has been automatically closed because it has not had activity in the
-          last 37 days. If this issue is still valid, please ping a maintainer and ask them to label it as "help wanted" or "no stalebot".
-          Thank you for your contributions.
+          last 30 days.
         stale-pr-message: >
           This pull request has been automatically marked as stale because it has not had
-          activity in the last 30 days. It will be closed in 7 days if no further activity occurs. Please
-          feel free to give a status update now, ping for review, or re-open when it's ready.
-          Thank you for your contributions!
-        close-pr-message: >
-          This pull request has been automatically closed because it has not had
-          activity in the last 37 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
+          activity in the last 30 days.
+          Please feel free to give a status update now, ping for review, when it's ready.
           Thank you for your contributions!
         stale-issue-label: 'stale'
         exempt-issue-labels: 'no stalebot,help wanted'


### PR DESCRIPTION
Set `days-before-close` to `-1` to disable closing stale PRs or Issues. Defined in https://github.com/actions/stale/blob/main/action.yml

Fixes: https://github.com/envoyproxy/gateway/issues/820

Signed-off-by: Arko Dasgupta <arko@tetrate.io>