### PR TITLE
Always set codec type to AUTO in the xds listener

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -762,7 +762,6 @@ xds:
                           inlineString: |
                             [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
                       path: /dev/stdout
-                  codecType: HTTP2
                   commonHttpProtocolOptions:
                     headersWithUnderscoresAction: REJECT_REQUEST
                   http2ProtocolOptions:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -570,7 +570,6 @@
                               }
                             }
                           ],
-                          "codecType": "HTTP2",
                           "commonHttpProtocolOptions": {
                             "headersWithUnderscoresAction": "REJECT_REQUEST"
                           },

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -340,7 +340,6 @@ xds:
                           inlineString: |
                             [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
                       path: /dev/stdout
-                  codecType: HTTP2
                   commonHttpProtocolOptions:
                     headersWithUnderscoresAction: REJECT_REQUEST
                   http2ProtocolOptions:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
@@ -94,7 +94,6 @@ xds:
                         inlineString: |
                           [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
                     path: /dev/stdout
-                codecType: HTTP2
                 commonHttpProtocolOptions:
                   headersWithUnderscoresAction: REJECT_REQUEST
                 http2ProtocolOptions:

--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -110,9 +110,6 @@ func (t *Translator) addXdsHTTPFilterChain(xdsListener *listenerv3.Listener, irL
 	}
 
 	if irListener.IsHTTP2 {
-		// Set codec to HTTP2
-		mgr.CodecType = hcmv3.HttpConnectionManager_HTTP2
-
 		mgr.HttpFilters = append(mgr.HttpFilters, xdsfilters.GRPCWeb)
 		// always enable grpc stats filter
 		mgr.HttpFilters = append(mgr.HttpFilters, xdsfilters.GRPCStats)

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.listeners.yaml
@@ -7,7 +7,6 @@
     - name: envoy.filters.network.http_connection_manager
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-        codecType: HTTP2
         commonHttpProtocolOptions:
           headersWithUnderscoresAction: REJECT_REQUEST
         http2ProtocolOptions:


### PR DESCRIPTION
There is no good reason to pin to HTTP2 and disable HTTP1.1 when a GRPCRoute and HTTPRoute are attached to the same listener.

More info on codec type in https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto

Fixes: https://github.com/envoyproxy/gateway/issues/1142