### PR TITLE
Sets Envoy Proxy Image to v1.25

### DIFF
--- a/internal/ir/infra.go
+++ b/internal/ir/infra.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	DefaultProxyName  = "default"
-	DefaultProxyImage = "envoyproxy/envoy-dev:latest"
+	DefaultProxyImage = "envoyproxy/envoy:v1.25-latest"
 )
 
 // Infra defines managed infrastructure.


### PR DESCRIPTION
Hardcodes the proxy image to v1.25. This should be automated for future releases.

xref: #957

Signed-off-by: danehans <daneyonhansen@gmail.com>