### PR TITLE
Allow upgrade to websocket for HTTP 1.1 listeners

### DIFF
--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -92,6 +92,17 @@ func addXdsHTTPFilterChain(xdsListener *listener.Listener, irListener *ir.HTTPLi
 		}},
 	}
 
+	// Allow websocket upgrades for HTTP 1.1
+	// Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism
+	if !irListener.IsHTTP2 {
+		mgr.UpgradeConfigs = []*hcm.HttpConnectionManager_UpgradeConfig{
+			{
+				UpgradeType: "websocket",
+			},
+		}
+
+	}
+
 	// TODO: Make this a generic interface for all API Gateway features.
 	if err := patchHCMWithRateLimit(mgr, irListener); err != nil {
 		return err

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.listeners.yaml
@@ -37,4 +37,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
@@ -37,6 +37,8 @@
             resourceApiVersion: V3
           routeConfigName: third-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   filterChains:
   - filterChainMatch:
       serverNames:
@@ -66,6 +68,8 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: https
+        upgradeConfigs:
+        - upgradeType: websocket
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -110,6 +114,8 @@
             resourceApiVersion: V3
           routeConfigName: second-listener
         statPrefix: https
+        upgradeConfigs:
+        - upgradeType: websocket
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.listeners.yaml
@@ -46,4 +46,6 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
   name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
@@ -37,6 +37,8 @@
             resourceApiVersion: V3
           routeConfigName: first-listener
         statPrefix: https
+        upgradeConfigs:
+        - upgradeType: websocket
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:


### PR DESCRIPTION
Fixes: https://github.com/envoyproxy/gateway/issues/836

Signed-off-by: Arko Dasgupta <arko@tetrate.io>