### PR TITLE
align version command

### DIFF
--- a/docs/latest/conf.py
+++ b/docs/latest/conf.py
@@ -19,7 +19,7 @@ master_doc = 'index'
 
 # General information about the project.
 version = os.environ["BUILD_VERSION"]
-envoyVersion = os.environ["ENVOY_VERSION"]
+envoyVersion = os.environ["ENVOY_PROXY_VERSION"]
 gatewayAPIVersion = os.environ["GATEWAYAPI_VERSION"]
 
 project = 'Envoy Gateway'

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -19,7 +19,7 @@ func GetRootCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(getServerCommand())
-	cmd.AddCommand(getVersionsCommand())
+	cmd.AddCommand(getVersionCommand())
 	cmd.AddCommand(getCertGenCommand())
 
 	return cmd

--- a/internal/cmd/version/version.go
+++ b/internal/cmd/version/version.go
@@ -20,7 +20,7 @@ import (
 type Info struct {
 	EnvoyGatewayVersion string `json:"envoyGatewayVersion"`
 	GatewayAPIVersion   string `json:"gatewayAPIVersion"`
-	EnvoyVersion        string `json:"envoyVersion"`
+	EnvoyProxyVersion   string `json:"envoyProxyVersion"`
 	GitCommitID         string `json:"gitCommitID"`
 }
 
@@ -28,7 +28,7 @@ func Get() Info {
 	return Info{
 		EnvoyGatewayVersion: envoyGatewayVersion,
 		GatewayAPIVersion:   gatewayAPIVersion,
-		EnvoyVersion:        envoyVersion,
+		EnvoyProxyVersion:   envoyProxyVersion,
 		GitCommitID:         gitCommitID,
 	}
 }
@@ -36,7 +36,7 @@ func Get() Info {
 var (
 	envoyGatewayVersion string
 	gatewayAPIVersion   string
-	envoyVersion        = strings.Split(ir.DefaultProxyImage, ":")[1]
+	envoyProxyVersion   = strings.Split(ir.DefaultProxyImage, ":")[1]
 	gitCommitID         string
 )
 
@@ -65,7 +65,7 @@ func Print(w io.Writer, format string) error {
 		}
 	default:
 		_, _ = fmt.Fprintf(w, "ENVOY_GATEWAY_VERSION: %s\n", v.EnvoyGatewayVersion)
-		_, _ = fmt.Fprintf(w, "ENVOY_VERSION: %s\n", v.EnvoyVersion)
+		_, _ = fmt.Fprintf(w, "ENVOY_PROXY_VERSION: %s\n", v.EnvoyProxyVersion)
 		_, _ = fmt.Fprintf(w, "GATEWAYAPI_VERSION: %s\n", v.GatewayAPIVersion)
 		_, _ = fmt.Fprintf(w, "GIT_COMMIT_ID: %s\n", v.GitCommitID)
 	}

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -11,13 +11,13 @@ import (
 	"github.com/envoyproxy/gateway/internal/cmd/version"
 )
 
-// getVersionsCommand returns the version cobra command to be executed.
-func getVersionsCommand() *cobra.Command {
+// getVersionCommand returns the version cobra command to be executed.
+func getVersionCommand() *cobra.Command {
 	var output string
 
 	cmd := &cobra.Command{
-		Use:     "versions",
-		Aliases: []string{"version"},
+		Use:     "version",
+		Aliases: []string{"versions", "v"},
 		Short:   "Show versions",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return version.Print(cmd.OutOrStdout(), output)

--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -10,7 +10,7 @@ docs: docs.clean $(tools/sphinx-build) ## Generate Envoy Gateway Docs Sources
 	cp docs/index.html $(DOCS_OUTPUT_DIR)/index.html
 	@for VERSION in $(RELEASE_VERSIONS); do \
 		env BUILD_VERSION=$$VERSION \
-		ENVOY_VERSION=$(shell go run ./cmd/envoy-gateway versions -o json | jq -r ".envoyVersion") \
+		ENVOY_PROXY_VERSION=$(shell go run ./cmd/envoy-gateway versions -o json | jq -r ".envoyProxyVersion") \
 		GATEWAYAPI_VERSION=$(shell go run ./cmd/envoy-gateway versions -o json | jq -r ".gatewayAPIVersion") \
 		$(tools/sphinx-build) -j auto -b html docs/$$VERSION $(DOCS_OUTPUT_DIR)/$$VERSION; \
 	done


### PR DESCRIPTION
Signed-off-by: hejianpeng <hejianpeng2@huawei.com>

fixes: https://github.com/envoyproxy/gateway/issues/952

1. rename `versions` to `version`, align with kubectl
2. rename `envoyVersion` to `envoyProxyVersion`