### PR TITLE
[release/v0.4] chore: bump envoy proxy to v1.26

### DIFF
--- a/api/config/v1alpha1/shared_types.go
+++ b/api/config/v1alpha1/shared_types.go
@@ -15,7 +15,7 @@ const (
 	// DefaultDeploymentMemoryResourceRequests for deployment memory resource
 	DefaultDeploymentMemoryResourceRequests = "512Mi"
 	// DefaultEnvoyProxyImage is the default image used by envoyproxy
-	DefaultEnvoyProxyImage = "envoyproxy/envoy:v1.25-latest"
+	DefaultEnvoyProxyImage = "envoyproxy/envoy:v1.26-latest"
 	// DefaultRateLimitImage is the default image used by ratelimit.
 	DefaultRateLimitImage = "envoyproxy/ratelimit:542a6047"
 )


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/releases/tag/v1.26.0

**What this PR does / why we need it**:
Releases the latest version of envoy proxy with the latest version of envoy gateway
