### PR TITLE
docs: missing NodePort service type description comment

### DIFF
--- a/api/config/v1alpha1/shared_types.go
+++ b/api/config/v1alpha1/shared_types.go
@@ -131,9 +131,10 @@ type KubernetesServiceSpec struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Type determines how the Service is exposed. Defaults to LoadBalancer.
-	// Valid options are ClusterIP and LoadBalancer.
+	// Valid options are ClusterIP, LoadBalancer and NodePort.
 	// "LoadBalancer" means a service will be exposed via an external load balancer (if the cloud provider supports it).
 	// "ClusterIP" means a service will only be accessible inside the cluster, via the cluster IP.
+	// "NodePort" means a service will be exposed on a static Port on all Nodes of the cluster.
 	// +kubebuilder:default:="LoadBalancer"
 	// +optional
 	Type *ServiceType `json:"type,omitempty"`

--- a/charts/gateway-helm/crds/generated/config.gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-helm/crds/generated/config.gateway.envoyproxy.io_envoyproxies.yaml
@@ -709,12 +709,13 @@ spec:
                           type:
                             default: LoadBalancer
                             description: Type determines how the Service is exposed.
-                              Defaults to LoadBalancer. Valid options are ClusterIP
-                              and LoadBalancer. "LoadBalancer" means a service will
-                              be exposed via an external load balancer (if the cloud
-                              provider supports it). "ClusterIP" means a service will
-                              only be accessible inside the cluster, via the cluster
-                              IP.
+                              Defaults to LoadBalancer. Valid options are ClusterIP,
+                              LoadBalancer and NodePort. "LoadBalancer" means a service
+                              will be exposed via an external load balancer (if the
+                              cloud provider supports it). "ClusterIP" means a service
+                              will only be accessible inside the cluster, via the
+                              cluster IP. "NodePort" means a service will be exposed
+                              on a static Port on all Nodes of the cluster.
                             enum:
                             - ClusterIP
                             - LoadBalancer

--- a/docs/latest/api/config_types.md
+++ b/docs/latest/api/config_types.md
@@ -311,7 +311,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `annotations` _object (keys:string, values:string)_ | Annotations that should be appended to the service. By default, no annotations are appended. |
-| `type` _[ServiceType](#servicetype)_ | Type determines how the Service is exposed. Defaults to LoadBalancer. Valid options are ClusterIP and LoadBalancer. "LoadBalancer" means a service will be exposed via an external load balancer (if the cloud provider supports it). "ClusterIP" means a service will only be accessible inside the cluster, via the cluster IP. |
+| `type` _[ServiceType](#servicetype)_ | Type determines how the Service is exposed. Defaults to LoadBalancer. Valid options are ClusterIP, LoadBalancer and NodePort. "LoadBalancer" means a service will be exposed via an external load balancer (if the cloud provider supports it). "ClusterIP" means a service will only be accessible inside the cluster, via the cluster IP. "NodePort" means a service will be exposed on a static Port on all Nodes of the cluster. |
 
 
 ## LogComponent


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing comment for NodePort type service
