### PR TITLE
Remove youngnick from maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,7 +13,6 @@ maintainers:
 - arkodg
 - skriss
 - Xunzhuo
-- youngnick
 - zirain
 
 reviewers:


### PR DESCRIPTION
This PR removes me from Envoy Gateway maintainers. I haven't been able to contribute anything worth while for some time, so I think that this is really updating to reflect the actual state.

I've really enjoyed working with everyone on this project, and I really wish the project and everyone involved all the best.