### PR TITLE
Changes HTTPRoute hostname matching to ignore trailing port numbers.

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -319,7 +319,8 @@ xds:
                 headers:
                 - name: :authority
                   stringMatch:
-                    exact: www.example.com
+                    safeRegex:
+                      regex: "www\\.example\\.com(?::\\d+)?"
                 prefix: /
               name: default-backend-rule-0-match-0-www.example.com
               route:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -585,7 +585,9 @@
 									"headers": [{
 										"name": ":authority",
 										"stringMatch": {
-											"exact": "www.example.com"
+											"safeRegex": {
+												"regex": "www\\.example\\.com(?::\\d+)?"
+											}
 										}
 									}],
 									"prefix": "/"
@@ -609,7 +611,9 @@
 									"headers": [{
 										"name": ":authority",
 										"stringMatch": {
-											"exact": "www.grpc-example.com"
+											"safeRegex": {
+												"regex": "www\\.grpc-example\\.com(?::\\d+)?"
+											}
 										}
 									}],
 									"path": "/com.example.Things/DoThing"

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -401,7 +401,8 @@ xds:
                 headers:
                 - name: :authority
                   stringMatch:
-                    exact: www.example.com
+                    safeRegex:
+                      regex: "www\\.example\\.com(?::\\d+)?"
                 prefix: /
               name: default-backend-rule-0-match-0-www.example.com
               route:
@@ -418,7 +419,8 @@ xds:
                 headers:
                 - name: :authority
                   stringMatch:
-                    exact: www.grpc-example.com
+                    safeRegex:
+                      regex: "www\\.grpc-example\\.com(?::\\d+)?"
                 path: /com.example.Things/DoThing
               name: default-backend-rule-0-match-0-www.grpc-example.com
               route:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
@@ -14,7 +14,8 @@ xds:
               headers:
               - name: :authority
                 stringMatch:
-                  exact: www.example.com
+                  safeRegex:
+                    regex: "www\\.example\\.com(?::\\d+)?"
               prefix: /
             name: default-backend-rule-0-match-0-www.example.com
             route:
@@ -31,7 +32,8 @@ xds:
               headers:
               - name: :authority
                 stringMatch:
-                  exact: www.grpc-example.com
+                  safeRegex:
+                    regex: "www\\.grpc-example\\.com(?::\\d+)?"
               path: /com.example.Things/DoThing
             name: default-backend-rule-0-match-0-www.grpc-example.com
             route:

--- a/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
+++ b/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
@@ -14,7 +14,9 @@
 								"headers": [{
 									"name": ":authority",
 									"stringMatch": {
-										"exact": "www.example.com"
+										"safeRegex": {
+											"regex": "www\\.example\\.com(?::\\d+)?"
+										}
 									}
 								}],
 								"prefix": "/"
@@ -42,7 +44,9 @@
 								"headers": [{
 									"name": ":authority",
 									"stringMatch": {
-										"exact": "www.example2.com"
+										"safeRegex": {
+											"regex": "www\\.example2\\.com(?::\\d+)?"
+										}
 									}
 								}],
 								"prefix": "/v2/"

--- a/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
@@ -14,7 +14,8 @@ xds:
               headers:
               - name: :authority
                 stringMatch:
-                  exact: www.example.com
+                  safeRegex:
+                    regex: "www\\.example\\.com(?::\\d+)?"
               prefix: /
             name: envoy-gateway-system-backend-rule-0-match-0-www.example.com
             route:

--- a/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -97,7 +97,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -107,7 +107,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -93,7 +93,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
@@ -91,7 +91,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
@@ -89,7 +89,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
@@ -95,7 +95,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
@@ -95,7 +95,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
@@ -89,7 +89,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
@@ -89,7 +89,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -90,7 +90,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         redirect:
           scheme: https
           statusCode: 301

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         redirect:
           scheme: https
           statusCode: 301

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -91,7 +91,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         redirect:
           scheme: http
           statusCode: 302

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
@@ -103,7 +103,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -97,7 +97,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
@@ -107,7 +107,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -93,7 +93,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
@@ -91,7 +91,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
@@ -89,7 +89,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-sourceip-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-sourceip-ratelimit.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         rateLimit:
           global:
             rules:

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -80,7 +80,7 @@ xdsIR:
               prefix: "/"
             headerMatches:
               - name: ":authority"
-                exact: gateway.envoyproxy.io
+                safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
             destinations:
               - host: 7.7.7.7
                 port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -81,7 +81,7 @@ xdsIR:
               prefix: "/"
             headerMatches:
               - name: ":authority"
-                exact: gateway.envoyproxy.io
+                safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
             destinations:
               - host: 7.7.7.7
                 port: 8080
@@ -91,7 +91,7 @@ xdsIR:
               prefix: "/"
             headerMatches:
               - name: ":authority"
-                exact: whales.envoyproxy.io
+                safeRegex: "whales\\.envoyproxy\\.io(?::\\d+)?"
             destinations:
               - host: 7.7.7.7
                 port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
@@ -89,7 +89,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
@@ -86,7 +86,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
@@ -86,7 +86,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         # I believe the correct way to handle an invalid filter should be to allow the HTTPRoute to function
         # normally but leave out the filter config and set the status, but this behaviour can be changed.
         destinations:

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-valid-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-authenfilter.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         requestAuthentication:
           jwt:
             providers:

--- a/internal/gatewayapi/testdata/httproute-with-valid-multi-match-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-multi-match-authenfilter.out.yaml
@@ -102,7 +102,7 @@ xdsIR:
           exact: "/test/path/1"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         requestAuthentication:
           jwt:
             providers:
@@ -119,7 +119,7 @@ xdsIR:
           exact: "/test/path/2"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         requestAuthentication:
           jwt:
             providers:

--- a/internal/gatewayapi/testdata/httproute-with-valid-multi-match-multi-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-multi-match-multi-authenfilter.out.yaml
@@ -102,7 +102,7 @@ xdsIR:
           exact: "/test/path/1"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         requestAuthentication:
           jwt:
             providers:
@@ -119,7 +119,7 @@ xdsIR:
           exact: "/test/path/2"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         requestAuthentication:
           jwt:
             providers:

--- a/internal/gatewayapi/testdata/httproute-with-valid-ratelimitfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-ratelimitfilter.out.yaml
@@ -88,7 +88,7 @@ xdsIR:
           prefix: "/"
         headerMatches:
         - name: ":authority"
-          exact: gateway.envoyproxy.io
+          safeRegex: "gateway\\.envoyproxy\\.io(?::\\d+)?"
         rateLimit:
           global:
             rules:

--- a/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
@@ -20,7 +20,7 @@ gateways:
             - group: gateway.networking.k8s.io
               kind: HTTPRoute
             - group: gateway.networking.k8s.io
-              kind: GRPCRoute              
+              kind: GRPCRoute
           attachedRoutes: 1
           conditions:
             - type: Programmed
@@ -79,7 +79,7 @@ xdsIR:
               prefix: "/"
             headerMatches:
               - name: ":authority"
-                suffix: envoyproxy.io
+                safeRegex: "(?:.+\\.)?envoyproxy\\.io(?::\\d+)?"
             destinations:
               - host: 7.7.7.7
                 port: 8080

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
@@ -218,7 +218,7 @@ xdsIR:
           exact: "yes"
         headerMatches:
         - name: :authority
-          exact: example.com
+          safeRegex: "example\\.com(?::\\d+)?"
         destinations:
         - host: 7.7.7.7
           port: 8080
@@ -228,7 +228,7 @@ xdsIR:
           prefix: "/v1/example"
         headerMatches:
         - name: :authority
-          exact: example.com
+          safeRegex: "example\\.com(?::\\d+)?"
         destinations:
         - host: 8.8.8.8
           port: 8080
@@ -238,7 +238,7 @@ xdsIR:
           prefix: "/v1/status"
         headerMatches:
         - name: :authority
-          exact: example.net
+          safeRegex: "example\\.net(?::\\d+)?"
         - name: "version"
           exact: "one"
         destinations:
@@ -250,7 +250,7 @@ xdsIR:
           prefix: "/v1/status"
         headerMatches:
         - name: :authority
-          exact: example.net
+          safeRegex: "example\\.net(?::\\d+)?"
         destinations:
         - host: 8.8.8.8
           port: 8080


### PR DESCRIPTION
This is useful for testing behind NAT, e.g. when deploying in a VM.

HTTP authority is e.g. 'example.com:1234', but the Gateway API restricts the values of Hostnames to domain names [1]. I see two interpretations: (1) port numbers are not allowed or (2) only the host portion should be matched. (1) is not a problem if the cluster owner only uses the standard ports, so (2) seems like a more useful interpretation.

This cannot use a simple `contains_match`, since the separating colon is optional. For performance, perhaps exact matches should be special-cased somehow: that ignoring the port is only done for routes with a certain annotation.

1. https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.Hostname