### PR TITLE
templatize values.yaml to allow passing custom image repo and tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ vendor/
 
 # GitHub Codespaces
 .devcontainer/
+
+# values.yaml file is generated from its template counterpart.
+*values.yaml

--- a/charts/gateway-helm/.helmignore
+++ b/charts/gateway-helm/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Template files
+*.tmpl.*

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -1,8 +1,8 @@
 deployment:
   envoyGateway:
     image:
-      repository: docker.io/envoyproxy/gateway-dev
-      tag: latest
+      repository: {{ .ImageRepository }}
+      tag: {{ .ImageTag }}
     imagePullPolicy: Always
     resources:
       limits:

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -1,8 +1,8 @@
 deployment:
   envoyGateway:
     image:
-      repository: {{ .ImageRepository }}
-      tag: {{ .ImageTag }}
+      repository: {{ .EGImageRepository }}
+      tag: {{ .EGImageTag }}
     imagePullPolicy: Always
     resources:
       limits:

--- a/helm/main.go
+++ b/helm/main.go
@@ -1,3 +1,8 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
 package main
 
 import (

--- a/helm/main.go
+++ b/helm/main.go
@@ -22,8 +22,8 @@ const (
 
 var (
 	overlays = struct {
-		ImageTag        string
-		ImageRepository string
+		EGImageTag        string
+		EGImageRepository string
 	}{
 		os.Getenv("RELEASE_TAG"),
 		os.Getenv("IMAGE"),
@@ -41,7 +41,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if len(overlays.ImageTag) == 0 || len(overlays.ImageRepository) == 0 {
+	if len(overlays.EGImageTag) == 0 || len(overlays.EGImageRepository) == 0 {
 		fmt.Printf("missing required env vars, got: %+v\n", overlays)
 		os.Exit(1)
 	}

--- a/helm/main.go
+++ b/helm/main.go
@@ -46,7 +46,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	renderChartFiles(envoyGatewayChartsDirectory)
+	if err := renderChartFiles(envoyGatewayChartsDirectory); err != nil {
+		fmt.Printf("unable to render template, error: %+v\n", err)
+		os.Exit(1)
+	}
 }
 
 func renderChartFiles(chart string) (err error) {

--- a/helm/main.go
+++ b/helm/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+const (
+	envoyGatewayChartsDirectory = "charts/gateway-helm"
+	templateFileExtension       = ".tmpl"
+)
+
+var (
+	overlays = struct {
+		ImageTag        string
+		ImageRepository string
+	}{
+		os.Getenv("RELEASE_TAG"),
+		os.Getenv("IMAGE"),
+	}
+
+	projectPath string
+	chartPath   string
+)
+
+func main() {
+	var err error
+	projectPath, err = os.Getwd()
+	if err != nil {
+		fmt.Printf("error getting working directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(overlays.ImageTag) == 0 || len(overlays.ImageRepository) == 0 {
+		fmt.Printf("missing required env vars, got: %+v\n", overlays)
+		os.Exit(1)
+	}
+
+	renderChartFiles(envoyGatewayChartsDirectory)
+}
+
+func renderChartFiles(chart string) (err error) {
+	chartPath = path.Join(projectPath, chart)
+
+	templates, err := getTemplateFilesFromChartDir()
+	if err != nil {
+		fmt.Printf("cannot read dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	for _, tmpl := range templates {
+		filename := strings.ReplaceAll(tmpl, templateFileExtension, "")
+
+		templateBytes, err := os.ReadFile(filepath.Clean(tmpl))
+		if err != nil {
+			return err
+		}
+
+		t, err := template.New(tmpl).Parse(string(templateBytes))
+		if err != nil {
+			return err
+		}
+
+		if err = renderTemplate(t, overlays, filename); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getTemplateFilesFromChartDir() ([]string, error) {
+	var tmplFiles []string
+	err := filepath.WalkDir(chartPath, func(p string, entry fs.DirEntry, err error) error {
+		if strings.Contains(entry.Name(), templateFileExtension) {
+			tmplFiles = append(tmplFiles, path.Join(chartPath, entry.Name()))
+		}
+		return nil
+	})
+	return tmplFiles, err
+}
+
+func renderTemplate(t *template.Template, data interface{}, filePath string) (err error) {
+	w, err := os.Create(filepath.Clean(filePath))
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+	return t.Execute(w, data)
+}

--- a/tools/make/common.mk
+++ b/tools/make/common.mk
@@ -118,7 +118,7 @@ export USAGE_OPTIONS
 
 .PHONY: generate
 generate: ## Generate go code from templates and tags
-generate: kube-generate go.generate docs-api
+generate: kube-generate helm-generate go.generate docs-api
 
 ## help: Show this help info.
 .PHONY: help

--- a/tools/make/env.mk
+++ b/tools/make/env.mk
@@ -1,0 +1,17 @@
+# This is a wrapper to hold common environment variables used in other make wrappers
+#
+# This file does not contain any specific make targets.
+
+
+# Docker variables
+
+# REGISTRY is the image registry to use for build and push image targets.
+REGISTRY ?= docker.io/envoyproxy
+# IMAGE_NAME is the name of EG image
+# Use gateway-dev in default when developing
+# Use gateway when releasing an image.
+IMAGE_NAME ?= gateway-dev
+# IMAGE is the image URL for build and push image targets.
+IMAGE ?= ${REGISTRY}/${IMAGE_NAME}
+# Tag is the tag to use for build and push image targets.
+TAG ?= $(REV)

--- a/tools/make/helm.mk
+++ b/tools/make/helm.mk
@@ -21,7 +21,7 @@ helm-push: ## Push envoy gateway helm chart to OCI registry.
 	helm push ${OUTPUT_DIR}/charts/${CHART_NAME}-${CHART_VERSION}.tgz ${OCI_REGISTRY}
 
 helm-install:
-helm-install: ## Install envoy gateway helm chart from OCI registry.
+helm-install: helm-generate ## Install envoy gateway helm chart from OCI registry.
 	@$(LOG_TARGET)
 	helm install eg ${OCI_REGISTRY}/${CHART_NAME} --version ${CHART_VERSION} -n envoy-gateway-system --create-namespace
 

--- a/tools/make/helm.mk
+++ b/tools/make/helm.mk
@@ -2,6 +2,8 @@
 #
 # All make targets related to helmß are defined in this file.
 
+include tools/make/env.mk
+
 OCI_REGISTRY ?= oci://docker.io/envoyproxy
 CHART_NAME ?= gateway-helm
 CHART_VERSION ?= ${RELEASE_VERSION}
@@ -9,6 +11,7 @@ CHART_VERSION ?= ${RELEASE_VERSION}
 ##@ Helm
 helm-package:
 helm-package: ## Package envoy gateway helm chart.
+helm-package: helm-generate
 	@$(LOG_TARGET)
 	helm package charts/${CHART_NAME} --app-version ${TAG} --version ${CHART_VERSION} --destination ${OUTPUT_DIR}/charts/
 
@@ -21,3 +24,12 @@ helm-install:
 helm-install: ## Install envoy gateway helm chart from OCI registry.
 	@$(LOG_TARGET)
 	helm install eg ${OCI_REGISTRY}/${CHART_NAME} --version ${CHART_VERSION} -n envoy-gateway-system --create-namespace
+
+helm-release:
+helm-release: ## Package envoy gateway helm chart for release
+helm-release: helm-generate
+	@$(LOG_TARGET)
+	helm package charts/${CHART_NAME} --app-version ${TAG} --version ${CHART_VERSION} --destination ${OUTPUT_DIR}/charts/
+
+helm-generate:
+	IMAGE=${IMAGE} RELEASE_TAG=${TAG} go run helm/*

--- a/tools/make/image.mk
+++ b/tools/make/image.mk
@@ -2,17 +2,7 @@
 #
 # All make targets related to docker image are defined in this file.
 
-# Docker variables
-# REGISTRY is the image registry to use for build and push image targets.
-REGISTRY ?= docker.io/envoyproxy
-# IMAGE_NAME is the name of EG image
-# Use gateway-dev in default when developing
-# Use gateway when releasing an image.
-IMAGE_NAME ?= gateway-dev
-# IMAGE is the image URL for build and push image targets.
-IMAGE ?= ${REGISTRY}/${IMAGE_NAME}
-# Tag is the tag to use for build and push image targets.
-TAG ?= $(REV)
+include tools/make/env.mk
 
 DOCKER := DOCKER_BUILDKIT=1 docker
 DOCKER_SUPPORTED_API_VERSION ?= 1.32

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -56,9 +56,9 @@ endif
 IMAGE_PULL_POLICY ?= Always
 
 .PHONY: kube-deploy
-kube-deploy: manifests generate ## Install Envoy Gateway into the Kubernetes cluster specified in ~/.kube/config.
+kube-deploy: manifests helm-generate ## Install Envoy Gateway into the Kubernetes cluster specified in ~/.kube/config.
 	@$(LOG_TARGET)
-	helm install eg charts/gateway-helm --set deployment.envoyGateway.image.repository=$(IMAGE) --set deployment.envoyGateway.image.tag=$(TAG) --set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) -n envoy-gateway-system --create-namespace
+	helm install eg charts/gateway-helm --set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) -n envoy-gateway-system --create-namespace
 
 .PHONY: kube-undeploy
 kube-undeploy: manifests ## Uninstall the Envoy Gateway into the Kubernetes cluster specified in ~/.kube/config.

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -56,7 +56,7 @@ endif
 IMAGE_PULL_POLICY ?= Always
 
 .PHONY: kube-deploy
-kube-deploy: manifests ## Install Envoy Gateway into the Kubernetes cluster specified in ~/.kube/config.
+kube-deploy: manifests generate ## Install Envoy Gateway into the Kubernetes cluster specified in ~/.kube/config.
 	@$(LOG_TARGET)
 	helm install eg charts/gateway-helm --set deployment.envoyGateway.image.repository=$(IMAGE) --set deployment.envoyGateway.image.tag=$(TAG) --set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) -n envoy-gateway-system --create-namespace
 


### PR DESCRIPTION
This commit allows generating `values.yaml` using a `values.tmpl.yaml` (template file)
in order to dynamically fill in the image repository and tag details while doing helm packaging.
Note that helm does not natively support templates in values.yaml hence the additional overlay

This also introduces a separate `helm-release` target that does helm packaging with image
`docker.io/envoyproxy/gateway:<tag>`.
The old `helm-package` target will continue building based on `${IMAGE}:${TAG}` vars.

If used, the helm install CLI will not require explicit `--set` commands into the deployment object

Fixes #1178 