### PR TITLE
Make jwt fetch more reliable

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
@@ -359,12 +359,14 @@
                                 "providers": {
                                   "envoy-gateway-system/backend/rule/0/match/0-www.example.com-example": {
                                     "remoteJwks": {
+                                      "asyncFetch": {},
                                       "cacheDuration": "300s",
                                       "httpUri": {
                                         "cluster": "raw_githubusercontent_com_443",
                                         "timeout": "5s",
                                         "uri": "https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/authn/jwks.json"
-                                      }
+                                      },
+                                      "retryPolicy": {}
                                     }
                                   }
                                 },

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
@@ -215,11 +215,13 @@ xds:
                       providers:
                         envoy-gateway-system/backend/rule/0/match/0-www.example.com-example:
                           remoteJwks:
+                            asyncFetch: {}
                             cacheDuration: 300s
                             httpUri:
                               cluster: raw_githubusercontent_com_443
                               timeout: 5s
                               uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/authn/jwks.json
+                            retryPolicy: {}
                       requirementMap:
                         envoy-gateway-system/backend/rule/0/match/0-www.example.com:
                           providerName: envoy-gateway-system/backend/rule/0/match/0-www.example.com-example

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.listener.yaml
@@ -49,11 +49,13 @@ xds:
                     providers:
                       envoy-gateway-system/backend/rule/0/match/0-www.example.com-example:
                         remoteJwks:
+                          asyncFetch: {}
                           cacheDuration: 300s
                           httpUri:
                             cluster: raw_githubusercontent_com_443
                             timeout: 5s
                             uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/authn/jwks.json
+                          retryPolicy: {}
                     requirementMap:
                       envoy-gateway-system/backend/rule/0/match/0-www.example.com:
                         providerName: envoy-gateway-system/backend/rule/0/match/0-www.example.com-example

--- a/internal/xds/translator/authentication.go
+++ b/internal/xds/translator/authentication.go
@@ -117,6 +117,8 @@ func buildJwtAuthn(irListener *ir.HTTPListener) (*jwtauthnv3.JwtAuthentication, 
 							Timeout: &durationpb.Duration{Seconds: 5},
 						},
 						CacheDuration: &durationpb.Duration{Seconds: 5 * 60},
+						AsyncFetch:    &jwtauthnv3.JwksAsyncFetch{},
+						RetryPolicy:   &corev3.RetryPolicy{},
 					},
 				}
 

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.listeners.yaml
@@ -27,11 +27,13 @@
                 issuer: https://www.example.com
                 payloadInMetadata: https://www.example.com
                 remoteJwks:
+                  asyncFetch: {}
                   cacheDuration: 300s
                   httpUri:
                     cluster: localhost_443
                     timeout: 5s
                     uri: https://localhost/jwt/public-key/jwks.json
+                  retryPolicy: {}
               first-route-www.test.com-example2:
                 audiences:
                 - one.foo.com
@@ -44,11 +46,13 @@
                 issuer: https://www.two.example.com
                 payloadInMetadata: https://www.two.example.com
                 remoteJwks:
+                  asyncFetch: {}
                   cacheDuration: 300s
                   httpUri:
                     cluster: "192_168_1_250_8080"
                     timeout: 5s
                     uri: https://192.168.1.250:8080/jwt/public-key/jwks.json
+                  retryPolicy: {}
               second-route-www.test.com-example:
                 audiences:
                 - foo.com
@@ -58,11 +62,13 @@
                 issuer: https://www.example.com
                 payloadInMetadata: https://www.example.com
                 remoteJwks:
+                  asyncFetch: {}
                   cacheDuration: 300s
                   httpUri:
                     cluster: localhost_443
                     timeout: 5s
                     uri: https://localhost/jwt/public-key/jwks.json
+                  retryPolicy: {}
               second-route-www.test.com-example2:
                 audiences:
                 - one.foo.com
@@ -70,11 +76,13 @@
                 issuer: https://www.two.example.com
                 payloadInMetadata: https://www.two.example.com
                 remoteJwks:
+                  asyncFetch: {}
                   cacheDuration: 300s
                   httpUri:
                     cluster: "192_168_1_250_8080"
                     timeout: 5s
                     uri: https://192.168.1.250:8080/jwt/public-key/jwks.json
+                  retryPolicy: {}
             requirementMap:
               first-route-www.test.com:
                 requiresAny:

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.listeners.yaml
@@ -49,22 +49,26 @@
                 issuer: https://www.example.com
                 payloadInMetadata: https://www.example.com
                 remoteJwks:
+                  asyncFetch: {}
                   cacheDuration: 300s
                   httpUri:
                     cluster: localhost_443
                     timeout: 5s
                     uri: https://localhost/jwt/public-key/jwks.json
+                  retryPolicy: {}
               second-route-example:
                 audiences:
                 - foo.com
                 issuer: https://www.example.com
                 payloadInMetadata: https://www.example.com
                 remoteJwks:
+                  asyncFetch: {}
                   cacheDuration: 300s
                   httpUri:
                     cluster: localhost_443
                     timeout: 5s
                     uri: https://localhost/jwt/public-key/jwks.json
+                  retryPolicy: {}
             requirementMap:
               first-route:
                 providerName: first-route-example

--- a/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.listeners.yaml
@@ -24,11 +24,13 @@
                 issuer: https://www.example.com
                 payloadInMetadata: https://www.example.com
                 remoteJwks:
+                  asyncFetch: {}
                   cacheDuration: 300s
                   httpUri:
                     cluster: "192_168_1_250_443"
                     timeout: 5s
                     uri: https://192.168.1.250/jwt/public-key/jwks.json
+                  retryPolicy: {}
             requirementMap:
               first-route:
                 providerName: first-route-example

--- a/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.listeners.yaml
@@ -24,11 +24,13 @@
                 issuer: https://www.example.com
                 payloadInMetadata: https://www.example.com
                 remoteJwks:
+                  asyncFetch: {}
                   cacheDuration: 300s
                   httpUri:
                     cluster: localhost_443
                     timeout: 5s
                     uri: https://localhost/jwt/public-key/jwks.json
+                  retryPolicy: {}
             requirementMap:
               first-route:
                 providerName: first-route-example


### PR DESCRIPTION
Async is useful because it will not block requests with jwt fetches, will not need to jwt fetch per thread Retrying once after a failed fetch is also useful
