### PR TITLE
Moves PR 1026 Docs to v0.3

### DIFF
--- a/docs/v0.3.0/design/gatewayapi-support.md
+++ b/docs/v0.3.0/design/gatewayapi-support.md
@@ -1,94 +1,119 @@
 # Gateway API Support
 
-As mentioned in the [system design][] document, Envoy Gateway's managed data plane is configured dynamically through 
+As mentioned in the [system design][] document, Envoy Gateway's managed data plane is configured dynamically through
 Kubernetes resources, primarily [Gateway API][] objects. Envoy Gateway supports configuration using the following Gateway API resources.
 
-## **GatewayClass**
+## GatewayClass
 
-A [GatewayClass][] is used to configure which Gateways and other reliant resources should be managed by Envoy Gateway.
-Envoy Gateway supports a single GatewayClass resource linked to the Envoy Gateway controller and accepts in order of age (oldest first) if there are multiple.
-The [ParametersReference][] on the GatewayClass must refer to an EnvoyProxy.
+A [GatewayClass][] represents a "class" of gateways, i.e. which Gateways should be managed by Envoy Gateway.
+Envoy Gateway supports managing __a single__ GatewayClass resource that matches its configured `controllerName` and
+follows Gateway API guidelines for [resolving conflicts][] when multiple GatewayClasses exist with a matching
+`controllerName`.
 
-## **Gateway**
+__Note:__ If specifying GatewayClass [parameters reference][], it must refer to an [EnvoyProxy][] resource.
 
-When a [Gateway][] resource is created that references the GatwewayClass Envoy Gateway is managing then Envoy Gateway will 
-create and manage a new Envoy Proxy deployment. All other Gateway API resources that are managed by this Gateway will be used
-to configure the Envoy Proxy deployment that it created. Envoy Gateway does not support Multiple certificate references or  Specifying an [address][]
-for the Gateway.
+## Gateway
 
-## **HTTPRoute**
+When a [Gateway][] resource is created that references the managed GatewayClass, Envoy Gateway will create and manage a
+new Envoy Proxy deployment. Gateway API resources that reference this Gateway will configure this managed Envoy Proxy
+deployment.
 
-[HTTPRoutes][] are supported as the primary way to configure HTTP traffic in Envoy Gateway.
-All of the following HTTPRoute filters are supported by Envoy Gateway.
+__Note:__ Envoy Gateway does not support multiple certificate references or specifying an [address][] for the Gateway.
 
-- `requestHeaderModifier`: [RequestHeaderModifiers](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter) can be used to modify or add request headers before the request is proxied to its destination.
-- `responseHeaderModifier`: [ResponseHeaderModifiers](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter) can be used to modify or add response headers before the response is sent back to the client.
-- `requestMirror`: [RequestMirrors](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter) configure destinations where the requests should also be mirrored to. Responses to mirrored requests will be ignored.
-- `requestRedirect`: [RequestRedirects](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter) configure policied for how requests that match the HTTPRoute should be modified and then redirected.
-- `urlRewrite`: [UrlRewrites](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter) allow for modification of the request's hostname and path before it is proxied to its destination.
-- `extensionRef`: [ExtensionRefs] are used by Envoy Gateway to add additional support for Ratelimitg and Authentication. For more information about Envoy Gateay's implementation of these filters please refer to the [Ratelimiting][] and [Authentication][] documentation.
+## HTTPRoute
 
-**Note:** currently the only [BackendRef][] kind (the destination where traffic should be sent to) that Envoy Gateway supports are [Kubernetes Services][]. Routing traffic to other destinations such as arbitrary URLs is not currently possible.
+An [HTTPRoute][] configures routing of HTTP traffic through one or more Gateways. The following HTTPRoute filters are
+supported by Envoy Gateway:
 
-**Note:** the `filters` field within [HTTPBackendRef][] is not supported.
+- `requestHeaderModifier`: [RequestHeaderModifiers](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter)
+  can be used to modify or add request headers before the request is proxied to its destination.
+- `responseHeaderModifier`: [ResponseHeaderModifiers](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter)
+  can be used to modify or add response headers before the response is sent back to the client.
+- `requestMirror`: [RequestMirrors](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter)
+  configure destinations where the requests should also be mirrored to. Responses to mirrored requests will be ignored.
+- `requestRedirect`: [RequestRedirects](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter)
+  configure policied for how requests that match the HTTPRoute should be modified and then redirected.
+- `urlRewrite`: [UrlRewrites](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter)
+  allow for modification of the request's hostname and path before it is proxied to its destination.
+- `extensionRef`: [ExtensionRefs][] are used by Envoy Gateway to implement extended filters. Currently, Envoy Gateway
+  supports rate limiting and request authentication filters. For more information about these filters, refer to the
+  [rate limiting][] and [request authentication][] documentation.
 
-## **TCPRoute**
+__Notes:__
+- The only [BackendRef][] kind supported by Envoy Gateway is a [Service][]. Routing traffic to other destinations such
+  as arbitrary URLs is not possible.
+- The `filters` field within [HTTPBackendRef][] is not supported.
 
-[TCPRoutes][] are used to configure routing of raw TCP traffic. Traffic can be forwarded to the desired BackendRef(s) based on a port.
+## TCPRoute
 
-**Note:** TCPRoutes only support proxying in non-transparent mode i.e. the backend will see the source IP and port of the deployed
-Envoy instance instead of the client.
+A [TCPRoute][] configures routing of raw TCP traffic through one or more Gateways. Traffic can be forwarded to the
+desired BackendRefs based on a TCP port number.
 
-## **UDPRoute**
+__Note:__ A TCPRoute only supports proxying in non-transparent mode, i.e. the backend will see the source IP and port of
+the Envoy Proxy instance instead of the client.
 
-[UDPRoutes][] are used to configure routing of raw UDP traffic. Traffic can be forwarded to the desired BackendRef(s) based on a port.
+## UDPRoute
 
-**Note:** Similar to TCPRoutes, UDPRoutes only support proxying in non-transparent mode i.e. the backend will see the source IP and port of the deployed
-Envoy instance instead of the client.
+A [UDPRoute][] configures routing of raw UDP traffic through one or more Gateways. Traffic can be forwarded to the
+desired BackendRefs based on a UDP port number.
 
-## **GRPCRoute**
+__Note:__ Similar to TCPRoutes, UDPRoutes only support proxying in non-transparent mode i.e. the backend will see the
+source IP and port of the Envoy Proxy instance instead of the client.
 
-[GRPCRoutes][] configure routing of [gRPC][] requests. They offer request matching by hostname, gRPC service, gRPC method, or HTTP/2 Header.
-Similar to HTTPRoutes, Envoy Gateway supports the following filters on GRPCRoutes to provide additional traffic processing.
+## GRPCRoute
 
-- `requestHeaderModifier`: [RequestHeaderModifiers](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteFilter) can be used to modify or add request headers before the request is proxied to its destination.
-- `responseHeaderModifier`: [ResponseHeaderModifiers](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteFilter) can be used to modify or add response headers before the response is sent back to the client.
-- `requestMirror`: [RequestMirrors](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteFilter) configure destinations where the requests should also be mirrored to. Responses to mirrored requests will be ignored.
+A [GRPCRoute][] configures routing of [gRPC][] requests through one or more Gateways. They offer request matching by
+hostname, gRPC service, gRPC method, or HTTP/2 Header. Envoy Gateway supports the following filters on GRPCRoutes to
+provide additional traffic processing:
 
-**Note:** currently the only [BackendRef](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteFilter) kind (the destination where traffic should be sent to) that Envoy Gateway supports are [Kubernetes Services][]. Routing traffic to other destinations such as arbitrary URLs is not currently possible
+- `requestHeaderModifier`: [RequestHeaderModifiers](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteFilter)
+  can be used to modify or add request headers before the request is proxied to its destination.
+- `responseHeaderModifier`: [ResponseHeaderModifiers](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteFilter)
+  can be used to modify or add response headers before the response is sent back to the client.
+- `requestMirror`: [RequestMirrors](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteFilter)
+  configure destinations where the requests should also be mirrored to. Responses to mirrored requests will be ignored.
 
-**Note:** the `filters` field within [HTTPBackendRef][] is not supported.
+__Notes:__
+- The only [BackendRef][grpc-filter] kind supported by Envoy Gateway is a [Service][]. Routing traffic to other
+  destinations such as arbitrary URLs is not currently possible.
+- The `filters` field within [HTTPBackendRef][] is not supported.
 
-## **TLSRoute**
+## TLSRoute
 
-[TLSRoutes][] are used similarly to TCPRoutes to configure routing of TCP traffic; however, unlike TCPRoutes, TLSRoutes can match against TLS-Specific Metadata.
+A [TLSRoute][] configures routing of TCP traffic through one or more Gateways. However, unlike TCPRoutes, TLSRoutes
+can match against TLS-specific metadata.
 
-## **ReferenceGrant**
+## ReferenceGrant
 
-[ReferenceGrants][] are used as a way to configure which resources in other namespaces are allowed to reference specific kinds of resources in
-the namespace of the ReferenceGrant. Normally an HTTPRoute created in namespace `foo` is not allowed to specify a Service in the `bar` namespace as the
-one of its BackendRefs. ReferenceGrants are commonly used to permit these types of cross-namespace references. Envoy Gateway supports the following use-cases for ReferenceGrants.
+A [ReferenceGrant][] is used to allow a resource to reference another resource in a different namespace. Normally an
+HTTPRoute created in namespace `foo` is not allowed to reference a Service in namespace `bar`. A ReferenceGrant permits
+these types of cross-namespace references. Envoy Gateway supports the following ReferenceGrant use-cases:
 
-- Allowing an HTTPRoute, GRPCRoute, TLSRoute, UDPRoute, or TCPRoute to include a BackendRef that references a Service that is not in the same namespace as the HTTPRoute.
-- Allowing an HTTPRoute's `requestMirror` filter to include a BackendRef that references a Service that is not in the same namespace as the HTTPRoute.
-- Allowing a Gateway's [SecretObjectReference][] to reference a secret that is not in the same namespace as the Gateway when configuring TLS on a Gateway.
+- Allowing an HTTPRoute, GRPCRoute, TLSRoute, UDPRoute, or TCPRoute to reference a Service in a different namespace.
+- Allowing an HTTPRoute's `requestMirror` filter to include a BackendRef that references a Service in a different
+  namespace.
+- Allowing a Gateway's [SecretObjectReference][] to reference a secret in a different namespace.
 
-[System Design]: https://gateway.envoyproxy.io/latest/design/system-design.html
+[system design]: https://gateway.envoyproxy.io/latest/design/system-design.html
 [Gateway API]: https://gateway-api.sigs.k8s.io/
 [GatewayClass]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.GatewayClass
-[ParametersReference]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.ParametersReference
+[parameters reference]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.ParametersReference
 [Gateway]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.Gateway
 [address]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.GatewayAddress
-[HTTPRoutes]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute
-[Kubernetes Services]: https://kubernetes.io/docs/concepts/services-networking/service/
+[HTTPRoute]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute
+[Service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [BackendRef]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.BackendRef
 [HTTPBackendRef]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPBackendRef
-[TCPRoutes]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute
-[UDPRoutes]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.UDPRoute
-[GRPCRoutes]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRoute
+[TCPRoute]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute
+[UDPRoute]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.UDPRoute
+[GRPCRoute]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRoute
 [gRPC]: https://grpc.io/
-[TLSRoutes]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TLSRoute
-[ReferenceGrants]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.ReferenceGrant
+[TLSRoute]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TLSRoute
+[ReferenceGrant]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.ReferenceGrant
 [SecretObjectReference]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.SecretObjectReference
-[Ratelimiting]: https://gateway.envoyproxy.io/latest/user/rate-limit.html
-[Authentication]: https://gateway.envoyproxy.io/latest/user/authn.html
+[rate limiting]: https://gateway.envoyproxy.io/latest/user/rate-limit.html
+[request authentication]: https://gateway.envoyproxy.io/latest/user/authn.html
+[EnvoyProxy]: https://gateway.envoyproxy.io/latest/api/config_types.html#envoyproxy
+[resolving conflicts]: https://gateway-api.sigs.k8s.io/concepts/guidelines/?h=conflict#conflicts
+[ExtensionRefs]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilterType
+[grpc-filter]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteFilter

--- a/docs/v0.3.0/design_docs.rst
+++ b/docs/v0.3.0/design_docs.rst
@@ -4,9 +4,10 @@ Design Docs
 Learn about the internal details of Envoy Gateway.
 
 .. toctree::
-  :maxdepth: 2
+  :maxdepth: 1
 
   design/system-design
+  design/gatewayapi-support
   design/gatewayapi-translator
   design/watching
   design/config-api
@@ -14,4 +15,3 @@ Learn about the internal details of Envoy Gateway.
   design/egctl
   design/ratelimit
   design/request-authentication
-  design/gatewayapi-support


### PR DESCRIPTION
PR #1026 updated the Gateway API support doc for the `latest` release. However, this PR landed after v0.3 was cut. The updates in PR #1026 improve the UX of this doc. This PR incorporates these updates for v0.3 docs.

Signed-off-by: danehans <daneyonhansen@gmail.com>