### PR TITLE
Revert "ci: add helm login to prevent authorization failed"

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -140,6 +140,4 @@ jobs:
     - name: Build and Push EG Latest Helm Chart
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       # use `0.0.0` as the default latest version.
-      run: |
-        helm registry login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin ${{ secrets.DOCKERHUB_PASSWORD }}
-        CHART_NAME=envoy-gateway OCI_REGISTRY=oci://docker.io/envoyproxy CHART_VERSION=0.0.0 TAG=latest make helm-package helm-push
+      run: CHART_NAME=envoy-gateway OCI_REGISTRY=oci://docker.io/envoyproxy CHART_VERSION=0.0.0 TAG=latest make helm-package helm-push


### PR DESCRIPTION
Reverts envoyproxy/gateway#1131

After docker login, we do not need to helm login anymore.

Need to create a repo called envoy-gateway in dockerhub to release helm chart.

We cannot reuse gateway / gateway-dev , preventing conflicts and overrides the same tag.

Hold after creating a new repo in dockerhub.