### PR TITLE
feat: support configure envoyproxy image from env

### DIFF
--- a/internal/ir/infra.go
+++ b/internal/ir/infra.go
@@ -8,6 +8,7 @@ package ir
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -15,9 +16,18 @@ import (
 )
 
 const (
-	DefaultProxyName  = "default"
+	DefaultProxyName = "default"
+)
+
+var (
 	DefaultProxyImage = "envoyproxy/envoy-dev:latest"
 )
+
+func init() {
+	if proxyImageTag := os.Getenv("PROXY_IMAGE"); proxyImageTag != "" {
+		DefaultProxyImage = proxyImageTag
+	}
+}
 
 // Infra defines managed infrastructure.
 // +k8s:deepcopy-gen=true

--- a/internal/provider/kubernetes/config/envoy-gateway/env.yaml
+++ b/internal/provider/kubernetes/config/envoy-gateway/env.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy-gateway
+  namespace: envoy-gateway-system
+  labels:
+    control-plane: envoy-gateway
+spec:
+  template:
+    spec:
+      containers:
+        - name: envoy-gateway # (1)
+          env:
+            - name: PROXY_IMAGE
+              value: ENVOY_PROXY_IMAGE

--- a/internal/provider/kubernetes/config/envoy-gateway/kustomization.yaml
+++ b/internal/provider/kubernetes/config/envoy-gateway/kustomization.yaml
@@ -10,3 +10,6 @@ configMapGenerator:
 - name: envoy-gateway-config
   files:
   - envoy-gateway.yaml
+
+patchesStrategicMerge:
+- envs.yaml

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -8,6 +8,8 @@ GATEWAY_RELEASE_URL ?= https://github.com/kubernetes-sigs/gateway-api/releases/d
 
 CONFORMANCE_UNIQUE_PORTS ?= true
 
+PROXY_IMAGE ?=
+
 # Set Kubernetes Resources Directory Path
 ifeq ($(origin KUBE_PROVIDER_DIR),undefined)
 KUBE_PROVIDER_DIR := $(ROOT_DIR)/internal/provider/kubernetes/config
@@ -112,6 +114,7 @@ generate-manifests: $(tools/kustomize) ## Generate Kubernetes release manifests.
 	cp -r $(KUBE_PROVIDER_DIR) $(OUTPUT_DIR)/manifests/provider
 	mkdir -pv $(OUTPUT_DIR)/manifests/infra
 	cp -r $(KUBE_INFRA_DIR) $(OUTPUT_DIR)/manifests/infra
+	cat $(OUTPUT_DIR)/manifests/provider/config/envoy-gateway/env.yaml | sed "s;ENVOY_PROXY_IMAGE;$(PROXY_IMAGE);g" > $(OUTPUT_DIR)/manifests/provider/config/envoy-gateway/envs.yaml
 	cd $(OUTPUT_DIR)/manifests/provider/config/envoy-gateway && $(ROOT_DIR)/$(tools/kustomize) edit set image envoyproxy/gateway-dev=$(IMAGE):$(TAG)
 	$(tools/kustomize) build $(OUTPUT_DIR)/manifests/provider/config/default > $(OUTPUT_DIR)/envoy-gateway.yaml
 	$(tools/kustomize) build $(OUTPUT_DIR)/manifests/infra/config/rbac > $(OUTPUT_DIR)/infra-manager-rbac.yaml


### PR DESCRIPTION
When generate manifests, we can specify the envoyproxy image, this is used for release manager/release workflow or end-user to specify the envoyproxy version.

The current envoyproxy image is hardcode and it is the latest dev version of envoyproxy, if the release manager is going to release, he/she will need to change the default dev version to the compatible stable version of envoyproxy:

```shell
make generate-manifests IMAGE=envoyproxy/gateway TAG=v0.3.0 PROXY_IMAGE=envoyproxy/envoy:v1.23.3 OUTPUT_DIR=release-artifacts
```

When make kube-deploy, we can also specify the envoyproxy image to test or dev:

```shell
TAG=latest IMAGE=envoyproxy/gateway-dev PROXY_IMAGE=envoyproxy/envoy:v1.23.3 make kube-deploy
```

Signed-off-by: bitliu <bitliu@tencent.com>