### PR TITLE
Adds EnvoyProxy to Translator and Kube Infra Manager

### DIFF
--- a/api/config/v1alpha1/helpers.go
+++ b/api/config/v1alpha1/helpers.go
@@ -55,9 +55,66 @@ func DefaultProvider() *Provider {
 	}
 }
 
+// GetProvider returns the Provider of EnvoyGateway or a default Provider if unspecified.
 func (e *EnvoyGateway) GetProvider() *Provider {
 	if e.Provider != nil {
 		return e.Provider
 	}
-	return DefaultProvider()
+	e.Provider = DefaultProvider()
+
+	return e.Provider
+}
+
+// DefaultResourceProvider returns a new ResourceProvider with default settings.
+func DefaultResourceProvider() *ResourceProvider {
+	return &ResourceProvider{
+		Type: ProviderTypeKubernetes,
+	}
+}
+
+// GetProvider returns the ResourceProvider of EnvoyProxy or a default ResourceProvider
+// if unspecified.
+func (e *EnvoyProxy) GetProvider() *ResourceProvider {
+	if e.Spec.Provider != nil {
+		return e.Spec.Provider
+	}
+	e.Spec.Provider = DefaultResourceProvider()
+
+	return e.Spec.Provider
+}
+
+// DefaultKubeResourceProvider returns a new KubernetesResourceProvider with default settings.
+func DefaultKubeResourceProvider() *KubernetesResourceProvider {
+	return &KubernetesResourceProvider{
+		EnvoyDeployment: DefaultKubernetesDeployment(),
+	}
+}
+
+// DefaultKubernetesDeployment returns a new KubernetesDeploymentSpec with default settings.
+func DefaultKubernetesDeployment() *KubernetesDeploymentSpec {
+	repl := int32(DefaultEnvoyReplicas)
+	return &KubernetesDeploymentSpec{
+		Replicas: &repl,
+	}
+}
+
+// GetKubeResourceProvider returns the KubernetesResourceProvider of ResourceProvider or
+// a default KubernetesResourceProvider if unspecified. If ResourceProvider is not of
+// type "Kubernetes", a nil KubernetesResourceProvider is returned.
+func (r *ResourceProvider) GetKubeResourceProvider() *KubernetesResourceProvider {
+	if r.Type != ProviderTypeKubernetes {
+		return nil
+	}
+
+	if r.Kubernetes == nil {
+		r.Kubernetes = DefaultKubeResourceProvider()
+		return r.Kubernetes
+	}
+
+	if r.Kubernetes.EnvoyDeployment == nil {
+		r.Kubernetes.EnvoyDeployment = DefaultKubernetesDeployment()
+		return r.Kubernetes
+	}
+
+	return r.Kubernetes
 }

--- a/api/config/v1alpha1/shared_types.go
+++ b/api/config/v1alpha1/shared_types.go
@@ -5,6 +5,11 @@
 
 package v1alpha1
 
+const (
+	// DefaultEnvoyReplicas is the default number of Envoy replicas.
+	DefaultEnvoyReplicas = 1
+)
+
 // ProviderType defines the types of providers supported by Envoy Gateway.
 //
 // +kubebuilder:validation:Enum=Kubernetes

--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -39,6 +39,9 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR XdsIRMap
 		if len(t.ProxyImage) > 0 {
 			gwInfraIR.Proxy.Image = t.ProxyImage
 		}
+		if resources.EnvoyProxy != nil {
+			gwInfraIR.Proxy.Config = resources.EnvoyProxy
+		}
 
 		// save the IR references in the map before the translation starts
 		xdsIR[irKey] = gwXdsIR

--- a/internal/gatewayapi/testdata/envoyproxy-valid.in.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-valid.in.yaml
@@ -1,0 +1,27 @@
+envoyproxy:
+  apiVersion: config.gateway.envoyproxy.io/v1alpha1
+  kind: EnvoyProxy
+  metadata:
+    namespace: envoy-gateway-system
+    name: test
+  spec:
+    provider:
+      type: Kubernetes
+      kubernetes:
+        envoyDeployment:
+          replicas: 2
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: Same

--- a/internal/gatewayapi/testdata/envoyproxy-valid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-valid.out.yaml
@@ -1,0 +1,63 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: Same
+    status:
+      listeners:
+        - name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+          attachedRoutes: 0
+          conditions:
+            - type: Programmed
+              status: "True"
+              reason: Programmed
+              message: Listener is ready
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+      - name: envoy-gateway-gateway-1-http
+        address: 0.0.0.0
+        port: 10080
+        hostnames:
+          - "*"
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      config:
+        apiVersion: config.gateway.envoyproxy.io/v1alpha1
+        kind: EnvoyProxy
+        metadata:
+          namespace: envoy-gateway-system
+          name: test
+        spec:
+          provider:
+            type: Kubernetes
+            kubernetes:
+              envoyDeployment:
+                replicas: 2
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+        - address: ""
+          ports:
+            - name: http
+              protocol: "HTTP"
+              servicePort: 80
+              containerPort: 10080

--- a/internal/infrastructure/kubernetes/deployment_test.go
+++ b/internal/infrastructure/kubernetes/deployment_test.go
@@ -153,6 +153,16 @@ func TestExpectedDeployment(t *testing.T) {
 	for _, port := range ports {
 		checkContainerHasPort(t, deploy, port)
 	}
+
+	// Set the deployment replicas.
+	repl := int32(2)
+	infra.Proxy.GetProxyConfig().GetProvider().GetKubeResourceProvider().EnvoyDeployment.Replicas = &repl
+
+	deploy, err = kube.expectedDeployment(infra)
+	require.NoError(t, err)
+
+	// Check the number of replicas is as expected.
+	assert.Equal(t, repl, *deploy.Spec.Replicas)
 }
 
 func deploymentWithImage(deploy *appsv1.Deployment, image string) *appsv1.Deployment {

--- a/internal/ir/infra.go
+++ b/internal/ir/infra.go
@@ -159,6 +159,15 @@ func (p *ProxyInfra) GetProxyMetadata() *InfraMetadata {
 	return p.Metadata
 }
 
+// GetProxyConfig returns the ProxyInfra config.
+func (p *ProxyInfra) GetProxyConfig() *v1alpha1.EnvoyProxy {
+	if p.Config == nil {
+		p.Config = new(v1alpha1.EnvoyProxy)
+	}
+
+	return p.Config
+}
+
 // Validate validates the provided Infra.
 func (i *Infra) Validate() error {
 	if i == nil {


### PR DESCRIPTION
Adds initial EnvoyProxy support to Gateway API Translator and Kube Infra Manager packages.

Fixes #713 

Signed-off-by: danehans <daneyonhansen@gmail.com>