### PR TITLE
ci: try to fix permissions for cherrypick action

### DIFF
--- a/.github/workflows/cherrypick.yaml
+++ b/.github/workflows/cherrypick.yaml
@@ -5,10 +5,6 @@ on:
       - main
     types: ["closed"]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   cherry_pick_release_v0_4:
     runs-on: ubuntu-latest
@@ -30,5 +26,3 @@ jobs:
           # put release manager here
           reviewers: |
             AliceProxy
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
default action permissions:
![image](https://github.com/envoyproxy/gateway/assets/4354057/c26808ac-2760-4f00-962a-49869a2339f9)


cherrypick action permissions:

![image](https://github.com/envoyproxy/gateway/assets/4354057/32c38c3c-08d8-44dd-94c0-4aab0f87d45f)
