### PR TITLE
fix function names for RL Infra

### DIFF
--- a/internal/infrastructure/kubernetes/infra.go
+++ b/internal/infrastructure/kubernetes/infra.go
@@ -91,31 +91,6 @@ func (i *Infra) CreateOrUpdateRateLimitInfra(ctx context.Context, infra *ir.Rate
 	if infra == nil {
 		return errors.New("ratelimit infra ir is nil")
 	}
-
-	if err := i.deleteRateLimitService(ctx, infra); err != nil {
-		return err
-	}
-
-	if err := i.deleteRateLimitDeployment(ctx, infra); err != nil {
-		return err
-	}
-
-	if err := i.deleteRateLimitConfigMap(ctx, infra); err != nil {
-		return err
-	}
-
-	if err := i.deleteRateLimitServiceAccount(ctx, infra); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteRateLimitInfra removes the managed kube infra, if it doesn't exist.
-func (i *Infra) DeleteRateLimitInfra(ctx context.Context, infra *ir.RateLimitInfra) error {
-	if infra == nil {
-		return errors.New("ratelimit infra ir is nil")
-	}
 	if err := i.createOrUpdateRateLimitServiceAccount(ctx, infra); err != nil {
 		return err
 	}
@@ -134,4 +109,29 @@ func (i *Infra) DeleteRateLimitInfra(ctx context.Context, infra *ir.RateLimitInf
 
 	return nil
 
+}
+
+// DeleteRateLimitInfra removes the managed kube infra, if it doesn't exist.
+func (i *Infra) DeleteRateLimitInfra(ctx context.Context, infra *ir.RateLimitInfra) error {
+	if infra == nil {
+		return errors.New("ratelimit infra ir is nil")
+	}
+
+	if err := i.deleteRateLimitService(ctx, infra); err != nil {
+		return err
+	}
+
+	if err := i.deleteRateLimitDeployment(ctx, infra); err != nil {
+		return err
+	}
+
+	if err := i.deleteRateLimitConfigMap(ctx, infra); err != nil {
+		return err
+	}
+
+	if err := i.deleteRateLimitServiceAccount(ctx, infra); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
The create and delete function names were incorrectly swapped.

Signed-off-by: Arko Dasgupta <arko@tetrate.io>