### PR TITLE
chore: bump sphinx to v6.2.1 and myst-parser to v1.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,11 +33,10 @@ updates:
     directory: /tools/src/setup-envtest
     schedule:
       interval: weekly
-  # Enable once https://github.com/envoyproxy/gateway/issues/848 is fixed.
-  #  - package-ecosystem: pip
-  #    directory: /tools/src/sphinx-build
-  #    schedule:
-  #      interval: weekly
+  - package-ecosystem: pip
+    directory: /tools/src/sphinx-build
+    schedule:
+      interval: weekly
   - package-ecosystem: pip
     directory: /tools/src/yamllint
     schedule:

--- a/tools/src/sphinx-build/requirements.txt
+++ b/tools/src/sphinx-build/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==5.3.0
-myst-parser==0.18.1
+Sphinx==6.2.1
+myst-parser==1.0.0


### PR DESCRIPTION
* Renable dependabot updates since the latest modules are compatible

Fixes https://github.com/envoyproxy/gateway/issues/848