### PR TITLE
add udproute support to kubernetes provider

### DIFF
--- a/internal/provider/kubernetes/config/rbac/role.yaml
+++ b/internal/provider/kubernetes/config/rbac/role.yaml
@@ -41,6 +41,7 @@ rules:
   - referencegrants
   - referencepolicies
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -53,5 +54,6 @@ rules:
   - gateways/status
   - httproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - update

--- a/internal/provider/kubernetes/predicates.go
+++ b/internal/provider/kubernetes/predicates.go
@@ -137,13 +137,20 @@ func (r *gatewayAPIReconciler) validateServiceForReconcile(obj client.Object) bo
 	if err := r.client.List(ctx, tlsRouteList, &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(serviceTLSRouteIndex, utils.NamespacedName(svc).String()),
 	}); err != nil {
-		r.log.Error(err, "unable to find associated HTTPRoutes")
+		r.log.Error(err, "unable to find associated TLSRoutes")
+		return false
+	}
+
+	udpRouteList := &gwapiv1a2.UDPRouteList{}
+	if err := r.client.List(ctx, udpRouteList, &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(serviceUDPRouteIndex, utils.NamespacedName(svc).String()),
+	}); err != nil {
+		r.log.Error(err, "unable to find associated UDPRoutes")
 		return false
 	}
 
 	// Check how many Route objects refer this Service
-	allAssociatedRoutes := len(httpRouteList.Items) +
-		len(tlsRouteList.Items)
+	allAssociatedRoutes := len(httpRouteList.Items) + len(tlsRouteList.Items) + len(udpRouteList.Items)
 
 	return allAssociatedRoutes != 0
 }

--- a/internal/provider/kubernetes/predicates_test.go
+++ b/internal/provider/kubernetes/predicates_test.go
@@ -213,7 +213,7 @@ func TestValidateServiceForReconcile(t *testing.T) {
 			expect:  false,
 		},
 		{
-			name: "route service routes exist",
+			name: "http route service routes exist",
 			configs: []client.Object{
 				test.GetGatewayClass("test-gc", v1alpha1.GatewayControllerName),
 				sampleGateway,
@@ -230,6 +230,28 @@ func TestValidateServiceForReconcile(t *testing.T) {
 			configs: []client.Object{
 				test.GetGatewayClass("test-gc", v1alpha1.GatewayControllerName),
 				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}),
+			},
+			service: test.GetService(types.NamespacedName{Name: "service"}, nil, nil),
+			expect:  true,
+		},
+		{
+			name: "tls route service routes exist",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", v1alpha1.GatewayControllerName),
+				sampleGateway,
+				test.GetTLSRoute(types.NamespacedName{Name: "tlsroute-test"}, "scheduled-status-test",
+					types.NamespacedName{Name: "service"}),
+			},
+			service: test.GetService(types.NamespacedName{Name: "service"}, nil, nil),
+			expect:  true,
+		},
+		{
+			name: "udp route service routes exist",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", v1alpha1.GatewayControllerName),
+				sampleGateway,
+				test.GetUDPRoute(types.NamespacedName{Name: "udproute-test"}, "scheduled-status-test",
+					types.NamespacedName{Name: "service"}),
 			},
 			service: test.GetService(types.NamespacedName{Name: "service"}, nil, nil),
 			expect:  true,
@@ -251,6 +273,7 @@ func TestValidateServiceForReconcile(t *testing.T) {
 			WithObjects(tc.configs...).
 			WithIndex(&gwapiv1b1.HTTPRoute{}, serviceHTTPRouteIndex, serviceHTTPRouteIndexFunc).
 			WithIndex(&gwapiv1a2.TLSRoute{}, serviceTLSRouteIndex, serviceTLSRouteIndexFunc).
+			WithIndex(&gwapiv1a2.UDPRoute{}, serviceUDPRouteIndex, serviceUDPRouteIndexFunc).
 			Build()
 		t.Run(tc.name, func(t *testing.T) {
 			res := r.validateServiceForReconcile(tc.service)

--- a/internal/provider/kubernetes/rbac.go
+++ b/internal/provider/kubernetes/rbac.go
@@ -5,8 +5,8 @@
 
 package kubernetes
 
-// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;tlsroutes;referencepolicies;referencegrants,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;tlsroutes/status,verbs=update
+// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;tlsroutes;udproutes;referencepolicies;referencegrants,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;tlsroutes/status;udproutes/status,verbs=update
 // +kubebuilder:rbac:groups="gateway.envoyproxy.io",resources=authenticationfilters,verbs=get;list;watch;update
 
 // RBAC for watched resources of Gateway API controllers.

--- a/internal/provider/kubernetes/test/utils.go
+++ b/internal/provider/kubernetes/test/utils.go
@@ -10,6 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
@@ -100,6 +101,62 @@ func GetHTTPRoute(nsName types.NamespacedName, parent string, serviceName types.
 								BackendObjectReference: gwapiv1b1.BackendObjectReference{
 									Name: gwapiv1b1.ObjectName(serviceName.Name),
 								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// GetTLSRoute returns a sample TLSRoute with a parent reference.
+func GetTLSRoute(nsName types.NamespacedName, parent string, serviceName types.NamespacedName) *gwapiv1a2.TLSRoute {
+	return &gwapiv1a2.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: nsName.Namespace,
+			Name:      nsName.Name,
+		},
+		Spec: gwapiv1a2.TLSRouteSpec{
+			CommonRouteSpec: gwapiv1a2.CommonRouteSpec{
+				ParentRefs: []gwapiv1a2.ParentReference{
+					{Name: gwapiv1a2.ObjectName(parent)},
+				},
+			},
+			Rules: []gwapiv1a2.TLSRouteRule{
+				{
+					BackendRefs: []gwapiv1a2.BackendRef{
+						{
+							BackendObjectReference: gwapiv1a2.BackendObjectReference{
+								Name: gwapiv1a2.ObjectName(serviceName.Name),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// GetUDPRoute returns a sample UDPRoute with a parent reference.
+func GetUDPRoute(nsName types.NamespacedName, parent string, serviceName types.NamespacedName) *gwapiv1a2.UDPRoute {
+	return &gwapiv1a2.UDPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: nsName.Namespace,
+			Name:      nsName.Name,
+		},
+		Spec: gwapiv1a2.UDPRouteSpec{
+			CommonRouteSpec: gwapiv1a2.CommonRouteSpec{
+				ParentRefs: []gwapiv1a2.ParentReference{
+					{Name: gwapiv1a2.ObjectName(parent)},
+				},
+			},
+			Rules: []gwapiv1a2.UDPRouteRule{
+				{
+					BackendRefs: []gwapiv1a2.BackendRef{
+						{
+							BackendObjectReference: gwapiv1a2.BackendObjectReference{
+								Name: gwapiv1a2.ObjectName(serviceName.Name),
 							},
 						},
 					},

--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -318,6 +318,7 @@ func buildXdsUDPListener(clusterName string, udpListener *ir.UDPListener) (*list
 				OnNoMatch: &matcher.Matcher_OnMatch{
 					OnMatch: &matcher.Matcher_OnMatch_Action{
 						Action: &xdscore.TypedExtensionConfig{
+							Name:        "route",
 							TypedConfig: routeAny,
 						},
 					},
@@ -328,15 +329,6 @@ func buildXdsUDPListener(clusterName string, udpListener *ir.UDPListener) (*list
 	udpProxyAny, err := anypb.New(udpProxy)
 	if err != nil {
 		return nil, err
-	}
-
-	filterChain := &listener.FilterChain{
-		Filters: []*listener.Filter{{
-			Name: "envoy.filters.udp_listener.udp_proxy",
-			ConfigType: &listener.Filter_TypedConfig{
-				TypedConfig: udpProxyAny,
-			},
-		}},
 	}
 
 	xdsListener := &listener.Listener{
@@ -358,7 +350,12 @@ func buildXdsUDPListener(clusterName string, udpListener *ir.UDPListener) (*list
 				},
 			},
 		},
-		FilterChains: []*listener.FilterChain{filterChain},
+		ListenerFilters: []*listener.ListenerFilter{{
+			Name: "envoy.filters.udp_listener.udp_proxy",
+			ConfigType: &listener.ListenerFilter_TypedConfig{
+				TypedConfig: udpProxyAny,
+			},
+		}},
 	}
 
 	return xdsListener, nil

--- a/internal/xds/translator/testdata/out/xds-ir/udp-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-route.listeners.yaml
@@ -8,21 +8,21 @@
       address: 0.0.0.0
       portValue: 10080
       protocol: UDP
-  filterChains:
-  - filters:
-    - name: envoy.filters.udp_listener.udp_proxy
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.UdpProxyConfig
-        accessLog:
-        - name: envoy.access_loggers.file
-          typedConfig:
-            '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-            path: /dev/stdout
-        matcher:
-          onNoMatch:
-            action:
-              typedConfig:
-                '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
-                cluster: udp-route
-        statPrefix: service
+  listenerFilters:
+  - name: envoy.filters.udp_listener.udp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.UdpProxyConfig
+      accessLog:
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          path: /dev/stdout
+      matcher:
+        onNoMatch:
+          action:
+            name: route
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
+              cluster: udp-route
+      statPrefix: service
   name: udp-route


### PR DESCRIPTION
This PR is a part of https://github.com/envoyproxy/gateway/issues/641

An example of UDPRoute

```yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: UDPRoute
metadata:
  name: coredns
spec:
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: eg
  rules:
  - backendRefs:
    - group: ""
      kind: Service
      name: coredns
      port: 53
```

Signed-off-by: zhaohuabing <zhaohuabing@gmail.com>