### PR TITLE
feat: Set `--cpuset-threads` in EnvoyProxy cmdline arg

### DIFF
--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -141,6 +141,7 @@ func expectedProxyContainers(infra *ir.ProxyInfra, deploymentConfig *egcfgv1a1.K
 		fmt.Sprintf("--service-node $(%s)", envoyPodEnvVar),
 		fmt.Sprintf("--config-yaml %s", bootstrapConfigurations),
 		fmt.Sprintf("--log-level %s", logLevel),
+		fmt.Sprintf("--cpuset-threads"),
 	}
 	if componentLogLevel := componentLogLevelArgs(proxyLogging.Level); componentLogLevel != "" {
 		args = append(args, fmt.Sprintf("--component-log-level %s", componentLogLevel))

--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -141,7 +141,7 @@ func expectedProxyContainers(infra *ir.ProxyInfra, deploymentConfig *egcfgv1a1.K
 		fmt.Sprintf("--service-node $(%s)", envoyPodEnvVar),
 		fmt.Sprintf("--config-yaml %s", bootstrapConfigurations),
 		fmt.Sprintf("--log-level %s", logLevel),
-		fmt.Sprintf("--cpuset-threads"),
+		"--cpuset-threads",
 	}
 	if componentLogLevel := componentLogLevelArgs(proxyLogging.Level); componentLogLevel != "" {
 		args = append(args, fmt.Sprintf("--component-log-level %s", componentLogLevel))

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -36,7 +36,7 @@ spec:
             - --service-node $(ENVOY_POD_NAME)
             - --config-yaml test bootstrap config
             - --log-level warn
-            - --cpuset-threads  
+            - --cpuset-threads
           command:
             - envoy
           env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -36,6 +36,7 @@ spec:
             - --service-node $(ENVOY_POD_NAME)
             - --config-yaml test bootstrap config
             - --log-level warn
+            - --cpuset-threads  
           command:
             - envoy
           env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -36,6 +36,7 @@ spec:
             - --service-node $(ENVOY_POD_NAME)
             - --config-yaml test bootstrap config
             - --log-level error
+            - --cpuset-threads
             - --component-log-level filter:info
           command:
             - envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -137,6 +137,7 @@ spec:
                       resource_api_version: V3
                     name: runtime-0
             - --log-level warn
+            - --cpuset-threads
           command:
             - envoy
           env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -135,6 +135,7 @@ spec:
                       resource_api_version: V3
                     name: runtime-0
             - --log-level warn
+            - --cpuset-threads
           command:
             - envoy
           env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -133,6 +133,7 @@ spec:
                       resource_api_version: V3
                     name: runtime-0
             - --log-level warn
+            - --cpuset-threads
           command:
             - envoy
           env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/enable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/enable-prometheus.yaml
@@ -159,6 +159,7 @@ spec:
                       resource_api_version: V3
                     name: runtime-0
             - --log-level warn
+            - --cpuset-threads  
           command:
             - envoy
           env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/enable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/enable-prometheus.yaml
@@ -159,7 +159,7 @@ spec:
                       resource_api_version: V3
                     name: runtime-0
             - --log-level warn
-            - --cpuset-threads  
+            - --cpuset-threads
           command:
             - envoy
           env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -135,6 +135,7 @@ spec:
                       resource_api_version: V3
                     name: runtime-0
             - --log-level warn
+            - --cpuset-threads
           command:
             - envoy
           env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -135,6 +135,7 @@ spec:
                       resource_api_version: V3
                     name: runtime-0
             - --log-level warn
+            - --cpuset-threads
           command:
             - envoy
           env:


### PR DESCRIPTION
* Use cpuset size instead of total hardware threads to determine total worker threads.

* Can be overridden by explicitly setting `--concurrency` arg

More in https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-cpuset-threads

Discussion in https://github.com/envoyproxy/envoy/pull/5975

Relates to https://github.com/envoyproxy/gateway/issues/1718
