### PR TITLE
[release/v0.5] Bump Envoy Proxy and RateLimit

### DIFF
--- a/api/config/v1alpha1/shared_types.go
+++ b/api/config/v1alpha1/shared_types.go
@@ -18,9 +18,9 @@ const (
 	// DefaultDeploymentMemoryResourceRequests for deployment memory resource
 	DefaultDeploymentMemoryResourceRequests = "512Mi"
 	// DefaultEnvoyProxyImage is the default image used by envoyproxy
-	DefaultEnvoyProxyImage = "envoyproxy/envoy-dev:latest"
+	DefaultEnvoyProxyImage = "envoyproxy/envoy:v1.27-latest"
 	// DefaultRateLimitImage is the default image used by ratelimit.
-	DefaultRateLimitImage = "envoyproxy/ratelimit:master"
+	DefaultRateLimitImage = "envoyproxy/ratelimit:e059638d"
 )
 
 // GroupVersionKind unambiguously identifies a Kind.

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -49,7 +49,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:v1.27-latest
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:v1.27-latest
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -146,7 +146,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:v1.27-latest
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/enable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/enable-prometheus.yaml
@@ -172,7 +172,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:v1.27-latest
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
@@ -71,7 +71,7 @@ spec:
           value: "/certs/tls.key"
         - name: CONFIG_GRPC_XDS_SERVER_TLS_CACERT
           value: "/certs/ca.crt"
-        image: envoyproxy/ratelimit:master
+        image: envoyproxy/ratelimit:e059638d
         imagePullPolicy: IfNotPresent
         name: envoy-ratelimit
         ports:


### PR DESCRIPTION
* Bumped Envoy Proxy to `v1.27` https://www.envoyproxy.io/docs/envoy/v1.27.0/version_history/v1.27/v1.27.0

* Bumped Envoy RateLimit to `e059638d` https://hub.docker.com/r/envoyproxy/ratelimit/tags

Fixes: https://github.com/envoyproxy/gateway/issues/1716

