### PR TITLE
Fix `invalid: protocol: Unsupported value: "HTTP"` error

### DIFF
--- a/internal/infrastructure/kubernetes/proxy_deployment.go
+++ b/internal/infrastructure/kubernetes/proxy_deployment.go
@@ -127,13 +127,25 @@ func (i *Infra) expectedProxyDeployment(infra *ir.Infra) (*appsv1.Deployment, er
 }
 
 func expectedProxyContainers(infra *ir.Infra) ([]corev1.Container, error) {
+	// Define slice to hold container ports
 	var ports []corev1.ContainerPort
+
+	// Iterate over listeners and ports to get container ports
 	for _, listener := range infra.Proxy.Listeners {
 		for _, p := range listener.Ports {
+			var protocol corev1.Protocol
+			switch p.Protocol {
+			case ir.HTTPProtocolType, ir.HTTPSProtocolType, ir.TLSProtocolType, ir.TCPProtocolType:
+				protocol = corev1.ProtocolTCP
+			case ir.UDPProtocolType:
+				protocol = corev1.ProtocolUDP
+			default:
+				return nil, fmt.Errorf("invalid protocol %q", p.Protocol)
+			}
 			port := corev1.ContainerPort{
 				Name:          p.Name,
 				ContainerPort: p.ContainerPort,
-				Protocol:      corev1.Protocol(p.Protocol),
+				Protocol:      protocol,
 			}
 			ports = append(ports, port)
 		}


### PR DESCRIPTION
When apply config as bellow:
```
apiVersion: gateway.networking.k8s.io/v1beta1
kind: GatewayClass
metadata:
  name: gateway-class
spec:
  controllerName: gateway.envoyproxy.io/gatewayclass-controller
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: shared-gw
  namespace: qat-infra
spec:
  gatewayClassName: gateway-class
  listeners:
    - name: http
      protocol: HTTP
      port: 8080
      allowedRoutes:
        namespaces:
          from: All
```

It throws an error and does not create envoy instance:

`2023-03-22T01:02:38.760+0700    ERROR   runner/runner.go:68     failed to create new infra      {"runner": "infrastructure", "error": "failed to update deployment envoy-gateway-system/envoy-qat-infra-shared-gw-7161742d: Deployment.apps \"envoy-qat-infra-shared-gw-7161742d\" is invalid: spec.template.spec.containers[0].ports[0].protocol: Unsupported value: \"HTTP\": supported values: \"SCTP\", \"TCP\", \"UDP\""}
`