### PR TITLE
fix: ensure all updates are processed in xds ir update test

### DIFF
--- a/internal/message/watchutil_test.go
+++ b/internal/message/watchutil_test.go
@@ -113,6 +113,7 @@ func TestXdsIRUpdates(t *testing.T) {
 				for _, x := range tc.xx {
 					m.Store("test", x)
 				}
+				time.Sleep(100 * time.Millisecond)
 				m.Close()
 			}()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
TestXdsIRUpdates added in #1795 is flaky. This adds a sleep to reduce the chance of failing. Open to suggestions to avoid the sleep but this pattern is also used in another test here https://github.com/envoyproxy/gateway/blob/080674a93bc42504575d7c0c83d21300abbb6e00/internal/message/watchutil_test.go#L43

