### PR TITLE
bug: change err log to info in findOwningGateway

### DIFF
--- a/internal/provider/kubernetes/predicates.go
+++ b/internal/provider/kubernetes/predicates.go
@@ -282,7 +282,7 @@ func (r gatewayAPIReconciler) findOwningGateway(ctx context.Context, labels map[
 	gatewayKey := types.NamespacedName{Namespace: gwNamespace, Name: gwName}
 	gtw := new(gwapiv1b1.Gateway)
 	if err := r.client.Get(ctx, gatewayKey, gtw); err != nil {
-		r.log.Error(err, "gateway not found")
+		r.log.Info("gateway not found", "namespace", gtw.Namespace, "name", gtw.Name)
 		return nil
 	}
 


### PR DESCRIPTION
* Its not an error case when the managed envoy service or deployment get reconciled after a gateway is deleted, since deleting the managed service and deployment asscoiated with the gateway might not be instanteous.

Fixes: https://github.com/envoyproxy/gateway/issues/1347