### PR TITLE
disable dependabot bump for tools/*/controller-gen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,6 @@ updates:
     schedule:
       interval: weekly
   - package-ecosystem: gomod
-    directory: /tools/src/controller-gen
-    schedule:
-      interval: weekly
-  - package-ecosystem: gomod
     directory: /tools/src/golangci-lint
     schedule:
       interval: weekly


### PR DESCRIPTION
* this causes `gen-check` to fail in CI since CI re generates the CRDs and this change causes a change in the CRD as well

* so disable the dependabot bump and make this bump manual instead.

Detailed error logs are here
```
2022-12-21T14:18:59.7382106Z [0;32m===========> Running gen-check ... [0m
2022-12-21T14:18:59.7605231Z [0;31m===========> ERROR: Some files need to be updated[0m
2022-12-21T14:18:59.7634427Z diff --git a/internal/provider/kubernetes/config/crd/bases/config.gateway.envoyproxy.io_envoyproxies.yaml b/internal/provider/kubernetes/config/crd/bases/config.gateway.envoyproxy.io_envoyproxies.yaml
2022-12-21T14:18:59.7635180Z index 09a060b..4660195 100644
2022-12-21T14:18:59.7635783Z --- a/internal/provider/kubernetes/config/crd/bases/config.gateway.envoyproxy.io_envoyproxies.yaml
2022-12-21T14:18:59.7680556Z make[1]: *** [tools/make/lint.mk:74: gen-check] Error 1
2022-12-21T14:18:59.7681047Z +++ b/internal/provider/kubernetes/config/crd/bases/config.gateway.envoyproxy.io_envoyproxies.yaml
2022-12-21T14:18:59.7681534Z @@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
2022-12-21T14:18:59.7681838Z  kind: CustomResourceDefinition
2022-12-21T14:18:59.7682056Z  metadata:
2022-12-21T14:18:59.7682265Z    annotations:
2022-12-21T14:18:59.7682595Z -    controller-gen.kubebuilder.io/version: v0.10.0
2022-12-21T14:18:59.7683065Z +    controller-gen.kubebuilder.io/version: v0.11.1
2022-12-21T14:18:59.7683367Z    creationTimestamp: null
2022-12-21T14:18:59.7683706Z    name: envoyproxies.config.gateway.envoyproxy.io
2022-12-21T14:18:59.7683959Z  spec:
2022-12-21T14:18:59.7684620Z diff --git a/internal/provider/kubernetes/config/crd/bases/gateway.envoyproxy.io_authenticationfilters.yaml b/internal/provider/kubernetes/config/crd/bases/gateway.envoyproxy.io_authenticationfilters.yaml
2022-12-21T14:18:59.7685100Z index 6823f56..13e475a 100644
2022-12-21T14:18:59.7685548Z --- a/internal/provider/kubernetes/config/crd/bases/gateway.envoyproxy.io_authenticationfilters.yaml
2022-12-21T14:18:59.7686013Z +++ b/internal/provider/kubernetes/config/crd/bases/gateway.envoyproxy.io_authenticationfilters.yaml
2022-12-21T14:18:59.7686436Z @@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
2022-12-21T14:18:59.7686724Z  kind: CustomResourceDefinition
2022-12-21T14:18:59.7686982Z  metadata:
2022-12-21T14:18:59.7687183Z    annotations:
2022-12-21T14:18:59.7688435Z -    controller-gen.kubebuilder.io/version: v0.10.0
2022-12-21T14:18:59.7688837Z +    controller-gen.kubebuilder.io/version: v0.11.1
2022-12-21T14:18:59.7689244Z    creationTimestamp: null
2022-12-21T14:18:59.7689590Z    name: authenticationfilters.gateway.envoyproxy.io
2022-12-21T14:18:59.7689856Z  spec:
2022-12-21T14:18:59.7690176Z make[1]: Leaving directory '/home/runner/work/gateway/gateway'
2022-12-21T14:18:59.7693522Z make: *** [Makefile:18: _run] Error 2
2022-12-21T14:18:59.7693896Z make: Target 'gen-check' not remade because of errors.
2022-12-21T14:18:59.7708042Z ##[error]Process completed with exit code 2.
```

Seen in https://github.com/envoyproxy/gateway/pull/827

Signed-off-by: Arko Dasgupta <arko@tetrate.io>