### PR TITLE
fix: the imported packages in pin.go are removed by goland

### DIFF
--- a/tools/make/tools.mk
+++ b/tools/make/tools.mk
@@ -23,7 +23,7 @@ tools/protoc-gen-go      = $(tools.bindir)/protoc-gen-go
 tools/protoc-gen-go-grpc = $(tools.bindir)/protoc-gen-go-grpc
 tools/helm-docs          = $(tools.bindir)/helm-docs
 $(tools.bindir)/%: $(tools.srcdir)/%/pin.go $(tools.srcdir)/%/go.mod
-	cd $(<D) && GOOS= GOARCH= go build -o $(abspath $@) $$(sed -En 's,^import "(.*)".*,\1,p' pin.go)
+	cd $(<D) && GOOS= GOARCH= go build -o $(abspath $@) $$(sed -En 's,^import _ "(.*)".*,\1,p' pin.go)
 
 
 # `pip install`-able things

--- a/tools/src/buf/pin.go
+++ b/tools/src/buf/pin.go
@@ -8,4 +8,4 @@
 
 package ignore
 
-import "github.com/bufbuild/buf/cmd/buf"
+import _ "github.com/bufbuild/buf/cmd/buf"

--- a/tools/src/controller-gen/pin.go
+++ b/tools/src/controller-gen/pin.go
@@ -8,4 +8,4 @@
 
 package ignore
 
-import "sigs.k8s.io/controller-tools/cmd/controller-gen"
+import _ "sigs.k8s.io/controller-tools/cmd/controller-gen"

--- a/tools/src/crd-ref-docs/pin.go
+++ b/tools/src/crd-ref-docs/pin.go
@@ -8,4 +8,4 @@
 
 package ignore
 
-import "github.com/elastic/crd-ref-docs"
+import _ "github.com/elastic/crd-ref-docs"

--- a/tools/src/golangci-lint/pin.go
+++ b/tools/src/golangci-lint/pin.go
@@ -8,4 +8,4 @@
 
 package ignore
 
-import "github.com/golangci/golangci-lint/cmd/golangci-lint"
+import _ "github.com/golangci/golangci-lint/cmd/golangci-lint"

--- a/tools/src/helm-docs/pin.go
+++ b/tools/src/helm-docs/pin.go
@@ -8,4 +8,4 @@
 
 package ignore
 
-import "github.com/norwoodj/helm-docs/cmd/helm-docs"
+import _ "github.com/norwoodj/helm-docs/cmd/helm-docs"

--- a/tools/src/kind/pin.go
+++ b/tools/src/kind/pin.go
@@ -8,4 +8,4 @@
 
 package ignore
 
-import "sigs.k8s.io/kind"
+import _ "sigs.k8s.io/kind"

--- a/tools/src/kustomize/pin.go
+++ b/tools/src/kustomize/pin.go
@@ -8,4 +8,4 @@
 
 package ignore
 
-import "sigs.k8s.io/kustomize/kustomize/v3"
+import _ "sigs.k8s.io/kustomize/kustomize/v3"

--- a/tools/src/protoc-gen-go-grpc/pin.go
+++ b/tools/src/protoc-gen-go-grpc/pin.go
@@ -8,4 +8,4 @@
 
 package ignore
 
-import "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+import _ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"

--- a/tools/src/protoc-gen-go/pin.go
+++ b/tools/src/protoc-gen-go/pin.go
@@ -8,4 +8,4 @@
 
 package ignore
 
-import "google.golang.org/protobuf/cmd/protoc-gen-go"
+import _ "google.golang.org/protobuf/cmd/protoc-gen-go"

--- a/tools/src/setup-envtest/pin.go
+++ b/tools/src/setup-envtest/pin.go
@@ -8,4 +8,4 @@
 
 package ignore
 
-import "sigs.k8s.io/controller-runtime/tools/setup-envtest"
+import _ "sigs.k8s.io/controller-runtime/tools/setup-envtest"


### PR DESCRIPTION
Add a [blank](https://go.dev/ref/spec#Blank_identifier) identifier to pin.go so the imported tool packages won't be automatically deleted by  Goland.