### PR TITLE
Update control plane certs only if user opts in

### DIFF
--- a/api/config/v1alpha1/envoygateway_types.go
+++ b/api/config/v1alpha1/envoygateway_types.go
@@ -160,6 +160,8 @@ type EnvoyGatewayKubernetesProvider struct {
 	// should be deployed
 	// +optional
 	Deploy *KubernetesDeployMode `json:"deploy,omitempty"`
+	// OverwriteControlPlaneCerts updates the secrets containing the control plane certs, when set.
+	OverwriteControlPlaneCerts bool `json:"overwrite_control_plane_certs,omitempty"`
 }
 
 // KubernetesWatchMode holds the configuration for which input resources to watch and reconcile.

--- a/docs/latest/api/config_types.md
+++ b/docs/latest/api/config_types.md
@@ -136,6 +136,7 @@ _Appears in:_
 | `rateLimitDeployment` _[KubernetesDeploymentSpec](#kubernetesdeploymentspec)_ | RateLimitDeployment defines the desired state of the Envoy ratelimit deployment resource. If unspecified, default settings for the manged Envoy ratelimit deployment resource are applied. |
 | `watch` _[KubernetesWatchMode](#kuberneteswatchmode)_ | Watch holds configuration of which input resources should be watched and reconciled. |
 | `deploy` _[KubernetesDeployMode](#kubernetesdeploymode)_ | Deploy holds configuration of how output managed resources such as the Envoy Proxy data plane should be deployed |
+| `overwrite_control_plane_certs` _boolean_ | OverwriteControlPlaneCerts updates the secrets containing the control plane certs, when set. |
 
 
 ## EnvoyGatewayLogComponent

--- a/internal/cmd/certgen.go
+++ b/internal/cmd/certgen.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/envoyproxy/gateway/internal/crypto"
 	"github.com/envoyproxy/gateway/internal/envoygateway"
-	"github.com/envoyproxy/gateway/internal/logging"
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/provider/kubernetes"
 )
 
@@ -52,7 +52,7 @@ func certGen() error {
 		return fmt.Errorf("failed to create controller-runtime client: %v", err)
 	}
 
-	if err := outputCerts(ctrl.SetupSignalHandler(), log, cli, certs, cfg.Namespace); err != nil {
+	if err := outputCerts(ctrl.SetupSignalHandler(), cli, cfg, certs); err != nil {
 		return fmt.Errorf("failed to output certificates: %v", err)
 	}
 
@@ -60,8 +60,10 @@ func certGen() error {
 }
 
 // outputCerts outputs the provided certs to a secret in namespace ns.
-func outputCerts(ctx context.Context, log logging.Logger, cli client.Client, certs *crypto.Certificates, ns string) error {
-	secrets, err := kubernetes.CreateOrUpdateSecrets(ctx, cli, kubernetes.CertsToSecret(ns, certs))
+func outputCerts(ctx context.Context, cli client.Client, cfg *config.Server, certs *crypto.Certificates) error {
+	secrets, err := kubernetes.CreateOrUpdateSecrets(ctx, cli, cfg, kubernetes.CertsToSecret(cfg.Namespace, certs))
+	log := cfg.Logger
+
 	if err != nil {
 		return fmt.Errorf("failed to create or update secrets: %v", err)
 	}

--- a/internal/infrastructure/kubernetes/ratelimit_infra_test.go
+++ b/internal/infrastructure/kubernetes/ratelimit_infra_test.go
@@ -15,12 +15,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/infrastructure/kubernetes/ratelimit"
 	"github.com/envoyproxy/gateway/internal/provider/kubernetes"
 )
 
 func createRateLimitTLSSecret(t *testing.T, client client.Client) {
-	_, secretErr := kubernetes.CreateOrUpdateSecrets(context.Background(), client, []corev1.Secret{
+	cfg, err := config.New()
+	require.NoError(t, err)
+	_, secretErr := kubernetes.CreateOrUpdateSecrets(context.Background(), client, cfg, []corev1.Secret{
 		{
 			Type: corev1.SecretTypeTLS,
 			TypeMeta: metav1.TypeMeta{

--- a/internal/infrastructure/kubernetes/ratelimit_infra_test.go
+++ b/internal/infrastructure/kubernetes/ratelimit_infra_test.go
@@ -15,15 +15,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/infrastructure/kubernetes/ratelimit"
 	"github.com/envoyproxy/gateway/internal/provider/kubernetes"
 )
 
 func createRateLimitTLSSecret(t *testing.T, client client.Client) {
-	cfg, err := config.New()
-	require.NoError(t, err)
-	_, secretErr := kubernetes.CreateOrUpdateSecrets(context.Background(), client, cfg, []corev1.Secret{
+	_, secretErr := kubernetes.CreateOrUpdateSecrets(context.Background(), client, []corev1.Secret{
 		{
 			Type: corev1.SecretTypeTLS,
 			TypeMeta: metav1.TypeMeta{
@@ -38,7 +35,7 @@ func createRateLimitTLSSecret(t *testing.T, client client.Client) {
 				},
 			},
 		},
-	})
+	}, false)
 	require.NoError(t, secretErr)
 }
 

--- a/internal/provider/kubernetes/secrets.go
+++ b/internal/provider/kubernetes/secrets.go
@@ -7,6 +7,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -17,7 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/envoyproxy/gateway/internal/crypto"
-	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+)
+
+var (
+	ErrSecretExists = errors.New("skipped creating secret since it already exists")
 )
 
 // caCertificateKey is the key name for accessing TLS CA certificate bundles
@@ -68,8 +72,7 @@ func CertsToSecret(namespace string, certs *crypto.Certificates) []corev1.Secret
 
 // CreateOrUpdateSecrets creates the provided secrets if they don't exist or updates
 // them if they do.
-func CreateOrUpdateSecrets(ctx context.Context, client client.Client, cfg *config.Server, secrets []corev1.Secret) ([]corev1.Secret, error) {
-	log := cfg.Logger
+func CreateOrUpdateSecrets(ctx context.Context, client client.Client, secrets []corev1.Secret, update bool) ([]corev1.Secret, error) {
 	var tidySecrets []corev1.Secret
 	for i := range secrets {
 		secret := secrets[i]
@@ -87,19 +90,14 @@ func CreateOrUpdateSecrets(ctx context.Context, client client.Client, cfg *confi
 			} else {
 				return nil, fmt.Errorf("failed to get secret %s/%s: %w", secret.Namespace, secret.Name, err)
 			}
-			// Update if current value is different and overwrite is set.
+			// Update if current value is different and update arg is set.
 		} else {
-			if cfg.EnvoyGateway == nil ||
-				cfg.EnvoyGateway.Provider == nil ||
-				cfg.EnvoyGateway.Provider.Kubernetes == nil ||
-				!cfg.EnvoyGateway.Provider.Kubernetes.OverwriteControlPlaneCerts {
-				log.Info("skipped creating secret, since it already exists. "+
+			if !update {
+				return nil, fmt.Errorf("%s/%s: %w;"+
 					"Either update it manually or set overwriteControlPlaneCerts "+
-					"in the EnvoyGateway config", "namespace", secret.Namespace, "name", secret.Name)
-				return nil, nil
+					"in the EnvoyGateway config", secret.Namespace, secret.Name, ErrSecretExists)
 			}
 
-			// Update if current value is different and overwrite is set.
 			if !reflect.DeepEqual(secret.Data, current.Data) {
 				if err := client.Update(ctx, &secret); err != nil {
 					return nil, fmt.Errorf("failed to update secret %s/%s: %w", secret.Namespace, secret.Name, err)

--- a/internal/provider/kubernetes/secrets.go
+++ b/internal/provider/kubernetes/secrets.go
@@ -87,8 +87,6 @@ func CreateOrUpdateSecrets(ctx context.Context, client client.Client, secrets []
 				if err := client.Create(ctx, &secret); err != nil {
 					return nil, fmt.Errorf("failed to create secret %s/%s: %w", secret.Namespace, secret.Name, err)
 				}
-			} else {
-				return nil, fmt.Errorf("failed to get secret %s/%s: %w", secret.Namespace, secret.Name, err)
 			}
 			// Update if current value is different and update arg is set.
 		} else {


### PR DESCRIPTION
* Make sure certgen does not update the control plane cert secrets if they already exist. This ensures that if a user creates certs as part of https://github.com/envoyproxy/gateway/issues/866 they are not overriden by certgen.

* If `overwriteControlPlaneCerts` is set in the `EnvoyGateway` config, certgen can be used to update the secrets with newer certs

Fixes: https://github.com/envoyproxy/gateway/issues/1471