### PR TITLE
feat(api): Support custom control plane cert configuration

### DIFF
--- a/api/config/v1alpha1/envoygateway_types.go
+++ b/api/config/v1alpha1/envoygateway_types.go
@@ -42,6 +42,11 @@ type EnvoyGatewaySpec struct {
 	// +optional
 	Provider *EnvoyGatewayProvider `json:"provider,omitempty"`
 
+	// XDSServer defines the desired xds server configuration.
+	//
+	// +optional
+	XDSServer *XDSServer `json:"xdsServer,omitempty"`
+
 	// RateLimit defines the configuration associated with the Rate Limit service
 	// deployed by Envoy Gateway required to implement the Global Rate limiting
 	// functionality. The specific rate limit service used here is the reference
@@ -103,6 +108,14 @@ type EnvoyGatewayKubernetesProvider struct {
 // EnvoyGatewayFileProvider defines configuration for the File provider.
 type EnvoyGatewayFileProvider struct {
 	// TODO: Add config as use cases are better understood.
+}
+
+// XDSServer defines configuration for the xds server.
+type XDSServer struct {
+	// TLSConfig configures the file paths to the tls cert, private key, and ca cert.
+	//
+	// +optional
+	TLSConfig *TLSConfig `json:"tlsConfig,omitempty"`
 }
 
 // RateLimit defines the configuration associated with the Rate Limit Service

--- a/api/config/v1alpha1/envoyproxy_types.go
+++ b/api/config/v1alpha1/envoyproxy_types.go
@@ -93,6 +93,14 @@ type EnvoyProxyKubernetesProvider struct {
 	//
 	// +optional
 	EnvoyService *KubernetesServiceSpec `json:"envoyService,omitempty"`
+
+	// TLSConfigSecret is a reference to the secret containing the TLS certificate,
+	// certificate authority certificate, and private key used to secure Envoy's
+	// client connection to the control plane. Defaults to {Name: "envoy",
+	// Certificate: "tls.crt", PrivateKey: "tls.key", CACertificate: "ca.crt"}.
+	//
+	// +optional
+	TLSConfigSecret *KubernetesTLSConfigSecret `json:"tlsConfigSecret,omitempty"`
 }
 
 // ProxyLogging defines logging parameters for managed proxies. This type is not

--- a/api/config/v1alpha1/shared_types.go
+++ b/api/config/v1alpha1/shared_types.go
@@ -14,6 +14,14 @@ const (
 	DefaultDeploymentCPUResourceRequests = "100m"
 	// DefaultDeploymentMemoryResourceRequests for deployment memory resource
 	DefaultDeploymentMemoryResourceRequests = "512Mi"
+	// DefaultTLSConfigSecretName is the default secret used for the Envoy deployment tls config.
+	DefaultTLSConfigSecretName = "envoy"
+	// DefaultTLSConfigCertificate is the default path used for a TLSConfig certificate.
+	DefaultTLSConfigCertificate = "tls.crt"
+	// DefaultTLSConfigPrivateKey is the default path used for a TLSConfig private key.
+	DefaultTLSConfigPrivateKey = "tls.key"
+	// DefaultTLSConfigCACertificate is the default path used for a TLSConfig CA cert.
+	DefaultTLSConfigCACertificate = "ca.crt"
 	// DefaultEnvoyProxyImage is the default image used by envoyproxy
 	DefaultEnvoyProxyImage = "envoyproxy/envoy-dev:latest"
 	// DefaultRateLimitImage is the default image used by ratelimit.
@@ -101,6 +109,24 @@ type KubernetesContainerSpec struct {
 	//
 	// +optional
 	Image *string `json:"image,omitempty"`
+}
+
+// KubernetesTLSConfigSecret is a reference to a secret containing a TLSConfig.
+type KubernetesTLSConfigSecret struct {
+	// Name is the name of the secret.
+	Name string `json:"name"`
+	// TLSConfig contains the file paths to a certificate, private key, and ca cert.
+	TLSConfig `json:",inline"`
+}
+
+// TLSConfig contains the file paths to a certificate, private key, and ca cert.
+type TLSConfig struct {
+	// Certificate is the path key where the certificate is stored.
+	Certificate string `json:"certificate"`
+	// PrivateKey is the path where the private key is stored.
+	PrivateKey string `json:"privateKey"`
+	// CACertificate is the path where CA certificate is stored.
+	CACertificate string `json:"caCertificate"`
 }
 
 // ServiceType string describes ingress methods for a service


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for user specified certificates. This allows a user to configure kubernetes secrets to use for control plane communication for both envoy-gateway and the envoy proxy deployment.

**Current State:**

I have only included API changes to get some consensus from the community on what this API will look like. Once there is some agreement I will proceed with adding the entire implementation to this PR.

The main piece of configuration proposed here is the `TLSConfig` which allows users to specify the paths to the tls cert, private key, and ca cert.

This is passed to the xds server via a `XDSServer` field added to the `EnvoyGatewaySpec`. This currently only contains a `TLSConfig` but could be extended in the future to expose additional xDS specific configuration.

It also adds a `KubernetesTLSConfigSecret` to the `EnvoyProxyKubernetesProvider` which wraps a `TLSConfig` with a reference to the secret name.

The xds server does not need a reference to the secret name because that will need to be passed in and added to the envoy-gateway deployment through helm.


TODO:
- [ ] Get concensus on API changes
- [ ] Implement API changes
- [ ] Update helm
- [ ] Update docs



**Which issue(s) this PR fixes**:
Fixes #866 
