### PR TITLE
accesslog: always send k8s.namespace.name and k8s.pod.name

### DIFF
--- a/api/config/v1alpha1/accesslogging_types.go
+++ b/api/config/v1alpha1/accesslogging_types.go
@@ -60,7 +60,8 @@ const (
 	// ProxyAccessLogSinkTypeFile defines the file accesslog sink.
 	ProxyAccessLogSinkTypeFile ProxyAccessLogSinkType = "File"
 	// ProxyAccessLogSinkTypeOpenTelemetry defines the OpenTelemetry accesslog sink.
-	// EnvoyGateway always sends `k8s.namespace.name` and `k8s.pod.name` as attributes.
+	// When the provider is Kubernetes, EnvoyGateway always sends `k8s.namespace.name`
+	// and `k8s.pod.name` as additional attributes.
 	ProxyAccessLogSinkTypeOpenTelemetry ProxyAccessLogSinkType = "OpenTelemetry"
 )
 

--- a/api/config/v1alpha1/accesslogging_types.go
+++ b/api/config/v1alpha1/accesslogging_types.go
@@ -60,6 +60,7 @@ const (
 	// ProxyAccessLogSinkTypeFile defines the file accesslog sink.
 	ProxyAccessLogSinkTypeFile ProxyAccessLogSinkType = "File"
 	// ProxyAccessLogSinkTypeOpenTelemetry defines the OpenTelemetry accesslog sink.
+	// EnvoyGateway always sends `k8s.namespace.name` and `k8s.pod.name` as atrributes.
 	ProxyAccessLogSinkTypeOpenTelemetry ProxyAccessLogSinkType = "OpenTelemetry"
 )
 

--- a/api/config/v1alpha1/accesslogging_types.go
+++ b/api/config/v1alpha1/accesslogging_types.go
@@ -60,7 +60,7 @@ const (
 	// ProxyAccessLogSinkTypeFile defines the file accesslog sink.
 	ProxyAccessLogSinkTypeFile ProxyAccessLogSinkType = "File"
 	// ProxyAccessLogSinkTypeOpenTelemetry defines the OpenTelemetry accesslog sink.
-	// EnvoyGateway always sends `k8s.namespace.name` and `k8s.pod.name` as atrributes.
+	// EnvoyGateway always sends `k8s.namespace.name` and `k8s.pod.name` as attributes.
 	ProxyAccessLogSinkTypeOpenTelemetry ProxyAccessLogSinkType = "OpenTelemetry"
 )
 

--- a/examples/fluent-bit/helm-values.yaml
+++ b/examples/fluent-bit/helm-values.yaml
@@ -42,7 +42,7 @@ config:
     [FILTER]
         Name grep
         Match kube.*
-        Regex $kubernetes['container_name'] envoy
+        Regex $kubernetes['container_name'] ^envoy$
 
     [FILTER]
         Name parser
@@ -58,4 +58,4 @@ config:
         Match                  kube.*
         Host                   loki.monitoring.svc.cluster.local
         Port                   3100
-        Labels                 job=fluentbit, app=$kubernetes['labels']['app'], namespace=$kubernetes['namespace_name'], pod=$kubernetes['pod_name'], container=$kubernetes['container_name']
+        Labels                 job=fluentbit, app=$kubernetes['labels']['app'], k8s_namespace_name=$kubernetes['namespace_name'], k8s_pod_name=$kubernetes['pod_name'], k8s_container_name=$kubernetes['container_name']

--- a/examples/otel-collector/helm-values.yaml
+++ b/examples/otel-collector/helm-values.yaml
@@ -15,7 +15,9 @@ config:
       actions:
         - action: insert
           key: loki.attribute.labels
-          value: pod, namespace
+          # k8s.pod.name is OpenTelemetry format for Kubernetes Pod name,
+          # Loki will convert this to k8s_pod_name label.
+          value: k8s.pod.name, k8s.namespace.name 
   receivers:
     otlp:
       protocols:

--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -197,10 +197,9 @@ func processAccessLog(envoyproxy *configv1a1.EnvoyProxy) *ir.AccessLog {
 				}
 
 				al := &ir.OpenTelemetryAccessLog{
-					Attributes: accessLog.Format.JSON,
-					Port:       uint32(sink.OpenTelemetry.Port),
-					Host:       sink.OpenTelemetry.Host,
-					Resources:  sink.OpenTelemetry.Resources,
+					Port:      uint32(sink.OpenTelemetry.Port),
+					Host:      sink.OpenTelemetry.Host,
+					Resources: sink.OpenTelemetry.Resources,
 				}
 
 				switch accessLog.Format.Type {

--- a/internal/xds/translator/accesslog.go
+++ b/internal/xds/translator/accesslog.go
@@ -134,7 +134,7 @@ func buildXdsAccessLog(al *ir.AccessLog, forListener bool) []*accesslog.AccessLo
 				},
 				TransportApiVersion: cfgcore.ApiVersion_V3,
 			},
-			ResourceAttributes: convertToKeyValueList(otel.Resources),
+			ResourceAttributes: convertToKeyValueList(otel.Resources, false),
 		}
 
 		format := EnvoyTextLogFormat
@@ -150,7 +150,7 @@ func buildXdsAccessLog(al *ir.AccessLog, forListener bool) []*accesslog.AccessLo
 			}
 		}
 
-		al.Attributes = convertToKeyValueList(otel.Attributes)
+		al.Attributes = convertToKeyValueList(otel.Attributes, true)
 
 		accesslogAny, _ := anypb.New(al)
 		accessLogs = append(accessLogs, &accesslog.AccessLog{
@@ -171,13 +171,32 @@ func buildXdsAccessLog(al *ir.AccessLog, forListener bool) []*accesslog.AccessLo
 	return accessLogs
 }
 
-func convertToKeyValueList(attributes map[string]string) *otlpcommonv1.KeyValueList {
-	if len(attributes) == 0 {
-		return nil
+func convertToKeyValueList(attributes map[string]string, additionalLabels bool) *otlpcommonv1.KeyValueList {
+	maxLen := len(attributes)
+	if additionalLabels {
+		maxLen += 2
+	}
+	keyValueList := &otlpcommonv1.KeyValueList{
+		Values: make([]*otlpcommonv1.KeyValue, 0, maxLen),
 	}
 
-	keyValueList := &otlpcommonv1.KeyValueList{
-		Values: make([]*otlpcommonv1.KeyValue, 0, len(attributes)),
+	// always set the k8s namespace and pod name for better UX
+	// EG cannot know the client namespace and pod name,
+	// so we set these on attributes that read from the environment.
+	if additionalLabels {
+		keyValueList.Values = append(keyValueList.Values, &otlpcommonv1.KeyValue{
+			Key:   "k8s.namespace.name",
+			Value: &otlpcommonv1.AnyValue{Value: &otlpcommonv1.AnyValue_StringValue{StringValue: "%ENVIRONMENT(ENVOY_GATEWAY_NAMESPACE)%"}},
+		})
+
+		keyValueList.Values = append(keyValueList.Values, &otlpcommonv1.KeyValue{
+			Key:   "k8s.pod.name",
+			Value: &otlpcommonv1.AnyValue{Value: &otlpcommonv1.AnyValue_StringValue{StringValue: "%ENVIRONMENT(ENVOY_POD_NAME)%"}},
+		})
+	}
+
+	if len(attributes) == 0 {
+		return keyValueList
 	}
 
 	// sort keys to ensure consistent ordering

--- a/internal/xds/translator/accesslog.go
+++ b/internal/xds/translator/accesslog.go
@@ -171,6 +171,12 @@ func buildXdsAccessLog(al *ir.AccessLog, forListener bool) []*accesslog.AccessLo
 	return accessLogs
 }
 
+// read more here: https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/k8s/
+const (
+	k8sNamespaceNameKey = "k8s.namespace.name"
+	k8sPodNameKey       = "k8s.pod.name"
+)
+
 func convertToKeyValueList(attributes map[string]string, additionalLabels bool) *otlpcommonv1.KeyValueList {
 	maxLen := len(attributes)
 	if additionalLabels {
@@ -185,12 +191,12 @@ func convertToKeyValueList(attributes map[string]string, additionalLabels bool) 
 	// so we set these on attributes that read from the environment.
 	if additionalLabels {
 		keyValueList.Values = append(keyValueList.Values, &otlpcommonv1.KeyValue{
-			Key:   "k8s.namespace.name",
+			Key:   k8sNamespaceNameKey,
 			Value: &otlpcommonv1.AnyValue{Value: &otlpcommonv1.AnyValue_StringValue{StringValue: "%ENVIRONMENT(ENVOY_GATEWAY_NAMESPACE)%"}},
 		})
 
 		keyValueList.Values = append(keyValueList.Values, &otlpcommonv1.KeyValue{
-			Key:   "k8s.pod.name",
+			Key:   k8sPodNameKey,
 			Value: &otlpcommonv1.AnyValue{Value: &otlpcommonv1.AnyValue_StringValue{StringValue: "%ENVIRONMENT(ENVOY_POD_NAME)%"}},
 		})
 	}

--- a/internal/xds/translator/accesslog.go
+++ b/internal/xds/translator/accesslog.go
@@ -190,6 +190,7 @@ func convertToKeyValueList(attributes map[string]string, additionalLabels bool) 
 	// EG cannot know the client namespace and pod name,
 	// so we set these on attributes that read from the environment.
 	if additionalLabels {
+		// TODO: check the provider type and set the appropriate attributes
 		keyValueList.Values = append(keyValueList.Values, &otlpcommonv1.KeyValue{
 			Key:   k8sNamespaceNameKey,
 			Value: &otlpcommonv1.AnyValue{Value: &otlpcommonv1.AnyValue_StringValue{StringValue: "%ENVIRONMENT(ENVOY_GATEWAY_NAMESPACE)%"}},

--- a/internal/xds/translator/testdata/in/xds-ir/accesslog.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/accesslog.yaml
@@ -15,7 +15,7 @@ accesslog:
   openTelemetry:
   - text: |
       [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
-    attribute:
+    attributes:
       "response_code": "%RESPONSE_CODE%"
     resources:
       "cluster_name": "cluster1"

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.listeners.yaml
@@ -33,6 +33,17 @@
     name: envoy.access_loggers.open_telemetry
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig
+      attributes:
+        values:
+        - key: k8s.namespace.name
+          value:
+            stringValue: '%ENVIRONMENT(ENVOY_GATEWAY_NAMESPACE)%'
+        - key: k8s.pod.name
+          value:
+            stringValue: '%ENVIRONMENT(ENVOY_POD_NAME)%'
+        - key: response_code
+          value:
+            stringValue: '%RESPONSE_CODE%'
       body:
         stringValue: |
           [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
@@ -80,6 +91,17 @@
         - name: envoy.access_loggers.open_telemetry
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig
+            attributes:
+              values:
+              - key: k8s.namespace.name
+                value:
+                  stringValue: '%ENVIRONMENT(ENVOY_GATEWAY_NAMESPACE)%'
+              - key: k8s.pod.name
+                value:
+                  stringValue: '%ENVIRONMENT(ENVOY_POD_NAME)%'
+              - key: response_code
+                value:
+                  stringValue: '%RESPONSE_CODE%'
             body:
               stringValue: |
                 [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"

--- a/test/e2e/tests/accesslog.go
+++ b/test/e2e/tests/accesslog.go
@@ -54,17 +54,18 @@ var FileAccessLogTest = suite.ConformanceTest{
 				Namespace: ns,
 			})
 
+			labels := map[string]string{
+				"job":                "fluentbit",
+				"k8s_namespace_name": "envoy-gateway-system",
+				"k8s_container_name": "envoy",
+			}
 			// let's wait for the log to be sent to stdout
 			if err := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
 				func(ctx context.Context) (bool, error) {
 					// query log count from loki
 					count, err := QueryLogCountFromLoki(t, suite.Client, types.NamespacedName{
 						Namespace: "envoy-gateway-system",
-					}, map[string]string{
-						"namespace": "envoy-gateway-system",
-						"job":       "fluentbit",
-						"container": "envoy",
-					})
+					}, labels)
 					if err != nil {
 						t.Logf("failed to get log count from loki: %v", err)
 						return false, nil
@@ -83,11 +84,7 @@ var FileAccessLogTest = suite.ConformanceTest{
 					// query log count from loki
 					preCount, err := QueryLogCountFromLoki(t, suite.Client, types.NamespacedName{
 						Namespace: "envoy-gateway-system",
-					}, map[string]string{
-						"namespace": "envoy-gateway-system",
-						"job":       "fluentbit",
-						"container": "envoy",
-					})
+					}, labels)
 					if err != nil {
 						t.Logf("failed to get log count from loki: %v", err)
 						return false, nil
@@ -108,11 +105,7 @@ var FileAccessLogTest = suite.ConformanceTest{
 					if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 15*time.Second, true, func(_ context.Context) (bool, error) {
 						count, err := QueryLogCountFromLoki(t, suite.Client, types.NamespacedName{
 							Namespace: "envoy-gateway-system",
-						}, map[string]string{
-							"namespace": "envoy-gateway-system",
-							"job":       "fluentbit",
-							"container": "envoy",
-						})
+						}, labels)
 						if err != nil {
 							t.Logf("failed to get log count from loki: %v", err)
 							return false, nil
@@ -134,7 +127,6 @@ var FileAccessLogTest = suite.ConformanceTest{
 				t.Errorf("failed to get log count from loki: %v", err)
 			}
 		})
-
 	},
 }
 
@@ -149,14 +141,16 @@ var OpenTelemetryTest = suite.ConformanceTest{
 			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
+			labels := map[string]string{
+				"k8s_namespace_name": "envoy-gateway-system",
+				"exporter":           "OTLP",
+			}
 			if err := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
 				func(ctx context.Context) (bool, error) {
 					// query log count from loki
 					preCount, err := QueryLogCountFromLoki(t, suite.Client, types.NamespacedName{
 						Namespace: "envoy-gateway-system",
-					}, map[string]string{
-						"exporter": "OTLP",
-					})
+					}, labels)
 					if err != nil {
 						t.Logf("failed to get log count from loki: %v", err)
 						return false, nil
@@ -175,9 +169,7 @@ var OpenTelemetryTest = suite.ConformanceTest{
 					if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 10*time.Second, true, func(_ context.Context) (bool, error) {
 						count, err := QueryLogCountFromLoki(t, suite.Client, types.NamespacedName{
 							Namespace: "envoy-gateway-system",
-						}, map[string]string{
-							"exporter": "OTLP",
-						})
+						}, labels)
 						if err != nil {
 							t.Logf("failed to get log count from loki: %v", err)
 							return false, nil


### PR DESCRIPTION
With fluent-bit, your can get these informations from [Kubernetes Filter](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes); with OpenTelemetry sink, we need send these manually.