### PR TITLE
translator: remove usage of deprecated Http2ProtocolOptions

### DIFF
--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
@@ -2,7 +2,6 @@
     localityWeightedLbConfig: {}
   connectTimeout: 5s
   dnsLookupFamily: V4_ONLY
-  http2ProtocolOptions: {}
   loadAssignment:
     clusterName: first-route
     endpoints:
@@ -17,3 +16,8 @@
   name: first-route
   outlierDetection: {}
   type: STATIC
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}


### PR DESCRIPTION
Envoy deprecated the usage of `Http2ProtocolOptions` in Envoy 1.17. This commit updates the xds.Translate function to follow recommended practices of using the `TypedExtensionProtocolOptions` to set http/2 protocol options.

The existing test case was modified due to the change in expected xDS configuration outputted when http/2 is enabled for a backendRef.


Fixes #844 