### PR TITLE
Fix testdata missing default fields (merge order bug)

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -685,6 +685,9 @@ xds:
                     routeConfigName: default-eg-grpc
                   statPrefix: http
                   useRemoteAddress: true
+                  normalizePath: true
+                  mergeSlashes: true
+                  pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
             name: default-eg-grpc
             perConnectionBufferLimitBytes: 32768
       - activeState:


### PR DESCRIPTION
Updates a section of `internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml` to expect the new default fields set by https://github.com/envoyproxy/gateway/pull/1341