### PR TITLE
remove empty route error check in auth xds logic

### DIFF
--- a/internal/xds/translator/authentication.go
+++ b/internal/xds/translator/authentication.go
@@ -48,10 +48,6 @@ func patchHCMWithJwtAuthnFilter(mgr *hcm.HttpConnectionManager, irListener *ir.H
 		return errors.New("ir listener is nil")
 	}
 
-	if len(irListener.Routes) == 0 {
-		return errors.New("ir listener contains no routes")
-	}
-
 	if !listenerContainsJwtAuthn(irListener) {
 		return nil
 	}


### PR DESCRIPTION
the Xds translator should not error out when the IR routes are empty

Signed-off-by: Arko Dasgupta <arko@tetrate.io>