### PR TITLE
fix: add the namespace resource within helm templates

### DIFF
--- a/charts/gateway-helm/templates/certgen-rbac.yaml
+++ b/charts/gateway-helm/templates/certgen-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "eg.fullname" . }}-certgen
+  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "eg.labels" . | nindent 4 }}
   annotations:
@@ -11,6 +12,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "eg.fullname" . }}-certgen
+  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "eg.labels" . | nindent 4 }}
   annotations:
@@ -29,6 +31,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "eg.fullname" . }}-certgen
+  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "eg.labels" . | nindent 4 }}
   annotations:

--- a/charts/gateway-helm/templates/certgen.yaml
+++ b/charts/gateway-helm/templates/certgen.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "eg.fullname" . }}-certgen
+  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "eg.labels" . | nindent 4 }}
   annotations:

--- a/charts/gateway-helm/templates/envoy-gateway-config.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: envoy-gateway-config
+  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "eg.labels" . | nindent 4 }}
 data:

--- a/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: envoy-gateway
+  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "eg.labels" . | nindent 4 }}
 ---
@@ -9,6 +10,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: envoy-gateway
+  namespace: '{{ .Release.Namespace }}'
   labels:
     control-plane: envoy-gateway
   {{- include "eg.labels" . | nindent 4 }}

--- a/charts/gateway-helm/templates/envoy-gateway-metrics-service.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-metrics-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: envoy-gateway-metrics-service
+  namespace: '{{ .Release.Namespace }}'
   labels:
     control-plane: envoy-gateway
   {{- include "eg.labels" . | nindent 4 }}

--- a/charts/gateway-helm/templates/envoy-gateway-service.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: envoy-gateway
+  namespace: '{{ .Release.Namespace }}'
   labels:
     control-plane: envoy-gateway
   {{- include "eg.labels" . | nindent 4 }}

--- a/charts/gateway-helm/templates/infra-manager-rbac.yaml
+++ b/charts/gateway-helm/templates/infra-manager-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "eg.fullname" . }}-infra-manager
+  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "eg.labels" . | nindent 4 }}
 rules:
@@ -29,6 +30,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "eg.fullname" . }}-infra-manager
+  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "eg.labels" . | nindent 4 }}
 roleRef:

--- a/charts/gateway-helm/templates/leader-election-rbac.yaml
+++ b/charts/gateway-helm/templates/leader-election-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "eg.fullname" . }}-leader-election-role
+  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "eg.labels" . | nindent 4 }}
 rules:
@@ -41,6 +42,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "eg.fullname" . }}-leader-election-rolebinding
+  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "eg.labels" . | nindent 4 }}
 roleRef:

--- a/charts/gateway-helm/templates/metrics-reader-rbac.yaml
+++ b/charts/gateway-helm/templates/metrics-reader-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "eg.fullname" . }}-metrics-reader
+  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "eg.labels" . | nindent 4 }}
 rules:

--- a/charts/gateway-helm/templates/namespace.yaml
+++ b/charts/gateway-helm/templates/namespace.yaml
@@ -1,0 +1,6 @@
+{{ if .Values.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: '{{ .Release.Namespace }}' 
+{{ end }}    

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -42,3 +42,4 @@ envoyGatewayMetricsService:
     protocol: TCP
     targetPort: https
 
+createNamespace: false

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -125,7 +125,7 @@ generate-manifests: helm-generate ## Generate Kubernetes release manifests.
 	@$(LOG_TARGET)
 	@$(call log, "Generating kubernetes manifests")
 	mkdir -p $(OUTPUT_DIR)/
-	helm template eg charts/gateway-helm --include-crds --set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) > $(OUTPUT_DIR)/install.yaml
+	helm template --set createNamespace=true eg charts/gateway-helm --include-crds --set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) --namespace envoy-gateway-system > $(OUTPUT_DIR)/install.yaml
 	@$(call log, "Added: $(OUTPUT_DIR)/install.yaml")
 	cp examples/kubernetes/quickstart.yaml $(OUTPUT_DIR)/quickstart.yaml
 	@$(call log, "Added: $(OUTPUT_DIR)/quickstart.yaml")


### PR DESCRIPTION
This is an unfortunate workaround due the difference in UX between `helm template` and `helm install`
The project recommends `helm install` as a way to install EG which supports a `--create-namespace` flag to create a namespace However we also generate a static YAML using `helm template` as part of the release artifact so a user can install the YAML directly using `kubectl` instead of `helm` . The issue here is `helm template` does not support `--create-namespace`, so instead this commit adds a knob called `createNamespace` to the Helm chart which is `false` by default, but turned on during `make generate-manifests`

Fixes: https://github.com/envoyproxy/gateway/issues/1307