### PR TITLE
docs: update Gateway API support doc for multi cert ref

### DIFF
--- a/docs/latest/design/gatewayapi-support.md
+++ b/docs/latest/design/gatewayapi-support.md
@@ -18,7 +18,7 @@ When a [Gateway][] resource is created that references the managed GatewayClass,
 new Envoy Proxy deployment. Gateway API resources that reference this Gateway will configure this managed Envoy Proxy
 deployment.
 
-__Note:__ Envoy Gateway does not support multiple certificate references or specifying an [address][] for the Gateway.
+__Note:__ Envoy Gateway does not support specifying an [address][] for the Gateway.
 
 ## HTTPRoute
 

--- a/docs/v0.4.0/design/gatewayapi-support.md
+++ b/docs/v0.4.0/design/gatewayapi-support.md
@@ -18,7 +18,7 @@ When a [Gateway][] resource is created that references the managed GatewayClass,
 new Envoy Proxy deployment. Gateway API resources that reference this Gateway will configure this managed Envoy Proxy
 deployment.
 
-__Note:__ Envoy Gateway does not support multiple certificate references or specifying an [address][] for the Gateway.
+__Note:__ Envoy Gateway does not support specifying an [address][] for the Gateway.
 
 ## HTTPRoute
 


### PR DESCRIPTION
Remove the note around not support multiple cert references because we support it now (thanks to https://github.com/envoyproxy/gateway/pull/1241)
