### PR TITLE
Updates Dev Release Guide

### DIFF
--- a/docs/latest/dev/releasing.md
+++ b/docs/latest/dev/releasing.md
@@ -2,7 +2,13 @@
 
 This document guides maintainers through the process of creating an Envoy Gateway release.
 
-## Creating a Minor Release
+- [Release Candidate](#release-candidate)
+- [Minor Release](#minor-release)
+- [Announce the Release](#announce-the-release)
+
+## Release Candidate
+
+The following steps should be used for creating a release candidate.
 
 ### Prerequisites
 
@@ -13,33 +19,95 @@ Set environment variables for use in subsequent steps:
 ```shell
 export MAJOR_VERSION=0
 export MINOR_VERSION=3
+export RELEASE_CANDIDATE_NUMBER=1
 export GITHUB_REMOTE=origin
 ```
 
 1. Clone the repo, checkout the `main` branch, ensure it’s up-to-date, and your local branch is clean.
-2. Create a topic branch to create the release notes and release docs. Reference previous [release notes][] for additional details.
-3. Sign, commit, and push your changes to your fork and submit a [Pull Request][] to merge the changes listed below
-   into the `main` branch. Do not proceed until all your PRs have merged and the [Build and Test][build-and-test GitHub action] has completed for your final PR:
-
-   1. Add Release Announcement.
-   2. Add Release Versioned Documents.
-
-   ``` shell
-      make docs-release TAG=v${MAJOR_VERSION}.${MINOR_VERSION}.0
-   ```
-
-4. Create a new release branch from `main`. The release branch should be named
+2. Create a topic branch for adding the release notes. Refer to previous [release notes][] for additional details.
+3. Sign, commit, and push your changes to your fork.
+4. Submit a [Pull Request][] to merge the changes into the `main` branch. Do not proceed until your PR has merged and
+   the [Build and Test][] has successfully completed.
+5. Create a new release branch from `main`. The release branch should be named
    `release/v${MAJOR_VERSION}.${MINOR_VERSION}`, e.g. `release/v0.3`.
 
    ```shell
    git checkout -b release/v${MAJOR_VERSION}.${MINOR_VERSION}
    ```
 
-5. Push the branch to the Envoy Gateway repo.
+6. Push the branch to the Envoy Gateway repo.
 
     ```shell
     git push ${GITHUB_REMOTE} release/v${MAJOR_VERSION}.${MINOR_VERSION}
     ```
+
+7. Create a topic branch for updating the Envoy proxy image to the tag supported by the release. Reference [PR #958][]
+   for additional details on updating the image tag.
+8. Sign, commit, and push your changes to your fork.
+9. Submit a [Pull Request][] to merge the changes into the `release/v${MAJOR_VERSION}.${MINOR_VERSION}` branch. Do not
+   proceed until your PR has merged into the release branch and the [Build and Test][] has completed for your PR.
+10. Ensure your release branch is up-to-date and tag the head of your release branch with the release candidate number.
+
+    ```shell
+    git tag -a v${MAJOR_VERSION}.${MINOR_VERSION}.0-rc.${RELEASE_CANDIDATE_NUMBER} -m 'Envoy Gateway v${MAJOR_VERSION}.${MINOR_VERSION}.0-rc.${RELEASE_CANDIDATE_NUMBER} Release Candidate'
+    ```
+
+11. Push the tag to the Envoy Gateway repository.
+
+    ```shell
+    git push v${MAJOR_VERSION}.${MINOR_VERSION}.0-rc.${RELEASE_CANDIDATE_NUMBER}
+    ```
+
+12. This will trigger the [release GitHub action][] that generates the release, release artifacts, etc.
+13. Confirm that the [release workflow][] completed successfully.
+14. Confirm that the Envoy Gateway [image][] with the correct release tag was published to Docker Hub.
+15. Confirm that the [release][] was created.
+16. Note that the [Quickstart Guide][] references are __not__ updated for release candidates. However, test
+    the quickstart steps using the release candidate by manually updating the links.
+17. [Generate][] the GitHub changelog.
+18. Ensure you check the "This is a pre-release" checkbox when editing the GitHub release.
+19. If you find any bugs in this process, please create an issue.
+
+## Minor Release
+
+The following steps should be used for creating a minor release.
+
+### Prerequisites
+
+- Permissions to push to the Envoy Gateway repository.
+- A release branch that has been cut from the corresponding release candidate. Refer to the
+  [Release Candidate](#release-candidate) section for additional details on cutting a release candidate.
+
+Set environment variables for use in subsequent steps:
+
+```shell
+export MAJOR_VERSION=0
+export MINOR_VERSION=3
+export GITHUB_REMOTE=origin
+```
+
+1. Clone the repo, checkout the `main` branch, ensure it’s up-to-date, and your local branch is clean.
+2. Create a topic branch for adding the release notes, release announcement, and versioned release docs.
+
+   1. Create the release notes. Reference previous [release notes][] for additional details. __Note:__  The release
+      notes should be an accumulation of the release candidate release notes and any changes since the release
+      candidate.
+   2. Create a release announcement. Refer to [PR #635] as an example release announcement.
+   3. Generate the versioned release docs:
+
+   ``` shell
+      make docs-release TAG=v${MAJOR_VERSION}.${MINOR_VERSION}
+   ```
+
+3. Sign, commit, and push your changes to your fork.
+4. Submit a [Pull Request][] to merge the changes into the `main` branch. Do not proceed until all your PRs have merged
+   and the [Build and Test][] has completed for your final PR.
+
+5. Checkout the release branch.
+
+   ```shell
+   git checkout -b release/v${MAJOR_VERSION}.${MINOR_VERSION} $GITHUB_REMOTE/release/v${MAJOR_VERSION}.${MINOR_VERSION}
+   ```
 
 6. Tag the head of your release branch with the release tag. For example:
 
@@ -69,52 +137,9 @@ export GITHUB_REMOTE=origin
    (https://gateway.envoyproxy.io/releases/v${MAJOR_VERSION}.${MINOR_VERSION}.html) to learn more about the release.
    ```
 
-14. Submit a PR to revert the Envoy proxy image to `envoyproxy/envoy-dev:latest`. __Note:__ This should not be required
-    when [Issue #957][] is fixed.
-
 If you find any bugs in this process, please create an issue.
 
-## Creating a Release Candidate
-
-### RC Prerequisites
-
-- Permissions to push to the Envoy Gateway repository.
-- A PR has been merged that updates the Envoy proxy image to the version supported by the release.
-  __Note:__ This should not be required when [Issue #957][] is fixed.
-
-Set environment variables for use in subsequent steps:
-
-```shell
-export MAJOR_VERSION=0
-export MINOR_VERSION=3
-export RELEASE_CANDIDATE_NUMBER=1
-export GITHUB_REMOTE=origin
-```
-
-1. Clone the repo, checkout the `main` branch, ensure it’s up-to-date, and your local branch is clean.
-2. Tag the head of the main branch with the release candidate number.
-
-   ```shell
-   git tag -a v${MAJOR_VERSION}.${MINOR_VERSION}.0-rc.${RELEASE_CANDIDATE_NUMBER} -m 'Envoy Gateway v${MAJOR_VERSION}.${MINOR_VERSION}.0-rc.${RELEASE_CANDIDATE_NUMBER} Release Candidate'
-   ```
-
-3. Push the tag to the Envoy Gateway repository.
-
-   ```shell
-   git push v${MAJOR_VERSION}.${MINOR_VERSION}.0-rc.${RELEASE_CANDIDATE_NUMBER}
-   ```
-
-4. This will trigger the [release GitHub action][] that generates the release, release artifacts, etc.
-5. Confirm that the [release workflow][] completed successfully.
-6. Confirm that the Envoy Gateway [image][] with the correct release tag was published to Docker Hub.
-7. Confirm that the [release][] was created.
-8. Note that the [Quickstart Guide][] references are __not__ updated for release candidates. However, test
-    the quickstart steps using the release candidate by manually updating the links.
-9. [Generate][] the GitHub changelog.
-10. Ensure you check the "This is a pre-release" checkbox when editing the GitHub release.
-11. If you find any bugs in this process, please create an issue.
-
-## Announcing the Release
+## Announce the Release
 
 It's important that the world knows about the release. Use the following steps to announce the release.
 
@@ -139,10 +164,11 @@ It's important that the world knows about the release. Use the following steps t
 [release notes]: https://github.com/envoyproxy/gateway/tree/main/release-notes
 [Pull Request]: https://github.com/envoyproxy/gateway/pulls
 [Quickstart Guide]: https://github.com/envoyproxy/gateway/blob/main/docs/user/quickstart.md
-[build-and-test GitHub action]: https://github.com/envoyproxy/gateway/blob/main/.github/workflows/build_and_test.yaml
+[Build and Test]: https://github.com/envoyproxy/gateway/blob/main/.github/workflows/build_and_test.yaml
 [release GitHub action]: https://github.com/envoyproxy/gateway/blob/main/.github/workflows/release.yaml
 [release workflow]: https://github.com/envoyproxy/gateway/actions/workflows/release.yaml
 [image]: https://hub.docker.com/r/envoyproxy/gateway/tags
 [release]: https://github.com/envoyproxy/gateway/releases
 [Generate]: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
-[Issue #957]: https://github.com/envoyproxy/gateway/issues/957
+[PR #635]: https://github.com/envoyproxy/gateway/pull/635
+[PR #958]: https://github.com/envoyproxy/gateway/pull/958


### PR DESCRIPTION
- Reorganizes release doc.
- Adds a table of contents.
- Adds a step for updating the Envoy proxy image.
- Updates the RC release process to tag from a release branch instead of main.

Fixes #957 

Signed-off-by: danehans <daneyonhansen@gmail.com>