### PR TITLE
Extensions: pass watched resources to IR

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -286,6 +286,9 @@ func applyHTTPFiltersContextToIRRoute(httpFiltersContext *HTTPFiltersContext, ir
 	if httpFiltersContext.RateLimit != nil {
 		irRoute.RateLimit = httpFiltersContext.RateLimit
 	}
+	if len(httpFiltersContext.ExtensionRefs) > 0 {
+		irRoute.ExtensionRefs = httpFiltersContext.ExtensionRefs
+	}
 
 }
 
@@ -493,6 +496,7 @@ func (t *Translator) processHTTPRouteParentRefListener(route RouteContext, route
 					Mirrors:               routeRoute.Mirrors,
 					RequestAuthentication: routeRoute.RequestAuthentication,
 					RateLimit:             routeRoute.RateLimit,
+					ExtensionRefs:         routeRoute.ExtensionRefs,
 				}
 				// Don't bother copying over the weights unless the route has invalid backends.
 				if routeRoute.BackendWeights.Invalid > 0 {

--- a/internal/gatewayapi/testdata/extensions/httproute-with-extension-filter-invalid-group.in.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-extension-filter-invalid-group.in.yaml
@@ -1,0 +1,50 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: ExtensionRef
+        extensionRef:
+          group: foo.example.io
+          kind: Foo
+          name: test
+extensionRefFilters:
+- apiVersion: foo.example.io
+  kind: Foo
+  metadata:
+    name: test
+    namespace: default
+  spec:
+    data: "stuff"

--- a/internal/gatewayapi/testdata/extensions/httproute-with-extension-filter-invalid-group.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-extension-filter-invalid-group.out.yaml
@@ -1,0 +1,100 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+      attachedRoutes: 0 
+      conditions:
+      - type: Programmed
+        status: "True"
+        reason: Programmed
+        message: Sending translated listener configuration to the data plane
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Listener has been successfully translated
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: ExtensionRef
+        extensionRef:
+          group: foo.example.io
+          kind: Foo
+          name: test 
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "False"
+        reason: UnsupportedValue
+        message: "Unable to translate APIVersion for Extension Filter: kind: Foo, default/test"
+      - type: ResolvedRefs
+        status: "False"
+        reason: BackendNotFound
+        message: "Unable to translate APIVersion for Extension Filter: kind: Foo, default/test"
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*.envoyproxy.io"
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+      - address: ""
+        ports:
+        - name: http
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80

--- a/internal/gatewayapi/testdata/extensions/httproute-with-non-matching-extension-filter.in.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-non-matching-extension-filter.in.yaml
@@ -1,0 +1,50 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: ExtensionRef
+        extensionRef:
+          group: foo.example.io
+          kind: Foo
+          name: example
+extensionRefFilters:
+- apiVersion: foo.example.io/v1alpha1
+  kind: Foo
+  metadata:
+    name: test
+    namespace: default
+  spec:
+    data: "stuff"

--- a/internal/gatewayapi/testdata/extensions/httproute-with-non-matching-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-non-matching-extension-filter.out.yaml
@@ -1,0 +1,100 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+      attachedRoutes: 0 
+      conditions:
+      - type: Programmed
+        status: "True"
+        reason: Programmed
+        message: Sending translated listener configuration to the data plane
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Listener has been successfully translated
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: ExtensionRef
+        extensionRef:
+          group: foo.example.io
+          kind: Foo
+          name: example 
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "False"
+        reason: UnsupportedValue
+        message: "Reference default/example not found for filter type: Foo"
+      - type: ResolvedRefs
+        status: "False"
+        reason: BackendNotFound
+        message: "Reference default/example not found for filter type: Foo"
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*.envoyproxy.io"
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+      - address: ""
+        ports:
+        - name: http
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80

--- a/internal/gatewayapi/testdata/extensions/httproute-with-unsupported-extension-filter.in.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-unsupported-extension-filter.in.yaml
@@ -1,0 +1,50 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: ExtensionRef
+        extensionRef:
+          group: foo.example.io
+          kind: Unsupported
+          name: test
+extensionRefFilters:
+- apiVersion: foo.example.io/v1alpha1
+  kind: Unsupported
+  metadata:
+    name: test
+    namespace: default
+  spec:
+    data: "stuff"

--- a/internal/gatewayapi/testdata/extensions/httproute-with-unsupported-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-unsupported-extension-filter.out.yaml
@@ -1,0 +1,100 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+      attachedRoutes: 0 
+      conditions:
+      - type: Programmed
+        status: "True"
+        reason: Programmed
+        message: Sending translated listener configuration to the data plane
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Listener has been successfully translated
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: ExtensionRef
+        extensionRef:
+          group: foo.example.io
+          kind: Unsupported
+          name: test 
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "False"
+        reason: UnsupportedValue
+        message: "Invalid filter ExtensionRef: unknown kind foo.example.io/Unsupported"
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: "Resolved all the Object references for the Route"
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*.envoyproxy.io"
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+      - address: ""
+        ports:
+        - name: http
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80

--- a/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.in.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.in.yaml
@@ -1,0 +1,50 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: ExtensionRef
+        extensionRef:
+          group: foo.example.io
+          kind: Foo
+          name: test
+extensionRefFilters:
+- apiVersion: foo.example.io/v1alpha1
+  kind: Foo
+  metadata:
+    name: test
+    namespace: default
+  spec:
+    data: "stuff"

--- a/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
@@ -1,0 +1,120 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+  status:
+    listeners:
+    - name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute        
+      attachedRoutes: 1
+      conditions:
+      - type: Programmed
+        status: "True"
+        reason: Programmed
+        message: Sending translated listener configuration to the data plane
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Listener has been successfully translated
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: ExtensionRef
+        extensionRef:
+          group: foo.example.io
+          kind: Foo
+          name: test
+  status:
+    parents:
+    - parentRef:
+        namespace: envoy-gateway
+        name: gateway-1
+        sectionName: http
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      conditions:
+      - type: Accepted
+        status: "True"
+        reason: Accepted
+        message: Route is accepted
+      - type: ResolvedRefs
+        status: "True"
+        reason: ResolvedRefs
+        message: Resolved all the Object references for the Route
+xdsIR:
+  envoy-gateway-gateway-1:
+    http:
+    - name: envoy-gateway-gateway-1-http
+      address: 0.0.0.0
+      port: 10080
+      hostnames:
+      - "*.envoyproxy.io"
+      routes:
+      - name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        pathMatch:
+          prefix: "/"
+        headerMatches:
+        - name: ":authority"
+          exact: gateway.envoyproxy.io
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+        extensionRefs:
+        - object:
+            apiVersion: foo.example.io/v1alpha1
+            kind: Foo
+            metadata:
+              name: test
+              namespace: default
+            spec:
+              data: "stuff"
+infraIR:
+  envoy-gateway-gateway-1:
+    proxy:
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+      name: envoy-gateway-gateway-1
+      image: envoyproxy/envoy:translator-tests
+      listeners:
+      - address: ""
+        ports:
+        - name: http
+          protocol: "HTTP"
+          containerPort: 10080
+          servicePort: 80

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -6,6 +6,7 @@
 package gatewayapi
 
 import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -65,6 +66,11 @@ type Translator struct {
 	// GlobalRateLimitEnabled is true when global
 	// ratelimiting has been configured by the admin.
 	GlobalRateLimitEnabled bool
+
+	// ExtensionGroupKinds stores the group/kind for all resources
+	// introduced by an Extension so that the translator can
+	// store referenced resources in the IR for later use.
+	ExtensionGroupKinds []schema.GroupKind
 }
 
 type TranslateResult struct {

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -230,7 +230,6 @@ type HTTPRoute struct {
 	// RequestAuthentication defines the schema for authenticating HTTP requests.
 	RequestAuthentication *RequestAuthentication
 	// ExtensionRefs holds unstructured resources that were introduced by an extension and used on the HTTPRoute as extensionRef filters
-	// TODO: (aliceproxy) in a follow-up PR, update the translator to store the watched resources in this IR
 	ExtensionRefs []*UnstructuredRef
 }
 


### PR DESCRIPTION
Work has already landed to support Envoy Gateway watching resources from extensions, and also for passing those resources back to the extension whenever the Route level xDS hook is called. This is the last piece of the work that updates the gateway API translator to store these watched resources in the IR so that they can be consumed later.