### PR TITLE
fix: enqueue a single request for all resources

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -147,7 +147,7 @@ func newResourceMapping() *resourceMappings {
 }
 
 func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	r.log.WithName(request.Name).Info("reconciling gateways", "namespace")
+	r.log.WithName(request.Name).Info("reconciling gateways")
 
 	var gatewayClasses gwapiv1b1.GatewayClassList
 	if err := r.client.List(ctx, &gatewayClasses); err != nil {

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -147,7 +147,7 @@ func newResourceMapping() *resourceMappings {
 }
 
 func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	r.log.WithName(request.Name).Info("reconciling object", "namespace", request.Namespace, "name", request.Name)
+	r.log.WithName(request.Name).Info("reconciling gateways", "namespace")
 
 	var gatewayClasses gwapiv1b1.GatewayClassList
 	if err := r.client.List(ctx, &gatewayClasses); err != nil {
@@ -313,7 +313,7 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, request reconcile.
 	// Store will be required to trigger a cleanup of envoy infra resources.
 	r.resources.GatewayAPIResources.Store(acceptedGC.Name, resourceTree)
 
-	r.log.WithName(request.Name).Info("reconciled gatewayAPI object successfully", "namespace", request.Namespace, "name", request.Name)
+	r.log.WithName(request.Name).Info("reconciled gateways successfully")
 	return reconcile.Result{}, nil
 }
 
@@ -1155,7 +1155,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Only enqueue GatewayClass objects that match this Envoy Gateway's controller name.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &gwapiv1b1.GatewayClass{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.hasMatchingController),
 	); err != nil {
 		return err
@@ -1164,8 +1164,9 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Only enqueue EnvoyProxy objects that match this Envoy Gateway's GatewayClass.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &egcfgv1a1.EnvoyProxy{}),
-		handler.EnqueueRequestsFromMapFunc(r.enqueueManagedClass),
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.ResourceVersionChangedPredicate{},
+		predicate.NewPredicateFuncs(r.hasManagedClass),
 	); err != nil {
 		return err
 	}
@@ -1173,7 +1174,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch Gateway CRUDs and reconcile affected GatewayClass.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &gwapiv1b1.Gateway{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.validateGatewayForReconcile),
 	); err != nil {
 		return err
@@ -1185,7 +1186,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch HTTPRoute CRUDs and process affected Gateways.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &gwapiv1b1.HTTPRoute{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1196,7 +1197,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch GRPCRoute CRUDs and process affected Gateways.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &gwapiv1a2.GRPCRoute{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1207,7 +1208,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch TLSRoute CRUDs and process affected Gateways.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &gwapiv1a2.TLSRoute{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1218,7 +1219,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch UDPRoute CRUDs and process affected Gateways.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &gwapiv1a2.UDPRoute{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1229,7 +1230,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch TCPRoute CRUDs and process affected Gateways.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &gwapiv1a2.TCPRoute{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1240,7 +1241,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch Service CRUDs and process affected *Route objects.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &corev1.Service{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.validateServiceForReconcile)); err != nil {
 		return err
 	}
@@ -1248,7 +1249,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch EndpointSlice CRUDs and process affected *Route objects.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &discoveryv1.EndpointSlice{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.validateEndpointSliceForReconcile)); err != nil {
 		return err
 	}
@@ -1258,7 +1259,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// resource address.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &corev1.Node{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.handleNode),
 	); err != nil {
 		return err
@@ -1267,7 +1268,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch Secret CRUDs and process affected Gateways.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &corev1.Secret{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.validateSecretForReconcile),
 	); err != nil {
 		return err
@@ -1276,7 +1277,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch ReferenceGrant CRUDs and process affected Gateways.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &gwapiv1a2.ReferenceGrant{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 	); err != nil {
 		return err
 	}
@@ -1287,7 +1288,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch Deployment CRUDs and process affected Gateways.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &appsv1.Deployment{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.validateDeploymentForReconcile),
 	); err != nil {
 		return err
@@ -1296,7 +1297,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch AuthenticationFilter CRUDs and enqueue associated HTTPRoute objects.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &egv1a1.AuthenticationFilter{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.httpRoutesForAuthenticationFilter)); err != nil {
 		return err
 	}
@@ -1304,7 +1305,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	// Watch RateLimitFilter CRUDs and enqueue associated HTTPRoute objects.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &egv1a1.RateLimitFilter{}),
-		&handler.EnqueueRequestForObject{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueClass),
 		predicate.NewPredicateFuncs(r.httpRoutesForRateLimitFilter)); err != nil {
 		return err
 	}
@@ -1326,7 +1327,7 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 		u := &unstructured.Unstructured{}
 		u.SetGroupVersionKind(gvk)
 		if err := c.Watch(source.Kind(mgr.GetCache(), u),
-			&handler.EnqueueRequestForObject{}); err != nil {
+			handler.EnqueueRequestsFromMapFunc(r.enqueueClass)); err != nil {
 			return err
 		}
 		r.log.Info("Watching additional resource", "resource", gvk.String())
@@ -1334,7 +1335,13 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	return nil
 }
 
-func (r *gatewayAPIReconciler) enqueueManagedClass(_ context.Context, obj client.Object) []reconcile.Request {
+func (r *gatewayAPIReconciler) enqueueClass(_ context.Context, _ client.Object) []reconcile.Request {
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{
+		Name: string(r.classController),
+	}}}
+}
+
+func (r *gatewayAPIReconciler) hasManagedClass(obj client.Object) bool {
 	ep, ok := obj.(*egcfgv1a1.EnvoyProxy)
 	if !ok {
 		panic(fmt.Sprintf("unsupported object type %T", obj))
@@ -1344,14 +1351,14 @@ func (r *gatewayAPIReconciler) enqueueManagedClass(_ context.Context, obj client
 	if ep.Namespace != r.namespace {
 		r.log.Info("envoyproxy namespace does not match Envoy Gateway's namespace",
 			"namespace", ep.Namespace, "name", ep.Name)
-		return []reconcile.Request{}
+		return false
 	}
 
 	gcList := new(gwapiv1b1.GatewayClassList)
 	err := r.client.List(context.TODO(), gcList)
 	if err != nil {
 		r.log.Error(err, "failed to list gatewayclasses")
-		return []reconcile.Request{}
+		return false
 	}
 
 	for i := range gcList.Items {
@@ -1360,14 +1367,11 @@ func (r *gatewayAPIReconciler) enqueueManagedClass(_ context.Context, obj client
 		if r.hasMatchingController(&gc) &&
 			classAccepted(&gc) &&
 			classRefsEnvoyProxy(&gc, ep) {
-			req := reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: gc.Name},
-			}
-			return []reconcile.Request{req}
+			return true
 		}
 	}
 
-	return []reconcile.Request{}
+	return false
 }
 
 // processParamsRef processes the parametersRef of the provided GatewayClass.


### PR DESCRIPTION
**What this PR does / why we need it**:

The current behavior of the controller is to run `Reconcile` for each resource that is updated. This gets quite expensive when you have 100s-1000s of resources.

This change allows for multiple resource updates to result in a single run of `Reconcile`.

This greatly reduces the cpu/memory consumption at startup and during periodic re-syncs of all resources.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1797 
