### PR TITLE
feat: optimize edsClusterConfig for the association between cluster resources and endpoint resources in envoy's configdump?include_eds interface

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -530,6 +530,7 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
+            serviceName: default-backend-rule-0-match-0-www.example.com
             edsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -544,6 +545,7 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
+            serviceName: default-backend-rule-0-match-0-www.grpc-example.com
             edsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -563,6 +565,7 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
+            serviceName: default-eg-tls-passthrough-backend
             edsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -577,6 +580,7 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
+            serviceName: default-eg-tcp-backend
             edsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -591,6 +595,7 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
+            serviceName: default-eg-udp-backend 
             edsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
@@ -91,6 +91,7 @@ xds:
         connectTimeout: 10s
         dnsLookupFamily: V4_ONLY
         edsClusterConfig:
+          serviceName: envoy-gateway-system-backend-rule-0-match-0-www.example.com
           edsConfig:
             ads: {}
             resourceApiVersion: V3

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -264,6 +264,7 @@
                 "connectTimeout": "10s",
                 "dnsLookupFamily": "V4_ONLY",
                 "edsClusterConfig": {
+                  "serviceName": "default-backend-rule-0-match-0-www.example.com",
                   "edsConfig": {
                     "ads": {},
                     "resourceApiVersion": "V3"
@@ -284,6 +285,7 @@
                 "connectTimeout": "10s",
                 "dnsLookupFamily": "V4_ONLY",
                 "edsClusterConfig": {
+                  "serviceName": "default-backend-rule-0-match-0-www.grpc-example.com",
                   "edsConfig": {
                     "ads": {},
                     "resourceApiVersion": "V3"
@@ -312,6 +314,7 @@
                 "connectTimeout": "10s",
                 "dnsLookupFamily": "V4_ONLY",
                 "edsClusterConfig": {
+                  "serviceName": "default-eg-tls-passthrough-backend",
                   "edsConfig": {
                     "ads": {},
                     "resourceApiVersion": "V3"
@@ -332,6 +335,7 @@
                 "connectTimeout": "10s",
                 "dnsLookupFamily": "V4_ONLY",
                 "edsClusterConfig": {
+                  "serviceName": "default-eg-tcp-backend",
                   "edsConfig": {
                     "ads": {},
                     "resourceApiVersion": "V3"
@@ -352,6 +356,7 @@
                 "connectTimeout": "10s",
                 "dnsLookupFamily": "V4_ONLY",
                 "edsClusterConfig": {
+                  "serviceName": "default-eg-udp-backend",
                   "edsConfig": {
                     "ads": {},
                     "resourceApiVersion": "V3"

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -144,6 +144,7 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
+            serviceName: default-backend-rule-0-match-0-www.example.com
             edsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -158,6 +159,7 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
+            serviceName: default-backend-rule-0-match-0-www.grpc-example.com
             edsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -177,6 +179,7 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
+            serviceName: default-eg-tls-passthrough-backend
             edsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -191,6 +194,7 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
+            serviceName: default-eg-tcp-backend
             edsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -205,6 +209,7 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
+            serviceName: default-eg-udp-backend
             edsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
@@ -9,6 +9,7 @@ xds:
         connectTimeout: 10s
         dnsLookupFamily: V4_ONLY
         edsClusterConfig:
+          serviceName: default-backend-rule-0-match-0-www.example.com 
           edsConfig:
             ads: {}
             resourceApiVersion: V3
@@ -23,6 +24,7 @@ xds:
         connectTimeout: 10s
         dnsLookupFamily: V4_ONLY
         edsClusterConfig:
+          serviceName: default-backend-rule-0-match-0-www.grpc-example.com
           edsConfig:
             ads: {}
             resourceApiVersion: V3
@@ -42,6 +44,7 @@ xds:
         connectTimeout: 10s
         dnsLookupFamily: V4_ONLY
         edsClusterConfig:
+          serviceName: default-eg-tls-passthrough-backend
           edsConfig:
             ads: {}
             resourceApiVersion: V3
@@ -56,6 +59,7 @@ xds:
         connectTimeout: 10s
         dnsLookupFamily: V4_ONLY
         edsClusterConfig:
+          serviceName: default-eg-tcp-backend
           edsConfig:
             ads: {}
             resourceApiVersion: V3
@@ -70,6 +74,7 @@ xds:
         connectTimeout: 10s
         dnsLookupFamily: V4_ONLY
         edsClusterConfig:
+          serviceName: default-eg-udp-backend
           edsConfig:
             ads: {}
             resourceApiVersion: V3

--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -47,6 +47,7 @@ func buildXdsCluster(routeName string, tSocket *corev3.TransportSocket, protocol
 	if endpointType == Static {
 		cluster.ClusterDiscoveryType = &clusterv3.Cluster_Type{Type: clusterv3.Cluster_EDS}
 		cluster.EdsClusterConfig = &clusterv3.Cluster_EdsClusterConfig{
+			ServiceName: clusterName,
 			EdsConfig: &corev3.ConfigSource{
 				ResourceApiVersion: resource.DefaultAPIVersion,
 				ConfigSourceSpecifier: &corev3.ConfigSource_Ads{

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route-www.test.com
   name: first-route-www.test.com
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -18,6 +19,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: second-route-www.test.com
   name: second-route-www.test.com
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -59,6 +61,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: "192_168_1_250_8080"
   name: "192_168_1_250_8080"
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -18,6 +19,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: second-route
   name: second-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -18,6 +19,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: second-route
   name: second-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -30,6 +32,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: third-route
   name: third-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -68,6 +71,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: "192_168_1_250_443"
   name: "192_168_1_250_443"
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: direct-route
   name: direct-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: mirror-route
   name: mirror-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -18,6 +19,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: mirror-route-mirror-0
   name: mirror-route-mirror-0
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: redirect-route
   name: redirect-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: regex-route
   name: regex-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: request-header-route
   name: request-header-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: response-header-route
   name: response-header-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: response-header-route
   name: response-header-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: response-header-route
   name: response-header-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: rewrite-route
   name: rewrite-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: rewrite-route
   name: rewrite-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: rewrite-route
   name: rewrite-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: rewrite-route
   name: rewrite-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-stripped-host-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-stripped-host-port.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -18,6 +19,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: second-route
   name: second-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -30,6 +32,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: third-route
   name: third-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -42,6 +45,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: fourth-route
   name: fourth-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -54,6 +58,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: fifth-listener
   name: fifth-listener
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -66,6 +71,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: sixth-listener
   name: sixth-listener
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: tcp-route-simple
   name: tcp-route-simple
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -18,6 +19,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: tcp-route-simple-1
   name: tcp-route-simple-1
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -30,6 +32,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: tcp-route-simple-2
   name: tcp-route-simple-2
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -42,6 +45,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: tcp-route-simple-3
   name: tcp-route-simple-3
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -54,6 +58,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: tcp-route-simple-4
   name: tcp-route-simple-4
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -18,6 +19,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: second-route
   name: second-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -30,6 +32,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: third-route
   name: third-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -18,6 +19,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: second-route
   name: second-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -30,6 +32,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: third-route
   name: third-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -18,6 +19,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: second-route
   name: second-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -30,6 +32,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: third-route
   name: third-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: first-route
   name: first-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: tcp-route-complex
   name: tcp-route-complex
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: tcp-route-simple
   name: tcp-route-simple
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: tcp-route-weighted-backend
   name: tcp-route-weighted-backend
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: tls-passthrough
   name: tls-passthrough
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
@@ -6,6 +6,7 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
+    serviceName: udp-route
   name: udp-route
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768


### PR DESCRIPTION
In the `config_dump?inclueds_eds` interface of the envoy of the gateway, there is no association information between the endpoints resource and the cluster resource, which is inconvenient for us to troubleshoot, as shown in the following figure
![4231c518e0472eea72e2e81658663b40](https://github.com/envoyproxy/gateway/assets/12018633/fb083f0c-4449-4dbe-891f-4871ae468903)
After optimization, the picture is as follows:
![0f54296543a303df65e78bf33f79c080](https://github.com/envoyproxy/gateway/assets/12018633/2a94b2fc-61f0-4a4d-a186-0c41fe867b2b)
