### PR TITLE
fix: only set gw.Spec.Addresses in gw.Status.Addresses

### DIFF
--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -26,7 +26,7 @@ func UpdateGatewayStatusProgrammedCondition(gw *gwapiv1b1.Gateway, svc *corev1.S
 	var addresses, hostnames []string
 	// Update the status addresses field.
 	if svc != nil {
-		// If the addresses if explictly set in the Gateway spec by the user, use it
+		// If the addresses if explicitly set in the Gateway spec by the user, use it
 		// to populate the Status
 		if len(gw.Spec.Addresses) > 0 {
 			// Make sure the addresses have been populated into ExternalIPs

--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -26,35 +26,43 @@ func UpdateGatewayStatusProgrammedCondition(gw *gwapiv1b1.Gateway, svc *corev1.S
 	var addresses, hostnames []string
 	// Update the status addresses field.
 	if svc != nil {
-		if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
-			for i := range svc.Status.LoadBalancer.Ingress {
-				switch {
-				case len(svc.Status.LoadBalancer.Ingress[i].IP) > 0:
-					addresses = append(addresses, svc.Status.LoadBalancer.Ingress[i].IP)
-				case len(svc.Status.LoadBalancer.Ingress[i].Hostname) > 0:
-					// Remove when the following supports the hostname address type:
-					// https://github.com/kubernetes-sigs/gateway-api/blob/v0.5.0/conformance/utils/kubernetes/helpers.go#L201-L207
-					if svc.Status.LoadBalancer.Ingress[i].Hostname == "localhost" {
-						addresses = append(addresses, "127.0.0.1")
+		// If the addresses if explictly set in the Gateway spec by the user, use it
+		// to populate the Status
+		if len(gw.Spec.Addresses) > 0 {
+			// Make sure the addresses have been populated into ExternalIPs
+			// and use that value
+			if len(svc.Spec.ExternalIPs) > 0 {
+				addresses = append(addresses, svc.Spec.ExternalIPs...)
+			}
+		} else {
+			if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+				for i := range svc.Status.LoadBalancer.Ingress {
+					switch {
+					case len(svc.Status.LoadBalancer.Ingress[i].IP) > 0:
+						addresses = append(addresses, svc.Status.LoadBalancer.Ingress[i].IP)
+					case len(svc.Status.LoadBalancer.Ingress[i].Hostname) > 0:
+						// Remove when the following supports the hostname address type:
+						// https://github.com/kubernetes-sigs/gateway-api/blob/v0.5.0/conformance/utils/kubernetes/helpers.go#L201-L207
+						if svc.Status.LoadBalancer.Ingress[i].Hostname == "localhost" {
+							addresses = append(addresses, "127.0.0.1")
+						}
+						hostnames = append(hostnames, svc.Status.LoadBalancer.Ingress[i].Hostname)
 					}
-					hostnames = append(hostnames, svc.Status.LoadBalancer.Ingress[i].Hostname)
 				}
 			}
-		}
 
-		if svc.Spec.Type == corev1.ServiceTypeClusterIP {
-			for i := range svc.Spec.ClusterIPs {
-				if svc.Spec.ClusterIPs[i] != "" {
-					addresses = append(addresses, svc.Spec.ClusterIPs[i])
+			if svc.Spec.Type == corev1.ServiceTypeClusterIP {
+				for i := range svc.Spec.ClusterIPs {
+					if svc.Spec.ClusterIPs[i] != "" {
+						addresses = append(addresses, svc.Spec.ClusterIPs[i])
+					}
 				}
 			}
-		}
 
-		if svc.Spec.Type == corev1.ServiceTypeNodePort {
-			addresses = nodeAddresses
+			if svc.Spec.Type == corev1.ServiceTypeNodePort {
+				addresses = nodeAddresses
+			}
 		}
-
-		addresses = append(addresses, svc.Spec.ExternalIPs...)
 
 		var gwAddresses []gwapiv1b1.GatewayAddress
 		for i := range addresses {


### PR DESCRIPTION
Dont append, just set/override the gw.Status.Addresses with the values from gw.Spec.Addresses (which eventually get set in svc.Spec.ExternalIPs)

Relates to https://github.com/envoyproxy/gateway/issues/1463

https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.Gateway