### PR TITLE
fix(egctl): don't skip resource caused by ns mismatch

### DIFF
--- a/internal/cmd/egctl/testdata/translate/in/quickstart.yaml
+++ b/internal/cmd/egctl/testdata/translate/in/quickstart.yaml
@@ -1,0 +1,91 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: eg
+spec:
+  gatewayClassName: eg
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  labels:
+    app: backend
+    service: backend
+spec:
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+  selector:
+    app: backend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: backend
+        version: v1
+    spec:
+      serviceAccountName: backend
+      containers:
+        - image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
+          imagePullPolicy: IfNotPresent
+          name: backend
+          ports:
+            - containerPort: 3000
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: backend
+spec:
+  parentRefs:
+    - name: eg
+  hostnames:
+    - "www.example.com"
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: backend
+          port: 3000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
@@ -1,0 +1,20 @@
+'@type': type.googleapis.com/envoy.admin.v3.RoutesConfigDump
+configKey: envoy-gateway-system-eg
+dynamicRouteConfigs:
+- routeConfig:
+    '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: envoy-gateway-system-eg-http
+    virtualHosts:
+    - domains:
+      - '*'
+      name: envoy-gateway-system-eg-http
+      routes:
+      - match:
+          headers:
+          - name: :authority
+            stringMatch:
+              exact: www.example.com
+          prefix: /
+        route:
+          cluster: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+resourceType: route

--- a/internal/cmd/egctl/translate_test.go
+++ b/internal/cmd/egctl/translate_test.go
@@ -94,6 +94,14 @@ func TestTranslate(t *testing.T) {
 			resourceType: string(RouteEnvoyConfigType),
 			expect:       true,
 		},
+		{
+			name:         "quickstart",
+			from:         "gateway-api",
+			to:           "xds",
+			output:       yamlOutput,
+			resourceType: string(RouteEnvoyConfigType),
+			expect:       true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Here I use the quickstart.yaml of this project as the test case.
Without this commit, the HTTPRoute in quickstart.yaml will be skipped
because it doesn't have a namespace.
Signed-off-by: muyuan0 <127020730+muyuan0@users.noreply.github.com>