### PR TITLE
Add HTTPRoute support for request mirror filters

### DIFF
--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.in.yaml
@@ -1,0 +1,50 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-1
+            port: 8080
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-1
+            port: 8080
+

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
@@ -1,0 +1,112 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Programmed
+        status: "True"
+        reason: Programmed
+        message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-1
+            port: 8080
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-1
+            port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*.envoyproxy.io"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        pathMatch:
+          prefix: "/"
+        headerMatches:
+        - name: ":authority"
+          exact: gateway.envoyproxy.io
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+        mirrors:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+      - address: ""
+        ports:
+        - name: http
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.in.yaml
@@ -1,0 +1,50 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-1
+            port: 8080
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: mirror-service
+            port: 8080
+

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
@@ -1,0 +1,115 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Programmed
+        status: "True"
+        reason: Programmed
+        message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-1
+            port: 8080
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: mirror-service
+            port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*.envoyproxy.io"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        pathMatch:
+          prefix: "/"
+        headerMatches:
+        - name: ":authority"
+          exact: gateway.envoyproxy.io
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+        mirrors:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+        - host: 7.6.5.4
+          port: 8080
+          weight: 1
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+      - address: ""
+        ports:
+        - name: http
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.in.yaml
@@ -1,0 +1,42 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-1

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
@@ -1,0 +1,105 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Programmed
+        status: "True"
+        reason: Programmed
+        message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-1
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "False"
+        reason: PortNotSpecified
+        message: A valid port number corresponding to a port on the Service must be specified
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*.envoyproxy.io"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        pathMatch:
+          prefix: "/"
+        headerMatches:
+        - name: ":authority"
+          exact: gateway.envoyproxy.io
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+      - address: ""
+        ports:
+        - name: http
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.in.yaml
@@ -1,0 +1,43 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-unknown
+            port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
@@ -1,0 +1,106 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Programmed
+        status: "True"
+        reason: Programmed
+        message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-unknown
+            port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "False"
+        reason: BackendNotFound
+        message: Service default/service-unknown not found
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*.envoyproxy.io"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        pathMatch:
+          prefix: "/"
+        headerMatches:
+        - name: ":authority"
+          exact: gateway.envoyproxy.io
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+      - address: ""
+        ports:
+        - name: http
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter.in.yaml
@@ -1,0 +1,43 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-1
+            port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
@@ -1,0 +1,106 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      attachedRoutes: 1
+      conditions:
+      - type: Programmed
+        status: "True"
+        reason: Programmed
+        message: Listener is ready
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-1
+            port: 8080
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*.envoyproxy.io"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        pathMatch:
+          prefix: "/"
+        headerMatches:
+        - name: ":authority"
+          exact: gateway.envoyproxy.io
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+        mirrors:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+      - address: ""
+        ports:
+        - name: http
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -72,6 +72,21 @@ func TestTranslate(t *testing.T) {
 				)
 			}
 
+			resources.Services = append(resources.Services,
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "mirror-service",
+					},
+					Spec: v1.ServiceSpec{
+						ClusterIP: "7.6.5.4",
+						Ports: []v1.ServicePort{
+							{Port: 8080, Protocol: v1.ProtocolTCP},
+						},
+					},
+				},
+			)
+
 			resources.Namespaces = append(resources.Namespaces, &v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "envoy-gateway",

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -212,6 +212,8 @@ type HTTPRoute struct {
 	DirectResponse *DirectResponse
 	// Redirections to be returned for this route. Takes precedence over Destinations.
 	Redirect *Redirect
+	// Destinations that requests to this HTTPRoute will be mirrored to
+	Mirrors []*RouteDestination
 	// Destinations associated with this matched route.
 	Destinations []*RouteDestination
 	// Rewrite to be changed for this route.
@@ -319,6 +321,11 @@ func (h HTTPRoute) Validate() error {
 	}
 	if h.URLRewrite != nil {
 		if err := h.URLRewrite.Validate(); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	for _, mirror := range h.Mirrors {
+		if err := mirror.Validate(); err != nil {
 			errs = multierror.Append(errs, err)
 		}
 	}

--- a/internal/ir/xds_test.go
+++ b/internal/ir/xds_test.go
@@ -427,10 +427,36 @@ var (
 			},
 		},
 	}
+	requestMirrorFilter = HTTPRoute{
+		Name: "mirrorfilter",
+		PathMatch: &StringMatch{
+			Exact: ptrTo("mirrorfilter"),
+		},
+		Mirrors: []*RouteDestination{
+			&happyRouteDestination,
+		},
+	}
+
+	requestMirrorFilterMultiple = HTTPRoute{
+		Name: "mirrorfilterMultiple",
+		PathMatch: &StringMatch{
+			Exact: ptrTo("mirrorfiltermultiple"),
+		},
+		Mirrors: []*RouteDestination{
+			&happyRouteDestination,
+			&otherHappyRouteDestination,
+		},
+	}
 
 	// RouteDestination
 	happyRouteDestination = RouteDestination{
 		Host: "10.11.12.13",
+		Port: 8080,
+	}
+
+	// RouteDestination
+	otherHappyRouteDestination = RouteDestination{
+		Host: "11.12.13.14",
 		Port: 8080,
 	}
 )
@@ -805,6 +831,15 @@ func TestValidateHTTPRoute(t *testing.T) {
 		{
 			name:  "jwt-authen-httproute",
 			input: jwtAuthenHTTPRoute,
+		},
+		{
+			name:  "mirror-filter",
+			input: requestMirrorFilter,
+			want:  nil,
+		},
+		{
+			name:  "mirror-filter-multiple",
+			input: requestMirrorFilterMultiple,
 			want:  nil,
 		},
 	}

--- a/internal/ir/zz_generated.deepcopy.go
+++ b/internal/ir/zz_generated.deepcopy.go
@@ -232,6 +232,17 @@ func (in *HTTPRoute) DeepCopyInto(out *HTTPRoute) {
 		*out = new(Redirect)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Mirrors != nil {
+		in, out := &in.Mirrors, &out.Mirrors
+		*out = make([]*RouteDestination, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(RouteDestination)
+				**out = **in
+			}
+		}
+	}
 	if in.Destinations != nil {
 		in, out := &in.Destinations, &out.Destinations
 		*out = make([]*RouteDestination, len(*in))

--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -905,6 +905,56 @@ func testHTTPRoute(ctx context.Context, t *testing.T, provider *Provider, resour
 				},
 			},
 		},
+		{
+			name: "mirror-httproute",
+			route: gwapiv1b1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "httproute-mirror-test",
+					Namespace: ns.Name,
+				},
+				Spec: gwapiv1b1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1b1.CommonRouteSpec{
+						ParentRefs: []gwapiv1b1.ParentReference{
+							{
+								Name: gwapiv1b1.ObjectName(gw.Name),
+							},
+						},
+					},
+					Hostnames: []gwapiv1b1.Hostname{"test.hostname.local"},
+					Rules: []gwapiv1b1.HTTPRouteRule{
+						{
+							Matches: []gwapiv1b1.HTTPRouteMatch{
+								{
+									Path: &gwapiv1b1.HTTPPathMatch{
+										Type:  gatewayapi.PathMatchTypePtr(gwapiv1b1.PathMatchPathPrefix),
+										Value: gatewayapi.StringPtr("/mirror/"),
+									},
+								},
+							},
+							BackendRefs: []gwapiv1b1.HTTPBackendRef{
+								{
+									BackendRef: gwapiv1b1.BackendRef{
+										BackendObjectReference: gwapiv1b1.BackendObjectReference{
+											Name: "test",
+										},
+									},
+								},
+							},
+							Filters: []gwapiv1b1.HTTPRouteFilter{
+								{
+									Type: gwapiv1b1.HTTPRouteFilterType("RequestMirror"),
+									RequestMirror: &gwapiv1b1.HTTPRequestMirrorFilter{
+										BackendRef: gwapiv1b1.BackendObjectReference{
+											Name: "test",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-mirror.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-mirror.yaml
@@ -1,0 +1,15 @@
+name: "http-route"
+http:
+- name: "first-listener"
+  address: "0.0.0.0"
+  port: 10080
+  hostnames:
+  - "*"
+  routes:
+  - name: "mirror-route" 
+    destinations:
+    - host: "1.2.3.4"
+      port: 50000
+    mirrors:
+    - host: "2.3.4.5"
+      port: 60000

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
@@ -1,0 +1,36 @@
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  dnsLookupFamily: V4_ONLY
+  loadAssignment:
+    clusterName: mirror-route
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 1.2.3.4
+              portValue: 50000
+      loadBalancingWeight: 1
+      locality: {}
+  name: mirror-route
+  outlierDetection: {}
+  type: STATIC
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  dnsLookupFamily: V4_ONLY
+  loadAssignment:
+    clusterName: mirror-route-mirror-0
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 2.3.4.5
+              portValue: 60000
+      loadBalancingWeight: 1
+      locality: {}
+  name: mirror-route-mirror-0
+  outlierDetection: {}
+  type: STATIC

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.listeners.yaml
@@ -1,0 +1,42 @@
+- accessLog:
+  - filter:
+      responseFlagFilter:
+        flags:
+        - NR
+    name: envoy.access_loggers.file
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /dev/stdout
+  address:
+    socketAddress:
+      address: 0.0.0.0
+      portValue: 10080
+  defaultFilterChain:
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        accessLog:
+        - name: envoy.access_loggers.file
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            path: /dev/stdout
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        rds:
+          configSource:
+            apiConfigSource:
+              apiType: DELTA_GRPC
+              grpcServices:
+              - envoyGrpc:
+                  clusterName: xds_cluster
+              setNodeOnFirstMessageOnly: true
+              transportApiVersion: V3
+            resourceApiVersion: V3
+          routeConfigName: first-listener
+        statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
+  name: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.routes.yaml
@@ -1,0 +1,12 @@
+- name: first-listener
+  virtualHosts:
+  - domains:
+    - '*'
+    name: first-listener
+    routes:
+    - match:
+        prefix: /
+      route:
+        cluster: mirror-route
+        requestMirrorPolicies:
+        - cluster: mirror-route-mirror-0

--- a/internal/xds/translator/translator_test.go
+++ b/internal/xds/translator/translator_test.go
@@ -43,6 +43,9 @@ func TestTranslate(t *testing.T) {
 			name: "http-route-redirect",
 		},
 		{
+			name: "http-route-mirror",
+		},
+		{
 			name: "http-route-direct-response",
 		},
 		{


### PR DESCRIPTION
Adds support for request mirror filters for HTTPRoutes. 


Resolves https://github.com/envoyproxy/gateway/issues/656 but as noted on that issue, the request mirrors will need to be added for gRPCRoutes as well.

if there is anything left that needs to be done for request mirror filters on gRPCRoutes once support for them lands from https://github.com/envoyproxy/gateway/pull/805 then I can take that as a separate/follow-up issue.