### PR TITLE
chore: Cleanup Gateway API Route Destination Logic

### DIFF
--- a/internal/gatewayapi/contexts.go
+++ b/internal/gatewayapi/contexts.go
@@ -157,7 +157,7 @@ type RouteContext interface {
 
 	// GetRouteType returns the Kind of the Route object, HTTPRoute,
 	// TLSRoute, TCPRoute, UDPRoute etc.
-	GetRouteType() string
+	GetRouteType() v1beta1.Kind
 
 	// GetRouteStatus returns the RouteStatus object associated with the Route.
 	GetRouteStatus() *v1beta1.RouteStatus
@@ -188,7 +188,7 @@ type HTTPRouteContext struct {
 	parentRefs map[v1beta1.ParentReference]*RouteParentContext
 }
 
-func (h *HTTPRouteContext) GetRouteType() string {
+func (h *HTTPRouteContext) GetRouteType() v1beta1.Kind {
 	return KindHTTPRoute
 }
 
@@ -265,7 +265,7 @@ type GRPCRouteContext struct {
 	parentRefs map[v1beta1.ParentReference]*RouteParentContext
 }
 
-func (g *GRPCRouteContext) GetRouteType() string {
+func (g *GRPCRouteContext) GetRouteType() v1beta1.Kind {
 	return KindGRPCRoute
 }
 
@@ -352,7 +352,7 @@ type TLSRouteContext struct {
 	parentRefs map[v1beta1.ParentReference]*RouteParentContext
 }
 
-func (t *TLSRouteContext) GetRouteType() string {
+func (t *TLSRouteContext) GetRouteType() v1beta1.Kind {
 	return KindTLSRoute
 }
 
@@ -443,7 +443,7 @@ type UDPRouteContext struct {
 	parentRefs map[v1beta1.ParentReference]*RouteParentContext
 }
 
-func (u *UDPRouteContext) GetRouteType() string {
+func (u *UDPRouteContext) GetRouteType() v1beta1.Kind {
 	return KindUDPRoute
 }
 
@@ -530,7 +530,7 @@ type TCPRouteContext struct {
 	parentRefs map[v1beta1.ParentReference]*RouteParentContext
 }
 
-func (t *TCPRouteContext) GetRouteType() string {
+func (t *TCPRouteContext) GetRouteType() v1beta1.Kind {
 	return KindTCPRoute
 }
 

--- a/internal/gatewayapi/filters.go
+++ b/internal/gatewayapi/filters.go
@@ -821,20 +821,23 @@ func (t *Translator) processRequestMirrorFilter(
 		return
 	}
 
-	mirrorDest, _ := t.processRouteDestination(mirrorBackendRef, filterContext.ParentRef, filterContext.Route, resources)
+	mirrorDests, _ := t.processRouteDestinations(mirrorBackendRef, filterContext.ParentRef, filterContext.Route, resources)
 
-	// If we're already mirroring requests to this backend then there is no need to configure it twice
-	for _, mirror := range filterContext.Mirrors {
-		if mirror != nil {
-			if mirror.Host == mirrorDest.Host &&
-				mirror.Port == mirrorDest.Port {
-				return
+	// Only add missing mirror destinations
+	for _, mirrorDest := range mirrorDests {
+		var found bool
+		for _, mirror := range filterContext.Mirrors {
+			if mirror != nil {
+				if mirror.Host == mirrorDest.Host && mirror.Port == mirrorDest.Port {
+					found = true
+				}
 			}
 		}
+
+		if !found {
+			filterContext.Mirrors = append(filterContext.Mirrors, mirrorDest)
+		}
 	}
-
-	filterContext.Mirrors = append(filterContext.Mirrors, mirrorDest)
-
 }
 
 func (t *Translator) processUnresolvedHTTPFilter(errMsg string, filterContext *HTTPFiltersContext) {

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -1029,7 +1029,7 @@ func (t *Translator) processAllowedListenersForParentRefs(routeContext RouteCont
 		var allowedListeners []*ListenerContext
 		for _, listener := range selectedListeners {
 			acceptedKind := routeContext.GetRouteType()
-			if listener.AllowsKind(v1beta1.RouteGroupKind{Group: GroupPtr(v1beta1.GroupName), Kind: v1beta1.Kind(acceptedKind)}) &&
+			if listener.AllowsKind(v1beta1.RouteGroupKind{Group: GroupPtr(v1beta1.GroupName), Kind: acceptedKind}) &&
 				listener.AllowsNamespace(resources.GetNamespace(routeContext.GetNamespace())) {
 				allowedListeners = append(allowedListeners, listener)
 			}


### PR DESCRIPTION
* Use common `processRouteDestinations` functions for all xRoute

* Precursor to https://github.com/envoyproxy/gateway/issues/1256