### PR TITLE
chore: use patch for finalizer updates on GC

### DIFF
--- a/charts/gateway-helm/templates/generated/rbac/roles.yaml
+++ b/charts/gateway-helm/templates/generated/rbac/roles.yaml
@@ -58,8 +58,8 @@ rules:
   verbs:
   - get
   - list
-  - update
   - patch
+  - update
   - watch
 - apiGroups:
   - gateway.networking.k8s.io

--- a/charts/gateway-helm/templates/generated/rbac/roles.yaml
+++ b/charts/gateway-helm/templates/generated/rbac/roles.yaml
@@ -59,6 +59,7 @@ rules:
   - get
   - list
   - update
+  - patch
   - watch
 - apiGroups:
   - gateway.networking.k8s.io

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -855,9 +855,9 @@ func (r *gatewayAPIReconciler) removeFinalizer(ctx context.Context, gc *gwapiv1b
 		}
 
 		if slice.ContainsString(gc.Finalizers, gatewayClassFinalizer) {
-			updated := gc.DeepCopy()
-			updated.Finalizers = slice.RemoveString(updated.Finalizers, gatewayClassFinalizer)
-			if err := r.client.Update(ctx, updated); err != nil {
+			base := client.MergeFrom(gc.DeepCopy())
+			gc.Finalizers = slice.RemoveString(gc.Finalizers, gatewayClassFinalizer)
+			if err := r.client.Patch(context.Background(), gc, base); err != nil {
 				return fmt.Errorf("failed to remove finalizer from gatewayclass %s: %w", gc.Name, err)
 			}
 		}
@@ -880,9 +880,9 @@ func (r *gatewayAPIReconciler) addFinalizer(ctx context.Context, gc *gwapiv1b1.G
 		}
 
 		if !slice.ContainsString(gc.Finalizers, gatewayClassFinalizer) {
-			updated := gc.DeepCopy()
-			updated.Finalizers = append(updated.Finalizers, gatewayClassFinalizer)
-			if err := r.client.Update(ctx, updated); err != nil {
+			base := client.MergeFrom(gc.DeepCopy())
+			gc.Finalizers = append(gc.Finalizers, gatewayClassFinalizer)
+			if err := r.client.Patch(context.Background(), gc, base); err != nil {
 				return fmt.Errorf("failed to add finalizer to gatewayclass %s: %w", gc.Name, err)
 			}
 		}

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -845,50 +844,24 @@ func secretGatewayIndexFunc(rawObj client.Object) []string {
 
 // removeFinalizer removes the gatewayclass finalizer from the provided gc, if it exists.
 func (r *gatewayAPIReconciler) removeFinalizer(ctx context.Context, gc *gwapiv1b1.GatewayClass) error {
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		// Get the resource.
-		if err := r.client.Get(ctx, utils.NamespacedName(gc), gc); err != nil {
-			if kerrors.IsNotFound(err) {
-				return nil
-			}
-			return err
+	if slice.ContainsString(gc.Finalizers, gatewayClassFinalizer) {
+		base := client.MergeFrom(gc.DeepCopy())
+		gc.Finalizers = slice.RemoveString(gc.Finalizers, gatewayClassFinalizer)
+		if err := r.client.Patch(ctx, gc, base); err != nil {
+			return fmt.Errorf("failed to remove finalizer from gatewayclass %s: %w", gc.Name, err)
 		}
-
-		if slice.ContainsString(gc.Finalizers, gatewayClassFinalizer) {
-			base := client.MergeFrom(gc.DeepCopy())
-			gc.Finalizers = slice.RemoveString(gc.Finalizers, gatewayClassFinalizer)
-			if err := r.client.Patch(context.Background(), gc, base); err != nil {
-				return fmt.Errorf("failed to remove finalizer from gatewayclass %s: %w", gc.Name, err)
-			}
-		}
-		return nil
-	}); err != nil {
-		return err
 	}
 	return nil
 }
 
 // addFinalizer adds the gatewayclass finalizer to the provided gc, if it doesn't exist.
 func (r *gatewayAPIReconciler) addFinalizer(ctx context.Context, gc *gwapiv1b1.GatewayClass) error {
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		// Get the resource.
-		if err := r.client.Get(ctx, utils.NamespacedName(gc), gc); err != nil {
-			if kerrors.IsNotFound(err) {
-				return nil
-			}
-			return err
+	if !slice.ContainsString(gc.Finalizers, gatewayClassFinalizer) {
+		base := client.MergeFrom(gc.DeepCopy())
+		gc.Finalizers = append(gc.Finalizers, gatewayClassFinalizer)
+		if err := r.client.Patch(ctx, gc, base); err != nil {
+			return fmt.Errorf("failed to add finalizer to gatewayclass %s: %w", gc.Name, err)
 		}
-
-		if !slice.ContainsString(gc.Finalizers, gatewayClassFinalizer) {
-			base := client.MergeFrom(gc.DeepCopy())
-			gc.Finalizers = append(gc.Finalizers, gatewayClassFinalizer)
-			if err := r.client.Patch(context.Background(), gc, base); err != nil {
-				return fmt.Errorf("failed to add finalizer to gatewayclass %s: %w", gc.Name, err)
-			}
-		}
-		return nil
-	}); err != nil {
-		return err
 	}
 	return nil
 }

--- a/internal/provider/kubernetes/rbac.go
+++ b/internal/provider/kubernetes/rbac.go
@@ -6,7 +6,7 @@
 package kubernetes
 
 // RBAC for Gateway API resources.
-// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;grpcroutes;tlsroutes;tcproutes;udproutes;referencepolicies;referencegrants,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;grpcroutes;tlsroutes;tcproutes;udproutes;referencepolicies;referencegrants,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;grpcroutes/status;tlsroutes/status;tcproutes/status;udproutes/status,verbs=update
 
 // RBAC for Envoy Gateway custom resources.


### PR DESCRIPTION
For issue https://github.com/envoyproxy/gateway/issues/1420
in the corresponding failed pipeline: https://github.com/envoyproxy/gateway/actions/runs/4957252173/jobs/8868696936?pr=1407
The error occured when the first Update failed, and was retried later, while trying to remove Finalizer from GatewayClass.
Instead of doing a Get and Update, in loop, this PR updates the logic to use a single Patch call.
