### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -3,5 +3,8 @@
 ## The following maintainers, listed in alphabetical order, own everything.
 *       @AliceProxy @arkodg @skriss @Xunzhuo @youngnick @zirain
 
-## The following is a list emeritus maintainers of the project.
-*       @danehans
+
+## Maintainers Emeriti
+#
+# Daneyon Hansen (@danehans)
+# Alex Gervais (@alexgervais)


### PR DESCRIPTION
- Move Daneyon and Alex to Maintainers Emeriti (:cry:)

Signed-off-by: Flynn <emissary@flynn.kodachi.com>
