### PR TITLE
feat: Support EndpointSlice in Kubernetes Provider

### DIFF
--- a/charts/gateway-helm/templates/generated/rbac/roles.yaml
+++ b/charts/gateway-helm/templates/generated/rbac/roles.yaml
@@ -34,6 +34,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - gateway.envoyproxy.io
   resources:
   - authenticationfilters

--- a/internal/gatewayapi/resource.go
+++ b/internal/gatewayapi/resource.go
@@ -7,6 +7,7 @@ package gatewayapi
 
 import (
 	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -35,6 +36,7 @@ type Resources struct {
 	ReferenceGrants       []*v1alpha2.ReferenceGrant     `json:"referenceGrants,omitempty"`
 	Namespaces            []*v1.Namespace                `json:"namespaces,omitempty"`
 	Services              []*v1.Service                  `json:"services,omitempty"`
+	EndpointSlices        []*discoveryv1.EndpointSlice   `json:"endpointSlices,omitempty"`
 	Secrets               []*v1.Secret                   `json:"secrets,omitempty"`
 	AuthenticationFilters []*egv1a1.AuthenticationFilter `json:"authenticationFilters,omitempty"`
 	RateLimitFilters      []*egv1a1.RateLimitFilter      `json:"rateLimitFilters,omitempty"`
@@ -49,6 +51,7 @@ func NewResources() *Resources {
 		GRPCRoutes:            []*v1alpha2.GRPCRoute{},
 		TLSRoutes:             []*v1alpha2.TLSRoute{},
 		Services:              []*v1.Service{},
+		EndpointSlices:        []*discoveryv1.EndpointSlice{},
 		Secrets:               []*v1.Secret{},
 		ReferenceGrants:       []*v1alpha2.ReferenceGrant{},
 		Namespaces:            []*v1.Namespace{},

--- a/internal/gatewayapi/zz_generated.deepcopy.go
+++ b/internal/gatewayapi/zz_generated.deepcopy.go
@@ -14,6 +14,7 @@ import (
 	configv1alpha1 "github.com/envoyproxy/gateway/api/config/v1alpha1"
 	"github.com/envoyproxy/gateway/api/v1alpha1"
 	"k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -122,6 +123,17 @@ func (in *Resources) DeepCopyInto(out *Resources) {
 			if (*in)[i] != nil {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(v1.Service)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
+	if in.EndpointSlices != nil {
+		in, out := &in.EndpointSlices, &out.EndpointSlices
+		*out = make([]*discoveryv1.EndpointSlice, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(discoveryv1.EndpointSlice)
 				(*in).DeepCopyInto(*out)
 			}
 		}

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -204,6 +205,26 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, request reconcile.
 			resourceTree.Services = append(resourceTree.Services, service)
 			r.log.Info("added Service to resource tree", "namespace", serviceNamespaceName.Namespace,
 				"name", serviceNamespaceName.Name)
+
+			// Retrieve the EndpointSlices associated with the service
+			endpointSliceList := new(discoveryv1.EndpointSliceList)
+			opts := []client.ListOption{
+				client.MatchingLabels(map[string]string{
+					discoveryv1.LabelServiceName: serviceNamespaceName.Name,
+				}),
+				client.InNamespace(serviceNamespaceName.Namespace),
+			}
+			if err := r.client.List(ctx, endpointSliceList, opts...); err != nil {
+				r.log.Error(err, "failed to get EndpointSlices", "namespace", serviceNamespaceName.Namespace,
+					"service", serviceNamespaceName.Name)
+			} else {
+				for i := range endpointSliceList.Items {
+					endpointSlice := endpointSliceList.Items[i]
+					r.log.Info("added EndpointSlice to resource tree", "namespace", endpointSlice.Namespace,
+						"name", endpointSlice.Name)
+					resourceTree.EndpointSlices = append(resourceTree.EndpointSlices, &endpointSlice)
+				}
+			}
 		}
 	}
 
@@ -1127,6 +1148,14 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 		source.Kind(mgr.GetCache(), &corev1.Service{}),
 		&handler.EnqueueRequestForObject{},
 		predicate.NewPredicateFuncs(r.validateServiceForReconcile)); err != nil {
+		return err
+	}
+
+	// Watch EndpointSlice CRUDs and process affected *Route objects.
+	if err := c.Watch(
+		source.Kind(mgr.GetCache(), &discoveryv1.EndpointSlice{}),
+		&handler.EnqueueRequestForObject{},
+		predicate.NewPredicateFuncs(r.validateEndpointSliceForReconcile)); err != nil {
 		return err
 	}
 

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -218,8 +218,8 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, request reconcile.
 				r.log.Error(err, "failed to get EndpointSlices", "namespace", serviceNamespaceName.Namespace,
 					"service", serviceNamespaceName.Name)
 			} else {
-				for i := range endpointSliceList.Items {
-					endpointSlice := endpointSliceList.Items[i]
+				for _, endpointSlice := range endpointSliceList.Items {
+					endpointSlice := endpointSlice
 					r.log.Info("added EndpointSlice to resource tree", "namespace", endpointSlice.Namespace,
 						"name", endpointSlice.Name)
 					resourceTree.EndpointSlices = append(resourceTree.EndpointSlices, &endpointSlice)

--- a/internal/provider/kubernetes/predicates_test.go
+++ b/internal/provider/kubernetes/predicates_test.go
@@ -165,6 +165,64 @@ func TestValidateSecretForReconcile(t *testing.T) {
 	}
 }
 
+// TestValidateEndpointSliceForReconcile tests the validateEndpointSliceForReconcile
+// predicate function.
+func TestValidateEndpointSliceForReconcile(t *testing.T) {
+	sampleGateway := test.GetGateway(types.NamespacedName{Namespace: "default", Name: "scheduled-status-test"}, "test-gc")
+
+	testCases := []struct {
+		name          string
+		configs       []client.Object
+		endpointSlice client.Object
+		expect        bool
+	}{
+		{
+			name: "route service but no routes exist",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", v1alpha1.GatewayControllerName),
+				sampleGateway,
+			},
+			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "service"),
+			expect:        false,
+		},
+		{
+			name: "http route service routes exist",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", v1alpha1.GatewayControllerName),
+				sampleGateway,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}),
+			},
+			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "service"),
+			expect:        true,
+		},
+	}
+
+	// Create the reconciler.
+	logger, err := log.NewLogger()
+	require.NoError(t, err)
+	r := gatewayAPIReconciler{
+		classController: v1alpha1.GatewayControllerName,
+		log:             logger,
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		r.client = fakeclient.NewClientBuilder().
+			WithScheme(envoygateway.GetScheme()).
+			WithObjects(tc.configs...).
+			WithIndex(&gwapiv1b1.HTTPRoute{}, serviceHTTPRouteIndex, serviceHTTPRouteIndexFunc).
+			WithIndex(&gwapiv1a2.GRPCRoute{}, serviceGRPCRouteIndex, serviceGRPCRouteIndexFunc).
+			WithIndex(&gwapiv1a2.TLSRoute{}, serviceTLSRouteIndex, serviceTLSRouteIndexFunc).
+			WithIndex(&gwapiv1a2.TCPRoute{}, serviceTCPRouteIndex, serviceTCPRouteIndexFunc).
+			WithIndex(&gwapiv1a2.UDPRoute{}, serviceUDPRouteIndex, serviceUDPRouteIndexFunc).
+			Build()
+		t.Run(tc.name, func(t *testing.T) {
+			res := r.validateEndpointSliceForReconcile(tc.endpointSlice)
+			require.Equal(t, tc.expect, res)
+		})
+	}
+}
+
 // TestValidateServiceForReconcile tests the validateServiceForReconcile
 // predicate function.
 func TestValidateServiceForReconcile(t *testing.T) {

--- a/internal/provider/kubernetes/predicates_test.go
+++ b/internal/provider/kubernetes/predicates_test.go
@@ -186,6 +186,16 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 			expect:        false,
 		},
 		{
+			name: "http route service routes exist, but endpointslice is associated with another service",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", v1alpha1.GatewayControllerName),
+				sampleGateway,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", types.NamespacedName{Name: "service"}),
+			},
+			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "other-service"),
+			expect:        false,
+		},
+		{
 			name: "http route service routes exist",
 			configs: []client.Object{
 				test.GetGatewayClass("test-gc", v1alpha1.GatewayControllerName),

--- a/internal/provider/kubernetes/rbac.go
+++ b/internal/provider/kubernetes/rbac.go
@@ -16,3 +16,4 @@ package kubernetes
 // RBAC for watched resources of Gateway API controllers.
 // +kubebuilder:rbac:groups="",resources=secrets;services;namespaces;nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch

--- a/internal/provider/kubernetes/test/utils.go
+++ b/internal/provider/kubernetes/test/utils.go
@@ -8,6 +8,7 @@ package test
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -282,6 +283,32 @@ func GetService(nsname types.NamespacedName, labels map[string]string, ports map
 		})
 	}
 	return service
+}
+
+// GetEndpointSlice returns a sample EndpointSlice.
+func GetEndpointSlice(nsName types.NamespacedName, svcName string) *discoveryv1.EndpointSlice {
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nsName.Name,
+			Namespace: nsName.Namespace,
+			Labels:    map[string]string{discoveryv1.LabelServiceName: svcName},
+		},
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses: []string{"10.0.0.1"},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: &[]bool{true}[0],
+				},
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Name:     &[]string{"dummy"}[0],
+				Port:     &[]int32{8080}[0],
+				Protocol: &[]corev1.Protocol{corev1.ProtocolTCP}[0],
+			},
+		},
+	}
 }
 
 // GetAuthenticationFilter returns a pointer to an AuthenticationFilter with the


### PR DESCRIPTION
* Reconcile relavant EndpointSlices associated with a Service that is referenced in a xRoute
* Add the EndpointSlices to the provider message

Relates to https://github.com/envoyproxy/gateway/issues/1256
