### PR TITLE
fix: implement comparable interface for ir.Xds to skip unnecessary updates

### DIFF
--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -65,13 +65,13 @@ type Xds struct {
 }
 
 // Equal implements the Comparable interface used by watchable.DeepEqual to skip unnecessary updates.
-func (x1 *Xds) Equal(x2 *Xds) bool {
+func (x *Xds) Equal(y *Xds) bool {
 	// Deep copy to avoid modifying the original ordering.
-	x1 = x1.DeepCopy()
-	x1.sort()
-	x2 = x2.DeepCopy()
-	x2.sort()
-	return reflect.DeepEqual(x1, x2)
+	x = x.DeepCopy()
+	x.sort()
+	y = y.DeepCopy()
+	y.sort()
+	return reflect.DeepEqual(x, y)
 }
 
 // sort ensures the listeners are in a consistent order.

--- a/internal/ir/xds_test.go
+++ b/internal/ir/xds_test.go
@@ -8,6 +8,7 @@ package ir
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -672,6 +673,80 @@ func TestValidateTLSListenerConfig(t *testing.T) {
 			} else {
 				require.EqualError(t, test.input.Validate(), test.want.Error())
 			}
+		})
+	}
+}
+
+func TestEqualXds(t *testing.T) {
+	tests := []struct {
+		desc  string
+		a     *Xds
+		b     *Xds
+		equal bool
+	}{
+		{
+			desc: "out of order tcp listeners are equal",
+			a: &Xds{
+				TCP: []*TCPListener{
+					{Name: "listener-1"},
+					{Name: "listener-2"},
+				},
+			},
+			b: &Xds{
+				TCP: []*TCPListener{
+					{Name: "listener-2"},
+					{Name: "listener-1"},
+				},
+			},
+			equal: true,
+		},
+		{
+			desc: "out of order http routes are equal",
+			a: &Xds{
+				HTTP: []*HTTPListener{
+					{
+						Name: "listener-1",
+						Routes: []*HTTPRoute{
+							{Name: "route-1"},
+							{Name: "route-2"},
+						},
+					},
+				},
+			},
+			b: &Xds{
+				HTTP: []*HTTPListener{
+					{
+						Name: "listener-1",
+						Routes: []*HTTPRoute{
+							{Name: "route-2"},
+							{Name: "route-1"},
+						},
+					},
+				},
+			},
+			equal: true,
+		},
+		{
+			desc: "out of order udp listeners are equal",
+			a: &Xds{
+				UDP: []*UDPListener{
+					{Name: "listener-1"},
+					{Name: "listener-2"},
+				},
+			},
+			b: &Xds{
+				UDP: []*UDPListener{
+					{Name: "listener-2"},
+					{Name: "listener-1"},
+				},
+			},
+			equal: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.equal, cmp.Equal(tc.a, tc.b))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This change implements the comparable interface used by watchable to sort ir.Xds listeners when checking for differences. This reduces the number of xds updates that get pushed to envoy during re-syncs of k8s resources.

**Which issue(s) this PR fixes**:
fixes #1634 
