### PR TITLE
Use `/` to create internal IR names instead of `-`

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
@@ -1,6 +1,6 @@
 {
   "xds": {
-    "envoy-gateway-system-eg": {
+    "envoy-gateway-system/eg": {
       "configs": [
         {
           "@type": "type.googleapis.com/envoy.admin.v3.BootstrapConfigDump",
@@ -183,7 +183,7 @@
             {
               "endpointConfig": {
                 "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
-                "clusterName": "envoy-gateway-system-backend-rule-0-match-0-www.example.com",
+                "clusterName": "envoy-gateway-system/backend/rule/0/match/0-www.example.com",
                 "endpoints": [
                   {
                     "lbEndpoints": [
@@ -222,9 +222,9 @@
                     "ads": {},
                     "resourceApiVersion": "V3"
                   },
-                  "serviceName": "envoy-gateway-system-backend-rule-0-match-0-www.example.com"
+                  "serviceName": "envoy-gateway-system/backend/rule/0/match/0-www.example.com"
                 },
-                "name": "envoy-gateway-system-backend-rule-0-match-0-www.example.com",
+                "name": "envoy-gateway-system/backend/rule/0/match/0-www.example.com",
                 "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS"
@@ -350,7 +350,7 @@
                               "typedConfig": {
                                 "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                                 "providers": {
-                                  "envoy-gateway-system-backend-rule-0-match-0-www.example.com-example": {
+                                  "envoy-gateway-system/backend/rule/0/match/0-www.example.com-example": {
                                     "remoteJwks": {
                                       "cacheDuration": "300s",
                                       "httpUri": {
@@ -362,8 +362,8 @@
                                   }
                                 },
                                 "requirementMap": {
-                                  "envoy-gateway-system-backend-rule-0-match-0-www.example.com": {
-                                    "providerName": "envoy-gateway-system-backend-rule-0-match-0-www.example.com-example"
+                                  "envoy-gateway-system/backend/rule/0/match/0-www.example.com": {
+                                    "providerName": "envoy-gateway-system/backend/rule/0/match/0-www.example.com-example"
                                   }
                                 }
                               }
@@ -383,7 +383,7 @@
                               "ads": {},
                               "resourceApiVersion": "V3"
                             },
-                            "routeConfigName": "envoy-gateway-system-eg-http"
+                            "routeConfigName": "envoy-gateway-system/eg/http"
                           },
                           "statPrefix": "http",
                           "upgradeConfigs": [
@@ -396,7 +396,7 @@
                       }
                     ]
                   },
-                  "name": "envoy-gateway-system-eg-http",
+                  "name": "envoy-gateway-system/eg/http",
                   "perConnectionBufferLimitBytes": 32768
                 }
               }
@@ -410,13 +410,13 @@
               "routeConfig": {
                 "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
                 "ignorePortInHostMatching": true,
-                "name": "envoy-gateway-system-eg-http",
+                "name": "envoy-gateway-system/eg/http",
                 "virtualHosts": [
                   {
                     "domains": [
                       "*"
                     ],
-                    "name": "envoy-gateway-system-eg-http",
+                    "name": "envoy-gateway-system/eg/http",
                     "routes": [
                       {
                         "match": {
@@ -430,14 +430,14 @@
                           ],
                           "pathSeparatedPrefix": "/foo"
                         },
-                        "name": "envoy-gateway-system-backend-rule-0-match-0-www.example.com",
+                        "name": "envoy-gateway-system/backend/rule/0/match/0-www.example.com",
                         "route": {
-                          "cluster": "envoy-gateway-system-backend-rule-0-match-0-www.example.com"
+                          "cluster": "envoy-gateway-system/backend/rule/0/match/0-www.example.com"
                         },
                         "typedPerFilterConfig": {
                           "envoy.filters.http.jwt_authn": {
                             "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
-                            "requirementName": "envoy-gateway-system-backend-rule-0-match-0-www.example.com"
+                            "requirementName": "envoy-gateway-system/backend/rule/0/match/0-www.example.com"
                           }
                         }
                       }

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
@@ -1,5 +1,5 @@
 xds:
-  envoy-gateway-system-eg:
+  envoy-gateway-system/eg:
     configs:
     - '@type': type.googleapis.com/envoy.admin.v3.BootstrapConfigDump
       bootstrap:
@@ -103,7 +103,7 @@ xds:
       dynamicEndpointConfigs:
       - endpointConfig:
           '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-          clusterName: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+          clusterName: envoy-gateway-system/backend/rule/0/match/0-www.example.com
           endpoints:
           - lbEndpoints:
             - endpoint:
@@ -125,8 +125,8 @@ xds:
             edsConfig:
               ads: {}
               resourceApiVersion: V3
-            serviceName: envoy-gateway-system-backend-rule-0-match-0-www.example.com
-          name: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+            serviceName: envoy-gateway-system/backend/rule/0/match/0-www.example.com
+          name: envoy-gateway-system/backend/rule/0/match/0-www.example.com
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
@@ -208,7 +208,7 @@ xds:
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                       providers:
-                        envoy-gateway-system-backend-rule-0-match-0-www.example.com-example:
+                        envoy-gateway-system/backend/rule/0/match/0-www.example.com-example:
                           remoteJwks:
                             cacheDuration: 300s
                             httpUri:
@@ -216,8 +216,8 @@ xds:
                               timeout: 5s
                               uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/authn/jwks.json
                       requirementMap:
-                        envoy-gateway-system-backend-rule-0-match-0-www.example.com:
-                          providerName: envoy-gateway-system-backend-rule-0-match-0-www.example.com-example
+                        envoy-gateway-system/backend/rule/0/match/0-www.example.com:
+                          providerName: envoy-gateway-system/backend/rule/0/match/0-www.example.com-example
                   - name: envoy.filters.http.router
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -228,23 +228,23 @@ xds:
                     configSource:
                       ads: {}
                       resourceApiVersion: V3
-                    routeConfigName: envoy-gateway-system-eg-http
+                    routeConfigName: envoy-gateway-system/eg/http
                   statPrefix: http
                   upgradeConfigs:
                   - upgradeType: websocket
                   useRemoteAddress: true
-            name: envoy-gateway-system-eg-http
+            name: envoy-gateway-system/eg/http
             perConnectionBufferLimitBytes: 32768
     - '@type': type.googleapis.com/envoy.admin.v3.RoutesConfigDump
       dynamicRouteConfigs:
       - routeConfig:
           '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
           ignorePortInHostMatching: true
-          name: envoy-gateway-system-eg-http
+          name: envoy-gateway-system/eg/http
           virtualHosts:
           - domains:
             - '*'
-            name: envoy-gateway-system-eg-http
+            name: envoy-gateway-system/eg/http
             routes:
             - match:
                 headers:
@@ -252,10 +252,10 @@ xds:
                   stringMatch:
                     exact: www.example.com
                 pathSeparatedPrefix: /foo
-              name: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+              name: envoy-gateway-system/backend/rule/0/match/0-www.example.com
               route:
-                cluster: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+                cluster: envoy-gateway-system/backend/rule/0/match/0-www.example.com
               typedPerFilterConfig:
                 envoy.filters.http.jwt_authn:
                   '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                  requirementName: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+                  requirementName: envoy-gateway-system/backend/rule/0/match/0-www.example.com

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.bootstrap.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.bootstrap.yaml
@@ -1,5 +1,5 @@
 xds:
-  envoy-gateway-system-eg:
+  envoy-gateway-system/eg:
     '@type': type.googleapis.com/envoy.admin.v3.BootstrapConfigDump
     bootstrap:
       admin:

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.cluster.yaml
@@ -1,5 +1,5 @@
 xds:
-  envoy-gateway-system-eg:
+  envoy-gateway-system/eg:
     '@type': type.googleapis.com/envoy.admin.v3.ClustersConfigDump
     dynamicActiveClusters:
     - cluster:
@@ -12,8 +12,8 @@ xds:
           edsConfig:
             ads: {}
             resourceApiVersion: V3
-          serviceName: envoy-gateway-system-backend-rule-0-match-0-www.example.com
-        name: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+          serviceName: envoy-gateway-system/backend/rule/0/match/0-www.example.com
+        name: envoy-gateway-system/backend/rule/0/match/0-www.example.com
         outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.listener.yaml
@@ -1,5 +1,5 @@
 xds:
-  envoy-gateway-system-eg:
+  envoy-gateway-system/eg:
     '@type': type.googleapis.com/envoy.admin.v3.ListenersConfigDump
     dynamicListeners:
     - activeState:
@@ -47,7 +47,7 @@ xds:
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                     providers:
-                      envoy-gateway-system-backend-rule-0-match-0-www.example.com-example:
+                      envoy-gateway-system/backend/rule/0/match/0-www.example.com-example:
                         remoteJwks:
                           cacheDuration: 300s
                           httpUri:
@@ -55,8 +55,8 @@ xds:
                             timeout: 5s
                             uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/authn/jwks.json
                     requirementMap:
-                      envoy-gateway-system-backend-rule-0-match-0-www.example.com:
-                        providerName: envoy-gateway-system-backend-rule-0-match-0-www.example.com-example
+                      envoy-gateway-system/backend/rule/0/match/0-www.example.com:
+                        providerName: envoy-gateway-system/backend/rule/0/match/0-www.example.com-example
                 - name: envoy.filters.http.router
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -67,10 +67,10 @@ xds:
                   configSource:
                     ads: {}
                     resourceApiVersion: V3
-                  routeConfigName: envoy-gateway-system-eg-http
+                  routeConfigName: envoy-gateway-system/eg/http
                 statPrefix: http
                 upgradeConfigs:
                 - upgradeType: websocket
                 useRemoteAddress: true
-          name: envoy-gateway-system-eg-http
+          name: envoy-gateway-system/eg/http
           perConnectionBufferLimitBytes: 32768

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.route.yaml
@@ -1,15 +1,15 @@
 xds:
-  envoy-gateway-system-eg:
+  envoy-gateway-system/eg:
     '@type': type.googleapis.com/envoy.admin.v3.RoutesConfigDump
     dynamicRouteConfigs:
     - routeConfig:
         '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
         ignorePortInHostMatching: true
-        name: envoy-gateway-system-eg-http
+        name: envoy-gateway-system/eg/http
         virtualHosts:
         - domains:
           - '*'
-          name: envoy-gateway-system-eg-http
+          name: envoy-gateway-system/eg/http
           routes:
           - match:
               headers:
@@ -17,10 +17,10 @@ xds:
                 stringMatch:
                   exact: www.example.com
               pathSeparatedPrefix: /foo
-            name: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+            name: envoy-gateway-system/backend/rule/0/match/0-www.example.com
             route:
-              cluster: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+              cluster: envoy-gateway-system/backend/rule/0/match/0-www.example.com
             typedPerFilterConfig:
               envoy.filters.http.jwt_authn:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                requirementName: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+                requirementName: envoy-gateway-system/backend/rule/0/match/0-www.example.com

--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -421,7 +421,7 @@ udpRoutes:
         name: eg
         sectionName: udp
 xds:
-  default-eg:
+  default/eg:
     configs:
     - '@type': type.googleapis.com/envoy.admin.v3.BootstrapConfigDump
       bootstrap:
@@ -525,7 +525,7 @@ xds:
       dynamicEndpointConfigs:
       - endpointConfig:
           '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-          clusterName: default-backend-rule-0-match-0-www.example.com
+          clusterName: default/backend/rule/0/match/0-www.example.com
           endpoints:
           - lbEndpoints:
             - endpoint:
@@ -538,7 +538,7 @@ xds:
             locality: {}
       - endpointConfig:
           '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-          clusterName: default-backend-rule-0-match-0-www.grpc-example.com
+          clusterName: default/backend/rule/0/match/0-www.grpc-example.com
           endpoints:
           - lbEndpoints:
             - endpoint:
@@ -551,7 +551,7 @@ xds:
             locality: {}
       - endpointConfig:
           '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-          clusterName: default-eg-tls-passthrough-backend
+          clusterName: default/eg/tls-passthrough/backend
           endpoints:
           - lbEndpoints:
             - endpoint:
@@ -564,7 +564,7 @@ xds:
             locality: {}
       - endpointConfig:
           '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-          clusterName: default-eg-tcp-backend
+          clusterName: default/eg/tcp/backend
           endpoints:
           - lbEndpoints:
             - endpoint:
@@ -576,7 +576,7 @@ xds:
             locality: {}
       - endpointConfig:
           '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-          clusterName: default-eg-udp-backend
+          clusterName: default/eg/udp/backend
           endpoints:
           - lbEndpoints:
             - endpoint:
@@ -598,8 +598,8 @@ xds:
             edsConfig:
               ads: {}
               resourceApiVersion: V3
-            serviceName: default-backend-rule-0-match-0-www.example.com
-          name: default-backend-rule-0-match-0-www.example.com
+            serviceName: default/backend/rule/0/match/0-www.example.com
+          name: default/backend/rule/0/match/0-www.example.com
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
@@ -613,8 +613,8 @@ xds:
             edsConfig:
               ads: {}
               resourceApiVersion: V3
-            serviceName: default-backend-rule-0-match-0-www.grpc-example.com
-          name: default-backend-rule-0-match-0-www.grpc-example.com
+            serviceName: default/backend/rule/0/match/0-www.grpc-example.com
+          name: default/backend/rule/0/match/0-www.grpc-example.com
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
@@ -633,8 +633,8 @@ xds:
             edsConfig:
               ads: {}
               resourceApiVersion: V3
-            serviceName: default-eg-tls-passthrough-backend
-          name: default-eg-tls-passthrough-backend
+            serviceName: default/eg/tls-passthrough/backend
+          name: default/eg/tls-passthrough/backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
@@ -648,8 +648,8 @@ xds:
             edsConfig:
               ads: {}
               resourceApiVersion: V3
-            serviceName: default-eg-tcp-backend
-          name: default-eg-tcp-backend
+            serviceName: default/eg/tcp/backend
+          name: default/eg/tcp/backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
@@ -663,8 +663,8 @@ xds:
             edsConfig:
               ads: {}
               resourceApiVersion: V3
-            serviceName: default-eg-udp-backend
-          name: default-eg-udp-backend
+            serviceName: default/eg/udp/backend
+          name: default/eg/udp/backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
@@ -721,12 +721,12 @@ xds:
                     configSource:
                       ads: {}
                       resourceApiVersion: V3
-                    routeConfigName: default-eg-http
+                    routeConfigName: default/eg/http
                   statPrefix: http
                   upgradeConfigs:
                   - upgradeType: websocket
                   useRemoteAddress: true
-            name: default-eg-http
+            name: default/eg/http
             perConnectionBufferLimitBytes: 32768
       - activeState:
           listener:
@@ -787,10 +787,10 @@ xds:
                     configSource:
                       ads: {}
                       resourceApiVersion: V3
-                    routeConfigName: default-eg-grpc
+                    routeConfigName: default/eg/grpc
                   statPrefix: http
                   useRemoteAddress: true
-            name: default-eg-grpc
+            name: default/eg/grpc
             perConnectionBufferLimitBytes: 32768
       - activeState:
           listener:
@@ -829,13 +829,13 @@ xds:
                           inlineString: |
                             [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
                       path: /dev/stdout
-                  cluster: default-eg-tls-passthrough-backend
+                  cluster: default/eg/tls-passthrough/backend
                   statPrefix: passthrough
             listenerFilters:
             - name: envoy.filters.listener.tls_inspector
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-            name: default-eg-tls-passthrough-backend
+            name: default/eg/tls-passthrough/backend
             perConnectionBufferLimitBytes: 32768
       - activeState:
           listener:
@@ -871,9 +871,9 @@ xds:
                           inlineString: |
                             [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
                       path: /dev/stdout
-                  cluster: default-eg-tcp-backend
+                  cluster: default/eg/tcp/backend
                   statPrefix: tcp
-            name: default-eg-tcp-backend
+            name: default/eg/tcp/backend
             perConnectionBufferLimitBytes: 32768
       - activeState:
           listener:
@@ -915,19 +915,19 @@ xds:
                       name: route
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
-                        cluster: default-eg-udp-backend
+                        cluster: default/eg/udp/backend
                 statPrefix: service
-            name: default-eg-udp-backend
+            name: default/eg/udp/backend
     - '@type': type.googleapis.com/envoy.admin.v3.RoutesConfigDump
       dynamicRouteConfigs:
       - routeConfig:
           '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
           ignorePortInHostMatching: true
-          name: default-eg-http
+          name: default/eg/http
           virtualHosts:
           - domains:
             - '*'
-            name: default-eg-http
+            name: default/eg/http
             routes:
             - match:
                 headers:
@@ -935,17 +935,17 @@ xds:
                   stringMatch:
                     exact: www.example.com
                 prefix: /
-              name: default-backend-rule-0-match-0-www.example.com
+              name: default/backend/rule/0/match/0-www.example.com
               route:
-                cluster: default-backend-rule-0-match-0-www.example.com
+                cluster: default/backend/rule/0/match/0-www.example.com
       - routeConfig:
           '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
           ignorePortInHostMatching: true
-          name: default-eg-grpc
+          name: default/eg/grpc
           virtualHosts:
           - domains:
             - '*'
-            name: default-eg-grpc
+            name: default/eg/grpc
             routes:
             - match:
                 headers:
@@ -953,6 +953,6 @@ xds:
                   stringMatch:
                     exact: www.grpc-example.com
                 path: /com.example.Things/DoThing
-              name: default-backend-rule-0-match-0-www.grpc-example.com
+              name: default/backend/rule/0/match/0-www.grpc-example.com
               route:
-                cluster: default-backend-rule-0-match-0-www.grpc-example.com
+                cluster: default/backend/rule/0/match/0-www.grpc-example.com

--- a/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
@@ -82,7 +82,7 @@ httpRoutes:
       parentRef:
         name: eg
 xds:
-  envoy-gateway-system-eg:
+  envoy-gateway-system/eg:
     '@type': type.googleapis.com/envoy.admin.v3.ClustersConfigDump
     dynamicActiveClusters:
     - cluster:
@@ -95,8 +95,8 @@ xds:
           edsConfig:
             ads: {}
             resourceApiVersion: V3
-          serviceName: envoy-gateway-system-backend-rule-0-match-0-www.example.com
-        name: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+          serviceName: envoy-gateway-system/backend/rule/0/match/0-www.example.com
+        name: envoy-gateway-system/backend/rule/0/match/0-www.example.com
         outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -1,6 +1,6 @@
 {
   "xds": {
-    "default-eg": {
+    "default/eg": {
       "configs": [
         {
           "@type": "type.googleapis.com/envoy.admin.v3.BootstrapConfigDump",
@@ -183,7 +183,7 @@
             {
               "endpointConfig": {
                 "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
-                "clusterName": "default-backend-rule-0-match-0-www.example.com",
+                "clusterName": "default/backend/rule/0/match/0-www.example.com",
                 "endpoints": [
                   {
                     "lbEndpoints": [
@@ -208,7 +208,7 @@
             {
               "endpointConfig": {
                 "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
-                "clusterName": "default-backend-rule-0-match-0-www.grpc-example.com",
+                "clusterName": "default/backend/rule/0/match/0-www.grpc-example.com",
                 "endpoints": [
                   {
                     "lbEndpoints": [
@@ -233,7 +233,7 @@
             {
               "endpointConfig": {
                 "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
-                "clusterName": "default-eg-tls-passthrough-backend",
+                "clusterName": "default/eg/tls-passthrough/backend",
                 "endpoints": [
                   {
                     "lbEndpoints": [
@@ -258,7 +258,7 @@
             {
               "endpointConfig": {
                 "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
-                "clusterName": "default-eg-tcp-backend",
+                "clusterName": "default/eg/tcp/backend",
                 "endpoints": [
                   {
                     "lbEndpoints": [
@@ -282,7 +282,7 @@
             {
               "endpointConfig": {
                 "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
-                "clusterName": "default-eg-udp-backend",
+                "clusterName": "default/eg/udp/backend",
                 "endpoints": [
                   {
                     "lbEndpoints": [
@@ -321,9 +321,9 @@
                     "ads": {},
                     "resourceApiVersion": "V3"
                   },
-                  "serviceName": "default-backend-rule-0-match-0-www.example.com"
+                  "serviceName": "default/backend/rule/0/match/0-www.example.com"
                 },
-                "name": "default-backend-rule-0-match-0-www.example.com",
+                "name": "default/backend/rule/0/match/0-www.example.com",
                 "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS"
@@ -342,9 +342,9 @@
                     "ads": {},
                     "resourceApiVersion": "V3"
                   },
-                  "serviceName": "default-backend-rule-0-match-0-www.grpc-example.com"
+                  "serviceName": "default/backend/rule/0/match/0-www.grpc-example.com"
                 },
-                "name": "default-backend-rule-0-match-0-www.grpc-example.com",
+                "name": "default/backend/rule/0/match/0-www.grpc-example.com",
                 "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS",
@@ -371,9 +371,9 @@
                     "ads": {},
                     "resourceApiVersion": "V3"
                   },
-                  "serviceName": "default-eg-tls-passthrough-backend"
+                  "serviceName": "default/eg/tls-passthrough/backend"
                 },
-                "name": "default-eg-tls-passthrough-backend",
+                "name": "default/eg/tls-passthrough/backend",
                 "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS"
@@ -392,9 +392,9 @@
                     "ads": {},
                     "resourceApiVersion": "V3"
                   },
-                  "serviceName": "default-eg-tcp-backend"
+                  "serviceName": "default/eg/tcp/backend"
                 },
-                "name": "default-eg-tcp-backend",
+                "name": "default/eg/tcp/backend",
                 "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS"
@@ -413,9 +413,9 @@
                     "ads": {},
                     "resourceApiVersion": "V3"
                   },
-                  "serviceName": "default-eg-udp-backend"
+                  "serviceName": "default/eg/udp/backend"
                 },
-                "name": "default-eg-udp-backend",
+                "name": "default/eg/udp/backend",
                 "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS"
@@ -501,7 +501,7 @@
                               "ads": {},
                               "resourceApiVersion": "V3"
                             },
-                            "routeConfigName": "default-eg-http"
+                            "routeConfigName": "default/eg/http"
                           },
                           "statPrefix": "http",
                           "upgradeConfigs": [
@@ -514,7 +514,7 @@
                       }
                     ]
                   },
-                  "name": "default-eg-http",
+                  "name": "default/eg/http",
                   "perConnectionBufferLimitBytes": 32768
                 }
               }
@@ -608,7 +608,7 @@
                               "ads": {},
                               "resourceApiVersion": "V3"
                             },
-                            "routeConfigName": "default-eg-grpc"
+                            "routeConfigName": "default/eg/grpc"
                           },
                           "statPrefix": "http",
                           "useRemoteAddress": true
@@ -616,7 +616,7 @@
                       }
                     ]
                   },
-                  "name": "default-eg-grpc",
+                  "name": "default/eg/grpc",
                   "perConnectionBufferLimitBytes": 32768
                 }
               }
@@ -678,7 +678,7 @@
                                 }
                               }
                             ],
-                            "cluster": "default-eg-tls-passthrough-backend",
+                            "cluster": "default/eg/tls-passthrough/backend",
                             "statPrefix": "passthrough"
                           }
                         }
@@ -693,7 +693,7 @@
                       }
                     }
                   ],
-                  "name": "default-eg-tls-passthrough-backend",
+                  "name": "default/eg/tls-passthrough/backend",
                   "perConnectionBufferLimitBytes": 32768
                 }
               }
@@ -750,14 +750,14 @@
                                 }
                               }
                             ],
-                            "cluster": "default-eg-tcp-backend",
+                            "cluster": "default/eg/tcp/backend",
                             "statPrefix": "tcp"
                           }
                         }
                       ]
                     }
                   ],
-                  "name": "default-eg-tcp-backend",
+                  "name": "default/eg/tcp/backend",
                   "perConnectionBufferLimitBytes": 32768
                 }
               }
@@ -819,7 +819,7 @@
                               "name": "route",
                               "typedConfig": {
                                 "@type": "type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route",
-                                "cluster": "default-eg-udp-backend"
+                                "cluster": "default/eg/udp/backend"
                               }
                             }
                           }
@@ -828,7 +828,7 @@
                       }
                     }
                   ],
-                  "name": "default-eg-udp-backend"
+                  "name": "default/eg/udp/backend"
                 }
               }
             }
@@ -841,13 +841,13 @@
               "routeConfig": {
                 "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
                 "ignorePortInHostMatching": true,
-                "name": "default-eg-http",
+                "name": "default/eg/http",
                 "virtualHosts": [
                   {
                     "domains": [
                       "*"
                     ],
-                    "name": "default-eg-http",
+                    "name": "default/eg/http",
                     "routes": [
                       {
                         "match": {
@@ -861,9 +861,9 @@
                           ],
                           "prefix": "/"
                         },
-                        "name": "default-backend-rule-0-match-0-www.example.com",
+                        "name": "default/backend/rule/0/match/0-www.example.com",
                         "route": {
-                          "cluster": "default-backend-rule-0-match-0-www.example.com"
+                          "cluster": "default/backend/rule/0/match/0-www.example.com"
                         }
                       }
                     ]
@@ -875,13 +875,13 @@
               "routeConfig": {
                 "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
                 "ignorePortInHostMatching": true,
-                "name": "default-eg-grpc",
+                "name": "default/eg/grpc",
                 "virtualHosts": [
                   {
                     "domains": [
                       "*"
                     ],
-                    "name": "default-eg-grpc",
+                    "name": "default/eg/grpc",
                     "routes": [
                       {
                         "match": {
@@ -895,9 +895,9 @@
                           ],
                           "path": "/com.example.Things/DoThing"
                         },
-                        "name": "default-backend-rule-0-match-0-www.grpc-example.com",
+                        "name": "default/backend/rule/0/match/0-www.grpc-example.com",
                         "route": {
-                          "cluster": "default-backend-rule-0-match-0-www.grpc-example.com"
+                          "cluster": "default/backend/rule/0/match/0-www.grpc-example.com"
                         }
                       }
                     ]

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -1,5 +1,5 @@
 xds:
-  default-eg:
+  default/eg:
     configs:
     - '@type': type.googleapis.com/envoy.admin.v3.BootstrapConfigDump
       bootstrap:
@@ -103,7 +103,7 @@ xds:
       dynamicEndpointConfigs:
       - endpointConfig:
           '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-          clusterName: default-backend-rule-0-match-0-www.example.com
+          clusterName: default/backend/rule/0/match/0-www.example.com
           endpoints:
           - lbEndpoints:
             - endpoint:
@@ -116,7 +116,7 @@ xds:
             locality: {}
       - endpointConfig:
           '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-          clusterName: default-backend-rule-0-match-0-www.grpc-example.com
+          clusterName: default/backend/rule/0/match/0-www.grpc-example.com
           endpoints:
           - lbEndpoints:
             - endpoint:
@@ -129,7 +129,7 @@ xds:
             locality: {}
       - endpointConfig:
           '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-          clusterName: default-eg-tls-passthrough-backend
+          clusterName: default/eg/tls-passthrough/backend
           endpoints:
           - lbEndpoints:
             - endpoint:
@@ -142,7 +142,7 @@ xds:
             locality: {}
       - endpointConfig:
           '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-          clusterName: default-eg-tcp-backend
+          clusterName: default/eg/tcp/backend
           endpoints:
           - lbEndpoints:
             - endpoint:
@@ -154,7 +154,7 @@ xds:
             locality: {}
       - endpointConfig:
           '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-          clusterName: default-eg-udp-backend
+          clusterName: default/eg/udp/backend
           endpoints:
           - lbEndpoints:
             - endpoint:
@@ -176,8 +176,8 @@ xds:
             edsConfig:
               ads: {}
               resourceApiVersion: V3
-            serviceName: default-backend-rule-0-match-0-www.example.com
-          name: default-backend-rule-0-match-0-www.example.com
+            serviceName: default/backend/rule/0/match/0-www.example.com
+          name: default/backend/rule/0/match/0-www.example.com
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
@@ -191,8 +191,8 @@ xds:
             edsConfig:
               ads: {}
               resourceApiVersion: V3
-            serviceName: default-backend-rule-0-match-0-www.grpc-example.com
-          name: default-backend-rule-0-match-0-www.grpc-example.com
+            serviceName: default/backend/rule/0/match/0-www.grpc-example.com
+          name: default/backend/rule/0/match/0-www.grpc-example.com
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
@@ -211,8 +211,8 @@ xds:
             edsConfig:
               ads: {}
               resourceApiVersion: V3
-            serviceName: default-eg-tls-passthrough-backend
-          name: default-eg-tls-passthrough-backend
+            serviceName: default/eg/tls-passthrough/backend
+          name: default/eg/tls-passthrough/backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
@@ -226,8 +226,8 @@ xds:
             edsConfig:
               ads: {}
               resourceApiVersion: V3
-            serviceName: default-eg-tcp-backend
-          name: default-eg-tcp-backend
+            serviceName: default/eg/tcp/backend
+          name: default/eg/tcp/backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
@@ -241,8 +241,8 @@ xds:
             edsConfig:
               ads: {}
               resourceApiVersion: V3
-            serviceName: default-eg-udp-backend
-          name: default-eg-udp-backend
+            serviceName: default/eg/udp/backend
+          name: default/eg/udp/backend
           outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
@@ -299,12 +299,12 @@ xds:
                     configSource:
                       ads: {}
                       resourceApiVersion: V3
-                    routeConfigName: default-eg-http
+                    routeConfigName: default/eg/http
                   statPrefix: http
                   upgradeConfigs:
                   - upgradeType: websocket
                   useRemoteAddress: true
-            name: default-eg-http
+            name: default/eg/http
             perConnectionBufferLimitBytes: 32768
       - activeState:
           listener:
@@ -365,10 +365,10 @@ xds:
                     configSource:
                       ads: {}
                       resourceApiVersion: V3
-                    routeConfigName: default-eg-grpc
+                    routeConfigName: default/eg/grpc
                   statPrefix: http
                   useRemoteAddress: true
-            name: default-eg-grpc
+            name: default/eg/grpc
             perConnectionBufferLimitBytes: 32768
       - activeState:
           listener:
@@ -407,13 +407,13 @@ xds:
                           inlineString: |
                             [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
                       path: /dev/stdout
-                  cluster: default-eg-tls-passthrough-backend
+                  cluster: default/eg/tls-passthrough/backend
                   statPrefix: passthrough
             listenerFilters:
             - name: envoy.filters.listener.tls_inspector
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-            name: default-eg-tls-passthrough-backend
+            name: default/eg/tls-passthrough/backend
             perConnectionBufferLimitBytes: 32768
       - activeState:
           listener:
@@ -449,9 +449,9 @@ xds:
                           inlineString: |
                             [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
                       path: /dev/stdout
-                  cluster: default-eg-tcp-backend
+                  cluster: default/eg/tcp/backend
                   statPrefix: tcp
-            name: default-eg-tcp-backend
+            name: default/eg/tcp/backend
             perConnectionBufferLimitBytes: 32768
       - activeState:
           listener:
@@ -493,19 +493,19 @@ xds:
                       name: route
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
-                        cluster: default-eg-udp-backend
+                        cluster: default/eg/udp/backend
                 statPrefix: service
-            name: default-eg-udp-backend
+            name: default/eg/udp/backend
     - '@type': type.googleapis.com/envoy.admin.v3.RoutesConfigDump
       dynamicRouteConfigs:
       - routeConfig:
           '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
           ignorePortInHostMatching: true
-          name: default-eg-http
+          name: default/eg/http
           virtualHosts:
           - domains:
             - '*'
-            name: default-eg-http
+            name: default/eg/http
             routes:
             - match:
                 headers:
@@ -513,17 +513,17 @@ xds:
                   stringMatch:
                     exact: www.example.com
                 prefix: /
-              name: default-backend-rule-0-match-0-www.example.com
+              name: default/backend/rule/0/match/0-www.example.com
               route:
-                cluster: default-backend-rule-0-match-0-www.example.com
+                cluster: default/backend/rule/0/match/0-www.example.com
       - routeConfig:
           '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
           ignorePortInHostMatching: true
-          name: default-eg-grpc
+          name: default/eg/grpc
           virtualHosts:
           - domains:
             - '*'
-            name: default-eg-grpc
+            name: default/eg/grpc
             routes:
             - match:
                 headers:
@@ -531,6 +531,6 @@ xds:
                   stringMatch:
                     exact: www.grpc-example.com
                 path: /com.example.Things/DoThing
-              name: default-backend-rule-0-match-0-www.grpc-example.com
+              name: default/backend/rule/0/match/0-www.grpc-example.com
               route:
-                cluster: default-backend-rule-0-match-0-www.grpc-example.com
+                cluster: default/backend/rule/0/match/0-www.grpc-example.com

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.bootstrap.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.bootstrap.yaml
@@ -1,5 +1,5 @@
 xds:
-  default-eg:
+  default/eg:
     '@type': type.googleapis.com/envoy.admin.v3.BootstrapConfigDump
     bootstrap:
       admin:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
@@ -1,5 +1,5 @@
 xds:
-  default-eg:
+  default/eg:
     '@type': type.googleapis.com/envoy.admin.v3.ClustersConfigDump
     dynamicActiveClusters:
     - cluster:
@@ -12,8 +12,8 @@ xds:
           edsConfig:
             ads: {}
             resourceApiVersion: V3
-          serviceName: default-backend-rule-0-match-0-www.example.com
-        name: default-backend-rule-0-match-0-www.example.com
+          serviceName: default/backend/rule/0/match/0-www.example.com
+        name: default/backend/rule/0/match/0-www.example.com
         outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS
@@ -27,8 +27,8 @@ xds:
           edsConfig:
             ads: {}
             resourceApiVersion: V3
-          serviceName: default-backend-rule-0-match-0-www.grpc-example.com
-        name: default-backend-rule-0-match-0-www.grpc-example.com
+          serviceName: default/backend/rule/0/match/0-www.grpc-example.com
+        name: default/backend/rule/0/match/0-www.grpc-example.com
         outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS
@@ -47,8 +47,8 @@ xds:
           edsConfig:
             ads: {}
             resourceApiVersion: V3
-          serviceName: default-eg-tls-passthrough-backend
-        name: default-eg-tls-passthrough-backend
+          serviceName: default/eg/tls-passthrough/backend
+        name: default/eg/tls-passthrough/backend
         outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS
@@ -62,8 +62,8 @@ xds:
           edsConfig:
             ads: {}
             resourceApiVersion: V3
-          serviceName: default-eg-tcp-backend
-        name: default-eg-tcp-backend
+          serviceName: default/eg/tcp/backend
+        name: default/eg/tcp/backend
         outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS
@@ -77,8 +77,8 @@ xds:
           edsConfig:
             ads: {}
             resourceApiVersion: V3
-          serviceName: default-eg-udp-backend
-        name: default-eg-udp-backend
+          serviceName: default/eg/udp/backend
+        name: default/eg/udp/backend
         outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.endpoint.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.endpoint.yaml
@@ -1,10 +1,10 @@
 xds:
-  default-eg:
+  default/eg:
     '@type': type.googleapis.com/envoy.admin.v3.EndpointsConfigDump
     dynamicEndpointConfigs:
     - endpointConfig:
         '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-        clusterName: default-backend-rule-0-match-0-www.example.com
+        clusterName: default/backend/rule/0/match/0-www.example.com
         endpoints:
         - lbEndpoints:
           - endpoint:
@@ -17,7 +17,7 @@ xds:
           locality: {}
     - endpointConfig:
         '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-        clusterName: default-backend-rule-0-match-0-www.grpc-example.com
+        clusterName: default/backend/rule/0/match/0-www.grpc-example.com
         endpoints:
         - lbEndpoints:
           - endpoint:
@@ -30,7 +30,7 @@ xds:
           locality: {}
     - endpointConfig:
         '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-        clusterName: default-eg-tls-passthrough-backend
+        clusterName: default/eg/tls-passthrough/backend
         endpoints:
         - lbEndpoints:
           - endpoint:
@@ -43,7 +43,7 @@ xds:
           locality: {}
     - endpointConfig:
         '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-        clusterName: default-eg-tcp-backend
+        clusterName: default/eg/tcp/backend
         endpoints:
         - lbEndpoints:
           - endpoint:
@@ -55,7 +55,7 @@ xds:
           locality: {}
     - endpointConfig:
         '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-        clusterName: default-eg-udp-backend
+        clusterName: default/eg/udp/backend
         endpoints:
         - lbEndpoints:
           - endpoint:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
@@ -1,5 +1,5 @@
 xds:
-  default-eg:
+  default/eg:
     '@type': type.googleapis.com/envoy.admin.v3.ListenersConfigDump
     dynamicListeners:
     - activeState:
@@ -53,12 +53,12 @@ xds:
                   configSource:
                     ads: {}
                     resourceApiVersion: V3
-                  routeConfigName: default-eg-http
+                  routeConfigName: default/eg/http
                 statPrefix: http
                 upgradeConfigs:
                 - upgradeType: websocket
                 useRemoteAddress: true
-          name: default-eg-http
+          name: default/eg/http
           perConnectionBufferLimitBytes: 32768
     - activeState:
         listener:
@@ -119,10 +119,10 @@ xds:
                   configSource:
                     ads: {}
                     resourceApiVersion: V3
-                  routeConfigName: default-eg-grpc
+                  routeConfigName: default/eg/grpc
                 statPrefix: http
                 useRemoteAddress: true
-          name: default-eg-grpc
+          name: default/eg/grpc
           perConnectionBufferLimitBytes: 32768
     - activeState:
         listener:
@@ -161,13 +161,13 @@ xds:
                         inlineString: |
                           [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
                     path: /dev/stdout
-                cluster: default-eg-tls-passthrough-backend
+                cluster: default/eg/tls-passthrough/backend
                 statPrefix: passthrough
           listenerFilters:
           - name: envoy.filters.listener.tls_inspector
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-          name: default-eg-tls-passthrough-backend
+          name: default/eg/tls-passthrough/backend
           perConnectionBufferLimitBytes: 32768
     - activeState:
         listener:
@@ -203,9 +203,9 @@ xds:
                         inlineString: |
                           [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
                     path: /dev/stdout
-                cluster: default-eg-tcp-backend
+                cluster: default/eg/tcp/backend
                 statPrefix: tcp
-          name: default-eg-tcp-backend
+          name: default/eg/tcp/backend
           perConnectionBufferLimitBytes: 32768
     - activeState:
         listener:
@@ -247,6 +247,6 @@ xds:
                     name: route
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
-                      cluster: default-eg-udp-backend
+                      cluster: default/eg/udp/backend
               statPrefix: service
-          name: default-eg-udp-backend
+          name: default/eg/udp/backend

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
@@ -1,15 +1,15 @@
 xds:
-  default-eg:
+  default/eg:
     '@type': type.googleapis.com/envoy.admin.v3.RoutesConfigDump
     dynamicRouteConfigs:
     - routeConfig:
         '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
         ignorePortInHostMatching: true
-        name: default-eg-http
+        name: default/eg/http
         virtualHosts:
         - domains:
           - '*'
-          name: default-eg-http
+          name: default/eg/http
           routes:
           - match:
               headers:
@@ -17,17 +17,17 @@ xds:
                 stringMatch:
                   exact: www.example.com
               prefix: /
-            name: default-backend-rule-0-match-0-www.example.com
+            name: default/backend/rule/0/match/0-www.example.com
             route:
-              cluster: default-backend-rule-0-match-0-www.example.com
+              cluster: default/backend/rule/0/match/0-www.example.com
     - routeConfig:
         '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
         ignorePortInHostMatching: true
-        name: default-eg-grpc
+        name: default/eg/grpc
         virtualHosts:
         - domains:
           - '*'
-          name: default-eg-grpc
+          name: default/eg/grpc
           routes:
           - match:
               headers:
@@ -35,6 +35,6 @@ xds:
                 stringMatch:
                   exact: www.grpc-example.com
               path: /com.example.Things/DoThing
-            name: default-backend-rule-0-match-0-www.grpc-example.com
+            name: default/backend/rule/0/match/0-www.grpc-example.com
             route:
-              cluster: default-backend-rule-0-match-0-www.grpc-example.com
+              cluster: default/backend/rule/0/match/0-www.grpc-example.com

--- a/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
+++ b/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
@@ -1,19 +1,19 @@
 {
   "xds": {
-    "default-eg": {
+    "default/eg": {
       "@type": "type.googleapis.com/envoy.admin.v3.RoutesConfigDump",
       "dynamicRouteConfigs": [
         {
           "routeConfig": {
             "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
             "ignorePortInHostMatching": true,
-            "name": "default-eg-http",
+            "name": "default/eg/http",
             "virtualHosts": [
               {
                 "domains": [
                   "*"
                 ],
-                "name": "default-eg-http",
+                "name": "default/eg/http",
                 "routes": [
                   {
                     "match": {
@@ -27,9 +27,9 @@
                       ],
                       "prefix": "/"
                     },
-                    "name": "default-backend-rule-0-match-0-www.example.com",
+                    "name": "default/backend/rule/0/match/0-www.example.com",
                     "route": {
-                      "cluster": "default-backend-rule-0-match-0-www.example.com"
+                      "cluster": "default/backend/rule/0/match/0-www.example.com"
                     }
                   }
                 ]
@@ -39,20 +39,20 @@
         }
       ]
     },
-    "default-eg2": {
+    "default/eg2": {
       "@type": "type.googleapis.com/envoy.admin.v3.RoutesConfigDump",
       "dynamicRouteConfigs": [
         {
           "routeConfig": {
             "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
             "ignorePortInHostMatching": true,
-            "name": "default-eg2-http",
+            "name": "default/eg2/http",
             "virtualHosts": [
               {
                 "domains": [
                   "*"
                 ],
-                "name": "default-eg2-http",
+                "name": "default/eg2/http",
                 "routes": [
                   {
                     "match": {
@@ -66,9 +66,9 @@
                       ],
                       "prefix": "/v2/"
                     },
-                    "name": "default-backend-rule-0-match-0-www.example2.com",
+                    "name": "default/backend/rule/0/match/0-www.example2.com",
                     "route": {
-                      "cluster": "default-backend-rule-0-match-0-www.example2.com"
+                      "cluster": "default/backend/rule/0/match/0-www.example2.com"
                     }
                   }
                 ]

--- a/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
@@ -1,15 +1,15 @@
 xds:
-  envoy-gateway-system-eg:
+  envoy-gateway-system/eg:
     '@type': type.googleapis.com/envoy.admin.v3.RoutesConfigDump
     dynamicRouteConfigs:
     - routeConfig:
         '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
         ignorePortInHostMatching: true
-        name: envoy-gateway-system-eg-http
+        name: envoy-gateway-system/eg/http
         virtualHosts:
         - domains:
           - '*'
-          name: envoy-gateway-system-eg-http
+          name: envoy-gateway-system/eg/http
           routes:
           - match:
               headers:
@@ -17,6 +17,6 @@ xds:
                 stringMatch:
                   exact: www.example.com
               prefix: /
-            name: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+            name: envoy-gateway-system/backend/rule/0/match/0-www.example.com
             route:
-              cluster: envoy-gateway-system-backend-rule-0-match-0-www.example.com
+              cluster: envoy-gateway-system/backend/rule/0/match/0-www.example.com

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -386,27 +386,27 @@ type crossNamespaceTo struct {
 }
 
 func irStringKey(gatewayNs, gatewayName string) string {
-	return fmt.Sprintf("%s-%s", gatewayNs, gatewayName)
+	return fmt.Sprintf("%s/%s", gatewayNs, gatewayName)
 }
 
 func irHTTPListenerName(listener *ListenerContext) string {
-	return fmt.Sprintf("%s-%s-%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name)
+	return fmt.Sprintf("%s/%s/%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name)
 }
 
 func irTLSListenerName(listener *ListenerContext, tlsRoute *TLSRouteContext) string {
-	return fmt.Sprintf("%s-%s-%s-%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name, tlsRoute.Name)
+	return fmt.Sprintf("%s/%s/%s/%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name, tlsRoute.Name)
 }
 
 func irTCPListenerName(listener *ListenerContext, tcpRoute *TCPRouteContext) string {
-	return fmt.Sprintf("%s-%s-%s-%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name, tcpRoute.Name)
+	return fmt.Sprintf("%s/%s/%s/%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name, tcpRoute.Name)
 }
 
 func irUDPListenerName(listener *ListenerContext, udpRoute *UDPRouteContext) string {
-	return fmt.Sprintf("%s-%s-%s-%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name, udpRoute.Name)
+	return fmt.Sprintf("%s/%s/%s/%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name, udpRoute.Name)
 }
 
 func routeName(route RouteContext, ruleIdx, matchIdx int) string {
-	return fmt.Sprintf("%s-%s-rule-%d-match-%d", route.GetNamespace(), route.GetName(), ruleIdx, matchIdx)
+	return fmt.Sprintf("%s/%s/rule/%d/match/%d", route.GetNamespace(), route.GetName(), ruleIdx, matchIdx)
 }
 
 func irTLSConfigs(tlsSecrets []*v1.Secret) []*ir.TLSListenerConfig {

--- a/internal/gatewayapi/testdata/disable-accesslog.out.yaml
+++ b/internal/gatewayapi/testdata/disable-accesslog.out.yaml
@@ -35,7 +35,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: GRPCRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       config:
         apiVersion: config.gateway.envoyproxy.io/v1alpha1
@@ -109,13 +109,13 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     http:
     - address: 0.0.0.0
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/envoypatchpolicy-valid.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-valid.out.yaml
@@ -35,7 +35,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: GRPCRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -48,9 +48,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -59,7 +59,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
     jsonPatches:
     - name: envoy-gateway-gateway-1-http

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog.out.yaml
@@ -35,7 +35,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: GRPCRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       config:
         apiVersion: config.gateway.envoyproxy.io/v1alpha1
@@ -123,9 +123,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       openTelemetry:
       - host: otel-collector.monitoring.svc.cluster.local
@@ -143,5 +143,5 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/envoyproxy-valid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-valid.out.yaml
@@ -35,7 +35,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: GRPCRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       config:
         apiVersion: config.gateway.envoyproxy.io/v1alpha1
@@ -107,9 +107,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -118,5 +118,5 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/extensions/httproute-with-extension-filter-invalid-group.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-extension-filter-invalid-group.out.yaml
@@ -83,7 +83,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -96,9 +96,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -107,5 +107,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/extensions/httproute-with-non-matching-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-non-matching-extension-filter.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,5 +105,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/extensions/httproute-with-unsupported-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-unsupported-extension-filter.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,5 +105,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,7 +105,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -128,7 +128,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
@@ -70,7 +70,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -83,9 +83,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -94,7 +94,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -104,7 +104,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: envoy-gateway-httproute-1-rule-0-match-0-*
+        name: envoy-gateway/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
@@ -70,7 +70,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -83,9 +83,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -94,5 +94,5 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/gateway-with-addresses-with-ipaddress.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-addresses-with-ipaddress.out.yaml
@@ -37,7 +37,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       addresses:
       - 1.2.3.4
@@ -53,9 +53,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
@@ -73,7 +73,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -81,9 +81,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
@@ -69,7 +69,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -77,9 +77,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind-and-supported.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind-and-supported.out.yaml
@@ -71,7 +71,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -79,9 +79,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
@@ -69,7 +69,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -77,9 +77,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-tls-route-kind.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-tls-route-kind.out.yaml
@@ -37,7 +37,7 @@ gateways:
       name: tls
       supportedKinds: []
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -45,7 +45,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tlsRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TLSRoute
@@ -79,7 +79,7 @@ tlsRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-multiple-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-multiple-tls-configuration.out.yaml
@@ -84,7 +84,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -92,9 +92,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
@@ -72,7 +72,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -80,9 +80,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
@@ -67,7 +67,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -75,9 +75,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-valid-certificate-for-fqdn.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-valid-certificate-for-fqdn.out.yaml
@@ -79,7 +79,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -87,9 +87,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
@@ -76,7 +76,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -84,9 +84,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
@@ -78,7 +78,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -86,9 +86,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
@@ -76,7 +76,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -84,9 +84,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
@@ -66,7 +66,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -74,9 +74,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcp-with-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcp-with-hostname.out.yaml
@@ -29,7 +29,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -37,9 +37,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-mismatch-port-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-mismatch-port-protocol.out.yaml
@@ -33,7 +33,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -46,7 +46,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tcpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TCPRoute
@@ -80,7 +80,7 @@ tcpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-backends.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-backends.out.yaml
@@ -33,7 +33,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -46,7 +46,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tcpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TCPRoute
@@ -84,7 +84,7 @@ tcpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-rules.out.yaml
@@ -33,7 +33,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -46,7 +46,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tcpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TCPRoute
@@ -85,7 +85,7 @@ tcpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -77,7 +77,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -90,9 +90,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -101,7 +101,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-tls
+      name: envoy-gateway/gateway-1/tls
       port: 10443
       routes:
       - backendWeights:
@@ -111,7 +111,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
@@ -102,7 +102,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -119,7 +119,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tlsRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TLSRoute
@@ -153,7 +153,7 @@ tlsRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -162,7 +162,7 @@ xdsIR:
       hostnames:
       - foo.bar.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-tls-terminate
+      name: envoy-gateway/gateway-1/tls-terminate
       port: 10443
       routes:
       - backendWeights:
@@ -172,7 +172,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-foo.bar.com
+        name: default/httproute-1/rule/0/match/0-foo.bar.com
         pathMatch:
           distinct: false
           name: ""
@@ -187,7 +187,7 @@ xdsIR:
       - host: 7.7.7.7
         port: 8080
         weight: 1
-      name: envoy-gateway-gateway-1-tls-passthrough-tlsroute-1
+      name: envoy-gateway/gateway-1/tls-passthrough/tlsroute-1
       port: 10090
       tls:
         passthrough:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udp-with-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udp-with-hostname.out.yaml
@@ -29,7 +29,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: UDPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -37,9 +37,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-mismatch-port-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-mismatch-port-protocol.out.yaml
@@ -33,7 +33,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: UDPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -46,7 +46,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 udpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: UDPRoute
@@ -80,7 +80,7 @@ udpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-backends.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-backends.out.yaml
@@ -33,7 +33,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: UDPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -46,7 +46,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 udpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: UDPRoute
@@ -84,7 +84,7 @@ udpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-rules.out.yaml
@@ -33,7 +33,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: UDPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -46,7 +46,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 udpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: UDPRoute
@@ -85,7 +85,7 @@ udpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-tcproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-tcproute.out.yaml
@@ -33,7 +33,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -46,9 +46,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-udproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-udproute.out.yaml
@@ -33,7 +33,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: UDPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -46,9 +46,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
@@ -66,7 +66,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -74,9 +74,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration-with-same-algorithm-different-fqdn.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration-with-same-algorithm-different-fqdn.out.yaml
@@ -79,7 +79,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -92,9 +92,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -103,7 +103,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-tls
+      name: envoy-gateway/gateway-1/tls
       port: 10443
       routes:
       - backendWeights:
@@ -113,7 +113,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration.out.yaml
@@ -79,7 +79,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -92,9 +92,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -103,7 +103,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-tls
+      name: envoy-gateway/gateway-1/tls
       port: 10443
       routes:
       - backendWeights:
@@ -113,7 +113,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
@@ -76,7 +76,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -89,9 +89,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -100,7 +100,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-tls
+      name: envoy-gateway/gateway-1/tls
       port: 10443
       routes:
       - backendWeights:
@@ -110,7 +110,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-preexisting-status-condition.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-preexisting-status-condition.out.yaml
@@ -70,7 +70,7 @@ httpRoutes:
         name: gateway-1
         namespace: default
 infraIR:
-  default-gateway-1:
+  default/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -83,9 +83,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: default
-      name: default-gateway-1
+      name: default/gateway-1
 xdsIR:
-  default-gateway-1:
+  default/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -94,7 +94,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: default-gateway-1-http
+      name: default/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -104,7 +104,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
@@ -33,7 +33,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -46,7 +46,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tcpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TCPRoute
@@ -111,7 +111,7 @@ tcpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -120,6 +120,6 @@ xdsIR:
       destinations:
       - host: 7.7.7.7
         port: 8163
-      name: envoy-gateway-gateway-1-tcp-tcproute-1
+      name: envoy-gateway/gateway-1/tcp/tcproute-1
       port: 10162
       tls: {}

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-udproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-udproutes.out.yaml
@@ -33,7 +33,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: UDPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -46,7 +46,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 udpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: UDPRoute
@@ -111,7 +111,7 @@ udpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -120,5 +120,5 @@ xdsIR:
       destinations:
       - host: 7.7.7.7
         port: 8162
-      name: envoy-gateway-gateway-1-udp-udproute-1
+      name: envoy-gateway/gateway-1/udp/udproute-1
       port: 10162

--- a/internal/gatewayapi/testdata/gateway-with-stale-status-condition.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-stale-status-condition.out.yaml
@@ -76,7 +76,7 @@ httpRoutes:
         name: gateway-1
         namespace: default
 infraIR:
-  default-gateway-1:
+  default/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -89,9 +89,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: default
-      name: default-gateway-1
+      name: default/gateway-1
 xdsIR:
-  default-gateway-1:
+  default/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -100,7 +100,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: default-gateway-1-https
+      name: default/gateway-1/https
       port: 10443
       routes:
       - backendWeights:
@@ -110,7 +110,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-or-tls-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-or-tls-port.out.yaml
@@ -57,7 +57,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TLSRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -70,7 +70,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tcpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TCPRoute
@@ -104,7 +104,7 @@ tcpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -113,6 +113,6 @@ xdsIR:
       destinations:
       - host: 7.7.7.7
         port: 8163
-      name: envoy-gateway-gateway-1-tcp1-tcproute-1
+      name: envoy-gateway/gateway-1/tcp1/tcproute-1
       port: 10162
       tls: {}

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-udp-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-udp-port.out.yaml
@@ -55,7 +55,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: UDPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -68,7 +68,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 udpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: UDPRoute
@@ -102,7 +102,7 @@ udpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -111,5 +111,5 @@ xdsIR:
       destinations:
       - host: 7.7.7.7
         port: 8162
-      name: envoy-gateway-gateway-1-udp1-udproute-1
+      name: envoy-gateway/gateway-1/udp1/udproute-1
       port: 10162

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-http-and-tlsroute-same-hostname-and-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-http-and-tlsroute-same-hostname-and-port.out.yaml
@@ -96,7 +96,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -104,7 +104,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tlsRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TLSRoute
@@ -138,7 +138,7 @@ tlsRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
@@ -130,7 +130,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -147,9 +147,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -158,7 +158,7 @@ xdsIR:
       hostnames:
       - foo.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-1
+      name: envoy-gateway/gateway-1/http-1
       port: 10080
       routes:
       - backendWeights:
@@ -168,7 +168,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-2-rule-0-match-0-foo.com
+        name: default/httproute-2/rule/0/match/0-foo.com
         pathMatch:
           distinct: false
           name: ""
@@ -180,7 +180,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-foo.com
+        name: default/httproute-1/rule/0/match/0-foo.com
         pathMatch:
           distinct: false
           name: ""
@@ -189,7 +189,7 @@ xdsIR:
       hostnames:
       - bar.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-2
+      name: envoy-gateway/gateway-1/http-2
       port: 10081
       routes:
       - backendWeights:
@@ -199,7 +199,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-2-rule-0-match-0-bar.com
+        name: default/httproute-2/rule/0/match/0-bar.com
         pathMatch:
           distinct: false
           name: ""
@@ -211,7 +211,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-bar.com
+        name: default/httproute-1/rule/0/match/0-bar.com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
@@ -96,7 +96,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -104,9 +104,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
@@ -96,7 +96,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -104,9 +104,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
@@ -93,7 +93,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -110,7 +110,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tcpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TCPRoute
@@ -144,7 +144,7 @@ tcpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -153,7 +153,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -163,7 +163,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""
@@ -173,6 +173,6 @@ xdsIR:
       destinations:
       - host: 7.7.7.7
         port: 8163
-      name: envoy-gateway-gateway-1-tcp-tcproute-1
+      name: envoy-gateway/gateway-1/tcp/tcproute-1
       port: 10080
       tls: {}

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
@@ -93,7 +93,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -110,7 +110,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 udpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: UDPRoute
@@ -144,7 +144,7 @@ udpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -153,7 +153,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -163,7 +163,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""
@@ -173,5 +173,5 @@ xdsIR:
       destinations:
       - host: 7.7.7.7
         port: 8162
-      name: envoy-gateway-gateway-1-udp-udproute-1
+      name: envoy-gateway/gateway-1/udp/udproute-1
       port: 10080

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-with-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-with-sectionname.out.yaml
@@ -55,7 +55,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -72,7 +72,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tcpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TCPRoute
@@ -141,7 +141,7 @@ tcpRoutes:
         namespace: envoy-gateway
         sectionName: tcp2
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -150,13 +150,13 @@ xdsIR:
       destinations:
       - host: 7.7.7.7
         port: 8163
-      name: envoy-gateway-gateway-1-tcp1-tcproute-1
+      name: envoy-gateway/gateway-1/tcp1/tcproute-1
       port: 10162
       tls: {}
     - address: 0.0.0.0
       destinations:
       - host: 7.7.7.7
         port: 8163
-      name: envoy-gateway-gateway-1-tcp2-tcproute-2
+      name: envoy-gateway/gateway-1/tcp2/tcproute-2
       port: 10163
       tls: {}

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
@@ -55,7 +55,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -72,7 +72,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tcpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TCPRoute
@@ -137,7 +137,7 @@ tcpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -146,13 +146,13 @@ xdsIR:
       destinations:
       - host: 7.7.7.7
         port: 8163
-      name: envoy-gateway-gateway-1-tcp1-tcproute-1
+      name: envoy-gateway/gateway-1/tcp1/tcproute-1
       port: 10161
       tls: {}
     - address: 0.0.0.0
       destinations:
       - host: 7.7.7.7
         port: 8163
-      name: envoy-gateway-gateway-1-tcp2-tcproute-1
+      name: envoy-gateway/gateway-1/tcp2/tcproute-1
       port: 10162
       tls: {}

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-with-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-with-sectionname.out.yaml
@@ -55,7 +55,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: UDPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -72,7 +72,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 udpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: UDPRoute
@@ -141,7 +141,7 @@ udpRoutes:
         namespace: envoy-gateway
         sectionName: udp2
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -150,11 +150,11 @@ xdsIR:
       destinations:
       - host: 7.7.7.7
         port: 8162
-      name: envoy-gateway-gateway-1-udp1-udproute-1
+      name: envoy-gateway/gateway-1/udp1/udproute-1
       port: 10162
     - address: 0.0.0.0
       destinations:
       - host: 7.7.7.7
         port: 8162
-      name: envoy-gateway-gateway-1-udp2-udproute-2
+      name: envoy-gateway/gateway-1/udp2/udproute-2
       port: 10163

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-without-sectionname.out.yaml
@@ -55,7 +55,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: UDPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -72,7 +72,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 udpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: UDPRoute
@@ -137,7 +137,7 @@ udpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -146,11 +146,11 @@ xdsIR:
       destinations:
       - host: 7.7.7.7
         port: 8162
-      name: envoy-gateway-gateway-1-udp1-udproute-1
+      name: envoy-gateway/gateway-1/udp1/udproute-1
       port: 10161
     - address: 0.0.0.0
       destinations:
       - host: 7.7.7.7
         port: 8162
-      name: envoy-gateway-gateway-1-udp2-udproute-1
+      name: envoy-gateway/gateway-1/udp2/udproute-1
       port: 10162

--- a/internal/gatewayapi/testdata/grpcroute-with-header-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-header-match.out.yaml
@@ -74,7 +74,7 @@ grpcRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -87,9 +87,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -98,7 +98,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: true
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -112,4 +112,4 @@ xdsIR:
         - distinct: false
           exact: foo
           name: magic
-        name: default-grpcroute-1-rule-0-match-0-*
+        name: default/grpcroute-1/rule/0/match/0-*

--- a/internal/gatewayapi/testdata/grpcroute-with-method-and-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-method-and-service-match.out.yaml
@@ -78,7 +78,7 @@ grpcRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -91,9 +91,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -102,7 +102,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: true
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -112,7 +112,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-grpcroute-1-rule-0-match-0-*
+        name: default/grpcroute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           exact: /com.example/Example
@@ -124,7 +124,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-grpcroute-1-rule-0-match-1-*
+        name: default/grpcroute-1/rule/0/match/1-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/grpcroute-with-method-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-method-match.out.yaml
@@ -76,7 +76,7 @@ grpcRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -89,9 +89,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -100,7 +100,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: true
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -110,7 +110,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-grpcroute-1-rule-0-match-1-*
+        name: default/grpcroute-1/rule/0/match/1-*
         pathMatch:
           distinct: false
           name: ""
@@ -126,4 +126,4 @@ xdsIR:
         - distinct: false
           name: :path
           suffix: /ExampleExact
-        name: default-grpcroute-1-rule-0-match-0-*
+        name: default/grpcroute-1/rule/0/match/0-*

--- a/internal/gatewayapi/testdata/grpcroute-with-request-header-modifier.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-request-header-modifier.out.yaml
@@ -75,7 +75,7 @@ grpcRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -88,9 +88,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -99,7 +99,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: true
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - addRequestHeaders:
@@ -113,4 +113,4 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-grpcroute-1-rule-0-match--1-*
+        name: default/grpcroute-1/rule/0/match/-1-*

--- a/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
@@ -76,7 +76,7 @@ grpcRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -89,9 +89,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -100,7 +100,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: true
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -110,7 +110,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-grpcroute-1-rule-0-match-1-*
+        name: default/grpcroute-1/rule/0/match/1-*
         pathMatch:
           distinct: false
           name: ""
@@ -122,7 +122,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-grpcroute-1-rule-0-match-0-*
+        name: default/grpcroute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
@@ -246,7 +246,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -287,9 +287,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -298,7 +298,7 @@ xdsIR:
       hostnames:
       - foo.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-1
+      name: envoy-gateway/gateway-1/http-1
       port: 10081
       routes:
       - backendWeights:
@@ -308,7 +308,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-foo.com
+        name: default/httproute-1/rule/0/match/0-foo.com
         pathMatch:
           distinct: false
           name: ""
@@ -317,7 +317,7 @@ xdsIR:
       hostnames:
       - bar.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-2
+      name: envoy-gateway/gateway-1/http-2
       port: 10082
       routes:
       - backendWeights:
@@ -327,7 +327,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-bar.com
+        name: default/httproute-1/rule/0/match/0-bar.com
         pathMatch:
           distinct: false
           name: ""
@@ -336,7 +336,7 @@ xdsIR:
       hostnames:
       - foo1.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-3
+      name: envoy-gateway/gateway-1/http-3
       port: 10083
       routes:
       - backendWeights:
@@ -346,7 +346,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-foo1.com
+        name: default/httproute-1/rule/0/match/0-foo1.com
         pathMatch:
           distinct: false
           name: ""
@@ -355,7 +355,7 @@ xdsIR:
       hostnames:
       - bar1.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-4
+      name: envoy-gateway/gateway-1/http-4
       port: 10084
       routes:
       - backendWeights:
@@ -365,7 +365,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-bar1.com
+        name: default/httproute-1/rule/0/match/0-bar1.com
         pathMatch:
           distinct: false
           name: ""
@@ -374,7 +374,7 @@ xdsIR:
       hostnames:
       - foo2.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-5
+      name: envoy-gateway/gateway-1/http-5
       port: 10085
       routes:
       - backendWeights:
@@ -384,7 +384,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-foo2.com
+        name: default/httproute-1/rule/0/match/0-foo2.com
         pathMatch:
           distinct: false
           name: ""
@@ -393,7 +393,7 @@ xdsIR:
       hostnames:
       - bar2.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-6
+      name: envoy-gateway/gateway-1/http-6
       port: 10086
       routes:
       - backendWeights:
@@ -403,7 +403,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-bar2.com
+        name: default/httproute-1/rule/0/match/0-bar2.com
         pathMatch:
           distinct: false
           name: ""
@@ -412,7 +412,7 @@ xdsIR:
       hostnames:
       - foo3.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-7
+      name: envoy-gateway/gateway-1/http-7
       port: 10087
       routes:
       - backendWeights:
@@ -422,7 +422,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-foo3.com
+        name: default/httproute-1/rule/0/match/0-foo3.com
         pathMatch:
           distinct: false
           name: ""
@@ -431,7 +431,7 @@ xdsIR:
       hostnames:
       - bar3.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-8
+      name: envoy-gateway/gateway-1/http-8
       port: 10088
       routes:
       - backendWeights:
@@ -441,7 +441,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-bar3.com
+        name: default/httproute-1/rule/0/match/0-bar3.com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
@@ -246,7 +246,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -259,9 +259,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -270,7 +270,7 @@ xdsIR:
       hostnames:
       - foo.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-1
+      name: envoy-gateway/gateway-1/http-1
       port: 10080
       routes:
       - backendWeights:
@@ -280,7 +280,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-foo.com
+        name: default/httproute-1/rule/0/match/0-foo.com
         pathMatch:
           distinct: false
           name: ""
@@ -289,7 +289,7 @@ xdsIR:
       hostnames:
       - bar.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-2
+      name: envoy-gateway/gateway-1/http-2
       port: 10080
       routes:
       - backendWeights:
@@ -299,7 +299,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-bar.com
+        name: default/httproute-1/rule/0/match/0-bar.com
         pathMatch:
           distinct: false
           name: ""
@@ -308,7 +308,7 @@ xdsIR:
       hostnames:
       - foo1.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-3
+      name: envoy-gateway/gateway-1/http-3
       port: 10080
       routes:
       - backendWeights:
@@ -318,7 +318,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-foo1.com
+        name: default/httproute-1/rule/0/match/0-foo1.com
         pathMatch:
           distinct: false
           name: ""
@@ -327,7 +327,7 @@ xdsIR:
       hostnames:
       - bar1.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-4
+      name: envoy-gateway/gateway-1/http-4
       port: 10080
       routes:
       - backendWeights:
@@ -337,7 +337,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-bar1.com
+        name: default/httproute-1/rule/0/match/0-bar1.com
         pathMatch:
           distinct: false
           name: ""
@@ -346,7 +346,7 @@ xdsIR:
       hostnames:
       - foo2.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-5
+      name: envoy-gateway/gateway-1/http-5
       port: 10080
       routes:
       - backendWeights:
@@ -356,7 +356,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-foo2.com
+        name: default/httproute-1/rule/0/match/0-foo2.com
         pathMatch:
           distinct: false
           name: ""
@@ -365,7 +365,7 @@ xdsIR:
       hostnames:
       - bar2.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-6
+      name: envoy-gateway/gateway-1/http-6
       port: 10080
       routes:
       - backendWeights:
@@ -375,7 +375,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-bar2.com
+        name: default/httproute-1/rule/0/match/0-bar2.com
         pathMatch:
           distinct: false
           name: ""
@@ -384,7 +384,7 @@ xdsIR:
       hostnames:
       - foo3.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-7
+      name: envoy-gateway/gateway-1/http-7
       port: 10080
       routes:
       - backendWeights:
@@ -394,7 +394,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-foo3.com
+        name: default/httproute-1/rule/0/match/0-foo3.com
         pathMatch:
           distinct: false
           name: ""
@@ -403,7 +403,7 @@ xdsIR:
       hostnames:
       - bar3.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-8
+      name: envoy-gateway/gateway-1/http-8
       port: 10080
       routes:
       - backendWeights:
@@ -413,7 +413,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-bar3.com
+        name: default/httproute-1/rule/0/match/0-bar3.com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
@@ -100,7 +100,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -117,9 +117,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -128,7 +128,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -138,7 +138,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""
@@ -147,7 +147,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-tls
+      name: envoy-gateway/gateway-1/tls
       port: 10443
       routes:
       - backendWeights:
@@ -157,7 +157,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -96,7 +96,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -109,9 +109,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -120,7 +120,7 @@ xdsIR:
       hostnames:
       - foo.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-1
+      name: envoy-gateway/gateway-1/http-1
       port: 10080
       routes:
       - backendWeights:
@@ -130,7 +130,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-foo.com
+        name: default/httproute-1/rule/0/match/0-foo.com
         pathMatch:
           distinct: false
           name: ""
@@ -139,7 +139,7 @@ xdsIR:
       hostnames:
       - bar.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-2
+      name: envoy-gateway/gateway-1/http-2
       port: 10080
       routes:
       - backendWeights:
@@ -149,7 +149,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-bar.com
+        name: default/httproute-1/rule/0/match/0-bar.com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
@@ -70,7 +70,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -83,9 +83,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -94,7 +94,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -104,7 +104,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-matching-port.out.yaml
@@ -74,7 +74,7 @@ httpRoutes:
         port: 80
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -87,9 +87,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -98,7 +98,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -108,7 +108,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -98,7 +98,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http-2
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -111,9 +111,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -122,13 +122,13 @@ xdsIR:
       hostnames:
       - foo.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-1
+      name: envoy-gateway/gateway-1/http-1
       port: 10080
     - address: 0.0.0.0
       hostnames:
       - bar.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-2
+      name: envoy-gateway/gateway-1/http-2
       port: 10080
       routes:
       - backendWeights:
@@ -138,7 +138,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-bar.com
+        name: default/httproute-1/rule/0/match/0-bar.com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
@@ -72,7 +72,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -85,9 +85,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -96,7 +96,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -106,7 +106,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-not-attaching-to-listener-non-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-not-attaching-to-listener-non-matching-port.out.yaml
@@ -73,7 +73,7 @@ httpRoutes:
         namespace: envoy-gateway
         port: 81
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -86,9 +86,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -97,5 +97,5 @@ xdsIR:
       hostnames:
       - foo.com
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http-1
+      name: envoy-gateway/gateway-1/http-1
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
@@ -74,7 +74,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -87,9 +87,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -98,7 +98,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -114,7 +114,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -77,7 +77,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -90,9 +90,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -101,7 +101,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -117,7 +117,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 3
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -72,7 +72,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -85,9 +85,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -96,7 +96,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -106,7 +106,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
@@ -69,7 +69,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -82,9 +82,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -93,7 +93,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -103,4 +103,4 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match--1-*
+        name: default/httproute-1/rule/0/match/-1-*

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -90,7 +90,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -103,9 +103,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -114,7 +114,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - addRequestHeaders:
@@ -138,7 +138,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -100,7 +100,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -113,9 +113,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -124,7 +124,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - addRequestHeaders:
@@ -154,7 +154,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -86,7 +86,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -99,9 +99,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -110,7 +110,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -124,7 +124,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,7 +105,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -119,7 +119,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
@@ -84,7 +84,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -97,9 +97,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -108,7 +108,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - addRequestHeaders:
@@ -129,7 +129,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
@@ -86,7 +86,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -99,9 +99,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -110,5 +110,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
@@ -87,7 +87,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -100,9 +100,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -111,5 +111,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -78,7 +78,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -91,9 +91,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -102,7 +102,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -116,7 +116,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
@@ -82,7 +82,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -95,9 +95,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -106,5 +106,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
@@ -82,7 +82,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -95,9 +95,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -106,7 +106,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -120,7 +120,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
@@ -71,7 +71,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -84,9 +84,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -95,7 +95,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -103,7 +103,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
@@ -74,7 +74,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -87,9 +87,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -98,7 +98,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -106,7 +106,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
@@ -72,7 +72,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -85,9 +85,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -96,7 +96,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -104,7 +104,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
@@ -71,7 +71,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -84,9 +84,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -95,7 +95,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -103,7 +103,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
@@ -71,7 +71,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -84,9 +84,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -95,7 +95,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -103,7 +103,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -72,7 +72,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -85,9 +85,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -96,7 +96,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -104,7 +104,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-ratelimitfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-ratelimitfilter.out.yaml
@@ -83,7 +83,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -96,9 +96,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -107,5 +107,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
@@ -88,7 +88,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -101,9 +101,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -112,7 +112,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -130,7 +130,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
@@ -88,7 +88,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -101,9 +101,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -112,7 +112,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -133,7 +133,7 @@ xdsIR:
         - host: 7.6.5.4
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
@@ -82,7 +82,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -95,9 +95,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -106,7 +106,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -120,7 +120,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
@@ -82,7 +82,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -95,9 +95,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -106,7 +106,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -120,7 +120,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
@@ -82,7 +82,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -95,9 +95,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -106,7 +106,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -124,7 +124,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-non-existent-authenfilter-ref.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-existent-authenfilter-ref.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,5 +105,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-authenfilter-ref.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-authenfilter-ref.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,5 +105,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -74,7 +74,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -87,9 +87,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -98,5 +98,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -83,7 +83,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -96,9 +96,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -107,7 +107,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -117,7 +117,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,7 +105,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -115,7 +115,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,5 +105,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,5 +105,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -80,7 +80,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -93,9 +93,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -104,5 +104,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -84,7 +84,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -97,9 +97,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -108,7 +108,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -118,7 +118,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
@@ -96,7 +96,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -109,9 +109,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -120,7 +120,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - addResponseHeaders:
@@ -150,7 +150,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -90,7 +90,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -103,9 +103,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -114,7 +114,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - addResponseHeaders:
@@ -138,7 +138,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
@@ -100,7 +100,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -113,9 +113,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -124,7 +124,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - addResponseHeaders:
@@ -154,7 +154,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -86,7 +86,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -99,9 +99,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -110,7 +110,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -124,7 +124,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,7 +105,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -119,7 +119,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
@@ -84,7 +84,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -97,9 +97,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -108,7 +108,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - addResponseHeaders:
@@ -129,7 +129,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-headers.out.yaml
@@ -86,7 +86,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -99,9 +99,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -110,5 +110,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-invalid-headers.out.yaml
@@ -87,7 +87,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -100,9 +100,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -111,5 +111,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
@@ -78,7 +78,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -91,9 +91,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -102,7 +102,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -116,7 +116,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-valid-headers.out.yaml
@@ -82,7 +82,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -95,9 +95,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -106,5 +106,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
@@ -82,7 +82,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -95,9 +95,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -106,7 +106,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -120,7 +120,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
@@ -71,7 +71,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -84,9 +84,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -95,7 +95,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -105,7 +105,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
@@ -69,7 +69,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -82,9 +82,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -93,7 +93,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -107,4 +107,4 @@ xdsIR:
         - distinct: false
           exact: POST
           name: :method
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
@@ -101,7 +101,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -114,9 +114,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -125,7 +125,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -139,7 +139,7 @@ xdsIR:
         - distinct: false
           name: Header-1
           safeRegex: '*regex*'
-        name: default-httproute-1-rule-2-match-0-*
+        name: default/httproute-1/rule/2/match/0-*
         pathMatch:
           distinct: false
           name: ""
@@ -155,7 +155,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-1-match-0-*
+        name: default/httproute-1/rule/1/match/0-*
         pathMatch:
           distinct: false
           name: ""
@@ -171,7 +171,7 @@ xdsIR:
         - distinct: false
           exact: exact
           name: Header-1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
@@ -75,7 +75,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -88,9 +88,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -99,7 +99,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -116,7 +116,7 @@ xdsIR:
         - distinct: false
           exact: Val-2
           name: Header-2
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
@@ -75,7 +75,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -88,9 +88,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -99,7 +99,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -109,7 +109,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: default-httproute-1-rule-0-match-0-*
+        name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-sourceip-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-sourceip-ratelimit.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,7 +105,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -119,7 +119,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -73,7 +73,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -86,9 +86,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -97,7 +97,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -111,7 +111,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -74,7 +74,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -87,9 +87,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -98,7 +98,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -112,7 +112,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""
@@ -128,7 +128,7 @@ xdsIR:
         - distinct: false
           exact: whales.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-whales.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-whales.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,7 +105,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -119,7 +119,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
@@ -82,7 +82,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -95,9 +95,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -106,7 +106,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -120,7 +120,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
@@ -79,7 +79,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -92,9 +92,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -103,7 +103,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -117,7 +117,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
@@ -79,7 +79,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -92,9 +92,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -103,7 +103,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -117,7 +117,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-hostname.out.yaml
@@ -85,7 +85,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -98,9 +98,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -109,5 +109,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-multiple-filters.out.yaml
@@ -87,7 +87,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -100,9 +100,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -111,5 +111,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path-type.out.yaml
@@ -83,7 +83,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -96,9 +96,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -107,5 +107,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path.out.yaml
@@ -82,7 +82,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -95,9 +95,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -106,5 +106,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-missing-path.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-missing-path.out.yaml
@@ -80,7 +80,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -93,9 +93,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -104,5 +104,5 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,7 +105,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -119,7 +119,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-valid-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-authenfilter.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,7 +105,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -119,7 +119,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-valid-multi-match-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-multi-match-authenfilter.out.yaml
@@ -95,7 +95,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -108,9 +108,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -119,7 +119,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -133,7 +133,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           exact: /test/path/1
@@ -156,7 +156,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-1-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/1/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           exact: /test/path/2

--- a/internal/gatewayapi/testdata/httproute-with-valid-multi-match-multi-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-multi-match-multi-authenfilter.out.yaml
@@ -95,7 +95,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -108,9 +108,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -119,7 +119,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -133,7 +133,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           exact: /test/path/1
@@ -156,7 +156,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-1-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/1/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           exact: /test/path/2

--- a/internal/gatewayapi/testdata/httproute-with-valid-ratelimitfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-ratelimitfilter.out.yaml
@@ -81,7 +81,7 @@ httpRoutes:
         namespace: envoy-gateway
         sectionName: http
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -94,9 +94,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -105,7 +105,7 @@ xdsIR:
       hostnames:
       - '*.envoyproxy.io'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -119,7 +119,7 @@ xdsIR:
         - distinct: false
           exact: gateway.envoyproxy.io
           name: :authority
-        name: default-httproute-1-rule-0-match-0-gateway.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
@@ -72,7 +72,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -85,9 +85,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -96,7 +96,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -110,7 +110,7 @@ xdsIR:
         - distinct: false
           name: :authority
           suffix: envoyproxy.io
-        name: default-httproute-1-rule-0-match-0-*.envoyproxy.io
+        name: default/httproute-1/rule/0/match/0-*.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
@@ -220,7 +220,7 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -233,9 +233,9 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -244,7 +244,7 @@ xdsIR:
       hostnames:
       - '*'
       isHTTP2: false
-      name: envoy-gateway-gateway-1-http
+      name: envoy-gateway/gateway-1/http
       port: 10080
       routes:
       - backendWeights:
@@ -258,7 +258,7 @@ xdsIR:
         - distinct: false
           exact: example.com
           name: :authority
-        name: envoy-gateway-httproute-2-rule-0-match-0-example.com
+        name: envoy-gateway/httproute-2/rule/0/match/0-example.com
         pathMatch:
           distinct: false
           name: ""
@@ -278,7 +278,7 @@ xdsIR:
         - distinct: false
           exact: example.com
           name: :authority
-        name: envoy-gateway-httproute-3-rule-0-match-0-example.com
+        name: envoy-gateway/httproute-3/rule/0/match/0-example.com
         pathMatch:
           distinct: false
           name: ""
@@ -297,7 +297,7 @@ xdsIR:
         - distinct: false
           exact: one
           name: version
-        name: envoy-gateway-httproute-4-rule-0-match-0-example.net
+        name: envoy-gateway/httproute-4/rule/0/match/0-example.net
         pathMatch:
           distinct: false
           name: ""
@@ -313,7 +313,7 @@ xdsIR:
         - distinct: false
           exact: example.net
           name: :authority
-        name: envoy-gateway-httproute-5-rule-0-match-0-example.net
+        name: envoy-gateway/httproute-5/rule/0/match/0-example.net
         pathMatch:
           distinct: false
           name: ""
@@ -325,7 +325,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        name: envoy-gateway-httproute-1-rule-0-match-0-*
+        name: envoy-gateway/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/tcproute-attaching-to-gateway-with-listener-tls-terminate.out.yaml
+++ b/internal/gatewayapi/testdata/tcproute-attaching-to-gateway-with-listener-tls-terminate.out.yaml
@@ -39,7 +39,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -52,7 +52,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tcpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TCPRoute
@@ -86,7 +86,7 @@ tcpRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -95,7 +95,7 @@ xdsIR:
       destinations:
       - host: 7.7.7.7
         port: 8080
-      name: envoy-gateway-gateway-1-tls-tcproute-1
+      name: envoy-gateway/gateway-1/tls/tcproute-1
       port: 10090
       tls:
         terminate:

--- a/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
@@ -36,7 +36,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TLSRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -49,7 +49,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tlsRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TLSRoute
@@ -83,7 +83,7 @@ tlsRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -93,7 +93,7 @@ xdsIR:
       - host: 7.7.7.7
         port: 8080
         weight: 1
-      name: envoy-gateway-gateway-1-tls-tlsroute-1
+      name: envoy-gateway/gateway-1/tls/tlsroute-1
       port: 10090
       tls:
         passthrough:

--- a/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
@@ -35,7 +35,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TLSRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -48,7 +48,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tlsRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TLSRoute
@@ -117,7 +117,7 @@ tlsRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -127,7 +127,7 @@ xdsIR:
       - host: 7.7.7.7
         port: 8080
         weight: 1
-      name: envoy-gateway-gateway-1-tls-tlsroute-1
+      name: envoy-gateway/gateway-1/tls/tlsroute-1
       port: 10091
       tls:
         passthrough:
@@ -138,7 +138,7 @@ xdsIR:
       - host: 7.7.7.7
         port: 8080
         weight: 1
-      name: envoy-gateway-gateway-1-tls-tlsroute-2
+      name: envoy-gateway/gateway-1/tls/tlsroute-2
       port: 10091
       tls:
         passthrough:

--- a/internal/gatewayapi/testdata/tlsroute-not-attaching-to-gateway-with-no-mode.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-not-attaching-to-gateway-with-no-mode.out.yaml
@@ -30,7 +30,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TLSRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -38,7 +38,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tlsRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TLSRoute
@@ -72,7 +72,7 @@ tlsRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -36,7 +36,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TLSRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -49,7 +49,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tlsRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TLSRoute
@@ -84,7 +84,7 @@ tlsRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -94,7 +94,7 @@ xdsIR:
       - host: 7.7.7.7
         port: 8080
         weight: 1
-      name: envoy-gateway-gateway-1-tls-tlsroute-1
+      name: envoy-gateway/gateway-1/tls/tlsroute-1
       port: 10090
       tls:
         passthrough:

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
@@ -35,7 +35,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TLSRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -48,7 +48,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tlsRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TLSRoute
@@ -82,7 +82,7 @@ tlsRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -92,7 +92,7 @@ xdsIR:
       - host: 7.7.7.7
         port: 8080
         weight: 1
-      name: envoy-gateway-gateway-1-tls-tlsroute-1
+      name: envoy-gateway/gateway-1/tls/tlsroute-1
       port: 10091
       tls:
         passthrough:

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
@@ -35,7 +35,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TLSRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -48,7 +48,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tlsRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TLSRoute
@@ -84,7 +84,7 @@ tlsRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout
@@ -94,7 +94,7 @@ xdsIR:
       - host: 7.7.7.7
         port: 8080
         weight: 1
-      name: envoy-gateway-gateway-1-tls-tlsroute-1
+      name: envoy-gateway/gateway-1/tls/tlsroute-1
       port: 10091
       tls:
         passthrough:

--- a/internal/gatewayapi/testdata/tlsroute-with-listener-both-passthrough-and-cert-data.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-listener-both-passthrough-and-cert-data.out.yaml
@@ -35,7 +35,7 @@ gateways:
       - group: gateway.networking.k8s.io
         kind: TLSRoute
 infraIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     proxy:
       listeners:
       - address: ""
@@ -43,7 +43,7 @@ infraIR:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
           gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
-      name: envoy-gateway-gateway-1
+      name: envoy-gateway/gateway-1
 tlsRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: TLSRoute
@@ -77,7 +77,7 @@ tlsRoutes:
         name: gateway-1
         namespace: envoy-gateway
 xdsIR:
-  envoy-gateway-gateway-1:
+  envoy-gateway/gateway-1:
     accessLog:
       text:
       - path: /dev/stdout

--- a/internal/provider/utils/utils.go
+++ b/internal/provider/utils/utils.go
@@ -23,14 +23,17 @@ func NamespacedName(obj client.Object) types.NamespacedName {
 }
 
 // GetHashedName returns a partially hashed name for the string including up to 48 characters of the original name before the hash
-func GetHashedName(name string) string {
+func GetHashedName(nsName string) string {
 
 	h := sha256.New() // Using sha256 instead of sha1 due to Blocklisted import crypto/sha1: weak cryptographic primitive (gosec)
-	hSum := h.Sum([]byte(name))
+	hSum := h.Sum([]byte(nsName))
 	hashedName := strings.ToLower(fmt.Sprintf("%x", hSum))
 
-	if len(name) > 48 {
-		return fmt.Sprintf("%s-%s", name[0:48], hashedName[0:8])
+	// replace `/` with `-` to create a valid K8s resource name
+	resourceName := strings.ReplaceAll(nsName, "/", "-")
+
+	if len(resourceName) > 48 {
+		return fmt.Sprintf("%s-%s", resourceName[0:48], hashedName[0:8])
 	}
-	return fmt.Sprintf("%s-%s", name, hashedName[0:8])
+	return fmt.Sprintf("%s-%s", resourceName, hashedName[0:8])
 }


### PR DESCRIPTION
* Also had to replace `/` with `-` when creating K8s resource names :)

Relates to https://github.com/envoyproxy/gateway/issues/1640