### PR TITLE
Update codecov patch coverage threshold to 60%

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -5,3 +5,8 @@ coverage:
         target: 60%
         threshold: 5%
         if_ci_failed: error
+    patch:
+      default:
+        target: 60%
+        threshold: 5%
+        if_ci_failed: error


### PR DESCRIPTION
Else it ends up using the current project coverage as the default threshold