### PR TITLE
docs: missing docs for tls termination for tcp

### DIFF
--- a/docs/latest/user_docs.rst
+++ b/docs/latest/user_docs.rst
@@ -17,6 +17,7 @@ Learn how to deploy, use, and operate Envoy Gateway.
   user/secure-gateways
   user/tls-cert-manager
   user/tls-passthrough
+  user/tls-termination
   user/tcp-routing
   user/udp-routing
   user/grpc-routing


### PR DESCRIPTION
**What type of PR is this?**
docs: missing docs for tls termination for tcp
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
-->

**What this PR does / why we need it**:
TLS termination was added in this [PR](https://github.com/envoyproxy/gateway/pull/1431) and docs was also added but it was not added to user_docs.rst file so it is not visible on the latest docs.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1642
