### PR TITLE
feat: support deployment strategy settings.

### DIFF
--- a/api/config/v1alpha1/helpers.go
+++ b/api/config/v1alpha1/helpers.go
@@ -6,6 +6,7 @@
 package v1alpha1
 
 import (
+	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -152,6 +153,13 @@ func DefaultKubernetesDeploymentReplicas() *int32 {
 	return &repl
 }
 
+// DefaultKubernetesDeploymentStrategy returns the default deployment strategy settings.
+func DefaultKubernetesDeploymentStrategy() *appv1.DeploymentStrategy {
+	return &appv1.DeploymentStrategy{
+		Type: appv1.RollingUpdateDeploymentStrategyType,
+	}
+}
+
 // DefaultKubernetesContainerImage returns the default envoyproxy image.
 func DefaultKubernetesContainerImage(image string) *string {
 	return pointer.String(image)
@@ -161,6 +169,7 @@ func DefaultKubernetesContainerImage(image string) *string {
 func DefaultKubernetesDeployment(image string) *KubernetesDeploymentSpec {
 	return &KubernetesDeploymentSpec{
 		Replicas:  DefaultKubernetesDeploymentReplicas(),
+		Strategy:  DefaultKubernetesDeploymentStrategy(),
 		Pod:       DefaultKubernetesPod(),
 		Container: DefaultKubernetesContainer(image),
 	}
@@ -223,25 +232,7 @@ func (r *EnvoyProxyProvider) GetEnvoyProxyKubeProvider() *EnvoyProxyKubernetesPr
 		r.Kubernetes.EnvoyDeployment = DefaultKubernetesDeployment(DefaultEnvoyProxyImage)
 	}
 
-	if r.Kubernetes.EnvoyDeployment.Replicas == nil {
-		r.Kubernetes.EnvoyDeployment.Replicas = DefaultKubernetesDeploymentReplicas()
-	}
-
-	if r.Kubernetes.EnvoyDeployment.Pod == nil {
-		r.Kubernetes.EnvoyDeployment.Pod = DefaultKubernetesPod()
-	}
-
-	if r.Kubernetes.EnvoyDeployment.Container == nil {
-		r.Kubernetes.EnvoyDeployment.Container = DefaultKubernetesContainer(DefaultEnvoyProxyImage)
-	}
-
-	if r.Kubernetes.EnvoyDeployment.Container.Resources == nil {
-		r.Kubernetes.EnvoyDeployment.Container.Resources = DefaultResourceRequirements()
-	}
-
-	if r.Kubernetes.EnvoyDeployment.Container.Image == nil {
-		r.Kubernetes.EnvoyDeployment.Container.Image = DefaultKubernetesContainerImage(DefaultEnvoyProxyImage)
-	}
+	r.Kubernetes.EnvoyDeployment.defaultKubernetesDeploymentSpec(DefaultEnvoyProxyImage)
 
 	if r.Kubernetes.EnvoyService == nil {
 		r.Kubernetes.EnvoyService = DefaultKubernetesService()
@@ -271,27 +262,36 @@ func (r *EnvoyGatewayProvider) GetEnvoyGatewayKubeProvider() *EnvoyGatewayKubern
 		r.Kubernetes.RateLimitDeployment = DefaultKubernetesDeployment(DefaultRateLimitImage)
 	}
 
-	if r.Kubernetes.RateLimitDeployment.Replicas == nil {
-		r.Kubernetes.RateLimitDeployment.Replicas = DefaultKubernetesDeploymentReplicas()
-	}
-
-	if r.Kubernetes.RateLimitDeployment.Pod == nil {
-		r.Kubernetes.RateLimitDeployment.Pod = DefaultKubernetesPod()
-	}
-
-	if r.Kubernetes.RateLimitDeployment.Container == nil {
-		r.Kubernetes.RateLimitDeployment.Container = DefaultKubernetesContainer(DefaultRateLimitImage)
-	}
-
-	if r.Kubernetes.RateLimitDeployment.Container.Resources == nil {
-		r.Kubernetes.RateLimitDeployment.Container.Resources = DefaultResourceRequirements()
-	}
-
-	if r.Kubernetes.RateLimitDeployment.Container.Image == nil {
-		r.Kubernetes.RateLimitDeployment.Container.Image = DefaultKubernetesContainerImage(DefaultRateLimitImage)
-	}
+	r.Kubernetes.RateLimitDeployment.defaultKubernetesDeploymentSpec(DefaultRateLimitImage)
 
 	return r.Kubernetes
+}
+
+// defaultKubernetesDeploymentSpec fill a default KubernetesDeploymentSpec if unspecified.
+func (deployment *KubernetesDeploymentSpec) defaultKubernetesDeploymentSpec(image string) {
+	if deployment.Replicas == nil {
+		deployment.Replicas = DefaultKubernetesDeploymentReplicas()
+	}
+
+	if deployment.Strategy == nil {
+		deployment.Strategy = DefaultKubernetesDeploymentStrategy()
+	}
+
+	if deployment.Pod == nil {
+		deployment.Pod = DefaultKubernetesPod()
+	}
+
+	if deployment.Container == nil {
+		deployment.Container = DefaultKubernetesContainer(image)
+	}
+
+	if deployment.Container.Resources == nil {
+		deployment.Container.Resources = DefaultResourceRequirements()
+	}
+
+	if deployment.Container.Image == nil {
+		deployment.Container.Image = DefaultKubernetesContainerImage(image)
+	}
 }
 
 // DefaultEnvoyGatewayAdmin returns a new EnvoyGatewayAdmin with default configuration parameters.

--- a/api/config/v1alpha1/shared_types.go
+++ b/api/config/v1alpha1/shared_types.go
@@ -5,7 +5,10 @@
 
 package v1alpha1
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
 
 const (
 	// DefaultDeploymentReplicas is the default number of deployment replicas.
@@ -48,6 +51,11 @@ type KubernetesDeploymentSpec struct {
 	//
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
+
+	// The deployment strategy to use to replace existing pods with new ones.
+	// +optional
+	// +patchStrategy=retainKeys
+	Strategy *appv1.DeploymentStrategy `json:"strategy,omitempty" patchStrategy:"retainKeys"`
 
 	// Pod defines the desired annotations and securityContext of container.
 	//

--- a/api/config/v1alpha1/zz_generated.deepcopy.go
+++ b/api/config/v1alpha1/zz_generated.deepcopy.go
@@ -11,7 +11,8 @@
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	"k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -572,19 +573,19 @@ func (in *KubernetesContainerSpec) DeepCopyInto(out *KubernetesContainerSpec) {
 	*out = *in
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
-		*out = make([]v1.EnvVar, len(*in))
+		*out = make([]corev1.EnvVar, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
-		*out = new(v1.ResourceRequirements)
+		*out = new(corev1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
-		*out = new(v1.SecurityContext)
+		*out = new(corev1.SecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Image != nil {
@@ -594,7 +595,7 @@ func (in *KubernetesContainerSpec) DeepCopyInto(out *KubernetesContainerSpec) {
 	}
 	if in.VolumeMounts != nil {
 		in, out := &in.VolumeMounts, &out.VolumeMounts
-		*out = make([]v1.VolumeMount, len(*in))
+		*out = make([]corev1.VolumeMount, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -634,6 +635,11 @@ func (in *KubernetesDeploymentSpec) DeepCopyInto(out *KubernetesDeploymentSpec) 
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Strategy != nil {
+		in, out := &in.Strategy, &out.Strategy
+		*out = new(v1.DeploymentStrategy)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Pod != nil {
 		in, out := &in.Pod, &out.Pod
 		*out = new(KubernetesPodSpec)
@@ -668,24 +674,24 @@ func (in *KubernetesPodSpec) DeepCopyInto(out *KubernetesPodSpec) {
 	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
-		*out = new(v1.PodSecurityContext)
+		*out = new(corev1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Affinity != nil {
 		in, out := &in.Affinity, &out.Affinity
-		*out = new(v1.Affinity)
+		*out = new(corev1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
-		*out = make([]v1.Toleration, len(*in))
+		*out = make([]corev1.Toleration, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
-		*out = make([]v1.Volume, len(*in))
+		*out = make([]corev1.Volume, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/charts/gateway-helm/crds/generated/config.gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-helm/crds/generated/config.gateway.envoyproxy.io_envoyproxies.yaml
@@ -3713,6 +3713,61 @@ spec:
                               to 1.
                             format: int32
                             type: integer
+                          strategy:
+                            description: The deployment strategy to use to replace
+                              existing pods with new ones.
+                            properties:
+                              rollingUpdate:
+                                description: 'Rolling update config params. Present
+                                  only if DeploymentStrategyType = RollingUpdate.
+                                  --- TODO: Update this to follow our convention for
+                                  oneOf, whatever we decide it to be.'
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'The maximum number of pods that
+                                      can be scheduled above the desired number of
+                                      pods. Value can be an absolute number (ex: 5)
+                                      or a percentage of desired pods (ex: 10%). This
+                                      can not be 0 if MaxUnavailable is 0. Absolute
+                                      number is calculated from percentage by rounding
+                                      up. Defaults to 25%. Example: when this is set
+                                      to 30%, the new ReplicaSet can be scaled up
+                                      immediately when the rolling update starts,
+                                      such that the total number of old and new pods
+                                      do not exceed 130% of desired pods. Once old
+                                      pods have been killed, new ReplicaSet can be
+                                      scaled up further, ensuring that total number
+                                      of pods running at any time during the update
+                                      is at most 130% of desired pods.'
+                                    x-kubernetes-int-or-string: true
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'The maximum number of pods that
+                                      can be unavailable during the update. Value
+                                      can be an absolute number (ex: 5) or a percentage
+                                      of desired pods (ex: 10%). Absolute number is
+                                      calculated from percentage by rounding down.
+                                      This can not be 0 if MaxSurge is 0. Defaults
+                                      to 25%. Example: when this is set to 30%, the
+                                      old ReplicaSet can be scaled down to 70% of
+                                      desired pods immediately when the rolling update
+                                      starts. Once new pods are ready, old ReplicaSet
+                                      can be scaled down further, followed by scaling
+                                      up the new ReplicaSet, ensuring that the total
+                                      number of pods available at all times during
+                                      the update is at least 70% of desired pods.'
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                description: Type of deployment. Can be "Recreate"
+                                  or "RollingUpdate". Default is RollingUpdate.
+                                type: string
+                            type: object
                         type: object
                       envoyService:
                         description: EnvoyService defines the desired state of the

--- a/docs/latest/api/config_types.md
+++ b/docs/latest/api/config_types.md
@@ -440,6 +440,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `replicas` _integer_ | Replicas is the number of desired pods. Defaults to 1. |
+| `strategy` _[DeploymentStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#deploymentstrategy-v1-apps)_ | The deployment strategy to use to replace existing pods with new ones. |
 | `pod` _[KubernetesPodSpec](#kubernetespodspec)_ | Pod defines the desired annotations and securityContext of container. |
 | `container` _[KubernetesContainerSpec](#kubernetescontainerspec)_ | Container defines the resources and securityContext of container. |
 

--- a/internal/envoygateway/config/decoder_test.go
+++ b/internal/envoygateway/config/decoder_test.go
@@ -136,6 +136,7 @@ func TestDecode(t *testing.T) {
 						Kubernetes: &v1alpha1.EnvoyGatewayKubernetesProvider{
 							RateLimitDeployment: &v1alpha1.KubernetesDeploymentSpec{
 								Replicas: v1alpha1.DefaultKubernetesDeploymentReplicas(),
+								Strategy: v1alpha1.DefaultKubernetesDeploymentStrategy(),
 								Container: &v1alpha1.KubernetesContainerSpec{
 									Env: []corev1.EnvVar{
 										{

--- a/internal/envoygateway/config/testdata/decoder/in/gateway-ratelimit.yaml
+++ b/internal/envoygateway/config/testdata/decoder/in/gateway-ratelimit.yaml
@@ -7,6 +7,8 @@ provider:
   kubernetes:
     rateLimitDeployment:
       replicas: 1
+      strategy:
+        type: RollingUpdate
       container:
         env:
         - name: env_a

--- a/internal/infrastructure/kubernetes/proxy/resource_provider.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider.go
@@ -182,6 +182,7 @@ func (r *ResourceRender) Deployment() (*appsv1.Deployment, error) {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: deploymentConfig.Replicas,
+			Strategy: *deploymentConfig.Strategy,
 			Selector: selector,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
@@ -78,6 +78,7 @@ func TestDeployment(t *testing.T) {
 			infra:    newTestInfra(),
 			deploy: &egcfgv1a1.KubernetesDeploymentSpec{
 				Replicas: pointer.Int32(2),
+				Strategy: egcfgv1a1.DefaultKubernetesDeploymentStrategy(),
 				Pod: &egcfgv1a1.KubernetesPodSpec{
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",
@@ -115,6 +116,7 @@ func TestDeployment(t *testing.T) {
 			infra:    newTestInfra(),
 			deploy: &egcfgv1a1.KubernetesDeploymentSpec{
 				Replicas: pointer.Int32(2),
+				Strategy: egcfgv1a1.DefaultKubernetesDeploymentStrategy(),
 				Pod: &egcfgv1a1.KubernetesPodSpec{
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",
@@ -156,6 +158,7 @@ func TestDeployment(t *testing.T) {
 			infra:    newTestInfra(),
 			deploy: &egcfgv1a1.KubernetesDeploymentSpec{
 				Replicas: pointer.Int32(2),
+				Strategy: egcfgv1a1.DefaultKubernetesDeploymentStrategy(),
 				Pod: &egcfgv1a1.KubernetesPodSpec{
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",
@@ -188,6 +191,7 @@ func TestDeployment(t *testing.T) {
 			infra:    newTestInfra(),
 			deploy: &egcfgv1a1.KubernetesDeploymentSpec{
 				Replicas: pointer.Int32(2),
+				Strategy: egcfgv1a1.DefaultKubernetesDeploymentStrategy(),
 				Pod: &egcfgv1a1.KubernetesPodSpec{
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy

--- a/internal/infrastructure/kubernetes/ratelimit/resource_provider.go
+++ b/internal/infrastructure/kubernetes/ratelimit/resource_provider.go
@@ -112,6 +112,7 @@ func (r *ResourceRender) Deployment() (*appsv1.Deployment, error) {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: r.rateLimitDeployment.Replicas,
+			Strategy: *r.rateLimitDeployment.Strategy,
 			Selector: selector,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/infrastructure/kubernetes/ratelimit/resource_provider_test.go
+++ b/internal/infrastructure/kubernetes/ratelimit/resource_provider_test.go
@@ -144,6 +144,7 @@ func TestDeployment(t *testing.T) {
 			rateLimit: rateLimit,
 			deploy: &egcfgv1a1.KubernetesDeploymentSpec{
 				Replicas: pointer.Int32(2),
+				Strategy: egcfgv1a1.DefaultKubernetesDeploymentStrategy(),
 				Pod: &egcfgv1a1.KubernetesPodSpec{
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",
@@ -175,6 +176,7 @@ func TestDeployment(t *testing.T) {
 			rateLimit: rateLimit,
 			deploy: &egcfgv1a1.KubernetesDeploymentSpec{
 				Replicas: pointer.Int32(2),
+				Strategy: egcfgv1a1.DefaultKubernetesDeploymentStrategy(),
 				Pod: &egcfgv1a1.KubernetesPodSpec{
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",
@@ -216,6 +218,7 @@ func TestDeployment(t *testing.T) {
 			rateLimit: rateLimit,
 			deploy: &egcfgv1a1.KubernetesDeploymentSpec{
 				Replicas: pointer.Int32(2),
+				Strategy: egcfgv1a1.DefaultKubernetesDeploymentStrategy(),
 				Pod: &egcfgv1a1.KubernetesPodSpec{
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",
@@ -248,6 +251,7 @@ func TestDeployment(t *testing.T) {
 			rateLimit: rateLimit,
 			deploy: &egcfgv1a1.KubernetesDeploymentSpec{
 				Replicas: pointer.Int32(2),
+				Strategy: egcfgv1a1.DefaultKubernetesDeploymentStrategy(),
 				Pod: &egcfgv1a1.KubernetesPodSpec{
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",
@@ -297,6 +301,7 @@ func TestDeployment(t *testing.T) {
 			},
 			deploy: &egcfgv1a1.KubernetesDeploymentSpec{
 				Replicas: pointer.Int32(2),
+				Strategy: egcfgv1a1.DefaultKubernetesDeploymentStrategy(),
 				Pod: &egcfgv1a1.KubernetesPodSpec{
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",
@@ -350,6 +355,7 @@ func TestDeployment(t *testing.T) {
 			},
 			deploy: &egcfgv1a1.KubernetesDeploymentSpec{
 				Replicas: pointer.Int32(2),
+				Strategy: egcfgv1a1.DefaultKubernetesDeploymentStrategy(),
 				Pod: &egcfgv1a1.KubernetesPodSpec{
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",
@@ -411,6 +417,7 @@ func TestDeployment(t *testing.T) {
 			},
 			deploy: &egcfgv1a1.KubernetesDeploymentSpec{
 				Replicas: pointer.Int32(2),
+				Strategy: egcfgv1a1.DefaultKubernetesDeploymentStrategy(),
 				Pod: &egcfgv1a1.KubernetesPodSpec{
 					Annotations: map[string]string{
 						"prometheus.io/scrape": "true",

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/affinity.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/affinity.yaml
@@ -9,6 +9,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy-ratelimit

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/custom.yaml
@@ -9,6 +9,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy-ratelimit

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default-env.yaml
@@ -9,6 +9,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy-ratelimit

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
@@ -9,6 +9,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy-ratelimit

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/extension-env.yaml
@@ -9,6 +9,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy-ratelimit

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/override-env.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/override-env.yaml
@@ -9,6 +9,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy-ratelimit

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/redis-tls-settings.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/redis-tls-settings.yaml
@@ -9,6 +9,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy-ratelimit

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/tolerations.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/tolerations.yaml
@@ -9,6 +9,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy-ratelimit

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/volumes.yaml
@@ -9,6 +9,8 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: envoy-ratelimit

--- a/internal/infrastructure/kubernetes/resource/resource.go
+++ b/internal/infrastructure/kubernetes/resource/resource.go
@@ -34,6 +34,10 @@ func ExpectedServiceSpec(serviceType *egcfgv1a1.ServiceType) corev1.ServiceSpec 
 	return serviceSpec
 }
 
+func ExpectedDeploymentStrategy() {
+
+}
+
 // CompareSvc compare entire Svc.Spec but ignored the ports[*].nodePort, ClusterIP and ClusterIPs in case user have modified for some scene.
 func CompareSvc(currentSvc, originalSvc *corev1.Service) bool {
 	return cmp.Equal(currentSvc.Spec, originalSvc.Spec,

--- a/internal/infrastructure/kubernetes/resource/resource.go
+++ b/internal/infrastructure/kubernetes/resource/resource.go
@@ -34,10 +34,6 @@ func ExpectedServiceSpec(serviceType *egcfgv1a1.ServiceType) corev1.ServiceSpec 
 	return serviceSpec
 }
 
-func ExpectedDeploymentStrategy() {
-
-}
-
 // CompareSvc compare entire Svc.Spec but ignored the ports[*].nodePort, ClusterIP and ClusterIPs in case user have modified for some scene.
 func CompareSvc(currentSvc, originalSvc *corev1.Service) bool {
 	return cmp.Equal(currentSvc.Spec, originalSvc.Spec,


### PR DESCRIPTION
Fixes #1520 


For more others settings, users can use the deployment patch yaml set them. like follows

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/name: envoy
    app.kubernetes.io/component: proxy
    app.kubernetes.io/managed-by: envoy-gateway
    gateway.envoyproxy.io/owning-gateway-name: default
    gateway.envoyproxy.io/owning-gateway-namespace: default
  name: envoy-default-eg-63636f73
  namespace: envoy-gateway-system
spec:
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 50%
      maxUnavailable: 70%
```