### PR TITLE
e2e: improve accesslog tests

### DIFF
--- a/test/e2e/testdata/accesslog-file.yaml
+++ b/test/e2e/testdata/accesslog-file.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
-  name: http-infra-backend-v1
+  name: accesslog-file
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
@@ -10,7 +10,7 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: /
+            value: /file
       backendRefs:
         - name: infra-backend-v1
           port: 8080

--- a/test/e2e/testdata/accesslog-otel.yaml
+++ b/test/e2e/testdata/accesslog-otel.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: accesslog-otel
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /otel
+      backendRefs:
+        - name: infra-backend-v2
+          port: 8080


### PR DESCRIPTION
see https://github.com/envoyproxy/gateway/issues/1563#issuecomment-1608562099, split HttpRoute for differnet tests

fixes: #1563 