### PR TITLE
fix: validate user config

### DIFF
--- a/internal/cmd/certgen.go
+++ b/internal/cmd/certgen.go
@@ -35,7 +35,7 @@ func getCertGenCommand() *cobra.Command {
 
 // certGen generates control plane certificates.
 func certGen() error {
-	cfg, err := getConfig(cfgPath)
+	cfg, err := getConfig()
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/certgen.go
+++ b/internal/cmd/certgen.go
@@ -35,7 +35,7 @@ func getCertGenCommand() *cobra.Command {
 
 // certGen generates control plane certificates.
 func certGen() error {
-	cfg, err := getConfig()
+	cfg, err := getConfig(cfgPath)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -42,7 +42,7 @@ func getServerCommand() *cobra.Command {
 
 // server serves Envoy Gateway.
 func server() error {
-	cfg, err := getConfig(cfgPath)
+	cfg, err := getConfig()
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,12 @@ func server() error {
 }
 
 // getConfig gets the Server configuration
-func getConfig(cfgPath string) (*config.Server, error) {
+func getConfig() (*config.Server, error) {
+	return getConfigByPath(cfgPath)
+}
+
+// make `cfgPath` an argument to test it without polluting the global var
+func getConfigByPath(cfgPath string) (*config.Server, error) {
 	// Initialize with default config parameters.
 	cfg, err := config.New()
 	if err != nil {

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -42,7 +42,7 @@ func getServerCommand() *cobra.Command {
 
 // server serves Envoy Gateway.
 func server() error {
-	cfg, err := getConfig()
+	cfg, err := getConfig(cfgPath)
 	if err != nil {
 		return err
 	}
@@ -55,13 +55,10 @@ func server() error {
 }
 
 // getConfig gets the Server configuration
-func getConfig() (*config.Server, error) {
+func getConfig(cfgPath string) (*config.Server, error) {
 	// Initialize with default config parameters.
 	cfg, err := config.New()
 	if err != nil {
-		return nil, err
-	}
-	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 
@@ -81,6 +78,10 @@ func getConfig() (*config.Server, error) {
 		// Set defaults for unset fields
 		eg.SetDefaults()
 		cfg.EnvoyGateway = eg
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
 	}
 	return cfg, nil
 }

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -12,23 +12,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	invalidGatewayConfig = `
+kind: EnvoyGateway
+apiVersion: config.gateway.envoyproxy.io/v1alpha1
+gateway: {}
+`
+)
+
 func TestGetServerCommand(t *testing.T) {
 	got := getServerCommand()
 	assert.Equal(t, "server", got.Use)
 }
 
 func TestGetConfigValidate(t *testing.T) {
-	file, err := os.CreateTemp("", "config")
-	assert.NoError(t, err)
-	defer os.Remove(file.Name())
+	tests := []struct {
+		name   string
+		input  string
+		errors []string
+	}{
+		{
+			name:   "invalid gateway",
+			input:  invalidGatewayConfig,
+			errors: []string{"is unspecified"},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			file, err := os.CreateTemp("", "config")
+			assert.NoError(t, err)
+			defer os.Remove(file.Name())
 
-	_, err = file.Write([]byte(`
-kind: EnvoyGateway
-apiVersion: config.gateway.envoyproxy.io/v1alpha1
-gateway: {}
-`))
-	assert.NoError(t, err)
+			_, err = file.Write([]byte(test.input))
+			assert.NoError(t, err)
 
-	_, err = getConfigByPath(file.Name())
-	assert.Error(t, err)
+			_, err = getConfigByPath(file.Name())
+			for _, e := range test.errors {
+				assert.ErrorContains(t, err, e)
+			}
+		})
+	}
+
 }

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,4 +15,20 @@ import (
 func TestGetServerCommand(t *testing.T) {
 	got := getServerCommand()
 	assert.Equal(t, "server", got.Use)
+}
+
+func TestValidateUserConfig(t *testing.T) {
+	file, err := os.CreateTemp("", "config")
+	assert.NoError(t, err)
+	defer os.Remove(file.Name())
+
+	_, err = file.Write([]byte(`
+kind: EnvoyGateway
+apiVersion: config.gateway.envoyproxy.io/v1alpha1
+gateway: {}
+`))
+	assert.NoError(t, err)
+
+	_, err = getConfig(file.Name())
+	assert.Error(t, err)
 }

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -17,7 +17,7 @@ func TestGetServerCommand(t *testing.T) {
 	assert.Equal(t, "server", got.Use)
 }
 
-func TestValidateUserConfig(t *testing.T) {
+func TestGetConfigValidate(t *testing.T) {
 	file, err := os.CreateTemp("", "config")
 	assert.NoError(t, err)
 	defer os.Remove(file.Name())
@@ -29,6 +29,6 @@ gateway: {}
 `))
 	assert.NoError(t, err)
 
-	_, err = getConfig(file.Name())
+	_, err = getConfigByPath(file.Name())
 	assert.Error(t, err)
 }

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -13,6 +13,14 @@ import (
 )
 
 var (
+	validGatewayConfig = `
+apiVersion: config.gateway.envoyproxy.io/v1alpha1
+kind: EnvoyGateway
+provider:
+  type: Kubernetes
+gateway:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+`
 	invalidGatewayConfig = `
 kind: EnvoyGateway
 apiVersion: config.gateway.envoyproxy.io/v1alpha1
@@ -32,6 +40,11 @@ func TestGetConfigValidate(t *testing.T) {
 		errors []string
 	}{
 		{
+			name:   "valid gateway",
+			input:  validGatewayConfig,
+			errors: nil,
+		},
+		{
 			name:   "invalid gateway",
 			input:  invalidGatewayConfig,
 			errors: []string{"is unspecified"},
@@ -48,8 +61,12 @@ func TestGetConfigValidate(t *testing.T) {
 			assert.NoError(t, err)
 
 			_, err = getConfigByPath(file.Name())
-			for _, e := range test.errors {
-				assert.ErrorContains(t, err, e)
+			if test.errors == nil {
+				assert.NoError(t, err)
+			} else {
+				for _, e := range test.errors {
+					assert.ErrorContains(t, err, e)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Bing Han <h.bing612@gmail.com>

Move the cfg.Validate below to validate user config. Without this fix, the test will fail:
```
--- FAIL: TestValidateUserConfig (0.00s)
    server_test.go:33:
        	Error Trace:	/Users/hanbing/repo/go/envoyproxy-gateway/internal/cmd/server_test.go:33
        	Error:      	An error is expected but got nil.
        	Test:       	TestValidateUserConfig
FAIL
FAIL	github.com/envoyproxy/gateway/internal/cmd	0.601s
FAIL
```