### PR TITLE
chore: GHA to request reviews from gateway-reviewers

### DIFF
--- a/.github/workflows/cc_reviewers_pr.yaml
+++ b/.github/workflows/cc_reviewers_pr.yaml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     types:
     - opened
+    - reopened  
     branches:
     - "main"
     - "release/v*"        

--- a/.github/workflows/cc_reviewers_pr.yaml
+++ b/.github/workflows/cc_reviewers_pr.yaml
@@ -9,6 +9,9 @@ on:
     - "main"
     - "release/v*"        
 
+permissions:
+  pull-requests: write
+
 jobs:
   request:
     name: Request reviews from envoyproxy/gateway-reviewers 

--- a/.github/workflows/cc_reviewers_pr.yaml
+++ b/.github/workflows/cc_reviewers_pr.yaml
@@ -1,19 +1,22 @@
 name: Request review on PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types:
-      - opened
+    - opened
+    branches:
+    - "main"
+    - "release/v*"        
 
 jobs:
   request:
-    name: Request reviews on opened PRs
+    name: Request reviews from envoyproxy/gateway-reviewers 
     runs-on: ubuntu-latest
 
     steps:
-      - name: Create PR review request
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.html_url }} \
-              --add-reviewer envoyproxy/gateway-reviewers 
+    - name: Create PR review request
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh pr edit ${{ github.event.pull_request.html_url }} \
+            --add-reviewer envoyproxy/gateway-reviewers 

--- a/.github/workflows/cc_reviewers_pr.yaml
+++ b/.github/workflows/cc_reviewers_pr.yaml
@@ -1,0 +1,19 @@
+name: Request review on PRs
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  request:
+    name: Request reviews on opened PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create PR review request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.html_url }} \
+              --add-reviewer envoyproxy/gateway-reviewers 


### PR DESCRIPTION
* GH recommends using CODEOWNERS to automatically request reviewers on PRs.
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners. However the teams mentioned within the `CODEOWNERS` file must have WRITE access. Since this is not the case for `envoyproxy/gateway-reviewers` who have `triage` access today, this PR adds a Github Action that adds envoyproxy/gateway-reviewers as reviewers using the GH CLI whenever a PR is opened

Adapted from https://stackoverflow.com/questions/66557514/how-to-automatically-request-a-review-from-someone-using-github-actions