### PR TITLE
Adds EnvoyProxy Support to Kubernetes Provider

### DIFF
--- a/api/config/v1alpha1/envoyproxy_types.go
+++ b/api/config/v1alpha1/envoyproxy_types.go
@@ -9,6 +9,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// KindEnvoyProxy is the name of the EnvoyProxy kind.
+	KindEnvoyProxy = "EnvoyProxy"
+)
+
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 

--- a/api/config/v1alpha1/validation/envoyproxy.go
+++ b/api/config/v1alpha1/validation/envoyproxy.go
@@ -1,0 +1,44 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package validation
+
+import (
+	"errors"
+	"fmt"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	egcfgv1a1 "github.com/envoyproxy/gateway/api/config/v1alpha1"
+)
+
+// ValidateEnvoyProxy validates the provided EnvoyProxy.
+func ValidateEnvoyProxy(ep *egcfgv1a1.EnvoyProxy) error {
+	var errs []error
+	if ep == nil {
+		return errors.New("envoyproxy is nil")
+	}
+	if err := validateEnvoyProxySpec(&ep.Spec); err != nil {
+		errs = append(errs, err)
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// validateEnvoyProxySpec validates the provided EnvoyProxy spec.
+func validateEnvoyProxySpec(spec *egcfgv1a1.EnvoyProxySpec) error {
+	var errs []error
+
+	switch {
+	case spec == nil:
+		errs = append(errs, errors.New("spec is nil"))
+	case spec.Provider == nil:
+		return utilerrors.NewAggregate(errs)
+	case spec.Provider.Type != egcfgv1a1.ProviderTypeKubernetes:
+		errs = append(errs, fmt.Errorf("unsupported provider type %v", spec.Provider.Type))
+	}
+
+	return utilerrors.NewAggregate(errs)
+}

--- a/api/config/v1alpha1/validation/envoyproxy_test.go
+++ b/api/config/v1alpha1/validation/envoyproxy_test.go
@@ -1,0 +1,69 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	egcfgv1a1 "github.com/envoyproxy/gateway/api/config/v1alpha1"
+)
+
+func TestValidateEnvoyProxy(t *testing.T) {
+	testCases := []struct {
+		name     string
+		obj      *egcfgv1a1.EnvoyProxy
+		expected bool
+	}{
+		{
+			name:     "nil envoyproxy",
+			obj:      nil,
+			expected: false,
+		},
+		{
+			name: "nil provider",
+			obj: &egcfgv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+				Spec: egcfgv1a1.EnvoyProxySpec{
+					Provider: nil,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "unsupported provider",
+			obj: &egcfgv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+				Spec: egcfgv1a1.EnvoyProxySpec{
+					Provider: &egcfgv1a1.ResourceProvider{
+						Type: egcfgv1a1.ProviderTypeFile,
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEnvoyProxy(tc.obj)
+			if tc.expected {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}

--- a/internal/gatewayapi/resource.go
+++ b/internal/gatewayapi/resource.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	egcfgv1a1 "github.com/envoyproxy/gateway/api/config/v1alpha1"
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/ir"
 )
@@ -32,6 +33,7 @@ type Resources struct {
 	Services        []*v1.Service
 	Secrets         []*v1.Secret
 	AuthenFilters   []*egv1a1.AuthenticationFilter
+	EnvoyProxy      *egcfgv1a1.EnvoyProxy
 }
 
 func NewResources() *Resources {
@@ -45,6 +47,7 @@ func NewResources() *Resources {
 		ReferenceGrants: []*v1alpha2.ReferenceGrant{},
 		Namespaces:      []*v1.Namespace{},
 		AuthenFilters:   []*egv1a1.AuthenticationFilter{},
+		EnvoyProxy:      new(egcfgv1a1.EnvoyProxy),
 	}
 }
 

--- a/internal/gatewayapi/zz_generated.deepcopy.go
+++ b/internal/gatewayapi/zz_generated.deepcopy.go
@@ -11,6 +11,7 @@
 package gatewayapi
 
 import (
+	configv1alpha1 "github.com/envoyproxy/gateway/api/config/v1alpha1"
 	"github.com/envoyproxy/gateway/api/v1alpha1"
 	"k8s.io/api/core/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -140,6 +141,11 @@ func (in *Resources) DeepCopyInto(out *Resources) {
 				(*in).DeepCopyInto(*out)
 			}
 		}
+	}
+	if in.EnvoyProxy != nil {
+		in, out := &in.EnvoyProxy, &out.EnvoyProxy
+		*out = new(configv1alpha1.EnvoyProxy)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/internal/provider/kubernetes/config/rbac/role.yaml
+++ b/internal/provider/kubernetes/config/rbac/role.yaml
@@ -24,6 +24,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.gateway.envoyproxy.io
+  resources:
+  - envoyproxies
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - gateway.envoyproxy.io
   resources:
   - authenticationfilters

--- a/internal/provider/kubernetes/controller_test.go
+++ b/internal/provider/kubernetes/controller_test.go
@@ -12,11 +12,17 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/envoyproxy/gateway/api/config/v1alpha1"
+	egcfgv1a1 "github.com/envoyproxy/gateway/api/config/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/envoygateway"
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	"github.com/envoyproxy/gateway/internal/gatewayapi"
+	"github.com/envoyproxy/gateway/internal/log"
 )
 
 func TestAddGatewayClassFinalizer(t *testing.T) {
@@ -143,6 +149,338 @@ func TestRemoveGatewayClassFinalizer(t *testing.T) {
 			err = r.client.Get(ctx, key, tc.gc)
 			require.NoError(t, err)
 			require.Equal(t, tc.expect, tc.gc.Finalizers)
+		})
+	}
+}
+
+func TestEnqueueManagedClass(t *testing.T) {
+	gcCtrlName := gwapiv1b1.GatewayController(v1alpha1.GatewayControllerName)
+
+	testCases := []struct {
+		name     string
+		ep       client.Object
+		classes  []*gwapiv1b1.GatewayClass
+		expected []reconcile.Request
+	}{
+		{
+			name: "no matching gatewayclasses",
+			ep: &egcfgv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: config.DefaultNamespace,
+					Name:      "test-envoyproxy",
+				},
+			},
+			classes: []*gwapiv1b1.GatewayClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-gc",
+					},
+					Spec: gwapiv1b1.GatewayClassSpec{
+						ControllerName: "SomeOtherController",
+						ParametersRef: &gwapiv1b1.ParametersReference{
+							Group:     gwapiv1b1.Group(egcfgv1a1.GroupVersion.Group),
+							Kind:      gwapiv1b1.Kind(egcfgv1a1.KindEnvoyProxy),
+							Name:      "test-envoyproxy",
+							Namespace: gatewayapi.NamespacePtr(config.DefaultNamespace),
+						},
+					},
+					Status: gwapiv1b1.GatewayClassStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1b1.GatewayClassConditionStatusAccepted),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expected: []reconcile.Request{},
+		},
+		{
+			name: "match one gatewayclass",
+			ep: &egcfgv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: config.DefaultNamespace,
+					Name:      "test-envoyproxy",
+				},
+			},
+			classes: []*gwapiv1b1.GatewayClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-gc",
+					},
+					Spec: gwapiv1b1.GatewayClassSpec{
+						ControllerName: gcCtrlName,
+						ParametersRef: &gwapiv1b1.ParametersReference{
+							Group:     gwapiv1b1.Group(egcfgv1a1.GroupVersion.Group),
+							Kind:      gwapiv1b1.Kind(egcfgv1a1.KindEnvoyProxy),
+							Name:      "test-envoyproxy",
+							Namespace: gatewayapi.NamespacePtr(config.DefaultNamespace),
+						},
+					},
+					Status: gwapiv1b1.GatewayClassStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1b1.GatewayClassConditionStatusAccepted),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expected: []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{Name: "test-gc"},
+				},
+			},
+		},
+		{
+			name: "envoyproxy in different namespace as eg",
+			ep: &egcfgv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "not-eg-ns",
+					Name:      "test-envoyproxy",
+				},
+			},
+			classes: []*gwapiv1b1.GatewayClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-gc",
+					},
+					Spec: gwapiv1b1.GatewayClassSpec{ControllerName: gcCtrlName},
+				},
+			},
+			expected: []reconcile.Request{},
+		},
+		{
+			name: "multiple gatewayclasses one with accepted status",
+			ep: &egcfgv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: config.DefaultNamespace,
+					Name:      "test-envoyproxy",
+				},
+			},
+			classes: []*gwapiv1b1.GatewayClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-gc1",
+					},
+					Spec: gwapiv1b1.GatewayClassSpec{
+						ControllerName: gcCtrlName,
+						ParametersRef: &gwapiv1b1.ParametersReference{
+							Group:     gwapiv1b1.Group(egcfgv1a1.GroupVersion.Group),
+							Kind:      gwapiv1b1.Kind(egcfgv1a1.KindEnvoyProxy),
+							Name:      "test-envoyproxy",
+							Namespace: gatewayapi.NamespacePtr(config.DefaultNamespace),
+						},
+					},
+					Status: gwapiv1b1.GatewayClassStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1b1.GatewayClassConditionStatusAccepted),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-gc2",
+					},
+					Spec: gwapiv1b1.GatewayClassSpec{
+						ControllerName: gcCtrlName,
+						ParametersRef: &gwapiv1b1.ParametersReference{
+							Group:     gwapiv1b1.Group(egcfgv1a1.GroupVersion.Group),
+							Kind:      gwapiv1b1.Kind(egcfgv1a1.KindEnvoyProxy),
+							Name:      "test-envoyproxy",
+							Namespace: gatewayapi.NamespacePtr(config.DefaultNamespace),
+						},
+					},
+					Status: gwapiv1b1.GatewayClassStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1b1.GatewayClassConditionStatusAccepted),
+								Status: metav1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			expected: []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{Name: "test-gc1"},
+				},
+			},
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+
+		// Create the reconciler.
+		logger, err := log.NewLogger()
+		require.NoError(t, err)
+		r := &gatewayAPIReconciler{
+			log:             logger,
+			classController: gcCtrlName,
+			namespace:       config.DefaultNamespace,
+		}
+
+		// Run the test cases.
+		t.Run(tc.name, func(t *testing.T) {
+			// Add the test case objects to the reconciler client.
+			objs := []client.Object{tc.ep}
+			for _, gc := range tc.classes {
+				objs = append(objs, gc)
+			}
+
+			// Create the client.
+			r.client = fakeclient.NewClientBuilder().
+				WithScheme(envoygateway.GetScheme()).
+				WithObjects(objs...).
+				Build()
+
+			// Process the test case gatewayclasses.
+			results := r.enqueueManagedClass(tc.ep)
+			require.Equal(t, tc.expected, results)
+		})
+	}
+}
+
+func TestProcessParamsRef(t *testing.T) {
+	gcCtrlName := gwapiv1b1.GatewayController(v1alpha1.GatewayControllerName)
+
+	testCases := []struct {
+		name     string
+		gc       *gwapiv1b1.GatewayClass
+		ep       *egcfgv1a1.EnvoyProxy
+		expected bool
+	}{
+		{
+			name: "valid envoyproxy reference",
+			gc: &gwapiv1b1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: gwapiv1b1.GatewayClassSpec{
+					ControllerName: gcCtrlName,
+					ParametersRef: &gwapiv1b1.ParametersReference{
+						Group:     gwapiv1b1.Group(egcfgv1a1.GroupVersion.Group),
+						Kind:      gwapiv1b1.Kind(egcfgv1a1.KindEnvoyProxy),
+						Name:      "test",
+						Namespace: gatewayapi.NamespacePtr(config.DefaultNamespace),
+					},
+				},
+			},
+			ep: &egcfgv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: config.DefaultNamespace,
+					Name:      "test",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "envoyproxy kind does not exist",
+			gc: &gwapiv1b1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: gwapiv1b1.GatewayClassSpec{
+					ControllerName: gcCtrlName,
+					ParametersRef: &gwapiv1b1.ParametersReference{
+						Group:     gwapiv1b1.Group(egcfgv1a1.GroupVersion.Group),
+						Kind:      gwapiv1b1.Kind(egcfgv1a1.KindEnvoyProxy),
+						Name:      "test",
+						Namespace: gatewayapi.NamespacePtr(config.DefaultNamespace),
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "referenced envoyproxy does not exist",
+			gc: &gwapiv1b1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: gwapiv1b1.GatewayClassSpec{
+					ControllerName: gcCtrlName,
+					ParametersRef: &gwapiv1b1.ParametersReference{
+						Group:     gwapiv1b1.Group(egcfgv1a1.GroupVersion.Group),
+						Kind:      gwapiv1b1.Kind(egcfgv1a1.KindEnvoyProxy),
+						Name:      "non-exist",
+						Namespace: gatewayapi.NamespacePtr(config.DefaultNamespace),
+					},
+				},
+			},
+			ep: &egcfgv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: config.DefaultNamespace,
+					Name:      "test",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "invalid gatewayclass parameters ref",
+			gc: &gwapiv1b1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: gwapiv1b1.GatewayClassSpec{
+					ControllerName: gcCtrlName,
+					ParametersRef: &gwapiv1b1.ParametersReference{
+						Group:     gwapiv1b1.Group("UnSupportedGroup"),
+						Kind:      gwapiv1b1.Kind("UnSupportedKind"),
+						Name:      "test",
+						Namespace: gatewayapi.NamespacePtr(config.DefaultNamespace),
+					},
+				},
+			},
+			ep: &egcfgv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: config.DefaultNamespace,
+					Name:      "test",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+
+		// Create the reconciler.
+		logger, err := log.NewLogger()
+		require.NoError(t, err)
+		r := &gatewayAPIReconciler{
+			log:             logger,
+			classController: gcCtrlName,
+		}
+
+		// Run the test cases.
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.ep != nil {
+				r.client = fakeclient.NewClientBuilder().
+					WithScheme(envoygateway.GetScheme()).
+					WithObjects(tc.ep).
+					Build()
+			} else {
+				r.client = fakeclient.NewClientBuilder().
+					Build()
+			}
+
+			// Process the test case gatewayclasses.
+			resourceTree := gatewayapi.NewResources()
+			err := r.processParamsRef(context.Background(), tc.gc, resourceTree)
+			if tc.expected {
+				require.NoError(t, err)
+				// Ensure the resource tree and map are as expected.
+				require.Equal(t, tc.ep, resourceTree.EnvoyProxy)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }

--- a/internal/provider/kubernetes/rbac.go
+++ b/internal/provider/kubernetes/rbac.go
@@ -5,9 +5,13 @@
 
 package kubernetes
 
+// RBAC for Gateway API resources.
 // +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;grpcroutes;tlsroutes;tcproutes;udproutes;referencepolicies;referencegrants,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;grpcroutes/status;tlsroutes/status;tcproutes/status;udproutes/status,verbs=update
+
+// RBAC for Envoy Gateway custom resources.
 // +kubebuilder:rbac:groups="gateway.envoyproxy.io",resources=authenticationfilters,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="config.gateway.envoyproxy.io",resources=envoyproxies,verbs=get;list;watch;update
 
 // RBAC for watched resources of Gateway API controllers.
 // +kubebuilder:rbac:groups="",resources=secrets;services;namespaces,verbs=get;list;watch

--- a/internal/provider/kubernetes/routes_test.go
+++ b/internal/provider/kubernetes/routes_test.go
@@ -18,7 +18,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/envoyproxy/gateway/api/config/v1alpha1"
+	cfgv1a1 "github.com/envoyproxy/gateway/api/config/v1alpha1"
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/envoygateway"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
@@ -28,7 +28,7 @@ import (
 
 func TestProcessHTTPRoutes(t *testing.T) {
 	// The gatewayclass configured for the reconciler and referenced by test cases.
-	gcCtrlName := gwapiv1b1.GatewayController(v1alpha1.GatewayControllerName)
+	gcCtrlName := gwapiv1b1.GatewayController(cfgv1a1.GatewayControllerName)
 	gc := &gwapiv1b1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
@@ -288,7 +288,7 @@ func TestValidateHTTPRouteParentRefs(t *testing.T) {
 						Name: "gc1",
 					},
 					Spec: gwapiv1b1.GatewayClassSpec{
-						ControllerName: gwapiv1b1.GatewayController(v1alpha1.GatewayControllerName),
+						ControllerName: gwapiv1b1.GatewayController(cfgv1a1.GatewayControllerName),
 					},
 				},
 			},
@@ -423,7 +423,7 @@ func TestValidateHTTPRouteParentRefs(t *testing.T) {
 						Name: "gc1",
 					},
 					Spec: gwapiv1b1.GatewayClassSpec{
-						ControllerName: gwapiv1b1.GatewayController(v1alpha1.GatewayControllerName),
+						ControllerName: gwapiv1b1.GatewayController(cfgv1a1.GatewayControllerName),
 					},
 				},
 			},
@@ -509,7 +509,7 @@ func TestValidateHTTPRouteParentRefs(t *testing.T) {
 						Name: "gc1",
 					},
 					Spec: gwapiv1b1.GatewayClassSpec{
-						ControllerName: gwapiv1b1.GatewayController(v1alpha1.GatewayControllerName),
+						ControllerName: gwapiv1b1.GatewayController(cfgv1a1.GatewayControllerName),
 					},
 				},
 				{
@@ -568,7 +568,7 @@ func TestValidateHTTPRouteParentRefs(t *testing.T) {
 	}
 
 	// Create the reconciler.
-	r := &gatewayAPIReconciler{classController: gwapiv1b1.GatewayController(v1alpha1.GatewayControllerName)}
+	r := &gatewayAPIReconciler{classController: gwapiv1b1.GatewayController(cfgv1a1.GatewayControllerName)}
 	ctx := context.Background()
 
 	for _, tc := range testCases {

--- a/internal/provider/kubernetes/test/utils.go
+++ b/internal/provider/kubernetes/test/utils.go
@@ -13,6 +13,7 @@ import (
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	egcfgv1a1 "github.com/envoyproxy/gateway/api/config/v1alpha1"
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
 )
@@ -21,6 +22,16 @@ type ObjectKindNamespacedName struct {
 	Kind      string
 	Namespace string
 	Name      string
+}
+
+// NewEnvoyProxy returns an EnvoyProxy object with the provided ns/name.
+func NewEnvoyProxy(ns, name string) *egcfgv1a1.EnvoyProxy {
+	return &egcfgv1a1.EnvoyProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+	}
 }
 
 // GetGatewayClass returns a sample GatewayClass.

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -22,17 +22,25 @@ import (
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-const ReasonOlderGatewayClassExists gwapiv1b1.GatewayClassConditionReason = "OlderGatewayClassExists"
+const (
+	ReasonOlderGatewayClassExists gwapiv1b1.GatewayClassConditionReason = "OlderGatewayClassExists"
+
+	MsgOlderGatewayClassExists   = "Invalid GatewayClass: another older GatewayClass with the same Spec.Controller exists"
+	MsgValidGatewayClass         = "Valid GatewayClass"
+	MsgGatewayClassInvalidParams = "Invalid parametersRef"
+)
 
 // computeGatewayClassAcceptedCondition computes the GatewayClass Accepted status condition.
-func computeGatewayClassAcceptedCondition(gatewayClass *gwapiv1b1.GatewayClass, accepted bool) metav1.Condition {
+func computeGatewayClassAcceptedCondition(gatewayClass *gwapiv1b1.GatewayClass,
+	accepted bool,
+	reason, msg string) metav1.Condition {
 	switch accepted {
 	case true:
 		return metav1.Condition{
 			Type:               string(gwapiv1b1.GatewayClassConditionStatusAccepted),
 			Status:             metav1.ConditionTrue,
-			Reason:             string(gwapiv1b1.GatewayClassReasonAccepted),
-			Message:            "Valid GatewayClass",
+			Reason:             reason,
+			Message:            msg,
 			ObservedGeneration: gatewayClass.Generation,
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		}
@@ -40,8 +48,8 @@ func computeGatewayClassAcceptedCondition(gatewayClass *gwapiv1b1.GatewayClass, 
 		return metav1.Condition{
 			Type:               string(gwapiv1b1.GatewayClassConditionStatusAccepted),
 			Status:             metav1.ConditionFalse,
-			Reason:             string(ReasonOlderGatewayClassExists),
-			Message:            "Invalid GatewayClass: another older GatewayClass with the same Spec.Controller exists",
+			Reason:             reason,
+			Message:            msg,
 			ObservedGeneration: gatewayClass.Generation,
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		}

--- a/internal/status/conditions_test.go
+++ b/internal/status/conditions_test.go
@@ -39,18 +39,30 @@ func TestComputeGatewayClassAcceptedCondition(t *testing.T) {
 			name:     "accepted gatewayclass",
 			accepted: true,
 			expect: metav1.Condition{
-				Type:   string(gwapiv1b1.GatewayClassConditionStatusAccepted),
-				Status: metav1.ConditionTrue,
-				Reason: string(gwapiv1b1.GatewayClassReasonAccepted),
+				Type:    string(gwapiv1b1.GatewayClassConditionStatusAccepted),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(gwapiv1b1.GatewayClassReasonAccepted),
+				Message: MsgValidGatewayClass,
 			},
 		},
 		{
 			name:     "not accepted gatewayclass",
 			accepted: false,
 			expect: metav1.Condition{
-				Type:   string(gwapiv1b1.GatewayClassConditionStatusAccepted),
-				Status: metav1.ConditionFalse,
-				Reason: string(ReasonOlderGatewayClassExists),
+				Type:    string(gwapiv1b1.GatewayClassConditionStatusAccepted),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(ReasonOlderGatewayClassExists),
+				Message: MsgOlderGatewayClassExists,
+			},
+		},
+		{
+			name:     "invalid parameters gatewayclass",
+			accepted: false,
+			expect: metav1.Condition{
+				Type:    string(gwapiv1b1.GatewayClassConditionStatusAccepted),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(gwapiv1b1.GatewayClassReasonInvalidParameters),
+				Message: MsgGatewayClassInvalidParams,
 			},
 		},
 	}
@@ -62,7 +74,7 @@ func TestComputeGatewayClassAcceptedCondition(t *testing.T) {
 			},
 		}
 
-		got := computeGatewayClassAcceptedCondition(gc, tc.accepted)
+		got := computeGatewayClassAcceptedCondition(gc, tc.accepted, tc.expect.Reason, tc.expect.Message)
 
 		assert.Equal(t, tc.expect.Type, got.Type)
 		assert.Equal(t, tc.expect.Status, got.Status)

--- a/internal/status/gatewayclass.go
+++ b/internal/status/gatewayclass.go
@@ -19,7 +19,7 @@ import (
 
 // SetGatewayClassAccepted inserts or updates the Accepted condition
 // for the provided GatewayClass.
-func SetGatewayClassAccepted(gc *gwapiv1b1.GatewayClass, accepted bool) *gwapiv1b1.GatewayClass {
-	gc.Status.Conditions = MergeConditions(gc.Status.Conditions, computeGatewayClassAcceptedCondition(gc, accepted))
+func SetGatewayClassAccepted(gc *gwapiv1b1.GatewayClass, accepted bool, reason, msg string) *gwapiv1b1.GatewayClass {
+	gc.Status.Conditions = MergeConditions(gc.Status.Conditions, computeGatewayClassAcceptedCondition(gc, accepted, reason, msg))
 	return gc
 }


### PR DESCRIPTION
Adds EnvoyProxy support to the Kubernetes provider.
- Updates status pkg to support GatewayClass [InvalidParamtersRef](https://github.com/kubernetes-sigs/gateway-api/blob/v0.6.0/apis/v1beta1/gatewayclass_types.go#L172) status condition.
- Updates the Kube controller to watch for EnvoyProxy API objects and trigger GatewayClass reconciliation. This supports processing the paramtersRef and updating GatewayClass status conditions.
- Adds unit and integration tests.

Signed-off-by: danehans <daneyonhansen@gmail.com>