### PR TITLE
provider: watch for resources from extensions

### DIFF
--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -202,11 +202,11 @@ func ValidateHTTPRouteFilter(filter *v1beta1.HTTPRouteFilter, extGKs ...schema.G
 		switch {
 		case filter.ExtensionRef == nil:
 			return errors.New("extensionRef field must be specified for an extended filter")
-		case string(filter.ExtensionRef.Group) != egv1a1.GroupVersion.Group:
-			return fmt.Errorf("invalid group; must be %s", egv1a1.GroupVersion.Group)
-		case string(filter.ExtensionRef.Kind) == egv1a1.KindAuthenticationFilter:
+		case string(filter.ExtensionRef.Group) == egv1a1.GroupVersion.Group &&
+			string(filter.ExtensionRef.Kind) == egv1a1.KindAuthenticationFilter:
 			return nil
-		case string(filter.ExtensionRef.Kind) == egv1a1.KindRateLimitFilter:
+		case string(filter.ExtensionRef.Group) == egv1a1.GroupVersion.Group &&
+			string(filter.ExtensionRef.Kind) == egv1a1.KindRateLimitFilter:
 			return nil
 		default:
 			for _, gk := range extGKs {
@@ -215,10 +215,10 @@ func ValidateHTTPRouteFilter(filter *v1beta1.HTTPRouteFilter, extGKs ...schema.G
 					return nil
 				}
 			}
-			return fmt.Errorf("unknown %s kind", string(filter.ExtensionRef.Kind))
+			return fmt.Errorf("unknown kind %s/%s", string(filter.ExtensionRef.Group), string(filter.ExtensionRef.Kind))
 		}
 	default:
-		return fmt.Errorf("unsupported filter type: %v", filter.Type)
+		return fmt.Errorf("unsupported filter type %v", filter.Type)
 	}
 }
 
@@ -257,9 +257,9 @@ func ValidateGRPCRouteFilter(filter *v1alpha2.GRPCRouteFilter, extGKs ...schema.
 				return nil
 			}
 		}
-		return fmt.Errorf("unknown %s kind", string(filter.ExtensionRef.Kind))
+		return fmt.Errorf("unknown kind %s/%s", string(filter.ExtensionRef.Group), string(filter.ExtensionRef.Kind))
 	default:
-		return fmt.Errorf("unsupported filter type: %v", filter.Type)
+		return fmt.Errorf("unsupported filter type %v", filter.Type)
 	}
 }
 

--- a/internal/gatewayapi/resource.go
+++ b/internal/gatewayapi/resource.go
@@ -7,6 +7,7 @@ package gatewayapi
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -35,6 +36,7 @@ type Resources struct {
 	AuthenticationFilters []*egv1a1.AuthenticationFilter
 	RateLimitFilters      []*egv1a1.RateLimitFilter
 	EnvoyProxy            *egcfgv1a1.EnvoyProxy
+	ExtensionRefFilters   []unstructured.Unstructured
 }
 
 func NewResources() *Resources {
@@ -50,6 +52,7 @@ func NewResources() *Resources {
 		RateLimitFilters:      []*egv1a1.RateLimitFilter{},
 		EnvoyProxy:            new(egcfgv1a1.EnvoyProxy),
 		AuthenticationFilters: []*egv1a1.AuthenticationFilter{},
+		ExtensionRefFilters:   []unstructured.Unstructured{},
 	}
 }
 

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -69,7 +69,7 @@ httpRoutes:
       - type: Accepted
         status: "False"
         reason: UnsupportedValue
-        message: "Invalid filter ExtensionRef: invalid group; must be gateway.envoyproxy.io"
+        message: "Invalid filter ExtensionRef: unknown kind unsupported.group.io/UnsupportedKind"
       - type: ResolvedRefs
         status: "True"
         reason: ResolvedRefs

--- a/internal/gatewayapi/zz_generated.deepcopy.go
+++ b/internal/gatewayapi/zz_generated.deepcopy.go
@@ -14,6 +14,7 @@ import (
 	configv1alpha1 "github.com/envoyproxy/gateway/api/config/v1alpha1"
 	"github.com/envoyproxy/gateway/api/v1alpha1"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -157,6 +158,13 @@ func (in *Resources) DeepCopyInto(out *Resources) {
 		in, out := &in.EnvoyProxy, &out.EnvoyProxy
 		*out = new(configv1alpha1.EnvoyProxy)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.ExtensionRefFilters != nil {
+		in, out := &in.ExtensionRefFilters, &out.ExtensionRefFilters
+		*out = make([]unstructured.Unstructured, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/internal/provider/kubernetes/filters.go
+++ b/internal/provider/kubernetes/filters.go
@@ -1,0 +1,40 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+)
+
+func (r *gatewayAPIReconciler) getAuthenticationFilters(ctx context.Context) ([]egv1a1.AuthenticationFilter, error) {
+	authenList := new(egv1a1.AuthenticationFilterList)
+	if err := r.client.List(ctx, authenList); err != nil {
+		return nil, fmt.Errorf("failed to list AuthenticationFilters: %v", err)
+	}
+
+	return authenList.Items, nil
+}
+
+func (r *gatewayAPIReconciler) getExtensionRefFilters(ctx context.Context) ([]unstructured.Unstructured, error) {
+	var resourceItems []unstructured.Unstructured
+	for _, gvk := range r.extGVKs {
+		uExtResources := &unstructured.UnstructuredList{}
+		uExtResources.SetGroupVersionKind(gvk)
+		if err := r.client.List(ctx, uExtResources); err != nil {
+			r.log.Info("no associated resources found for %s", gvk.String())
+			return nil, fmt.Errorf("failed to list %s: %v", gvk.String(), err)
+		}
+
+		resourceItems = append(resourceItems, uExtResources.Items...)
+	}
+
+	return resourceItems, nil
+}

--- a/internal/provider/kubernetes/routes.go
+++ b/internal/provider/kubernetes/routes.go
@@ -8,9 +8,9 @@ package kubernetes
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -135,7 +135,11 @@ func (r *gatewayAPIReconciler) processGRPCRoutes(ctx context.Context, gatewayNam
 
 			for i := range rule.Filters {
 				filter := rule.Filters[i]
-				if err := gatewayapi.ValidateGRPCRouteFilter(&filter); err != nil {
+				var extGKs []schema.GroupKind
+				for _, gvk := range r.extGVKs {
+					extGKs = append(extGKs, gvk.GroupKind())
+				}
+				if err := gatewayapi.ValidateGRPCRouteFilter(&filter, extGKs...); err != nil {
 					r.log.Error(err, "bypassing filter rule", "index", i)
 					continue
 				}
@@ -155,8 +159,8 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 	resourceMap *resourceMappings, resourceTree *gatewayapi.Resources) error {
 	httpRouteList := &gwapiv1b1.HTTPRouteList{}
 
-	// An HTTPRoute may reference an AuthenticationFilter or RateLimitFilter,
-	// so add them to the resource map first (if they exist).
+	// An HTTPRoute may reference an AuthenticationFilter, RateLimitFilter, or a filter managed
+	// by an extension so add them to the resource map first (if they exist).
 	authenFilters, err := r.getAuthenticationFilters(ctx)
 	if err != nil {
 		return err
@@ -173,6 +177,15 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 	for i := range rateLimitFilters {
 		filter := rateLimitFilters[i]
 		resourceMap.rateLimitFilters[utils.NamespacedName(&filter)] = &filter
+	}
+
+	extensionRefFilters, err := r.getExtensionRefFilters(ctx)
+	if err != nil {
+		return err
+	}
+	for i := range extensionRefFilters {
+		filter := extensionRefFilters[i]
+		resourceMap.extensionRefFilters[utils.NamespacedName(&filter)] = filter
 	}
 
 	if err := r.client.List(ctx, httpRouteList, &client.ListOptions{
@@ -227,7 +240,11 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 
 			for i := range rule.Filters {
 				filter := rule.Filters[i]
-				if err := gatewayapi.ValidateHTTPRouteFilter(&filter); err != nil {
+				var extGKs []schema.GroupKind
+				for _, gvk := range r.extGVKs {
+					extGKs = append(extGKs, gvk.GroupKind())
+				}
+				if err := gatewayapi.ValidateHTTPRouteFilter(&filter, extGKs...); err != nil {
 					r.log.Error(err, "bypassing filter rule", "index", i)
 					continue
 				}
@@ -285,35 +302,48 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 						}
 					}
 				} else if filter.Type == gwapiv1b1.HTTPRouteFilterExtensionRef {
-					if string(filter.ExtensionRef.Kind) == egv1a1.KindAuthenticationFilter {
+					// NOTE: filters must be in the same namespace as the HTTPRoute
+					switch string(filter.ExtensionRef.Kind) {
+					case egv1a1.KindAuthenticationFilter:
 						key := types.NamespacedName{
-							// The AuthenticationFilter must be in the same namespace as the HTTPRoute.
 							Namespace: httpRoute.Namespace,
 							Name:      string(filter.ExtensionRef.Name),
 						}
-						filter, ok := resourceMap.authenFilters[key]
+						authFilter, ok := resourceMap.authenFilters[key]
 						if !ok {
 							r.log.Error(err, "AuthenticationFilter not found; bypassing rule", "index", i)
 							continue
 						}
 
-						resourceTree.AuthenticationFilters = append(resourceTree.AuthenticationFilters, filter)
-					} else if string(filter.ExtensionRef.Kind) == egv1a1.KindRateLimitFilter {
+						resourceTree.AuthenticationFilters = append(resourceTree.AuthenticationFilters, authFilter)
+					case egv1a1.KindRateLimitFilter:
 						key := types.NamespacedName{
-							// The RateLimitFilter must be in the same namespace as the HTTPRoute.
 							Namespace: httpRoute.Namespace,
 							Name:      string(filter.ExtensionRef.Name),
 						}
-						filter, ok := resourceMap.rateLimitFilters[key]
+						rateLimitFilter, ok := resourceMap.rateLimitFilters[key]
 						if !ok {
 							r.log.Error(err, "RateLimitFilter not found; bypassing rule", "index", i)
 							continue
 						}
 
-						resourceTree.RateLimitFilters = append(resourceTree.RateLimitFilters, filter)
+						resourceTree.RateLimitFilters = append(resourceTree.RateLimitFilters, rateLimitFilter)
+					default:
+						// If the Kind does not match any Envoy Gateway resources, check if it's a Kind
+						// managed by an extension and add to resourceTree
+						key := types.NamespacedName{
+							Namespace: httpRoute.Namespace,
+							Name:      string(filter.ExtensionRef.Name),
+						}
+						extRefFilter, ok := resourceMap.extensionRefFilters[key]
+						if !ok {
+							r.log.Error(err, "Filter not found; bypassing rule", "name", filter.ExtensionRef.Name, "index", i)
+							continue
+						}
+
+						resourceTree.ExtensionRefFilters = append(resourceTree.ExtensionRefFilters, extRefFilter)
 					}
 				}
-
 			}
 		}
 
@@ -436,13 +466,4 @@ func (r *gatewayAPIReconciler) processUDPRoutes(ctx context.Context, gatewayName
 	}
 
 	return nil
-}
-
-func (r *gatewayAPIReconciler) getAuthenticationFilters(ctx context.Context) ([]egv1a1.AuthenticationFilter, error) {
-	authenList := new(egv1a1.AuthenticationFilterList)
-	if err := r.client.List(ctx, authenList); err != nil {
-		return nil, fmt.Errorf("failed to list AuthenticationFilters: %v", err)
-	}
-
-	return authenList.Items, nil
 }


### PR DESCRIPTION
Updates Kubernetes provider to watch for resources registered in the extensions config

This PR makes the assumption that registered resources are filters to be referenced in `HTTPRouteFIlter.extensionRef`. Policy attachments from extensions can be handled in a future iteration when we decide on a way to handle PolicyAttachements in general for EG

Relates to:
- https://github.com/envoyproxy/gateway/issues/20
- https://github.com/envoyproxy/gateway/pull/1074
- https://github.com/envoyproxy/gateway/pull/1163