### PR TITLE
Moves @danehans to Emeritus Maintainer

### DIFF
--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,4 +1,7 @@
 # Maintainers
 
 ## The following maintainers, listed in alphabetical order, own everything.
-*       @AliceProxy @arkodg @danehans @skriss @Xunzhuo @youngnick @zirain
+*       @AliceProxy @arkodg @skriss @Xunzhuo @youngnick @zirain
+
+## The following is a list emeritus maintainers of the project.
+*       @danehans


### PR DESCRIPTION
Establishes an emeritus section of the CODEOWNERS file and adds @danehans to this section.