### PR TITLE
Enable HTTPRouteMethodMatching conformance test

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -57,6 +57,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 			suite.SupportHTTPRouteQueryParamMatching:    true,
 			suite.SupportReferenceGrant:                 true,
 			suite.SupportHTTPResponseHeaderModification: true,
+			suite.SupportHTTPRouteMethodMatching:        true,
 		},
 	})
 	cSuite.Setup(t)
@@ -69,6 +70,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		tests.HTTPExactPathMatching,
 		tests.HTTPRouteCrossNamespace,
 		tests.HTTPRouteHeaderMatching,
+		tests.HTTPRouteMethodMatching,
 		tests.HTTPRouteMatchingAcrossRoutes,
 		tests.HTTPRouteHostnameIntersection,
 		tests.HTTPRouteListenerHostnameMatching,


### PR DESCRIPTION
Fixes #659

Enable the HTTPRoute method matching test after updating gateway API to v0.6.0

Letting the tests run first to see if other things needed to be updated/fixed