### PR TITLE
Use `path_separated_prefix` Route match

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -162,15 +162,10 @@ func (t *Translator) processHTTPRouteRules(httpRoute *HTTPRouteContext, parentRe
 func (t *Translator) processHTTPRouteRule(httpRoute *HTTPRouteContext, ruleIdx int, httpFiltersContext *HTTPFiltersContext, rule v1beta1.HTTPRouteRule) []*ir.HTTPRoute {
 	var ruleRoutes []*ir.HTTPRoute
 
-	// If no matches are specified, the default is a prefix
-	// path match on "/", which has the effect of matching every
-	// HTTP request.
+	// If no matches are specified, the implementation MUST match every HTTP request.
 	if len(rule.Matches) == 0 {
 		irRoute := &ir.HTTPRoute{
 			Name: routeName(httpRoute, ruleIdx, -1),
-			PathMatch: &ir.StringMatch{
-				Prefix: StringPtr("/"),
-			},
 		}
 		applyHTTPFiltersContexttoIRRoute(httpFiltersContext, irRoute)
 		ruleRoutes = append(ruleRoutes, irRoute)

--- a/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
@@ -62,8 +62,6 @@ xdsIR:
       - "*"
       routes:
       - name: default-httproute-1-rule-0-match--1-*
-        pathMatch:
-          prefix: "/"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -96,8 +96,8 @@ func buildXdsRouteMatch(pathMatch *ir.StringMatch, headerMatches []*ir.StringMat
 				Path: *pathMatch.Exact,
 			}
 		} else if pathMatch.Prefix != nil {
-			outMatch.PathSpecifier = &routev3.RouteMatch_Prefix{
-				Prefix: *pathMatch.Prefix,
+			outMatch.PathSpecifier = &routev3.RouteMatch_PathSeparatedPrefix{
+				PathSeparatedPrefix: *pathMatch.Prefix,
 			}
 		} else if pathMatch.SafeRegex != nil {
 			outMatch.PathSpecifier = &routev3.RouteMatch_SafeRegex{

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -96,8 +96,14 @@ func buildXdsRouteMatch(pathMatch *ir.StringMatch, headerMatches []*ir.StringMat
 				Path: *pathMatch.Exact,
 			}
 		} else if pathMatch.Prefix != nil {
-			outMatch.PathSpecifier = &routev3.RouteMatch_PathSeparatedPrefix{
-				PathSeparatedPrefix: *pathMatch.Prefix,
+			if *pathMatch.Prefix == "/" {
+				outMatch.PathSpecifier = &routev3.RouteMatch_Prefix{
+					Prefix: "/",
+				}
+			} else {
+				outMatch.PathSpecifier = &routev3.RouteMatch_PathSeparatedPrefix{
+					PathSeparatedPrefix: *pathMatch.Prefix,
+				}
 			}
 		} else if pathMatch.SafeRegex != nil {
 			outMatch.PathSpecifier = &routev3.RouteMatch_SafeRegex{

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.routes.yaml
@@ -9,7 +9,7 @@
         - name: :authority
           stringMatch:
             exact: gateway.envoyproxy.io
-        prefix: /origin
+        pathSeparatedPrefix: /origin
       route:
         cluster: rewrite-route
         regexRewrite:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.routes.yaml
@@ -9,7 +9,7 @@
         - name: :authority
           stringMatch:
             exact: gateway.envoyproxy.io
-        prefix: /origin
+        pathSeparatedPrefix: /origin
       route:
         appendXForwardedHost: true
         cluster: rewrite-route

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.routes.yaml
@@ -9,7 +9,7 @@
         - name: :authority
           stringMatch:
             exact: gateway.envoyproxy.io
-        prefix: /origin
+        pathSeparatedPrefix: /origin
       route:
         cluster: rewrite-route
         prefixRewrite: /rewrite

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -73,6 +73,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		tests.HTTPRouteCrossNamespace,
 		tests.HTTPRouteHeaderMatching,
 		tests.HTTPRouteMethodMatching,
+		tests.HTTPRouteMatching,
 		tests.HTTPRouteMatchingAcrossRoutes,
 		tests.HTTPRouteHostnameIntersection,
 		tests.HTTPRouteListenerHostnameMatching,


### PR DESCRIPTION
We were using `prefix` Route match in xds for
the `PathPrefix` Gateway API match defined here
https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPPathMatch

The match translates to a `path_separated_prefix` instead https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-routematch

This should fix the `HTTPRouteMatching` conformance test where requests with `/v2example` should match `/` and not `/v2`

Fixes: https://github.com/envoyproxy/gateway/issues/995

Signed-off-by: Arko Dasgupta <arko@tetrate.io>