### PR TITLE
0.4.0-rc.1: Pin Envoy Proxy and Envoy Ratelimit for release

### DIFF
--- a/api/config/v1alpha1/shared_types.go
+++ b/api/config/v1alpha1/shared_types.go
@@ -15,9 +15,9 @@ const (
 	// DefaultDeploymentMemoryResourceRequests for deployment memory resource
 	DefaultDeploymentMemoryResourceRequests = "512Mi"
 	// DefaultEnvoyProxyImage is the default image used by envoyproxy
-	DefaultEnvoyProxyImage = "envoyproxy/envoy-dev:latest"
+	DefaultEnvoyProxyImage = "envoyproxy/envoy:v1.25-latest"
 	// DefaultRateLimitImage is the default image used by ratelimit.
-	DefaultRateLimitImage = "envoyproxy/ratelimit:master"
+	DefaultRateLimitImage = "envoyproxy/ratelimit:542a6047"
 )
 
 // GroupVersionKind unambiguously identifies a Kind.


### PR DESCRIPTION
542a6047 is the most recent ratelimit tag as of this PR other than `master`