### PR TITLE
Set ALPN values in xds Listener

### DIFF
--- a/internal/cmd/egctl/testdata/translate/in/default-resources.yaml
+++ b/internal/cmd/egctl/testdata/translate/in/default-resources.yaml
@@ -145,7 +145,7 @@ metadata:
     app: backend
     service: backend
 spec:
-  clusterIP: "127.0.0.1"
+  clusterIP: "1.1.1.1"
   type: ClusterIP
   ports:
     - name: http
@@ -154,3 +154,21 @@ spec:
       targetPort: 9000
   selector:
     app: backend
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: endpointslice-providedBackend
+  namespace: default
+  labels:
+    kubernetes.io/service-name: providedBackend 
+addressType: IPv4
+ports:
+  - name: http
+    protocol: TCP
+    port: 9000
+endpoints:
+  - addresses:
+      - "127.0.0.1"
+    conditions:
+      ready: true

--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -73,6 +73,7 @@ envoyProxy:
               ads: {}
             name: runtime-0
     logging: {}
+    telemetry: {}
   status: {}
 gatewayClass:
   metadata:
@@ -88,7 +89,7 @@ gatewayClass:
       namespace: envoy-gateway-system
   status:
     conditions:
-    - lastTransitionTime: "2023-04-23T13:09:06Z"
+    - lastTransitionTime: "2023-06-14T22:53:49Z"
       message: Valid GatewayClass
       reason: Accepted
       status: "True"
@@ -131,12 +132,12 @@ gateways:
     listeners:
     - attachedRoutes: 1
       conditions:
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Sending translated listener configuration to the data plane
         reason: Programmed
         status: "True"
         type: Programmed
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Listener has been successfully translated
         reason: Accepted
         status: "True"
@@ -147,12 +148,12 @@ gateways:
         kind: TCPRoute
     - attachedRoutes: 1
       conditions:
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Sending translated listener configuration to the data plane
         reason: Programmed
         status: "True"
         type: Programmed
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Listener has been successfully translated
         reason: Accepted
         status: "True"
@@ -163,12 +164,12 @@ gateways:
         kind: UDPRoute
     - attachedRoutes: 1
       conditions:
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Sending translated listener configuration to the data plane
         reason: Programmed
         status: "True"
         type: Programmed
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Listener has been successfully translated
         reason: Accepted
         status: "True"
@@ -179,12 +180,12 @@ gateways:
         kind: TLSRoute
     - attachedRoutes: 1
       conditions:
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Sending translated listener configuration to the data plane
         reason: Programmed
         status: "True"
         type: Programmed
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Listener has been successfully translated
         reason: Accepted
         status: "True"
@@ -195,12 +196,12 @@ gateways:
         kind: HTTPRoute
     - attachedRoutes: 1
       conditions:
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Sending translated listener configuration to the data plane
         reason: Programmed
         status: "True"
         type: Programmed
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Listener has been successfully translated
         reason: Accepted
         status: "True"
@@ -234,12 +235,12 @@ grpcRoutes:
   status:
     parents:
     - conditions:
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Route is accepted
         reason: Accepted
         status: "True"
         type: Accepted
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Resolved all the Object references for the Route
         reason: ResolvedRefs
         status: "True"
@@ -272,12 +273,12 @@ httpRoutes:
   status:
     parents:
     - conditions:
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Route is accepted
         reason: Accepted
         status: "True"
         type: Accepted
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Resolved all the Object references for the Route
         reason: ResolvedRefs
         status: "True"
@@ -304,12 +305,12 @@ tcpRoutes:
   status:
     parents:
     - conditions:
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Route is accepted
         reason: Accepted
         status: "True"
         type: Accepted
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Resolved all the Object references for the Route
         reason: ResolvedRefs
         status: "True"
@@ -337,12 +338,12 @@ tlsRoutes:
   status:
     parents:
     - conditions:
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Route is accepted
         reason: Accepted
         status: "True"
         type: Accepted
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Resolved all the Object references for the Route
         reason: ResolvedRefs
         status: "True"
@@ -370,12 +371,12 @@ udpRoutes:
   status:
     parents:
     - conditions:
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Route is accepted
         reason: Accepted
         status: "True"
         type: Accepted
-      - lastTransitionTime: "2023-04-23T13:09:06Z"
+      - lastTransitionTime: "2023-06-14T22:53:49Z"
         message: Resolved all the Object references for the Route
         reason: ResolvedRefs
         status: "True"
@@ -466,7 +467,7 @@ xds:
             - endpoint:
                 address:
                   socketAddress:
-                    address: 127.0.0.1
+                    address: 1.1.1.1
                     portValue: 8000
               loadBalancingWeight: 1
             loadBalancingWeight: 1
@@ -479,7 +480,7 @@ xds:
             - endpoint:
                 address:
                   socketAddress:
-                    address: 127.0.0.1
+                    address: 1.1.1.1
                     portValue: 9000
               loadBalancingWeight: 1
             loadBalancingWeight: 1
@@ -530,10 +531,10 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
-            serviceName: default-backend-rule-0-match-0-www.example.com
             edsConfig:
               ads: {}
               resourceApiVersion: V3
+            serviceName: default-backend-rule-0-match-0-www.example.com
           name: default-backend-rule-0-match-0-www.example.com
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
@@ -545,10 +546,10 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
-            serviceName: default-backend-rule-0-match-0-www.grpc-example.com
             edsConfig:
               ads: {}
               resourceApiVersion: V3
+            serviceName: default-backend-rule-0-match-0-www.grpc-example.com
           name: default-backend-rule-0-match-0-www.grpc-example.com
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
@@ -565,10 +566,10 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
-            serviceName: default-eg-tls-passthrough-backend
             edsConfig:
               ads: {}
               resourceApiVersion: V3
+            serviceName: default-eg-tls-passthrough-backend
           name: default-eg-tls-passthrough-backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
@@ -580,10 +581,10 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
-            serviceName: default-eg-tcp-backend
             edsConfig:
               ads: {}
               resourceApiVersion: V3
+            serviceName: default-eg-tcp-backend
           name: default-eg-tcp-backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
@@ -595,10 +596,10 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
-            serviceName: default-eg-udp-backend 
             edsConfig:
               ads: {}
               resourceApiVersion: V3
+            serviceName: default-eg-udp-backend
           name: default-eg-udp-backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
@@ -641,10 +642,17 @@ xds:
                       path: /dev/stdout
                   commonHttpProtocolOptions:
                     headersWithUnderscoresAction: REJECT_REQUEST
+                  http2ProtocolOptions:
+                    initialConnectionWindowSize: 1048576
+                    initialStreamWindowSize: 65536
+                    maxConcurrentStreams: 100
                   httpFilters:
                   - name: envoy.filters.http.router
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                  mergeSlashes: true
+                  normalizePath: true
+                  pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
                   rds:
                     configSource:
                       ads: {}
@@ -654,9 +662,6 @@ xds:
                   upgradeConfigs:
                   - upgradeType: websocket
                   useRemoteAddress: true
-                  normalizePath: true
-                  mergeSlashes: true
-                  pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
             name: default-eg-http
             perConnectionBufferLimitBytes: 32768
       - activeState:
@@ -712,6 +717,9 @@ xds:
                   - name: envoy.filters.http.router
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                  mergeSlashes: true
+                  normalizePath: true
+                  pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
                   rds:
                     configSource:
                       ads: {}
@@ -719,9 +727,6 @@ xds:
                     routeConfigName: default-eg-grpc
                   statPrefix: http
                   useRemoteAddress: true
-                  normalizePath: true
-                  mergeSlashes: true
-                  pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
             name: default-eg-grpc
             perConnectionBufferLimitBytes: 32768
       - activeState:
@@ -886,4 +891,3 @@ xds:
               name: default-backend-rule-0-match-0-www.grpc-example.com
               route:
                 cluster: default-backend-rule-0-match-0-www.grpc-example.com
-

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -264,11 +264,11 @@
                 "connectTimeout": "10s",
                 "dnsLookupFamily": "V4_ONLY",
                 "edsClusterConfig": {
-                  "serviceName": "default-backend-rule-0-match-0-www.example.com",
                   "edsConfig": {
                     "ads": {},
                     "resourceApiVersion": "V3"
-                  }
+                  },
+                  "serviceName": "default-backend-rule-0-match-0-www.example.com"
                 },
                 "name": "default-backend-rule-0-match-0-www.example.com",
                 "outlierDetection": {},
@@ -285,11 +285,11 @@
                 "connectTimeout": "10s",
                 "dnsLookupFamily": "V4_ONLY",
                 "edsClusterConfig": {
-                  "serviceName": "default-backend-rule-0-match-0-www.grpc-example.com",
                   "edsConfig": {
                     "ads": {},
                     "resourceApiVersion": "V3"
-                  }
+                  },
+                  "serviceName": "default-backend-rule-0-match-0-www.grpc-example.com"
                 },
                 "name": "default-backend-rule-0-match-0-www.grpc-example.com",
                 "outlierDetection": {},
@@ -314,11 +314,11 @@
                 "connectTimeout": "10s",
                 "dnsLookupFamily": "V4_ONLY",
                 "edsClusterConfig": {
-                  "serviceName": "default-eg-tls-passthrough-backend",
                   "edsConfig": {
                     "ads": {},
                     "resourceApiVersion": "V3"
-                  }
+                  },
+                  "serviceName": "default-eg-tls-passthrough-backend"
                 },
                 "name": "default-eg-tls-passthrough-backend",
                 "outlierDetection": {},
@@ -335,11 +335,11 @@
                 "connectTimeout": "10s",
                 "dnsLookupFamily": "V4_ONLY",
                 "edsClusterConfig": {
-                  "serviceName": "default-eg-tcp-backend",
                   "edsConfig": {
                     "ads": {},
                     "resourceApiVersion": "V3"
-                  }
+                  },
+                  "serviceName": "default-eg-tcp-backend"
                 },
                 "name": "default-eg-tcp-backend",
                 "outlierDetection": {},
@@ -356,11 +356,11 @@
                 "connectTimeout": "10s",
                 "dnsLookupFamily": "V4_ONLY",
                 "edsClusterConfig": {
-                  "serviceName": "default-eg-udp-backend",
                   "edsConfig": {
                     "ads": {},
                     "resourceApiVersion": "V3"
-                  }
+                  },
+                  "serviceName": "default-eg-udp-backend"
                 },
                 "name": "default-eg-udp-backend",
                 "outlierDetection": {},
@@ -389,12 +389,12 @@
                       "name": "envoy.access_loggers.file",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-                        "path": "/dev/stdout",
                         "logFormat": {
                           "textFormatSource": {
                             "inlineString": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n"
                           }
-                        }
+                        },
+                        "path": "/dev/stdout"
                       }
                     }
                   ],
@@ -415,17 +415,22 @@
                               "name": "envoy.access_loggers.file",
                               "typedConfig": {
                                 "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-                                "path": "/dev/stdout",
                                 "logFormat": {
                                   "textFormatSource": {
                                     "inlineString": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n"
                                   }
-                                }
+                                },
+                                "path": "/dev/stdout"
                               }
                             }
                           ],
                           "commonHttpProtocolOptions": {
                             "headersWithUnderscoresAction": "REJECT_REQUEST"
+                          },
+                          "http2ProtocolOptions": {
+                            "initialConnectionWindowSize": 1048576,
+                            "initialStreamWindowSize": 65536,
+                            "maxConcurrentStreams": 100
                           },
                           "httpFilters": [
                             {
@@ -477,12 +482,12 @@
                       "name": "envoy.access_loggers.file",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-                        "path": "/dev/stdout",
                         "logFormat": {
                           "textFormatSource": {
                             "inlineString": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n"
                           }
-                        }
+                        },
+                        "path": "/dev/stdout"
                       }
                     }
                   ],
@@ -503,12 +508,12 @@
                               "name": "envoy.access_loggers.file",
                               "typedConfig": {
                                 "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-                                "path": "/dev/stdout",
                                 "logFormat": {
                                   "textFormatSource": {
                                     "inlineString": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n"
                                   }
-                                }
+                                },
+                                "path": "/dev/stdout"
                               }
                             }
                           ],
@@ -580,12 +585,12 @@
                       "name": "envoy.access_loggers.file",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-                        "path": "/dev/stdout",
                         "logFormat": {
                           "textFormatSource": {
                             "inlineString": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n"
                           }
-                        }
+                        },
+                        "path": "/dev/stdout"
                       }
                     }
                   ],
@@ -612,12 +617,12 @@
                                 "name": "envoy.access_loggers.file",
                                 "typedConfig": {
                                   "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-                                  "path": "/dev/stdout",
                                   "logFormat": {
                                     "textFormatSource": {
                                       "inlineString": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n"
                                     }
-                                  }
+                                  },
+                                  "path": "/dev/stdout"
                                 }
                               }
                             ],
@@ -657,12 +662,12 @@
                       "name": "envoy.access_loggers.file",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-                        "path": "/dev/stdout",
                         "logFormat": {
                           "textFormatSource": {
                             "inlineString": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n"
                           }
-                        }
+                        },
+                        "path": "/dev/stdout"
                       }
                     }
                   ],
@@ -684,12 +689,12 @@
                                 "name": "envoy.access_loggers.file",
                                 "typedConfig": {
                                   "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-                                  "path": "/dev/stdout",
                                   "logFormat": {
                                     "textFormatSource": {
                                       "inlineString": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n"
                                     }
-                                  }
+                                  },
+                                  "path": "/dev/stdout"
                                 }
                               }
                             ],
@@ -721,12 +726,12 @@
                       "name": "envoy.access_loggers.file",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-                        "path": "/dev/stdout",
                         "logFormat": {
                           "textFormatSource": {
                             "inlineString": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n"
                           }
-                        }
+                        },
+                        "path": "/dev/stdout"
                       }
                     }
                   ],
@@ -851,4 +856,5 @@
       ]
     }
   }
+ }
 }

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -144,10 +144,10 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
-            serviceName: default-backend-rule-0-match-0-www.example.com
             edsConfig:
               ads: {}
               resourceApiVersion: V3
+            serviceName: default-backend-rule-0-match-0-www.example.com
           name: default-backend-rule-0-match-0-www.example.com
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
@@ -159,10 +159,10 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
-            serviceName: default-backend-rule-0-match-0-www.grpc-example.com
             edsConfig:
               ads: {}
               resourceApiVersion: V3
+            serviceName: default-backend-rule-0-match-0-www.grpc-example.com
           name: default-backend-rule-0-match-0-www.grpc-example.com
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
@@ -179,10 +179,10 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
-            serviceName: default-eg-tls-passthrough-backend
             edsConfig:
               ads: {}
               resourceApiVersion: V3
+            serviceName: default-eg-tls-passthrough-backend
           name: default-eg-tls-passthrough-backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
@@ -194,10 +194,10 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
-            serviceName: default-eg-tcp-backend
             edsConfig:
               ads: {}
               resourceApiVersion: V3
+            serviceName: default-eg-tcp-backend
           name: default-eg-tcp-backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
@@ -209,10 +209,10 @@ xds:
           connectTimeout: 10s
           dnsLookupFamily: V4_ONLY
           edsClusterConfig:
-            serviceName: default-eg-udp-backend
             edsConfig:
               ads: {}
               resourceApiVersion: V3
+            serviceName: default-eg-udp-backend
           name: default-eg-udp-backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
@@ -255,10 +255,17 @@ xds:
                       path: /dev/stdout
                   commonHttpProtocolOptions:
                     headersWithUnderscoresAction: REJECT_REQUEST
+                  http2ProtocolOptions:
+                    initialConnectionWindowSize: 1048576
+                    initialStreamWindowSize: 65536
+                    maxConcurrentStreams: 100
                   httpFilters:
                   - name: envoy.filters.http.router
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                  mergeSlashes: true
+                  normalizePath: true
+                  pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
                   rds:
                     configSource:
                       ads: {}
@@ -268,9 +275,6 @@ xds:
                   upgradeConfigs:
                   - upgradeType: websocket
                   useRemoteAddress: true
-                  normalizePath: true
-                  mergeSlashes: true
-                  pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
             name: default-eg-http
             perConnectionBufferLimitBytes: 32768
       - activeState:
@@ -313,7 +317,7 @@ xds:
                   http2ProtocolOptions:
                     initialConnectionWindowSize: 1048576
                     initialStreamWindowSize: 65536
-                    maxConcurrentStreams: 100    
+                    maxConcurrentStreams: 100
                   httpFilters:
                   - name: envoy.filters.http.grpc_web
                     typedConfig:
@@ -325,7 +329,9 @@ xds:
                       statsForAllMethods: true
                   - name: envoy.filters.http.router
                     typedConfig:
-                      '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router   
+                      '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                  mergeSlashes: true
+                  normalizePath: true
                   pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
                   rds:
                     configSource:
@@ -334,8 +340,6 @@ xds:
                     routeConfigName: default-eg-grpc
                   statPrefix: http
                   useRemoteAddress: true
-                  normalizePath: true
-                  mergeSlashes: true
             name: default-eg-grpc
             perConnectionBufferLimitBytes: 32768
       - activeState:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
@@ -38,10 +38,17 @@ xds:
                     path: /dev/stdout
                 commonHttpProtocolOptions:
                   headersWithUnderscoresAction: REJECT_REQUEST
+                http2ProtocolOptions:
+                  initialConnectionWindowSize: 1048576
+                  initialStreamWindowSize: 65536
+                  maxConcurrentStreams: 100
                 httpFilters:
                 - name: envoy.filters.http.router
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                mergeSlashes: true
+                normalizePath: true
+                pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
                 rds:
                   configSource:
                     ads: {}
@@ -51,9 +58,6 @@ xds:
                 upgradeConfigs:
                 - upgradeType: websocket
                 useRemoteAddress: true
-                normalizePath: true
-                mergeSlashes: true
-                pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
           name: default-eg-http
           perConnectionBufferLimitBytes: 32768
     - activeState:
@@ -109,6 +113,9 @@ xds:
                 - name: envoy.filters.http.router
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                mergeSlashes: true
+                normalizePath: true
+                pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
                 rds:
                   configSource:
                     ads: {}
@@ -116,9 +123,6 @@ xds:
                   routeConfigName: default-eg-grpc
                 statPrefix: http
                 useRemoteAddress: true
-                normalizePath: true
-                mergeSlashes: true
-                pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
           name: default-eg-grpc
           perConnectionBufferLimitBytes: 32768
     - activeState:

--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -94,6 +94,9 @@ func (t *Translator) addXdsHTTPFilterChain(xdsListener *listenerv3.Listener, irL
 				RouteConfigName: irListener.Name,
 			},
 		},
+		// Add HTTP2 protocol options
+		// Set it by default to also support HTTP1.1 to HTTP2 Upgrades
+		Http2ProtocolOptions: http2ProtocolOptions(),
 		// https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for
 		UseRemoteAddress: &wrappers.BoolValue{Value: true},
 		// normalize paths according to RFC 3986
@@ -109,8 +112,6 @@ func (t *Translator) addXdsHTTPFilterChain(xdsListener *listenerv3.Listener, irL
 	if irListener.IsHTTP2 {
 		// Set codec to HTTP2
 		mgr.CodecType = hcmv3.HttpConnectionManager_HTTP2
-		// Add HTTP2 protocol options
-		mgr.Http2ProtocolOptions = http2ProtocolOptions()
 
 		mgr.HttpFilters = append(mgr.HttpFilters, xdsfilters.GRPCWeb)
 		// always enable grpc stats filter
@@ -298,6 +299,7 @@ func addXdsTLSInspectorFilter(xdsListener *listenerv3.Listener) error {
 func buildXdsDownstreamTLSSocket(tlsConfigs []*ir.TLSListenerConfig) (*corev3.TransportSocket, error) {
 	tlsCtx := &tlsv3.DownstreamTlsContext{
 		CommonTlsContext: &tlsv3.CommonTlsContext{
+			AlpnProtocols:                  []string{"h2", "http/1.1"},
 			TlsCertificateSdsSecretConfigs: []*tlsv3.SdsSecretConfig{},
 		},
 	}

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.listeners.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.listeners.yaml
@@ -97,6 +97,10 @@
                   stringValue: cluster1
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.jwt_authn
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.listeners.yaml
@@ -31,6 +31,10 @@
             path: /dev/stdout
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.jwt_authn
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.jwt_authn
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.jwt_authn
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-regex.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-regex.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
@@ -12,7 +12,7 @@
         http2ProtocolOptions:
           initialConnectionWindowSize: 1048576
           initialStreamWindowSize: 65536
-          maxConcurrentStreams: 100        
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:
@@ -39,6 +39,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:
@@ -60,6 +64,9 @@
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
         commonTlsContext:
+          alpnProtocols:
+          - h2
+          - http/1.1
           tlsCertificateSdsSecretConfigs:
           - name: first-listener
             sdsConfig:
@@ -74,6 +81,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:
@@ -95,6 +106,9 @@
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
         commonTlsContext:
+          alpnProtocols:
+          - h2
+          - http/1.1
           tlsCertificateSdsSecretConfigs:
           - name: second-listener
             sdsConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100        
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.ratelimit
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.ratelimit
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100        
         httpFilters:
         - name: envoy.filters.http.ratelimit
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.listeners.yaml
@@ -12,7 +12,7 @@
         http2ProtocolOptions:
           initialConnectionWindowSize: 1048576
           initialStreamWindowSize: 65536
-          maxConcurrentStreams: 100        
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.ratelimit
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
@@ -34,6 +34,9 @@
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
         commonTlsContext:
+          alpnProtocols:
+          - h2
+          - http/1.1
           tlsCertificateSdsSecretConfigs:
           - name: secret-1
             sdsConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
@@ -9,6 +9,10 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
         httpFilters:
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.listeners.yaml
@@ -14,6 +14,9 @@
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
         commonTlsContext:
+          alpnProtocols:
+          - h2
+          - http/1.1
           tlsCertificateSdsSecretConfigs:
           - name: envoy-gateway-tls-secret-1
             sdsConfig:


### PR DESCRIPTION
Setting ALPN Protocols in the listener
https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls.proto#envoy-v3-api-msg-extensions-transport-sockets-tls-v3-downstreamtlscontext should help support HTTP/1.1 to HTTP/2 upgrade for downstream HTTPS connections.

Partially addresses https://github.com/envoyproxy/gateway/issues/1517

```
curl --http2 -v -HHost:www.example.com --resolve "www.example.com:8443:127.0.0.1" --cacert example.com.crt https://www.example.com:8443/get
* Added www.example.com:8443:127.0.0.1 to DNS cache
* Hostname www.example.com was found in DNS cache
*   Trying 127.0.0.1:8443...
* Connected to www.example.com (127.0.0.1) port 8443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
Handling connection for 8443
*  CAfile: example.com.crt
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.example.com; O=example organization
*  start date: Jun 14 20:12:33 2023 GMT
*  expire date: Jun 13 20:12:33 2024 GMT
*  common name: www.example.com (matched)
*  issuer: O=example Inc.; CN=example.com
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /get]
* h2h3 [:scheme: https]
* h2h3 [:authority: www.example.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fbe97012800)
> GET /get HTTP/2
> Host:www.example.com
> user-agent: curl/7.86.0
> accept: */*
> 
< HTTP/2 200 
< content-type: application/json
< x-content-type-options: nosniff
< date: Wed, 14 Jun 2023 20:55:58 GMT
< content-length: 509
< x-envoy-upstream-service-time: 0
< server: envoy
< 
{
 "path": "/get",
 "host": "www.example.com",
 "method": "GET",
 "proto": "HTTP/1.1",
 "headers": {
  "Accept": [
   "*/*"
  ],
  "User-Agent": [
   "curl/7.86.0"
  ],
  "X-Envoy-Expected-Rq-Timeout-Ms": [
   "15000"
  ],
  "X-Envoy-Internal": [
   "true"
  ],
  "X-Forwarded-For": [
   "10.1.1.48"
  ],
  "X-Forwarded-Proto": [
   "https"
  ],
  "X-Request-Id": [
   "e155df8b-d1e9-4be8-8e15-c8e30970b21f"
  ]
 },
 "namespace": "default",
 "ingress": "",
 "service": "",
 "pod": "backend-74888f465f-hgwwk"
* Connection #0 to host www.example.com left intact
```
