### PR TITLE
Always ensure a pathMatch exists

### DIFF
--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -82,18 +82,15 @@ func buildXdsRoute(httpRoute *ir.HTTPRoute, listener *listener.Listener) *routev
 func buildXdsRouteMatch(pathMatch *ir.StringMatch, headerMatches []*ir.StringMatch, queryParamMatches []*ir.StringMatch) *routev3.RouteMatch {
 	outMatch := &routev3.RouteMatch{}
 
-	// Return early with a prefix match to '/' if no matches are specified
-	if pathMatch == nil && len(headerMatches) == 0 && len(queryParamMatches) == 0 {
+	// Add a prefix match to '/' if no matches are specified
+	if pathMatch == nil {
 		// Setup default path specifier. It may be overwritten by :host:.
 		outMatch.PathSpecifier = &routev3.RouteMatch_Prefix{
 			Prefix: "/",
 		}
-		return outMatch
-	}
-
-	// Path match
-	//nolint:gocritic
-	if pathMatch != nil {
+	} else {
+		// Path match
+		//nolint:gocritic
 		if pathMatch.Exact != nil {
 			outMatch.PathSpecifier = &routev3.RouteMatch_Path{
 				Path: *pathMatch.Exact,
@@ -111,7 +108,6 @@ func buildXdsRouteMatch(pathMatch *ir.StringMatch, headerMatches []*ir.StringMat
 			}
 		}
 	}
-
 	// Header matches
 	for _, headerMatch := range headerMatches {
 		stringMatcher := buildXdsStringMatcher(headerMatch)

--- a/internal/xds/translator/testdata/in/xds-ir/http-route.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route.yaml
@@ -6,8 +6,6 @@ http:
   - "*"
   routes:
   - name: "first-route"
-    pathMatch:
-      exact: "foo/bar"
     headerMatches:
     - name: user
       stringMatch:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
@@ -12,7 +12,7 @@
         - name: test
           stringMatch:
             suffix: end
-        path: foo/bar
+        prefix: /
         queryParameters:
         - name: debug
           stringMatch:


### PR DESCRIPTION
If `pathMatch` is empty, add a `prefix` path Match to `/`. Envoy expects precisely one of prefix, path, safe_regex, connect_matcher, path_separated_prefix, path_match_policy must be set. From https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html?highlight=routematch#envoy-v3-api-msg-config-route-v3-routematch

If unset, this below validation error is seen in the `xds-server`
```
cache/logrwrapper.go:29	handling v3 xDS resource request, response_nonce 1, nodeID envoy-default-eg-64656661-df8685f8c-zxk4d, node_version v1.25.0, resource_names_subscribe [], resource_names_unsubscribe [], type_url type.googleapis.com/envoy.config.route.v3.RouteConfiguration, errorCode 13, errorMessage Proto constraint validation failed (RouteConfigurationValidationError.VirtualHosts[0]: embedded message failed validation | caused by VirtualHostValidationError.Routes[0]: embedded message failed validation | caused by RouteValidationError.Match: embedded message failed validation | caused by field: "path_specifier", reason: is required): name: "default-eg-http
```

Signed-off-by: Arko Dasgupta <arko@tetrate.io>