### PR TITLE
ci: don't run build & test for docs in CI

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -35,7 +35,22 @@ jobs:
     - uses: ./tools/github-actions/setup-deps
     - run: make -k licensecheck
 
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          code:
+            - '!docs/**'
+
   coverage-test:
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Fix #1159

I find a way to skip the tests when the change is doc only, with minimal change on the current workflow.

The effect of doc only change can be seen at https://github.com/muyuan0/gateway/pull/3/
The effect of doc&code change can be seen at https://github.com/muyuan0/gateway/pull/4/

And now the push event will trigger the coverage-test whether it is doc only change or not.