### PR TITLE
Discard Status before publishing in provider

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -475,6 +475,9 @@ func (r *gatewayAPIReconciler) processGateways(ctx context.Context, acceptedGC *
 			return err
 		}
 
+		// Discard Status to reduce memory consumption in watchable
+		// It will be recomputed by the gateway-api layer
+		gtw.Status = gwapiv1b1.GatewayStatus{}
 		resourceTree.Gateways = append(resourceTree.Gateways, &gtw)
 	}
 	return nil

--- a/internal/provider/kubernetes/routes.go
+++ b/internal/provider/kubernetes/routes.go
@@ -72,6 +72,9 @@ func (r *gatewayAPIReconciler) processTLSRoutes(ctx context.Context, gatewayName
 		}
 
 		resourceMap.allAssociatedNamespaces[tlsRoute.Namespace] = struct{}{}
+		// Discard Status to reduce memory consumption in watchable
+		// It will be recomputed by the gateway-api layer
+		tlsRoute.Status = gwapiv1a2.TLSRouteStatus{}
 		resourceTree.TLSRoutes = append(resourceTree.TLSRoutes, &tlsRoute)
 	}
 
@@ -147,6 +150,9 @@ func (r *gatewayAPIReconciler) processGRPCRoutes(ctx context.Context, gatewayNam
 		}
 
 		resourceMap.allAssociatedNamespaces[grpcRoute.Namespace] = struct{}{}
+		// Discard Status to reduce memory consumption in watchable
+		// It will be recomputed by the gateway-api layer
+		grpcRoute.Status = gwapiv1a2.GRPCRouteStatus{}
 		resourceTree.GRPCRoutes = append(resourceTree.GRPCRoutes, &grpcRoute)
 	}
 
@@ -348,6 +354,9 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 		}
 
 		resourceMap.allAssociatedNamespaces[httpRoute.Namespace] = struct{}{}
+		// Discard Status to reduce memory consumption in watchable
+		// It will be recomputed by the gateway-api layer
+		httpRoute.Status = gwapiv1b1.HTTPRouteStatus{}
 		resourceTree.HTTPRoutes = append(resourceTree.HTTPRoutes, &httpRoute)
 	}
 
@@ -405,6 +414,9 @@ func (r *gatewayAPIReconciler) processTCPRoutes(ctx context.Context, gatewayName
 		}
 
 		resourceMap.allAssociatedNamespaces[tcpRoute.Namespace] = struct{}{}
+		// Discard Status to reduce memory consumption in watchable
+		// It will be recomputed by the gateway-api layer
+		tcpRoute.Status = gwapiv1a2.TCPRouteStatus{}
 		resourceTree.TCPRoutes = append(resourceTree.TCPRoutes, &tcpRoute)
 	}
 
@@ -462,6 +474,9 @@ func (r *gatewayAPIReconciler) processUDPRoutes(ctx context.Context, gatewayName
 		}
 
 		resourceMap.allAssociatedNamespaces[udpRoute.Namespace] = struct{}{}
+		// Discard Status to reduce memory consumption in watchable
+		// It will be recomputed by the gateway-api layer
+		udpRoute.Status = gwapiv1a2.UDPRouteStatus{}
 		resourceTree.UDPRoutes = append(resourceTree.UDPRoutes, &udpRoute)
 	}
 


### PR DESCRIPTION
* Discard the Status of the Gateway and xRoute resources before saving them in the watchable layer. This reduces the memory consumption within watchable / lesser things to cache. Its safe to discard the status since it is always recomputed by the gateway-api layer, and only written back into the K8s API Server if something, other than the `LastTransitionTime` has changed.

Fixes: https://github.com/envoyproxy/gateway/issues/1370