### PR TITLE
fix: Ignore ports in host headers when matching against HTTPRoute hostnames

### DIFF
--- a/docs/latest/user/egctl.md
+++ b/docs/latest/user/egctl.md
@@ -283,14 +283,10 @@ configs:
       name: default-eg-http
       virtualHosts:
       - domains:
-        - '*'
-        name: default-eg-http
+        - www.example.com
+        name: default-eg-http-www.example.com
         routes:
         - match:
-            headers:
-            - name: :authority
-              stringMatch:
-                exact: www.example.com
             prefix: /
           route:
             cluster: default-backend-rule-0-match-0-www.example.com
@@ -377,14 +373,10 @@ dynamicRouteConfigs:
     name: default-eg-http
     virtualHosts:
     - domains:
-      - '*'
+      - www.example.com
       name: default-eg-http
       routes:
       - match:
-          headers:
-          - name: :authority
-            stringMatch:
-              exact: www.example.com
           prefix: /
         route:
           cluster: default-backend-rule-0-match-0-www.example.com

--- a/internal/cmd/egctl/testdata/config/in/in.all.json
+++ b/internal/cmd/egctl/testdata/config/in/in.all.json
@@ -2203,20 +2203,12 @@
                             {
                                 "name": "default-eg-http",
                                 "domains": [
-                                    "*"
+                                    "www.example.com"
                                 ],
                                 "routes": [
                                     {
                                         "match": {
-                                            "prefix": "/",
-                                            "headers": [
-                                                {
-                                                    "name": ":authority",
-                                                    "string_match": {
-                                                        "exact": "www.example.com"
-                                                    }
-                                                }
-                                            ]
+                                            "prefix": "/"
                                         },
                                         "route": {
                                             "cluster": "default-backend-rule-0-match-0-www.example.com"

--- a/internal/cmd/egctl/testdata/config/out/out.all.json
+++ b/internal/cmd/egctl/testdata/config/out/out.all.json
@@ -2204,20 +2204,12 @@
                 "virtualHosts": [
                   {
                     "domains": [
-                      "*"
+                      "www.example.com"
                     ],
                     "name": "default-eg-http",
                     "routes": [
                       {
                         "match": {
-                          "headers": [
-                            {
-                              "name": ":authority",
-                              "stringMatch": {
-                                "exact": "www.example.com"
-                              }
-                            }
-                          ],
                           "prefix": "/"
                         },
                         "route": {

--- a/internal/cmd/egctl/testdata/config/out/out.all.yaml
+++ b/internal/cmd/egctl/testdata/config/out/out.all.yaml
@@ -1248,14 +1248,10 @@ default:
           name: default-eg-http
           virtualHosts:
           - domains:
-            - '*'
+            - www.example.com
             name: default-eg-http
             routes:
             - match:
-                headers:
-                - name: :authority
-                  stringMatch:
-                    exact: www.example.com
                 prefix: /
               route:
                 cluster: default-backend-rule-0-match-0-www.example.com

--- a/internal/cmd/egctl/testdata/config/out/out.route.json
+++ b/internal/cmd/egctl/testdata/config/out/out.route.json
@@ -11,20 +11,12 @@
             "virtualHosts": [
               {
                 "domains": [
-                  "*"
+                  "www.example.com"
                 ],
                 "name": "default-eg-http",
                 "routes": [
                   {
                     "match": {
-                      "headers": [
-                        {
-                          "name": ":authority",
-                          "stringMatch": {
-                            "exact": "www.example.com"
-                          }
-                        }
-                      ],
                       "prefix": "/"
                     },
                     "route": {

--- a/internal/cmd/egctl/testdata/config/out/out.route.yaml
+++ b/internal/cmd/egctl/testdata/config/out/out.route.yaml
@@ -8,14 +8,10 @@ default:
         name: default-eg-http
         virtualHosts:
         - domains:
-          - '*'
+          - www.example.com
           name: default-eg-http
           routes:
           - match:
-              headers:
-              - name: :authority
-                stringMatch:
-                  exact: www.example.com
               prefix: /
             route:
               cluster: default-backend-rule-0-match-0-www.example.com

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
@@ -423,20 +423,12 @@
                 "virtualHosts": [
                   {
                     "domains": [
-                      "*"
+                      "www.example.com"
                     ],
-                    "name": "envoy-gateway-system/eg/http",
+                    "name": "envoy-gateway-system/eg/http-www.example.com",
                     "routes": [
                       {
                         "match": {
-                          "headers": [
-                            {
-                              "name": ":authority",
-                              "stringMatch": {
-                                "exact": "www.example.com"
-                              }
-                            }
-                          ],
                           "pathSeparatedPrefix": "/foo"
                         },
                         "name": "envoy-gateway-system/backend/rule/0/match/0-www.example.com",

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
@@ -425,7 +425,7 @@
                     "domains": [
                       "www.example.com"
                     ],
-                    "name": "envoy-gateway-system/eg/http-www.example.com",
+                    "name": "envoy-gateway-system/eg/http/www.example.com",
                     "routes": [
                       {
                         "match": {

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
@@ -250,14 +250,10 @@ xds:
           name: envoy-gateway-system/eg/http
           virtualHosts:
           - domains:
-            - '*'
-            name: envoy-gateway-system/eg/http
+            - www.example.com
+            name: envoy-gateway-system/eg/http-www.example.com
             routes:
             - match:
-                headers:
-                - name: :authority
-                  stringMatch:
-                    exact: www.example.com
                 pathSeparatedPrefix: /foo
               name: envoy-gateway-system/backend/rule/0/match/0-www.example.com
               route:

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
@@ -251,7 +251,7 @@ xds:
           virtualHosts:
           - domains:
             - www.example.com
-            name: envoy-gateway-system/eg/http-www.example.com
+            name: envoy-gateway-system/eg/http/www.example.com
             routes:
             - match:
                 pathSeparatedPrefix: /foo

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.route.yaml
@@ -8,14 +8,10 @@ xds:
         name: envoy-gateway-system/eg/http
         virtualHosts:
         - domains:
-          - '*'
-          name: envoy-gateway-system/eg/http
+          - www.example.com
+          name: envoy-gateway-system/eg/http-www.example.com
           routes:
           - match:
-              headers:
-              - name: :authority
-                stringMatch:
-                  exact: www.example.com
               pathSeparatedPrefix: /foo
             name: envoy-gateway-system/backend/rule/0/match/0-www.example.com
             route:

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.route.yaml
@@ -9,7 +9,7 @@ xds:
         virtualHosts:
         - domains:
           - www.example.com
-          name: envoy-gateway-system/eg/http-www.example.com
+          name: envoy-gateway-system/eg/http/www.example.com
           routes:
           - match:
               pathSeparatedPrefix: /foo

--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -934,14 +934,10 @@ xds:
           name: default/eg/http
           virtualHosts:
           - domains:
-            - '*'
-            name: default/eg/http
+            - www.example.com
+            name: default/eg/http-www.example.com
             routes:
             - match:
-                headers:
-                - name: :authority
-                  stringMatch:
-                    exact: www.example.com
                 prefix: /
               name: default/backend/rule/0/match/0-www.example.com
               route:
@@ -952,14 +948,10 @@ xds:
           name: default/eg/grpc
           virtualHosts:
           - domains:
-            - '*'
-            name: default/eg/grpc
+            - www.grpc-example.com
+            name: default/eg/grpc-www.grpc-example.com
             routes:
             - match:
-                headers:
-                - name: :authority
-                  stringMatch:
-                    exact: www.grpc-example.com
                 path: /com.example.Things/DoThing
               name: default/backend/rule/0/match/0-www.grpc-example.com
               route:

--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -935,7 +935,7 @@ xds:
           virtualHosts:
           - domains:
             - www.example.com
-            name: default/eg/http-www.example.com
+            name: default/eg/http/www.example.com
             routes:
             - match:
                 prefix: /
@@ -949,7 +949,7 @@ xds:
           virtualHosts:
           - domains:
             - www.grpc-example.com
-            name: default/eg/grpc-www.grpc-example.com
+            name: default/eg/grpc/www.grpc-example.com
             routes:
             - match:
                 path: /com.example.Things/DoThing

--- a/internal/cmd/egctl/testdata/translate/out/envoy-patch-policy.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/envoy-patch-policy.all.yaml
@@ -198,10 +198,3 @@ xds:
           '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
           ignorePortInHostMatching: true
           name: default/eg/http
-          virtualHosts:
-          - domains:
-            - '*'
-            name: default/eg/http
-            rateLimits:
-            - actions:
-              - remoteAddress: {}

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -851,20 +851,12 @@
                 "virtualHosts": [
                   {
                     "domains": [
-                      "*"
+                      "www.example.com"
                     ],
-                    "name": "default/eg/http",
+                    "name": "default/eg/http-www.example.com",
                     "routes": [
                       {
                         "match": {
-                          "headers": [
-                            {
-                              "name": ":authority",
-                              "stringMatch": {
-                                "exact": "www.example.com"
-                              }
-                            }
-                          ],
                           "prefix": "/"
                         },
                         "name": "default/backend/rule/0/match/0-www.example.com",
@@ -885,20 +877,12 @@
                 "virtualHosts": [
                   {
                     "domains": [
-                      "*"
+                      "www.grpc-example.com"
                     ],
-                    "name": "default/eg/grpc",
+                    "name": "default/eg/grpc-www.grpc-example.com",
                     "routes": [
                       {
                         "match": {
-                          "headers": [
-                            {
-                              "name": ":authority",
-                              "stringMatch": {
-                                "exact": "www.grpc-example.com"
-                              }
-                            }
-                          ],
                           "path": "/com.example.Things/DoThing"
                         },
                         "name": "default/backend/rule/0/match/0-www.grpc-example.com",

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -853,7 +853,7 @@
                     "domains": [
                       "www.example.com"
                     ],
-                    "name": "default/eg/http-www.example.com",
+                    "name": "default/eg/http/www.example.com",
                     "routes": [
                       {
                         "match": {
@@ -879,7 +879,7 @@
                     "domains": [
                       "www.grpc-example.com"
                     ],
-                    "name": "default/eg/grpc-www.grpc-example.com",
+                    "name": "default/eg/grpc/www.grpc-example.com",
                     "routes": [
                       {
                         "match": {

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -508,14 +508,10 @@ xds:
           name: default/eg/http
           virtualHosts:
           - domains:
-            - '*'
-            name: default/eg/http
+            - www.example.com
+            name: default/eg/http-www.example.com
             routes:
             - match:
-                headers:
-                - name: :authority
-                  stringMatch:
-                    exact: www.example.com
                 prefix: /
               name: default/backend/rule/0/match/0-www.example.com
               route:
@@ -526,14 +522,10 @@ xds:
           name: default/eg/grpc
           virtualHosts:
           - domains:
-            - '*'
-            name: default/eg/grpc
+            - www.grpc-example.com
+            name: default/eg/grpc-www.grpc-example.com
             routes:
             - match:
-                headers:
-                - name: :authority
-                  stringMatch:
-                    exact: www.grpc-example.com
                 path: /com.example.Things/DoThing
               name: default/backend/rule/0/match/0-www.grpc-example.com
               route:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -509,7 +509,7 @@ xds:
           virtualHosts:
           - domains:
             - www.example.com
-            name: default/eg/http-www.example.com
+            name: default/eg/http/www.example.com
             routes:
             - match:
                 prefix: /
@@ -523,7 +523,7 @@ xds:
           virtualHosts:
           - domains:
             - www.grpc-example.com
-            name: default/eg/grpc-www.grpc-example.com
+            name: default/eg/grpc/www.grpc-example.com
             routes:
             - match:
                 path: /com.example.Things/DoThing

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
@@ -8,14 +8,10 @@ xds:
         name: default/eg/http
         virtualHosts:
         - domains:
-          - '*'
-          name: default/eg/http
+          - www.example.com
+          name: default/eg/http-www.example.com
           routes:
           - match:
-              headers:
-              - name: :authority
-                stringMatch:
-                  exact: www.example.com
               prefix: /
             name: default/backend/rule/0/match/0-www.example.com
             route:
@@ -26,14 +22,10 @@ xds:
         name: default/eg/grpc
         virtualHosts:
         - domains:
-          - '*'
-          name: default/eg/grpc
+          - www.grpc-example.com
+          name: default/eg/grpc-www.grpc-example.com
           routes:
           - match:
-              headers:
-              - name: :authority
-                stringMatch:
-                  exact: www.grpc-example.com
               path: /com.example.Things/DoThing
             name: default/backend/rule/0/match/0-www.grpc-example.com
             route:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
@@ -9,7 +9,7 @@ xds:
         virtualHosts:
         - domains:
           - www.example.com
-          name: default/eg/http-www.example.com
+          name: default/eg/http/www.example.com
           routes:
           - match:
               prefix: /
@@ -23,7 +23,7 @@ xds:
         virtualHosts:
         - domains:
           - www.grpc-example.com
-          name: default/eg/grpc-www.grpc-example.com
+          name: default/eg/grpc/www.grpc-example.com
           routes:
           - match:
               path: /com.example.Things/DoThing

--- a/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
+++ b/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
@@ -11,20 +11,12 @@
             "virtualHosts": [
               {
                 "domains": [
-                  "*"
+                  "www.example.com"
                 ],
-                "name": "default/eg/http",
+                "name": "default/eg/http-www.example.com",
                 "routes": [
                   {
                     "match": {
-                      "headers": [
-                        {
-                          "name": ":authority",
-                          "stringMatch": {
-                            "exact": "www.example.com"
-                          }
-                        }
-                      ],
                       "prefix": "/"
                     },
                     "name": "default/backend/rule/0/match/0-www.example.com",
@@ -50,20 +42,12 @@
             "virtualHosts": [
               {
                 "domains": [
-                  "*"
+                  "www.example2.com"
                 ],
-                "name": "default/eg2/http",
+                "name": "default/eg2/http-www.example2.com",
                 "routes": [
                   {
                     "match": {
-                      "headers": [
-                        {
-                          "name": ":authority",
-                          "stringMatch": {
-                            "exact": "www.example2.com"
-                          }
-                        }
-                      ],
                       "prefix": "/v2/"
                     },
                     "name": "default/backend/rule/0/match/0-www.example2.com",

--- a/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
+++ b/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
@@ -13,7 +13,7 @@
                 "domains": [
                   "www.example.com"
                 ],
-                "name": "default/eg/http-www.example.com",
+                "name": "default/eg/http/www.example.com",
                 "routes": [
                   {
                     "match": {
@@ -44,7 +44,7 @@
                 "domains": [
                   "www.example2.com"
                 ],
-                "name": "default/eg2/http-www.example2.com",
+                "name": "default/eg2/http/www.example2.com",
                 "routes": [
                   {
                     "match": {

--- a/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
@@ -8,14 +8,10 @@ xds:
         name: envoy-gateway-system/eg/http
         virtualHosts:
         - domains:
-          - '*'
-          name: envoy-gateway-system/eg/http
+          - www.example.com
+          name: envoy-gateway-system/eg/http-www.example.com
           routes:
           - match:
-              headers:
-              - name: :authority
-                stringMatch:
-                  exact: www.example.com
               prefix: /
             name: envoy-gateway-system/backend/rule/0/match/0-www.example.com
             route:

--- a/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
@@ -9,7 +9,7 @@ xds:
         virtualHosts:
         - domains:
           - www.example.com
-          name: envoy-gateway-system/eg/http-www.example.com
+          name: envoy-gateway-system/eg/http/www.example.com
           routes:
           - match:
               prefix: /

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.json
@@ -432,20 +432,12 @@
                 "virtualHosts": [
                   {
                     "domains": [
-                      "*"
+                      "ratelimit.example"
                     ],
-                    "name": "envoy-gateway-system/eg/http",
+                    "name": "envoy-gateway-system/eg/http-ratelimit.example",
                     "routes": [
                       {
                         "match": {
-                          "headers": [
-                            {
-                              "name": ":authority",
-                              "stringMatch": {
-                                "exact": "ratelimit.example"
-                              }
-                            }
-                          ],
                           "prefix": "/"
                         },
                         "name": "envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example",

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.json
@@ -434,7 +434,7 @@
                     "domains": [
                       "ratelimit.example"
                     ],
-                    "name": "envoy-gateway-system/eg/http-ratelimit.example",
+                    "name": "envoy-gateway-system/eg/http/ratelimit.example",
                     "routes": [
                       {
                         "match": {

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.yaml
@@ -254,14 +254,10 @@ xds:
           name: envoy-gateway-system/eg/http
           virtualHosts:
           - domains:
-            - '*'
-            name: envoy-gateway-system/eg/http
+            - ratelimit.example
+            name: envoy-gateway-system/eg/http-ratelimit.example
             routes:
             - match:
-                headers:
-                - name: :authority
-                  stringMatch:
-                    exact: ratelimit.example
                 prefix: /
               name: envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example
               route:

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.yaml
@@ -255,7 +255,7 @@ xds:
           virtualHosts:
           - domains:
             - ratelimit.example
-            name: envoy-gateway-system/eg/http-ratelimit.example
+            name: envoy-gateway-system/eg/http/ratelimit.example
             routes:
             - match:
                 prefix: /

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.route.yaml
@@ -8,14 +8,10 @@ xds:
         name: envoy-gateway-system/eg/http
         virtualHosts:
         - domains:
-          - '*'
-          name: envoy-gateway-system/eg/http
+          - ratelimit.example
+          name: envoy-gateway-system/eg/http-ratelimit.example
           routes:
           - match:
-              headers:
-              - name: :authority
-                stringMatch:
-                  exact: ratelimit.example
               prefix: /
             name: envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example
             route:

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.route.yaml
@@ -9,7 +9,7 @@ xds:
         virtualHosts:
         - domains:
           - ratelimit.example
-          name: envoy-gateway-system/eg/http-ratelimit.example
+          name: envoy-gateway-system/eg/http/ratelimit.example
           routes:
           - match:
               prefix: /

--- a/internal/extension/testutils/hooks.go
+++ b/internal/extension/testutils/hooks.go
@@ -80,7 +80,7 @@ func (c *XDSHookClient) PostRouteModifyHook(route *routeV3.Route, routeHostnames
 func (c *XDSHookClient) PostVirtualHostModifyHook(vh *routeV3.VirtualHost) (*routeV3.VirtualHost, error) {
 	// Only make the change when the VirtualHost's name matches the expected testdata
 	// This prevents us from having to update every single testfile.out
-	if vh.Name == "extension-post-xdsvirtualhost-hook-error" {
+	if vh.Name == "extension-post-xdsvirtualhost-hook-error-*" {
 		return nil, fmt.Errorf("extension post xds virtual host hook error")
 	} else if vh.Name == "extension-listener" {
 		// Setup a new VirtualHost to avoid operating directly on the passed in pointer for better test coverage that the

--- a/internal/extension/testutils/hooks.go
+++ b/internal/extension/testutils/hooks.go
@@ -80,7 +80,7 @@ func (c *XDSHookClient) PostRouteModifyHook(route *routeV3.Route, routeHostnames
 func (c *XDSHookClient) PostVirtualHostModifyHook(vh *routeV3.VirtualHost) (*routeV3.VirtualHost, error) {
 	// Only make the change when the VirtualHost's name matches the expected testdata
 	// This prevents us from having to update every single testfile.out
-	if vh.Name == "extension-post-xdsvirtualhost-hook-error-*" {
+	if vh.Name == "extension-post-xdsvirtualhost-hook-error/*" {
 		return nil, fmt.Errorf("extension post xds virtual host hook error")
 	} else if vh.Name == "extension-listener" {
 		// Setup a new VirtualHost to avoid operating directly on the passed in pointer for better test coverage that the

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -526,9 +526,6 @@ func (t *Translator) processHTTPRouteParentRefListener(route RouteContext, route
 					RateLimit:             routeRoute.RateLimit,
 					ExtensionRefs:         routeRoute.ExtensionRefs,
 				}
-				if hostRoute.Hostname == "*" {
-					hostRoute.Hostname = ""
-				}
 				// Don't bother copying over the weights unless the route has invalid backends.
 				if routeRoute.BackendWeights.Invalid > 0 {
 					hostRoute.BackendWeights = routeRoute.BackendWeights

--- a/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
@@ -124,10 +124,7 @@ xdsIR:
               namespace: default
             spec:
               data: stuff
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
@@ -104,6 +104,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: envoy-gateway/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -111,6 +111,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
@@ -172,6 +172,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo.bar.com
         name: default/httproute-1/rule/0/match/0-foo.bar.com
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration-with-same-algorithm-different-fqdn.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration-with-same-algorithm-different-fqdn.out.yaml
@@ -113,6 +113,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration.out.yaml
@@ -113,6 +113,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
@@ -110,6 +110,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/gateway-with-preexisting-status-condition.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-preexisting-status-condition.out.yaml
@@ -104,6 +104,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/gateway-with-stale-status-condition.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-stale-status-condition.out.yaml
@@ -110,6 +110,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
@@ -168,6 +168,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo.com
         name: default/httproute-2/rule/0/match/0-foo.com
         pathMatch:
           distinct: false
@@ -180,6 +181,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo.com
         name: default/httproute-1/rule/0/match/0-foo.com
         pathMatch:
           distinct: false
@@ -199,6 +201,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar.com
         name: default/httproute-2/rule/0/match/0-bar.com
         pathMatch:
           distinct: false
@@ -211,6 +214,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar.com
         name: default/httproute-1/rule/0/match/0-bar.com
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
@@ -163,6 +163,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
@@ -163,6 +163,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/grpcroute-with-header-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-header-match.out.yaml
@@ -112,4 +112,5 @@ xdsIR:
         - distinct: false
           exact: foo
           name: magic
+        hostname: '*'
         name: default/grpcroute-1/rule/0/match/0-*

--- a/internal/gatewayapi/testdata/grpcroute-with-method-and-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-method-and-service-match.out.yaml
@@ -112,6 +112,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/grpcroute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
@@ -124,6 +125,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/grpcroute-1/rule/0/match/1-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/grpcroute-with-method-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-method-match.out.yaml
@@ -110,6 +110,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/grpcroute-1/rule/0/match/1-*
         pathMatch:
           distinct: false
@@ -126,4 +127,5 @@ xdsIR:
         - distinct: false
           name: :path
           suffix: /ExampleExact
+        hostname: '*'
         name: default/grpcroute-1/rule/0/match/0-*

--- a/internal/gatewayapi/testdata/grpcroute-with-request-header-modifier.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-request-header-modifier.out.yaml
@@ -113,4 +113,5 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/grpcroute-1/rule/0/match/-1-*

--- a/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
@@ -110,6 +110,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/grpcroute-1/rule/0/match/1-*
         pathMatch:
           distinct: false
@@ -122,6 +123,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/grpcroute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/grpcroute-with-valid-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-valid-authenfilter.out.yaml
@@ -109,6 +109,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/grpcroute-1/rule/0/match/-1-*
         requestAuthentication:
           jwt:

--- a/internal/gatewayapi/testdata/grpcroute-with-valid-ratelimitfilter.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-valid-ratelimitfilter.out.yaml
@@ -109,6 +109,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/grpcroute-1/rule/0/match/-1-*
         rateLimit:
           global:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
@@ -308,6 +308,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo.com
         name: default/httproute-1/rule/0/match/0-foo.com
         pathMatch:
           distinct: false
@@ -327,6 +328,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar.com
         name: default/httproute-1/rule/0/match/0-bar.com
         pathMatch:
           distinct: false
@@ -346,6 +348,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo1.com
         name: default/httproute-1/rule/0/match/0-foo1.com
         pathMatch:
           distinct: false
@@ -365,6 +368,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar1.com
         name: default/httproute-1/rule/0/match/0-bar1.com
         pathMatch:
           distinct: false
@@ -384,6 +388,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo2.com
         name: default/httproute-1/rule/0/match/0-foo2.com
         pathMatch:
           distinct: false
@@ -403,6 +408,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar2.com
         name: default/httproute-1/rule/0/match/0-bar2.com
         pathMatch:
           distinct: false
@@ -422,6 +428,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo3.com
         name: default/httproute-1/rule/0/match/0-foo3.com
         pathMatch:
           distinct: false
@@ -441,6 +448,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar3.com
         name: default/httproute-1/rule/0/match/0-bar3.com
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
@@ -280,6 +280,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo.com
         name: default/httproute-1/rule/0/match/0-foo.com
         pathMatch:
           distinct: false
@@ -299,6 +300,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar.com
         name: default/httproute-1/rule/0/match/0-bar.com
         pathMatch:
           distinct: false
@@ -318,6 +320,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo1.com
         name: default/httproute-1/rule/0/match/0-foo1.com
         pathMatch:
           distinct: false
@@ -337,6 +340,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar1.com
         name: default/httproute-1/rule/0/match/0-bar1.com
         pathMatch:
           distinct: false
@@ -356,6 +360,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo2.com
         name: default/httproute-1/rule/0/match/0-foo2.com
         pathMatch:
           distinct: false
@@ -375,6 +380,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar2.com
         name: default/httproute-1/rule/0/match/0-bar2.com
         pathMatch:
           distinct: false
@@ -394,6 +400,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo3.com
         name: default/httproute-1/rule/0/match/0-foo3.com
         pathMatch:
           distinct: false
@@ -413,6 +420,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar3.com
         name: default/httproute-1/rule/0/match/0-bar3.com
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
@@ -138,6 +138,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false
@@ -157,6 +158,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -130,6 +130,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: foo.com
         name: default/httproute-1/rule/0/match/0-foo.com
         pathMatch:
           distinct: false
@@ -149,6 +150,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar.com
         name: default/httproute-1/rule/0/match/0-bar.com
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
@@ -104,6 +104,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-matching-port.out.yaml
@@ -108,6 +108,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -138,6 +138,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: bar.com
         name: default/httproute-1/rule/0/match/0-bar.com
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
@@ -106,6 +106,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
@@ -114,6 +114,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -117,6 +117,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 3
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -106,6 +106,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-distinct-sourcecidr-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-distinct-sourcecidr-ratelimit.out.yaml
@@ -115,10 +115,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
@@ -103,4 +103,5 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/-1-*

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -134,10 +134,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -150,10 +150,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -120,10 +120,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -115,10 +115,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
@@ -125,10 +125,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -112,10 +112,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
@@ -116,10 +116,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
@@ -103,6 +103,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
@@ -106,6 +106,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
@@ -104,6 +104,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
@@ -103,6 +103,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
@@ -103,6 +103,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -104,6 +104,7 @@ xdsIR:
           valid: 0
         directResponse:
           statusCode: 500
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
@@ -122,10 +122,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         mirrors:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
@@ -122,10 +122,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         mirrors:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
@@ -116,10 +116,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
@@ -116,10 +116,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
@@ -116,10 +116,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         mirrors:
         - host: 7.7.7.7
           port: 8080

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -113,10 +113,7 @@ xdsIR:
       - backendWeights:
           invalid: 0
           valid: 0
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -111,10 +111,7 @@ xdsIR:
       - backendWeights:
           invalid: 0
           valid: 0
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -114,10 +114,7 @@ xdsIR:
       - backendWeights:
           invalid: 0
           valid: 0
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
@@ -146,10 +146,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -134,10 +134,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
@@ -150,10 +150,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -120,10 +120,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
@@ -115,10 +115,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
@@ -125,10 +125,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
@@ -112,10 +112,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
@@ -116,10 +116,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
@@ -105,6 +105,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
@@ -107,4 +107,5 @@ xdsIR:
         - distinct: false
           exact: POST
           name: :method
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
@@ -139,6 +139,7 @@ xdsIR:
         - distinct: false
           name: Header-1
           safeRegex: '*regex*'
+        hostname: '*'
         name: default/httproute-1/rule/2/match/0-*
         pathMatch:
           distinct: false
@@ -155,6 +156,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/1/match/0-*
         pathMatch:
           distinct: false
@@ -171,6 +173,7 @@ xdsIR:
         - distinct: false
           exact: exact
           name: Header-1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
@@ -116,6 +116,7 @@ xdsIR:
         - distinct: false
           exact: Val-2
           name: Header-2
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
@@ -109,6 +109,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: default/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-sourcecidr-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-sourcecidr-ratelimit.out.yaml
@@ -115,10 +115,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -107,10 +107,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -108,10 +108,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
@@ -124,10 +121,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: whales.envoyproxy.io
-          name: :authority
+        hostname: whales.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-whales.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
@@ -115,10 +115,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
@@ -116,10 +116,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
@@ -113,10 +113,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
@@ -113,10 +113,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
@@ -115,10 +115,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-valid-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-authenfilter.out.yaml
@@ -115,10 +115,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-valid-multi-match-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-multi-match-authenfilter.out.yaml
@@ -129,10 +129,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
@@ -152,10 +149,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/1/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-valid-multi-match-multi-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-multi-match-multi-authenfilter.out.yaml
@@ -129,10 +129,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false
@@ -152,10 +149,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/1/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-valid-ratelimitfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-ratelimitfilter.out.yaml
@@ -115,10 +115,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: gateway.envoyproxy.io
-          name: :authority
+        hostname: gateway.envoyproxy.io
         name: default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
@@ -106,10 +106,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          name: :authority
-          suffix: envoyproxy.io
+        hostname: '*.envoyproxy.io'
         name: default/httproute-1/rule/0/match/0-*.envoyproxy.io
         pathMatch:
           distinct: false

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.in.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.in.yaml
@@ -34,6 +34,25 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     namespace: envoy-gateway
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    hostnames:
+    - "*.com"
+    - "*.net"
+    rules:
+    - matches:
+      - path:
+          value: "/foo"
+      backendRefs:
+      - name: service-1
+        port: 8080
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    namespace: envoy-gateway
     name: httproute-2
   spec:
     parentRefs:

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
@@ -16,7 +16,7 @@ gateways:
       protocol: HTTP
   status:
     listeners:
-    - attachedRoutes: 5
+    - attachedRoutes: 6
       conditions:
       - lastTransitionTime: null
         message: Sending translated listener configuration to the data plane
@@ -52,6 +52,43 @@ httpRoutes:
       matches:
       - path:
           value: /
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    creationTimestamp: null
+    name: httproute-1
+    namespace: envoy-gateway
+  spec:
+    hostnames:
+    - '*.com'
+    - '*.net'
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          value: /foo
   status:
     parents:
     - conditions:
@@ -254,10 +291,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: example.com
-          name: :authority
+        hostname: example.com
         name: envoy-gateway/httproute-2/rule/0/match/0-example.com
         pathMatch:
           distinct: false
@@ -274,10 +308,7 @@ xdsIR:
         - host: 8.8.8.8
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: example.com
-          name: :authority
+        hostname: example.com
         name: envoy-gateway/httproute-3/rule/0/match/0-example.com
         pathMatch:
           distinct: false
@@ -292,11 +323,9 @@ xdsIR:
           weight: 1
         headerMatches:
         - distinct: false
-          exact: example.net
-          name: :authority
-        - distinct: false
           exact: one
           name: version
+        hostname: example.net
         name: envoy-gateway/httproute-4/rule/0/match/0-example.net
         pathMatch:
           distinct: false
@@ -309,15 +338,38 @@ xdsIR:
         - host: 8.8.8.8
           port: 8080
           weight: 1
-        headerMatches:
-        - distinct: false
-          exact: example.net
-          name: :authority
+        hostname: example.net
         name: envoy-gateway/httproute-5/rule/0/match/0-example.net
         pathMatch:
           distinct: false
           name: ""
           prefix: /v1/status
+      - backendWeights:
+          invalid: 0
+          valid: 0
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+        hostname: '*.com'
+        name: envoy-gateway/httproute-1/rule/0/match/0-*.com
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /foo
+      - backendWeights:
+          invalid: 0
+          valid: 0
+        destinations:
+        - host: 7.7.7.7
+          port: 8080
+          weight: 1
+        hostname: '*.net'
+        name: envoy-gateway/httproute-1/rule/0/match/0-*.net
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /foo
       - backendWeights:
           invalid: 0
           valid: 0

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
@@ -377,6 +377,7 @@ xdsIR:
         - host: 7.7.7.7
           port: 8080
           weight: 1
+        hostname: '*'
         name: envoy-gateway/httproute-1/rule/0/match/0-*
         pathMatch:
           distinct: false

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -30,6 +30,7 @@ var (
 	ErrTLSServerCertEmpty            = errors.New("field ServerCertificate must be specified")
 	ErrTLSPrivateKey                 = errors.New("field PrivateKey must be specified")
 	ErrHTTPRouteNameEmpty            = errors.New("field Name must be specified")
+	ErrHTTPRouteHostnameEmpty        = errors.New("field Hostname must be specified")
 	ErrHTTPRouteMatchEmpty           = errors.New("either PathMatch, HeaderMatches or QueryParamMatches fields must be specified")
 	ErrRouteDestinationHostInvalid   = errors.New("field Address must be a valid IP address")
 	ErrRouteDestinationPortInvalid   = errors.New("field Port specified is invalid")
@@ -237,7 +238,7 @@ type HTTPRoute struct {
 	// Name of the HTTPRoute
 	Name string `json:"name" yaml:"name"`
 	// Hostname that the route matches against
-	Hostname string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+	Hostname string `json:"hostname" yaml:"hostname,omitempty"`
 	// PathMatch defines the match conditions on the path.
 	PathMatch *StringMatch `json:"pathMatch,omitempty" yaml:"pathMatch,omitempty"`
 	// HeaderMatches define the match conditions on the request headers for this route.
@@ -307,6 +308,9 @@ func (h HTTPRoute) Validate() error {
 	var errs error
 	if h.Name == "" {
 		errs = multierror.Append(errs, ErrHTTPRouteNameEmpty)
+	}
+	if h.Hostname == "" {
+		errs = multierror.Append(errs, ErrHTTPRouteHostnameEmpty)
 	}
 	if h.PathMatch == nil && (len(h.HeaderMatches) == 0) && (len(h.QueryParamMatches) == 0) {
 		errs = multierror.Append(errs, ErrHTTPRouteMatchEmpty)

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -236,6 +236,8 @@ type BackendWeights struct {
 type HTTPRoute struct {
 	// Name of the HTTPRoute
 	Name string `json:"name" yaml:"name"`
+	// Hostname that the route matches against
+	Hostname string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
 	// PathMatch defines the match conditions on the path.
 	PathMatch *StringMatch `json:"pathMatch,omitempty" yaml:"pathMatch,omitempty"`
 	// HeaderMatches define the match conditions on the request headers for this route.

--- a/internal/ir/xds_test.go
+++ b/internal/ir/xds_test.go
@@ -139,7 +139,8 @@ var (
 
 	// HTTPRoute
 	happyHTTPRoute = HTTPRoute{
-		Name: "happy",
+		Name:     "happy",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("example"),
 		},
@@ -147,10 +148,12 @@ var (
 	}
 	emptyMatchHTTPRoute = HTTPRoute{
 		Name:         "empty-match",
+		Hostname:     "*",
 		Destinations: []*RouteDestination{&happyRouteDestination},
 	}
 	invalidBackendHTTPRoute = HTTPRoute{
-		Name: "invalid-backend",
+		Name:     "invalid-backend",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("invalid-backend"),
 		},
@@ -159,7 +162,8 @@ var (
 		},
 	}
 	weightedInvalidBackendsHTTPRoute = HTTPRoute{
-		Name: "weighted-invalid-backends",
+		Name:     "weighted-invalid-backends",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("invalid-backends"),
 		},
@@ -171,7 +175,8 @@ var (
 	}
 
 	redirectHTTPRoute = HTTPRoute{
-		Name: "redirect",
+		Name:     "redirect",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("redirect"),
 		},
@@ -187,7 +192,8 @@ var (
 	}
 	// A direct response error is used when an invalid filter type is supplied
 	invalidFilterHTTPRoute = HTTPRoute{
-		Name: "filter-error",
+		Name:     "filter-error",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("filter-error"),
 		},
@@ -198,7 +204,8 @@ var (
 	}
 
 	redirectFilterInvalidStatus = HTTPRoute{
-		Name: "redirect-bad-status-scheme-nopat",
+		Name:     "redirect-bad-status-scheme-nopat",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("redirect"),
 		},
@@ -211,7 +218,8 @@ var (
 		},
 	}
 	redirectFilterBadPath = HTTPRoute{
-		Name: "redirect",
+		Name:     "redirect",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("redirect"),
 		},
@@ -227,7 +235,8 @@ var (
 		},
 	}
 	directResponseBadStatus = HTTPRoute{
-		Name: "redirect",
+		Name:     "redirect",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("redirect"),
 		},
@@ -238,7 +247,8 @@ var (
 	}
 
 	urlRewriteHTTPRoute = HTTPRoute{
-		Name: "rewrite",
+		Name:     "rewrite",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("rewrite"),
 		},
@@ -251,7 +261,8 @@ var (
 	}
 
 	urlRewriteFilterBadPath = HTTPRoute{
-		Name: "rewrite",
+		Name:     "rewrite",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("rewrite"),
 		},
@@ -265,7 +276,8 @@ var (
 	}
 
 	addRequestHeaderHTTPRoute = HTTPRoute{
-		Name: "addheader",
+		Name:     "addheader",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("addheader"),
 		},
@@ -289,7 +301,8 @@ var (
 	}
 
 	removeRequestHeaderHTTPRoute = HTTPRoute{
-		Name: "remheader",
+		Name:     "remheader",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("remheader"),
 		},
@@ -301,7 +314,8 @@ var (
 	}
 
 	addAndRemoveRequestHeadersDupeHTTPRoute = HTTPRoute{
-		Name: "duplicateheader",
+		Name:     "duplicateheader",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("duplicateheader"),
 		},
@@ -325,7 +339,8 @@ var (
 	}
 
 	addRequestHeaderEmptyHTTPRoute = HTTPRoute{
-		Name: "addemptyheader",
+		Name:     "addemptyheader",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("addemptyheader"),
 		},
@@ -339,7 +354,8 @@ var (
 	}
 
 	addResponseHeaderHTTPRoute = HTTPRoute{
-		Name: "addheader",
+		Name:     "addheader",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("addheader"),
 		},
@@ -363,7 +379,8 @@ var (
 	}
 
 	removeResponseHeaderHTTPRoute = HTTPRoute{
-		Name: "remheader",
+		Name:     "remheader",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("remheader"),
 		},
@@ -375,7 +392,8 @@ var (
 	}
 
 	addAndRemoveResponseHeadersDupeHTTPRoute = HTTPRoute{
-		Name: "duplicateheader",
+		Name:     "duplicateheader",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("duplicateheader"),
 		},
@@ -399,7 +417,8 @@ var (
 	}
 
 	addResponseHeaderEmptyHTTPRoute = HTTPRoute{
-		Name: "addemptyheader",
+		Name:     "addemptyheader",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("addemptyheader"),
 		},
@@ -413,7 +432,8 @@ var (
 	}
 
 	jwtAuthenHTTPRoute = HTTPRoute{
-		Name: "jwtauthen",
+		Name:     "jwtauthen",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("jwtauthen"),
 		},
@@ -431,7 +451,8 @@ var (
 		},
 	}
 	requestMirrorFilter = HTTPRoute{
-		Name: "mirrorfilter",
+		Name:     "mirrorfilter",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("mirrorfilter"),
 		},
@@ -441,7 +462,8 @@ var (
 	}
 
 	requestMirrorFilterMultiple = HTTPRoute{
-		Name: "mirrorfilterMultiple",
+		Name:     "mirrorfilterMultiple",
+		Hostname: "*",
 		PathMatch: &StringMatch{
 			Exact: ptrTo("mirrorfiltermultiple"),
 		},
@@ -807,12 +829,24 @@ func TestValidateHTTPRoute(t *testing.T) {
 		{
 			name: "invalid name",
 			input: HTTPRoute{
+				Hostname: "*",
 				PathMatch: &StringMatch{
 					Exact: ptrTo("example"),
 				},
 				Destinations: []*RouteDestination{&happyRouteDestination},
 			},
 			want: []error{ErrHTTPRouteNameEmpty},
+		},
+		{
+			name: "invalid hostname",
+			input: HTTPRoute{
+				Name: "invalid hostname",
+				PathMatch: &StringMatch{
+					Exact: ptrTo("example"),
+				},
+				Destinations: []*RouteDestination{&happyRouteDestination},
+			},
+			want: []error{ErrHTTPRouteHostnameEmpty},
 		},
 		{
 			name:  "empty match",
@@ -832,6 +866,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 		{
 			name: "empty name and invalid match",
 			input: HTTPRoute{
+				Hostname:      "*",
 				HeaderMatches: []*StringMatch{ptrTo(StringMatch{})},
 				Destinations:  []*RouteDestination{&happyRouteDestination},
 			},

--- a/internal/xds/translator/testdata/in/extension-xds-ir/http-route-extension-filter.yaml
+++ b/internal/xds/translator/testdata/in/extension-xds-ir/http-route-extension-filter.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     pathMatch:
       prefix: "/"
     destinations:

--- a/internal/xds/translator/testdata/in/extension-xds-ir/http-route-extension-listener-error.yaml
+++ b/internal/xds/translator/testdata/in/extension-xds-ir/http-route-extension-listener-error.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     pathMatch:
       prefix: "/"
     destinations:

--- a/internal/xds/translator/testdata/in/extension-xds-ir/http-route-extension-route-error.yaml
+++ b/internal/xds/translator/testdata/in/extension-xds-ir/http-route-extension-route-error.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "extension-post-xdsroute-hook-error"
+    hostname: "*"
     pathMatch:
       prefix: "/"
     destinations:

--- a/internal/xds/translator/testdata/in/extension-xds-ir/http-route-extension-virtualhost-error.yaml
+++ b/internal/xds/translator/testdata/in/extension-xds-ir/http-route-extension-virtualhost-error.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     pathMatch:
       prefix: "/"
     destinations:

--- a/internal/xds/translator/testdata/in/extension-xds-ir/http-route.yaml
+++ b/internal/xds/translator/testdata/in/extension-xds-ir/http-route.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     headerMatches:
     - name: user
       stringMatch:

--- a/internal/xds/translator/testdata/in/xds-ir/accesslog.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/accesslog.yaml
@@ -29,6 +29,7 @@ http:
   - "*"
   routes:
   - name: "direct-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/authn-multi-route-multi-provider.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/authn-multi-route-multi-provider.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route-www.test.com"
+    hostname: "*"
     pathMatch:
       exact: "foo/bar"
     requestAuthentication:
@@ -36,6 +37,7 @@ http:
     - host: "1.2.3.4"
       port: 50000
   - name: "second-route-www.test.com"
+    hostname: "*"
     pathMatch:
       exact: "foo/baz"
     requestAuthentication:

--- a/internal/xds/translator/testdata/in/xds-ir/authn-multi-route-single-provider.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/authn-multi-route-single-provider.yaml
@@ -9,6 +9,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     pathMatch:
       exact: "foo/bar"
     requestAuthentication:
@@ -27,6 +28,7 @@ http:
     - host: "1.2.3.4"
       port: 50000
   - name: "second-route"
+    hostname: "*"
     pathMatch:
       exact: "foo/baz"
     requestAuthentication:

--- a/internal/xds/translator/testdata/in/xds-ir/authn-ratelimit.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/authn-ratelimit.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:
@@ -30,6 +31,7 @@ http:
           remoteJWKS:
             uri: https://192.168.1.250/jwt/public-key/jwks.json
   - name: "second-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:
@@ -45,6 +47,7 @@ http:
     - host: "1.2.3.4"
       port: 50000
   - name: "third-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:

--- a/internal/xds/translator/testdata/in/xds-ir/authn-single-route-single-match.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/authn-single-route-single-match.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     pathMatch:
       exact: "foo/bar"
     requestAuthentication:

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-direct-response.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-direct-response.yaml
@@ -7,6 +7,7 @@ http:
   - "*"
   routes:
   - name: "direct-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-invalid.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-invalid.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     headerMatches:
     - name: user
       stringMatch:

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-mirror.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-mirror.yaml
@@ -7,6 +7,7 @@ http:
   - "*"
   routes:
   - name: "mirror-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-multiple-matches.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-multiple-matches.yaml
@@ -56,6 +56,7 @@ http:
   - destinations:
     - host: 7.7.7.7
       port: 8080
+    hostname: "*"
     name: envoy-gateway/httproute-1/rule/0/match/0-*
     pathMatch:
       prefix: /

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-multiple-matches.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-multiple-matches.yaml
@@ -9,7 +9,7 @@ http:
     - host: 7.7.7.7
       port: 8080
     hostname: example.com
-    name: envoy-gateway/httproute-2/rule/0/match/0-example.com
+    name: envoy-gateway/httproute-2/rule/0/match/0/example.com
     pathMatch:
       prefix: /v1/example
     queryParamMatches:
@@ -19,7 +19,7 @@ http:
     - host: 8.8.8.8
       port: 8080
     hostname: example.com
-    name: envoy-gateway/httproute-3/rule/0/match/0-example.com
+    name: envoy-gateway/httproute-3/rule/0/match/0/example.com
     pathMatch:
       prefix: /v1/example
   - destinations:
@@ -29,34 +29,34 @@ http:
     - exact: one
       name: version
     hostname: example.net
-    name: envoy-gateway/httproute-4/rule/0/match/0-example.net
+    name: envoy-gateway/httproute-4/rule/0/match/0/example.net
     pathMatch:
       prefix: /v1/status
   - destinations:
     - host: 8.8.8.8
       port: 8080
     hostname: example.net
-    name: envoy-gateway/httproute-5/rule/0/match/0-example.net
+    name: envoy-gateway/httproute-5/rule/0/match/0/example.net
     pathMatch:
       prefix: /v1/status
   - destinations:
     - host: 7.7.7.7
       port: 8080
     hostname: '*.com'
-    name: envoy-gateway/httproute-1/rule/0/match/0-*.com
+    name: envoy-gateway/httproute-1/rule/0/match/0/*.com
     pathMatch:
       prefix: /foo
   - destinations:
     - host: 7.7.7.7
       port: 8080
     hostname: '*.net'
-    name: envoy-gateway/httproute-1/rule/0/match/0-*.net
+    name: envoy-gateway/httproute-1/rule/0/match/0/*.net
     pathMatch:
       prefix: /foo
   - destinations:
     - host: 7.7.7.7
       port: 8080
     hostname: "*"
-    name: envoy-gateway/httproute-1/rule/0/match/0-*
+    name: envoy-gateway/httproute-1/rule/0/match/0/*
     pathMatch:
       prefix: /

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-multiple-matches.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-multiple-matches.yaml
@@ -1,0 +1,61 @@
+http:
+- name: first-listener
+  address: 0.0.0.0
+  port: 10080
+  hostnames:
+  - "*"
+  routes:
+  - destinations:
+    - host: 7.7.7.7
+      port: 8080
+    hostname: example.com
+    name: envoy-gateway/httproute-2/rule/0/match/0-example.com
+    pathMatch:
+      prefix: /v1/example
+    queryParamMatches:
+    - exact: "yes"
+      name: debug
+  - destinations:
+    - host: 8.8.8.8
+      port: 8080
+    hostname: example.com
+    name: envoy-gateway/httproute-3/rule/0/match/0-example.com
+    pathMatch:
+      prefix: /v1/example
+  - destinations:
+    - host: 7.7.7.7
+      port: 8080
+    headerMatches:
+    - exact: one
+      name: version
+    hostname: example.net
+    name: envoy-gateway/httproute-4/rule/0/match/0-example.net
+    pathMatch:
+      prefix: /v1/status
+  - destinations:
+    - host: 8.8.8.8
+      port: 8080
+    hostname: example.net
+    name: envoy-gateway/httproute-5/rule/0/match/0-example.net
+    pathMatch:
+      prefix: /v1/status
+  - destinations:
+    - host: 7.7.7.7
+      port: 8080
+    hostname: '*.com'
+    name: envoy-gateway/httproute-1/rule/0/match/0-*.com
+    pathMatch:
+      prefix: /foo
+  - destinations:
+    - host: 7.7.7.7
+      port: 8080
+    hostname: '*.net'
+    name: envoy-gateway/httproute-1/rule/0/match/0-*.net
+    pathMatch:
+      prefix: /foo
+  - destinations:
+    - host: 7.7.7.7
+      port: 8080
+    name: envoy-gateway/httproute-1/rule/0/match/0-*
+    pathMatch:
+      prefix: /

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-redirect.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-redirect.yaml
@@ -7,6 +7,7 @@ http:
   - "*"
   routes:
   - name: "redirect-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-regex.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-regex.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "regex-route"
+    hostname: "*"
     pathMatch:
       safeRegex: "/v1/.*"
     headerMatches:

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-request-headers.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-request-headers.yaml
@@ -7,6 +7,7 @@ http:
   - "*"
   routes:
   - name: "request-header-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-response-add-headers.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-response-add-headers.yaml
@@ -7,6 +7,7 @@ http:
   - "*"
   routes:
   - name: "response-header-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-response-add-remove-headers.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-response-add-remove-headers.yaml
@@ -7,6 +7,7 @@ http:
   - "*"
   routes:
   - name: "response-header-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-response-remove-headers.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-response-remove-headers.yaml
@@ -7,6 +7,7 @@ http:
   - "*"
   routes:
   - name: "response-header-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-rewrite-root-path-url-prefix.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-rewrite-root-path-url-prefix.yaml
@@ -9,9 +9,7 @@ http:
   - name: "rewrite-route"
     pathMatch:
       prefix: "/origin/"
-    headerMatches:
-    - name: ":authority"
-      exact: gateway.envoyproxy.io
+    hostname: gateway.envoyproxy.io
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-rewrite-url-fullpath.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-rewrite-url-fullpath.yaml
@@ -9,9 +9,7 @@ http:
   - name: "rewrite-route"
     pathMatch:
       prefix: "/origin"
-    headerMatches:
-    - name: ":authority"
-      exact: gateway.envoyproxy.io
+    hostname: gateway.envoyproxy.io
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-rewrite-url-host.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-rewrite-url-host.yaml
@@ -9,9 +9,7 @@ http:
   - name: "rewrite-route"
     pathMatch:
       prefix: "/origin"
-    headerMatches:
-    - name: ":authority"
-      exact: gateway.envoyproxy.io
+    hostname: gateway.envoyproxy.io
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-rewrite-url-prefix.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-rewrite-url-prefix.yaml
@@ -9,9 +9,7 @@ http:
   - name: "rewrite-route"
     pathMatch:
       prefix: "/origin"
-    headerMatches:
-    - name: ":authority"
-      exact: gateway.envoyproxy.io
+    hostname: gateway.envoyproxy.io
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-weighted-backend.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-weighted-backend.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     destinations:
     - host: "1.1.1.1"
       port: 50001

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-weighted-invalid-backend.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-weighted-invalid-backend.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/http-route.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     headerMatches:
     - name: user
       stringMatch:

--- a/internal/xds/translator/testdata/in/xds-ir/http2-route.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http2-route.yaml
@@ -7,6 +7,7 @@ http:
   isHTTP2: true
   routes:
   - name: "first-route"
+    hostname: "*"
     pathMatch:
       name: "test"
       exact: "foo/bar"

--- a/internal/xds/translator/testdata/in/xds-ir/jsonpatch-invalid-listener.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/jsonpatch-invalid-listener.yaml
@@ -58,6 +58,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     headerMatches:
     - name: user
       stringMatch:

--- a/internal/xds/translator/testdata/in/xds-ir/jsonpatch-invalid-patch.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/jsonpatch-invalid-patch.yaml
@@ -28,6 +28,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     headerMatches:
     - name: user
       stringMatch:

--- a/internal/xds/translator/testdata/in/xds-ir/jsonpatch-invalid.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/jsonpatch-invalid.yaml
@@ -62,6 +62,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     headerMatches:
     - name: user
       stringMatch:

--- a/internal/xds/translator/testdata/in/xds-ir/jsonpatch-missing-resource.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/jsonpatch-missing-resource.yaml
@@ -28,6 +28,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     headerMatches:
     - name: user
       stringMatch:

--- a/internal/xds/translator/testdata/in/xds-ir/jsonpatch.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/jsonpatch.yaml
@@ -62,6 +62,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     headerMatches:
     - name: user
       stringMatch:

--- a/internal/xds/translator/testdata/in/xds-ir/multiple-listeners-same-port.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/multiple-listeners-same-port.yaml
@@ -12,6 +12,7 @@ http:
     privateKey: [107, 101, 121, 45, 100, 97, 116, 97]
   routes:
   - name: "first-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000
@@ -28,6 +29,7 @@ http:
     privateKey: [107, 101, 121, 45, 100, 97, 116, 97]
   routes:
   - name: "second-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000
@@ -38,6 +40,7 @@ http:
   - "example.com"
   routes:
   - name: "third-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000
@@ -48,6 +51,7 @@ http:
   - "example.net"
   routes:
   - name: "fourth-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/ratelimit-custom-domain.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/ratelimit-custom-domain.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:
@@ -21,6 +22,7 @@ http:
     - host: "1.2.3.4"
       port: 50000
   - name: "second-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:
@@ -36,6 +38,7 @@ http:
     - host: "1.2.3.4"
       port: 50000
   - name: "third-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:

--- a/internal/xds/translator/testdata/in/xds-ir/ratelimit-sourceip.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/ratelimit-sourceip.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:
@@ -21,6 +22,7 @@ http:
     - host: "1.2.3.4"
       port: 50000
   - name: "second-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:
@@ -36,6 +38,7 @@ http:
     - host: "1.2.3.4"
       port: 50000
   - name: "third-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:
@@ -48,6 +51,7 @@ http:
     - host: "1.2.3.4"
       port: 50000
   - name: "fourth-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:

--- a/internal/xds/translator/testdata/in/xds-ir/ratelimit.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/ratelimit.yaml
@@ -6,6 +6,7 @@ http:
   - "*"
   routes:
   - name: "first-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:
@@ -21,6 +22,7 @@ http:
     - host: "1.2.3.4"
       port: 50000
   - name: "second-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:
@@ -36,6 +38,7 @@ http:
     - host: "1.2.3.4"
       port: 50000
   - name: "third-route"
+    hostname: "*"
     rateLimit:
       global:
         rules:

--- a/internal/xds/translator/testdata/in/xds-ir/simple-tls.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/simple-tls.yaml
@@ -15,6 +15,7 @@ http:
     privateKey: [107, 101, 121, 45, 100, 97, 116, 97]
   routes:
   - name: "first-route"
+    hostname: "*"
     destinations:
     - host: "1.2.3.4"
       port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/tracing-invalid.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/tracing-invalid.yaml
@@ -28,6 +28,7 @@ http:
       - "*"
     routes:
       - name: "direct-route"
+        hostname: "*"
         destinations:
           - host: "1.2.3.4"
             port: 50000

--- a/internal/xds/translator/testdata/in/xds-ir/tracing.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/tracing.yaml
@@ -28,6 +28,7 @@ http:
       - "*"
     routes:
       - name: "direct-route"
+        hostname: "*"
         destinations:
           - host: "1.2.3.4"
             port: 50000

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.routes.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: extension-listener
+    name: extension-listener-*
     routes:
     - match:
         prefix: /
@@ -29,6 +29,3 @@
           value: foo.example.io/v1alpha1
       route:
         cluster: first-route
-    - directResponse:
-        status: 200
-      name: mock-extension-inserted-route

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.routes.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: extension-listener-*
+    name: extension-listener/*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route.routes.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route.routes.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - directResponse:
         body:

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - directResponse:
         body:

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - directResponse:
         body:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - directResponse:
         body:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
@@ -1,0 +1,91 @@
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_ONLY
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: envoy-gateway/httproute-2/rule/0/match/0-example.com
+  name: envoy-gateway/httproute-2/rule/0/match/0-example.com
+  outlierDetection: {}
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_ONLY
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: envoy-gateway/httproute-3/rule/0/match/0-example.com
+  name: envoy-gateway/httproute-3/rule/0/match/0-example.com
+  outlierDetection: {}
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_ONLY
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: envoy-gateway/httproute-4/rule/0/match/0-example.net
+  name: envoy-gateway/httproute-4/rule/0/match/0-example.net
+  outlierDetection: {}
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_ONLY
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: envoy-gateway/httproute-5/rule/0/match/0-example.net
+  name: envoy-gateway/httproute-5/rule/0/match/0-example.net
+  outlierDetection: {}
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_ONLY
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: envoy-gateway/httproute-1/rule/0/match/0-*.com
+  name: envoy-gateway/httproute-1/rule/0/match/0-*.com
+  outlierDetection: {}
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_ONLY
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: envoy-gateway/httproute-1/rule/0/match/0-*.net
+  name: envoy-gateway/httproute-1/rule/0/match/0-*.net
+  outlierDetection: {}
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_ONLY
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: envoy-gateway/httproute-1/rule/0/match/0-*
+  name: envoy-gateway/httproute-1/rule/0/match/0-*
+  outlierDetection: {}
+  perConnectionBufferLimitBytes: 32768
+  type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
@@ -6,8 +6,8 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
-    serviceName: envoy-gateway/httproute-2/rule/0/match/0-example.com
-  name: envoy-gateway/httproute-2/rule/0/match/0-example.com
+    serviceName: envoy-gateway/httproute-2/rule/0/match/0/example.com
+  name: envoy-gateway/httproute-2/rule/0/match/0/example.com
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
@@ -19,8 +19,8 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
-    serviceName: envoy-gateway/httproute-3/rule/0/match/0-example.com
-  name: envoy-gateway/httproute-3/rule/0/match/0-example.com
+    serviceName: envoy-gateway/httproute-3/rule/0/match/0/example.com
+  name: envoy-gateway/httproute-3/rule/0/match/0/example.com
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
@@ -32,8 +32,8 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
-    serviceName: envoy-gateway/httproute-4/rule/0/match/0-example.net
-  name: envoy-gateway/httproute-4/rule/0/match/0-example.net
+    serviceName: envoy-gateway/httproute-4/rule/0/match/0/example.net
+  name: envoy-gateway/httproute-4/rule/0/match/0/example.net
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
@@ -45,8 +45,8 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
-    serviceName: envoy-gateway/httproute-5/rule/0/match/0-example.net
-  name: envoy-gateway/httproute-5/rule/0/match/0-example.net
+    serviceName: envoy-gateway/httproute-5/rule/0/match/0/example.net
+  name: envoy-gateway/httproute-5/rule/0/match/0/example.net
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
@@ -58,8 +58,8 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
-    serviceName: envoy-gateway/httproute-1/rule/0/match/0-*.com
-  name: envoy-gateway/httproute-1/rule/0/match/0-*.com
+    serviceName: envoy-gateway/httproute-1/rule/0/match/0/*.com
+  name: envoy-gateway/httproute-1/rule/0/match/0/*.com
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
@@ -71,8 +71,8 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
-    serviceName: envoy-gateway/httproute-1/rule/0/match/0-*.net
-  name: envoy-gateway/httproute-1/rule/0/match/0-*.net
+    serviceName: envoy-gateway/httproute-1/rule/0/match/0/*.net
+  name: envoy-gateway/httproute-1/rule/0/match/0/*.net
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
@@ -84,8 +84,8 @@
     edsConfig:
       ads: {}
       resourceApiVersion: V3
-    serviceName: envoy-gateway/httproute-1/rule/0/match/0-*
-  name: envoy-gateway/httproute-1/rule/0/match/0-*
+    serviceName: envoy-gateway/httproute-1/rule/0/match/0/*
+  name: envoy-gateway/httproute-1/rule/0/match/0/*
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.endpoints.yaml
@@ -1,4 +1,4 @@
-- clusterName: envoy-gateway/httproute-2/rule/0/match/0-example.com
+- clusterName: envoy-gateway/httproute-2/rule/0/match/0/example.com
   endpoints:
   - lbEndpoints:
     - endpoint:
@@ -8,7 +8,7 @@
             portValue: 8080
     loadBalancingWeight: 1
     locality: {}
-- clusterName: envoy-gateway/httproute-3/rule/0/match/0-example.com
+- clusterName: envoy-gateway/httproute-3/rule/0/match/0/example.com
   endpoints:
   - lbEndpoints:
     - endpoint:
@@ -18,7 +18,7 @@
             portValue: 8080
     loadBalancingWeight: 1
     locality: {}
-- clusterName: envoy-gateway/httproute-4/rule/0/match/0-example.net
+- clusterName: envoy-gateway/httproute-4/rule/0/match/0/example.net
   endpoints:
   - lbEndpoints:
     - endpoint:
@@ -28,7 +28,7 @@
             portValue: 8080
     loadBalancingWeight: 1
     locality: {}
-- clusterName: envoy-gateway/httproute-5/rule/0/match/0-example.net
+- clusterName: envoy-gateway/httproute-5/rule/0/match/0/example.net
   endpoints:
   - lbEndpoints:
     - endpoint:
@@ -38,7 +38,7 @@
             portValue: 8080
     loadBalancingWeight: 1
     locality: {}
-- clusterName: envoy-gateway/httproute-1/rule/0/match/0-*.com
+- clusterName: envoy-gateway/httproute-1/rule/0/match/0/*.com
   endpoints:
   - lbEndpoints:
     - endpoint:
@@ -48,7 +48,7 @@
             portValue: 8080
     loadBalancingWeight: 1
     locality: {}
-- clusterName: envoy-gateway/httproute-1/rule/0/match/0-*.net
+- clusterName: envoy-gateway/httproute-1/rule/0/match/0/*.net
   endpoints:
   - lbEndpoints:
     - endpoint:
@@ -58,7 +58,7 @@
             portValue: 8080
     loadBalancingWeight: 1
     locality: {}
-- clusterName: envoy-gateway/httproute-1/rule/0/match/0-*
+- clusterName: envoy-gateway/httproute-1/rule/0/match/0/*
   endpoints:
   - lbEndpoints:
     - endpoint:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.endpoints.yaml
@@ -1,0 +1,70 @@
+- clusterName: envoy-gateway/httproute-2/rule/0/match/0-example.com
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 7.7.7.7
+            portValue: 8080
+    loadBalancingWeight: 1
+    locality: {}
+- clusterName: envoy-gateway/httproute-3/rule/0/match/0-example.com
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 8.8.8.8
+            portValue: 8080
+    loadBalancingWeight: 1
+    locality: {}
+- clusterName: envoy-gateway/httproute-4/rule/0/match/0-example.net
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 7.7.7.7
+            portValue: 8080
+    loadBalancingWeight: 1
+    locality: {}
+- clusterName: envoy-gateway/httproute-5/rule/0/match/0-example.net
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 8.8.8.8
+            portValue: 8080
+    loadBalancingWeight: 1
+    locality: {}
+- clusterName: envoy-gateway/httproute-1/rule/0/match/0-*.com
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 7.7.7.7
+            portValue: 8080
+    loadBalancingWeight: 1
+    locality: {}
+- clusterName: envoy-gateway/httproute-1/rule/0/match/0-*.net
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 7.7.7.7
+            portValue: 8080
+    loadBalancingWeight: 1
+    locality: {}
+- clusterName: envoy-gateway/httproute-1/rule/0/match/0-*
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 7.7.7.7
+            portValue: 8080
+    loadBalancingWeight: 1
+    locality: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.listeners.yaml
@@ -1,0 +1,33 @@
+- address:
+    socketAddress:
+      address: 0.0.0.0
+      portValue: 10080
+  defaultFilterChain:
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        commonHttpProtocolOptions:
+          headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: first-listener
+        statPrefix: http
+        upgradeConfigs:
+        - upgradeType: websocket
+        useRemoteAddress: true
+  name: first-listener
+  perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.routes.yaml
@@ -1,0 +1,66 @@
+- ignorePortInHostMatching: true
+  name: first-listener
+  virtualHosts:
+  - domains:
+    - example.com
+    name: first-listener-example.com
+    routes:
+    - match:
+        pathSeparatedPrefix: /v1/example
+        queryParameters:
+        - name: debug
+          stringMatch:
+            exact: "yes"
+      name: envoy-gateway/httproute-2/rule/0/match/0-example.com
+      route:
+        cluster: envoy-gateway/httproute-2/rule/0/match/0-example.com
+    - match:
+        pathSeparatedPrefix: /v1/example
+      name: envoy-gateway/httproute-3/rule/0/match/0-example.com
+      route:
+        cluster: envoy-gateway/httproute-3/rule/0/match/0-example.com
+  - domains:
+    - example.net
+    name: first-listener-example.net
+    routes:
+    - match:
+        headers:
+        - name: version
+          stringMatch:
+            exact: one
+        pathSeparatedPrefix: /v1/status
+      name: envoy-gateway/httproute-4/rule/0/match/0-example.net
+      route:
+        cluster: envoy-gateway/httproute-4/rule/0/match/0-example.net
+    - match:
+        pathSeparatedPrefix: /v1/status
+      name: envoy-gateway/httproute-5/rule/0/match/0-example.net
+      route:
+        cluster: envoy-gateway/httproute-5/rule/0/match/0-example.net
+  - domains:
+    - '*.com'
+    name: first-listener-*.com
+    routes:
+    - match:
+        pathSeparatedPrefix: /foo
+      name: envoy-gateway/httproute-1/rule/0/match/0-*.com
+      route:
+        cluster: envoy-gateway/httproute-1/rule/0/match/0-*.com
+  - domains:
+    - '*.net'
+    name: first-listener-*.net
+    routes:
+    - match:
+        pathSeparatedPrefix: /foo
+      name: envoy-gateway/httproute-1/rule/0/match/0-*.net
+      route:
+        cluster: envoy-gateway/httproute-1/rule/0/match/0-*.net
+  - domains:
+    - '*'
+    name: first-listener-*
+    routes:
+    - match:
+        prefix: /
+      name: envoy-gateway/httproute-1/rule/0/match/0-*
+      route:
+        cluster: envoy-gateway/httproute-1/rule/0/match/0-*

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - example.com
-    name: first-listener-example.com
+    name: first-listener/example.com
     routes:
     - match:
         pathSeparatedPrefix: /v1/example
@@ -11,17 +11,17 @@
         - name: debug
           stringMatch:
             exact: "yes"
-      name: envoy-gateway/httproute-2/rule/0/match/0-example.com
+      name: envoy-gateway/httproute-2/rule/0/match/0/example.com
       route:
-        cluster: envoy-gateway/httproute-2/rule/0/match/0-example.com
+        cluster: envoy-gateway/httproute-2/rule/0/match/0/example.com
     - match:
         pathSeparatedPrefix: /v1/example
-      name: envoy-gateway/httproute-3/rule/0/match/0-example.com
+      name: envoy-gateway/httproute-3/rule/0/match/0/example.com
       route:
-        cluster: envoy-gateway/httproute-3/rule/0/match/0-example.com
+        cluster: envoy-gateway/httproute-3/rule/0/match/0/example.com
   - domains:
     - example.net
-    name: first-listener-example.net
+    name: first-listener/example.net
     routes:
     - match:
         headers:
@@ -29,38 +29,38 @@
           stringMatch:
             exact: one
         pathSeparatedPrefix: /v1/status
-      name: envoy-gateway/httproute-4/rule/0/match/0-example.net
+      name: envoy-gateway/httproute-4/rule/0/match/0/example.net
       route:
-        cluster: envoy-gateway/httproute-4/rule/0/match/0-example.net
+        cluster: envoy-gateway/httproute-4/rule/0/match/0/example.net
     - match:
         pathSeparatedPrefix: /v1/status
-      name: envoy-gateway/httproute-5/rule/0/match/0-example.net
+      name: envoy-gateway/httproute-5/rule/0/match/0/example.net
       route:
-        cluster: envoy-gateway/httproute-5/rule/0/match/0-example.net
+        cluster: envoy-gateway/httproute-5/rule/0/match/0/example.net
   - domains:
     - '*.com'
-    name: first-listener-*.com
+    name: first-listener/*.com
     routes:
     - match:
         pathSeparatedPrefix: /foo
-      name: envoy-gateway/httproute-1/rule/0/match/0-*.com
+      name: envoy-gateway/httproute-1/rule/0/match/0/*.com
       route:
-        cluster: envoy-gateway/httproute-1/rule/0/match/0-*.com
+        cluster: envoy-gateway/httproute-1/rule/0/match/0/*.com
   - domains:
     - '*.net'
-    name: first-listener-*.net
+    name: first-listener/*.net
     routes:
     - match:
         pathSeparatedPrefix: /foo
-      name: envoy-gateway/httproute-1/rule/0/match/0-*.net
+      name: envoy-gateway/httproute-1/rule/0/match/0/*.net
       route:
-        cluster: envoy-gateway/httproute-1/rule/0/match/0-*.net
+        cluster: envoy-gateway/httproute-1/rule/0/match/0/*.net
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         prefix: /
-      name: envoy-gateway/httproute-1/rule/0/match/0-*
+      name: envoy-gateway/httproute-1/rule/0/match/0/*
       route:
-        cluster: envoy-gateway/httproute-1/rule/0/match/0-*
+        cluster: envoy-gateway/httproute-1/rule/0/match/0/*

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-regex.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-regex.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-regex.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-regex.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
@@ -2,14 +2,10 @@
   name: first-listener
   virtualHosts:
   - domains:
-    - '*'
-    name: first-listener
+    - gateway.envoyproxy.io
+    name: first-listener-gateway.envoyproxy.io
     routes:
     - match:
-        headers:
-        - name: :authority
-          stringMatch:
-            exact: gateway.envoyproxy.io
         prefix: /origin/
       name: rewrite-route
       route:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - gateway.envoyproxy.io
-    name: first-listener-gateway.envoyproxy.io
+    name: first-listener/gateway.envoyproxy.io
     routes:
     - match:
         prefix: /origin/

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.routes.yaml
@@ -2,14 +2,10 @@
   name: first-listener
   virtualHosts:
   - domains:
-    - '*'
-    name: first-listener
+    - gateway.envoyproxy.io
+    name: first-listener-gateway.envoyproxy.io
     routes:
     - match:
-        headers:
-        - name: :authority
-          stringMatch:
-            exact: gateway.envoyproxy.io
         pathSeparatedPrefix: /origin
       name: rewrite-route
       route:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - gateway.envoyproxy.io
-    name: first-listener-gateway.envoyproxy.io
+    name: first-listener/gateway.envoyproxy.io
     routes:
     - match:
         pathSeparatedPrefix: /origin

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.routes.yaml
@@ -2,14 +2,10 @@
   name: first-listener
   virtualHosts:
   - domains:
-    - '*'
-    name: first-listener
+    - gateway.envoyproxy.io
+    name: first-listener-gateway.envoyproxy.io
     routes:
     - match:
-        headers:
-        - name: :authority
-          stringMatch:
-            exact: gateway.envoyproxy.io
         pathSeparatedPrefix: /origin
       name: rewrite-route
       route:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - gateway.envoyproxy.io
-    name: first-listener-gateway.envoyproxy.io
+    name: first-listener/gateway.envoyproxy.io
     routes:
     - match:
         pathSeparatedPrefix: /origin

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.routes.yaml
@@ -2,14 +2,10 @@
   name: first-listener
   virtualHosts:
   - domains:
-    - '*'
-    name: first-listener
+    - gateway.envoyproxy.io
+    name: first-listener-gateway.envoyproxy.io
     routes:
     - match:
-        headers:
-        - name: :authority
-          stringMatch:
-            exact: gateway.envoyproxy.io
         pathSeparatedPrefix: /origin
       name: rewrite-route
       route:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - gateway.envoyproxy.io
-    name: first-listener-gateway.envoyproxy.io
+    name: first-listener/gateway.envoyproxy.io
     routes:
     - match:
         pathSeparatedPrefix: /origin

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     rateLimits:
     - actions:
       - remoteAddress: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     rateLimits:
     - actions:
       - remoteAddress: {}

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.routes.yaml
@@ -2,8 +2,8 @@
   name: first-listener
   virtualHosts:
   - domains:
-    - foo.com
-    name: first-listener
+    - '*'
+    name: first-listener-*
     routes:
     - match:
         prefix: /
@@ -14,8 +14,8 @@
   name: second-listener
   virtualHosts:
   - domains:
-    - foo.net
-    name: second-listener
+    - '*'
+    name: second-listener-*
     routes:
     - match:
         prefix: /
@@ -26,8 +26,8 @@
   name: third-listener
   virtualHosts:
   - domains:
-    - example.com
-    name: third-listener
+    - '*'
+    name: third-listener-*
     routes:
     - match:
         prefix: /
@@ -35,8 +35,8 @@
       route:
         cluster: third-route
   - domains:
-    - example.net
-    name: fourth-listener
+    - '*'
+    name: fourth-listener-*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         prefix: /
@@ -15,7 +15,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: second-listener-*
+    name: second-listener/*
     routes:
     - match:
         prefix: /
@@ -27,7 +27,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: third-listener-*
+    name: third-listener/*
     routes:
     - match:
         prefix: /
@@ -36,7 +36,7 @@
         cluster: third-route
   - domains:
     - '*'
-    name: fourth-listener-*
+    name: fourth-listener/*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         path: foo/bar

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/tracing.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener
+    name: first-listener-*
     routes:
     - directResponse:
         body:

--- a/internal/xds/translator/testdata/out/xds-ir/tracing.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: first-listener-*
+    name: first-listener/*
     routes:
     - directResponse:
         body:

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -157,20 +157,15 @@ func (t *Translator) processHTTPListenerXdsTranslation(tCtx *types.ResourceVersi
 
 		// Check if an extension is loaded that wants to modify xDS Routes after they have been generated
 		for _, httpRoute := range httpListener.Routes {
-			hostname := httpRoute.Hostname
-			if hostname == "" {
-				hostname = "*"
-			}
-
 			// 1:1 between IR HTTPRoute Hostname and xDS VirtualHost.
-			vHost := vHosts[hostname]
+			vHost := vHosts[httpRoute.Hostname]
 			if vHost == nil {
 				// Allocate virtual host for this httpRoute.
 				vHost = &routev3.VirtualHost{
-					Name:    fmt.Sprintf("%s-%s", httpListener.Name, hostname),
-					Domains: []string{hostname},
+					Name:    fmt.Sprintf("%s-%s", httpListener.Name, httpRoute.Hostname),
+					Domains: []string{httpRoute.Hostname},
 				}
-				vHosts[hostname] = vHost
+				vHosts[httpRoute.Hostname] = vHost
 				vHostsList = append(vHostsList, vHost)
 			}
 

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -162,7 +162,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(tCtx *types.ResourceVersi
 			if vHost == nil {
 				// Allocate virtual host for this httpRoute.
 				vHost = &routev3.VirtualHost{
-					Name:    fmt.Sprintf("%s-%s", httpListener.Name, httpRoute.Hostname),
+					Name:    fmt.Sprintf("%s/%s", httpListener.Name, httpRoute.Hostname),
 					Domains: []string{httpRoute.Hostname},
 				}
 				vHosts[httpRoute.Hostname] = vHost

--- a/internal/xds/translator/translator_test.go
+++ b/internal/xds/translator/translator_test.go
@@ -63,6 +63,9 @@ func TestTranslateXds(t *testing.T) {
 			name: "http-route-mirror",
 		},
 		{
+			name: "http-route-multiple-matches",
+		},
+		{
 			name: "http-route-direct-response",
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
-->
fix

**What this PR does / why we need it**:
We need to be able to match on hostnames in httproute (that are more specific than hostnames in the listener) while also ignoring ports in host headers. Currently we do not ignore ports, and there is no workaround because hostnames may not contain ports, and nor can headermatch values. There are two approaches to solving this:
1. We could change the authority header match that currently exists to be some kind of regex which allows ports
2. We could create xds virtualhosts for each of the hostnames in the httproutes

This PR is the second approach

NB: This PR does **not** allow 'fallthrough' from one route hostname to a less specific one (eg from google.com to *.com) when there is no match for the first hostname, as envoy does not fall through after a virtual host is selected. This **is a breaking change of behaviour** as currently the less specific matcher will simply come later in the list of routes under the same virtual host. However, this is moving in line with the spec as discussed in https://github.com/kubernetes-sigs/gateway-api/discussions/2294

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1687
