### PR TITLE
gateway-api: fix supported route kind validation

### DIFF
--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
@@ -19,6 +19,7 @@ gateways:
     status:
       listeners:
         - name: http
+          supportedKinds: []
           attachedRoutes: 0
           conditions:
             - type: ResolvedRefs

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind-and-supported.in.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind-and-supported.in.yaml
@@ -1,0 +1,37 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+            kinds:
+              - group: gateway.networking.k8s.io
+                kind: FooRoute
+              - group:
+                kind: HTTPRoute
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
+            - name: service-1
+              port: 8080

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind-and-supported.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind-and-supported.out.yaml
@@ -7,44 +7,47 @@ gateways:
     spec:
       gatewayClassName: envoy-gateway-class
       listeners:
-        - name: tls
-          protocol: TLS
-          hostname: foo.com
+        - name: http
+          protocol: HTTP
           port: 80
-          tls:
-            mode: Passthrough
           allowedRoutes:
             namespaces:
               from: All
             kinds:
               - group: gateway.networking.k8s.io
+                kind: FooRoute
+              - group: 
                 kind: HTTPRoute
     status:
       listeners:
-        - name: tls
+        - name: http
           attachedRoutes: 0
-          supportedKinds: []
+          supportedKinds:
+            - kind: HTTPRoute
           conditions:
             - type: ResolvedRefs
               status: "False"
               reason: InvalidRouteKinds
-              message: "HTTPRoute is not supported, kind must be TLSRoute"
+              message: "FooRoute is not supported, kind must be HTTPRoute"
             - type: Programmed
               status: "False"
               reason: Invalid
               message: Listener is invalid, see other Conditions for details.
-tlsRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1alpha2
-    kind: TLSRoute
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: HTTPRoute
     metadata:
       namespace: default
-      name: tlsroute-1
+      name: httproute-1
     spec:
       parentRefs:
         - namespace: envoy-gateway
           name: gateway-1
       rules:
-        - backendRefs:
+        - matches:
+            - path:
+                value: "/"
+          backendRefs:
             - name: service-1
               port: 8080
     status:
@@ -65,8 +68,8 @@ infraIR:
     proxy:
       metadata:
         labels:
-          gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
       name: envoy-gateway-gateway-1
       image: envoyproxy/envoy:translator-tests
       listeners:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
@@ -20,11 +20,12 @@ gateways:
       listeners:
         - name: http
           attachedRoutes: 0
+          supportedKinds: []
           conditions:
             - type: ResolvedRefs
               status: "False"
               reason: InvalidRouteKinds
-              message: "Kind is not supported, kind must be HTTPRoute"
+              message: "FooRoute is not supported, kind must be HTTPRoute"
             - type: Programmed
               status: "False"
               reason: Invalid

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -80,6 +80,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		tests.GatewaySecretMissingReferenceGrant,
 		tests.GatewaySecretInvalidReferenceGrant,
 		tests.GatewayInvalidTLSConfiguration,
+		tests.GatewayInvalidRouteKind,
 		tests.HTTPRouteReferenceGrant,
 		tests.HTTPRoutePartiallyInvalidViaInvalidReferenceGrant,
 	}


### PR DESCRIPTION
The logic for validating `allowedRoute.kinds` of a listener was overwriting the SupportedKinds when multiple kinds are configured. This caused the `GatewayInvalidRouteKind` conformance test to fail. 

Items addressed:
- refactored `validateAllowedRoutes` to reduce nesting
- fixed `validateAllowedRoutes` logic so  it collects all of the SupportedKinds before setting them on the listener
- provide additional context to user to help identify which RouteKind is invalid on a listener
- updated unit tests for translator based on new expected output
- added additional unit test case for translator to test for when multiple Kinds are added which includes valid and invalid Kinds.

Fixes #782