### PR TITLE
fix: can't show debug level logging message

### DIFF
--- a/internal/logging/log.go
+++ b/internal/logging/log.go
@@ -55,7 +55,7 @@ func (l Logger) WithName(name string) Logger {
 	return Logger{
 		Logger:        zapr.NewLogger(logger).WithName(name),
 		logging:       l.logging,
-		sugaredLogger: l.sugaredLogger,
+		sugaredLogger: logger.Sugar(),
 	}
 }
 

--- a/internal/logging/log_test.go
+++ b/internal/logging/log_test.go
@@ -41,3 +41,30 @@ func TestLogger(t *testing.T) {
 	assert.True(t, defaultLogger.logging != nil)
 	assert.True(t, defaultLogger.sugaredLogger != nil)
 }
+
+func TestLoggerWithName(t *testing.T) {
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	defer func() {
+		// Restore the original stdout and close the pipe
+		os.Stdout = originalStdout
+		w.Close()
+	}()
+
+	config := v1alpha1.DefaultEnvoyGatewayLogging()
+	config.Level[v1alpha1.LogComponentInfrastructureRunner] = v1alpha1.LogLevelDebug
+
+	logger := NewLogger(config).WithName(string(v1alpha1.LogComponentInfrastructureRunner))
+	logger.Info("info message")
+	logger.Sugar().Debugf("debug message")
+
+	// Read from the pipe (captured stdout)
+	outputBytes := make([]byte, 200)
+	r.Read(outputBytes)
+	capturedOutput := string(outputBytes)
+	assert.Contains(t, capturedOutput, string(v1alpha1.LogComponentInfrastructureRunner))
+	assert.Contains(t, capturedOutput, "info message")
+	assert.Contains(t, capturedOutput, "debug message")
+}

--- a/internal/logging/log_test.go
+++ b/internal/logging/log_test.go
@@ -50,7 +50,8 @@ func TestLoggerWithName(t *testing.T) {
 	defer func() {
 		// Restore the original stdout and close the pipe
 		os.Stdout = originalStdout
-		w.Close()
+		err := w.Close()
+		assert.NoError(t, err)
 	}()
 
 	config := v1alpha1.DefaultEnvoyGatewayLogging()
@@ -62,7 +63,8 @@ func TestLoggerWithName(t *testing.T) {
 
 	// Read from the pipe (captured stdout)
 	outputBytes := make([]byte, 200)
-	r.Read(outputBytes)
+	_, err := r.Read(outputBytes)
+	assert.NoError(t, err)
 	capturedOutput := string(outputBytes)
 	assert.Contains(t, capturedOutput, string(v1alpha1.LogComponentInfrastructureRunner))
 	assert.Contains(t, capturedOutput, "info message")


### PR DESCRIPTION
**What type of PR is this?**

Fix: EG can't show debug level logging message because the sugar logger created in the WithName function is incorrect.