### PR TITLE
refactor: optimize client-go performance by protobuf context-type.

### DIFF
--- a/internal/infrastructure/manager.go
+++ b/internal/infrastructure/manager.go
@@ -10,13 +10,13 @@ import (
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	clicfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/envoyproxy/gateway/api/config/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/envoygateway"
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/infrastructure/kubernetes"
 	"github.com/envoyproxy/gateway/internal/ir"
+	kube "github.com/envoyproxy/gateway/internal/kubernetes"
 )
 
 var _ Manager = (*kubernetes.Infra)(nil)
@@ -37,7 +37,7 @@ type Manager interface {
 func NewManager(cfg *config.Server) (Manager, error) {
 	var mgr Manager
 	if cfg.EnvoyGateway.Provider.Type == v1alpha1.ProviderTypeKubernetes {
-		cli, err := client.New(clicfg.GetConfigOrDie(), client.Options{Scheme: envoygateway.GetScheme()})
+		cli, err := client.New(kube.GetProtobufConfigOrDie(), client.Options{Scheme: envoygateway.GetScheme()})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway"
 )
@@ -52,6 +53,10 @@ type client struct {
 
 func NewCLIClient(clientConfig clientcmd.ClientConfig) (CLIClient, error) {
 	return newClientInternal(clientConfig)
+}
+
+func GetProtobufConfigOrDie() *rest.Config {
+	return setRestDefaults(ctrl.GetConfigOrDie())
 }
 
 func newClientInternal(clientConfig clientcmd.ClientConfig) (*client, error) {
@@ -91,7 +96,7 @@ func setRestDefaults(config *rest.Config) *rest.Config {
 		}
 	}
 	if len(config.ContentType) == 0 {
-		config.ContentType = runtime.ContentTypeJSON
+		config.ContentType = runtime.ContentTypeProtobuf
 	}
 	if config.NegotiatedSerializer == nil {
 		// This codec factory ensures the resources are not converted. Therefore, resources

--- a/internal/provider/runner/runner.go
+++ b/internal/provider/runner/runner.go
@@ -9,10 +9,9 @@ import (
 	"context"
 	"fmt"
 
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/envoyproxy/gateway/api/config/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	kube "github.com/envoyproxy/gateway/internal/kubernetes"
 	"github.com/envoyproxy/gateway/internal/message"
 	"github.com/envoyproxy/gateway/internal/provider/kubernetes"
 )
@@ -39,11 +38,7 @@ func (r *Runner) Start(ctx context.Context) error {
 	r.Logger = r.Logger.WithName(r.Name()).WithValues("runner", r.Name())
 	if r.EnvoyGateway.Provider.Type == v1alpha1.ProviderTypeKubernetes {
 		r.Logger.Info("Using provider", "type", v1alpha1.ProviderTypeKubernetes)
-		cfg, err := ctrl.GetConfig()
-		if err != nil {
-			return fmt.Errorf("failed to get kubeconfig: %w", err)
-		}
-		p, err := kubernetes.New(cfg, &r.Config.Server, r.ProviderResources)
+		p, err := kubernetes.New(kube.GetProtobufConfigOrDie(), &r.Config.Server, r.ProviderResources)
 		if err != nil {
 			return fmt.Errorf("failed to create provider %s: %w", v1alpha1.ProviderTypeKubernetes, err)
 		}


### PR DESCRIPTION
**What type of PR is this?**
using `protobuf` context-type to optimize client-go performance.
![image](https://github.com/envoyproxy/gateway/assets/2174082/c67ea94a-5336-4758-b6c1-e339db154112)

using the `json` needs more memory and time
![image](https://github.com/envoyproxy/gateway/assets/2174082/b8a819db-ea2e-4304-9486-69b23b6e9ff5)

