### PR TITLE
dont run k8s infra tests in parallel

### DIFF
--- a/internal/infrastructure/kubernetes/proxy_configmap_test.go
+++ b/internal/infrastructure/kubernetes/proxy_configmap_test.go
@@ -176,7 +176,6 @@ func TestDeleteConfigProxyMap(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects(tc.current).Build()
 			kube := NewInfra(cli, cfg)
 

--- a/internal/infrastructure/kubernetes/proxy_deployment_test.go
+++ b/internal/infrastructure/kubernetes/proxy_deployment_test.go
@@ -262,7 +262,6 @@ func TestDeleteProxyDeployment(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			kube := &Infra{
 				Client:    fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build(),
 				Namespace: "test",

--- a/internal/infrastructure/kubernetes/proxy_service_test.go
+++ b/internal/infrastructure/kubernetes/proxy_service_test.go
@@ -120,8 +120,8 @@ func TestDeleteProxyService(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			kube := &Infra{
 				Client:    fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build(),
 				Namespace: "test",

--- a/internal/infrastructure/kubernetes/proxy_serviceaccount_test.go
+++ b/internal/infrastructure/kubernetes/proxy_serviceaccount_test.go
@@ -185,7 +185,6 @@ func TestCreateOrUpdateProxyServiceAccount(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			kube := &Infra{
 				Namespace: tc.ns,
 			}
@@ -221,7 +220,6 @@ func TestDeleteProxyServiceAccount(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			kube := &Infra{
 				Client:    fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build(),
 				Namespace: "test",

--- a/internal/infrastructure/kubernetes/ratelimit_configmap_test.go
+++ b/internal/infrastructure/kubernetes/ratelimit_configmap_test.go
@@ -186,7 +186,6 @@ func TestDeleteRateLimitConfigMap(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects(tc.current).Build()
 			kube := NewInfra(cli, cfg)
 

--- a/internal/infrastructure/kubernetes/ratelimit_deployment_test.go
+++ b/internal/infrastructure/kubernetes/ratelimit_deployment_test.go
@@ -132,7 +132,6 @@ func TestDeleteRateLimitDeployment(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			kube := &Infra{
 				Client:    fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build(),
 				Namespace: "test",

--- a/internal/infrastructure/kubernetes/ratelimit_service_test.go
+++ b/internal/infrastructure/kubernetes/ratelimit_service_test.go
@@ -46,8 +46,8 @@ func TestDeleteRateLimitService(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			kube := &Infra{
 				Client:    fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build(),
 				Namespace: "test",

--- a/internal/infrastructure/kubernetes/ratelimit_serviceaccount_test.go
+++ b/internal/infrastructure/kubernetes/ratelimit_serviceaccount_test.go
@@ -87,7 +87,6 @@ func TestCreateOrUpdateRateLimitServiceAccount(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			kube := &Infra{
 				Namespace: tc.ns,
 			}


### PR DESCRIPTION
* the k8s infra tests are performing CRUD ops on the same k8s env/cluster. They shouldnt be run in parallel as each test might affect the other.

* tested using `go test ./... -count 50 -race -covermode=atomic` which fails on the current `main` branch

Fixes: https://github.com/envoyproxy/gateway/issues/1034

Signed-off-by: Arko Dasgupta <arko@tetrate.io>