### PR TITLE
use / instead of - in IR Route Name

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
@@ -357,7 +357,7 @@
                               "typedConfig": {
                                 "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                                 "providers": {
-                                  "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example": {
+                                  "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example": {
                                     "remoteJwks": {
                                       "asyncFetch": {},
                                       "cacheDuration": "300s",
@@ -372,7 +372,7 @@
                                 },
                                 "requirementMap": {
                                   "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com": {
-                                    "providerName": "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example"
+                                    "providerName": "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example"
                                   }
                                 }
                               }

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
@@ -357,7 +357,7 @@
                               "typedConfig": {
                                 "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                                 "providers": {
-                                  "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example": {
+                                  "httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example": {
                                     "remoteJwks": {
                                       "asyncFetch": {},
                                       "cacheDuration": "300s",
@@ -371,8 +371,8 @@
                                   }
                                 },
                                 "requirementMap": {
-                                  "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com": {
-                                    "providerName": "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example"
+                                  "httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com": {
+                                    "providerName": "httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example"
                                   }
                                 }
                               }
@@ -425,20 +425,20 @@
                     "domains": [
                       "www.example.com"
                     ],
-                    "name": "envoy-gateway-system/eg/http/www.example.com",
+                    "name": "envoy-gateway-system/eg/http/www_example_com",
                     "routes": [
                       {
                         "match": {
                           "pathSeparatedPrefix": "/foo"
                         },
-                        "name": "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com",
+                        "name": "httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com",
                         "route": {
                           "cluster": "httproute/envoy-gateway-system/backend/rule/0"
                         },
                         "typedPerFilterConfig": {
                           "envoy.filters.http.jwt_authn": {
                             "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
-                            "requirementName": "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com"
+                            "requirementName": "httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com"
                           }
                         }
                       }

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.json
@@ -357,7 +357,7 @@
                               "typedConfig": {
                                 "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                                 "providers": {
-                                  "httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com-example": {
+                                  "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example": {
                                     "remoteJwks": {
                                       "asyncFetch": {},
                                       "cacheDuration": "300s",
@@ -371,8 +371,8 @@
                                   }
                                 },
                                 "requirementMap": {
-                                  "httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com": {
-                                    "providerName": "httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com-example"
+                                  "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com": {
+                                    "providerName": "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example"
                                   }
                                 }
                               }
@@ -431,14 +431,14 @@
                         "match": {
                           "pathSeparatedPrefix": "/foo"
                         },
-                        "name": "httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com",
+                        "name": "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com",
                         "route": {
                           "cluster": "httproute/envoy-gateway-system/backend/rule/0"
                         },
                         "typedPerFilterConfig": {
                           "envoy.filters.http.jwt_authn": {
                             "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
-                            "requirementName": "httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com"
+                            "requirementName": "httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com"
                           }
                         }
                       }

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
@@ -213,7 +213,7 @@ xds:
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                       providers:
-                        httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example:
+                        httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example:
                           remoteJwks:
                             asyncFetch: {}
                             cacheDuration: 300s
@@ -224,7 +224,7 @@ xds:
                             retryPolicy: {}
                       requirementMap:
                         httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com:
-                          providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example
+                          providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example
                   - name: envoy.filters.http.router
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
@@ -213,7 +213,7 @@ xds:
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                       providers:
-                        httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com-example:
+                        httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example:
                           remoteJwks:
                             asyncFetch: {}
                             cacheDuration: 300s
@@ -223,8 +223,8 @@ xds:
                               uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/authn/jwks.json
                             retryPolicy: {}
                       requirementMap:
-                        httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com:
-                          providerName: httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com-example
+                        httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com:
+                          providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example
                   - name: envoy.filters.http.router
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -255,10 +255,10 @@ xds:
             routes:
             - match:
                 pathSeparatedPrefix: /foo
-              name: httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com
+              name: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com
               route:
                 cluster: httproute/envoy-gateway-system/backend/rule/0
               typedPerFilterConfig:
                 envoy.filters.http.jwt_authn:
                   '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                  requirementName: httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com
+                  requirementName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.all.yaml
@@ -213,7 +213,7 @@ xds:
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                       providers:
-                        httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example:
+                        httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example:
                           remoteJwks:
                             asyncFetch: {}
                             cacheDuration: 300s
@@ -223,8 +223,8 @@ xds:
                               uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/authn/jwks.json
                             retryPolicy: {}
                       requirementMap:
-                        httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com:
-                          providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example
+                        httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com:
+                          providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example
                   - name: envoy.filters.http.router
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -251,14 +251,14 @@ xds:
           virtualHosts:
           - domains:
             - www.example.com
-            name: envoy-gateway-system/eg/http/www.example.com
+            name: envoy-gateway-system/eg/http/www_example_com
             routes:
             - match:
                 pathSeparatedPrefix: /foo
-              name: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com
+              name: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com
               route:
                 cluster: httproute/envoy-gateway-system/backend/rule/0
               typedPerFilterConfig:
                 envoy.filters.http.jwt_authn:
                   '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                  requirementName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com
+                  requirementName: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.listener.yaml
@@ -47,7 +47,7 @@ xds:
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                     providers:
-                      httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example:
+                      httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example:
                         remoteJwks:
                           asyncFetch: {}
                           cacheDuration: 300s
@@ -57,8 +57,8 @@ xds:
                             uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/authn/jwks.json
                           retryPolicy: {}
                     requirementMap:
-                      httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com:
-                        providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example
+                      httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com:
+                        providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example
                 - name: envoy.filters.http.router
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.listener.yaml
@@ -47,7 +47,7 @@ xds:
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                     providers:
-                      httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example:
+                      httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example:
                         remoteJwks:
                           asyncFetch: {}
                           cacheDuration: 300s
@@ -58,7 +58,7 @@ xds:
                           retryPolicy: {}
                     requirementMap:
                       httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com:
-                        providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example
+                        providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com/example
                 - name: envoy.filters.http.router
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.listener.yaml
@@ -47,7 +47,7 @@ xds:
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                     providers:
-                      httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com-example:
+                      httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example:
                         remoteJwks:
                           asyncFetch: {}
                           cacheDuration: 300s
@@ -57,8 +57,8 @@ xds:
                             uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/authn/jwks.json
                           retryPolicy: {}
                     requirementMap:
-                      httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com:
-                        providerName: httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com-example
+                      httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com:
+                        providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com-example
                 - name: envoy.filters.http.router
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.route.yaml
@@ -9,14 +9,14 @@ xds:
         virtualHosts:
         - domains:
           - www.example.com
-          name: envoy-gateway-system/eg/http/www.example.com
+          name: envoy-gateway-system/eg/http/www_example_com
           routes:
           - match:
               pathSeparatedPrefix: /foo
-            name: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com
+            name: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com
             route:
               cluster: httproute/envoy-gateway-system/backend/rule/0
             typedPerFilterConfig:
               envoy.filters.http.jwt_authn:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                requirementName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com
+                requirementName: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com

--- a/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/authn-single-route-single-match-to-xds.route.yaml
@@ -13,10 +13,10 @@ xds:
           routes:
           - match:
               pathSeparatedPrefix: /foo
-            name: httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com
+            name: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com
             route:
               cluster: httproute/envoy-gateway-system/backend/rule/0
             typedPerFilterConfig:
               envoy.filters.http.jwt_authn:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                requirementName: httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com
+                requirementName: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com

--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -937,11 +937,11 @@ xds:
           virtualHosts:
           - domains:
             - www.example.com
-            name: default/eg/http/www.example.com
+            name: default/eg/http/www_example_com
             routes:
             - match:
                 prefix: /
-              name: httproute/default/backend/rule/0/match/0/www.example.com
+              name: httproute/default/backend/rule/0/match/0/www_example_com
               route:
                 cluster: httproute/default/backend/rule/0
       - routeConfig:
@@ -951,10 +951,10 @@ xds:
           virtualHosts:
           - domains:
             - www.grpc-example.com
-            name: default/eg/grpc/www.grpc-example.com
+            name: default/eg/grpc/www_grpc-example_com
             routes:
             - match:
                 path: /com.example.Things/DoThing
-              name: grpcroute/default/backend/rule/0/match/0/www.grpc-example.com
+              name: grpcroute/default/backend/rule/0/match/0/www_grpc-example_com
               route:
                 cluster: grpcroute/default/backend/rule/0

--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -941,7 +941,7 @@ xds:
             routes:
             - match:
                 prefix: /
-              name: httproute/default/backend/rule/0/match/0-www.example.com
+              name: httproute/default/backend/rule/0/match/0/www.example.com
               route:
                 cluster: httproute/default/backend/rule/0
       - routeConfig:
@@ -955,6 +955,6 @@ xds:
             routes:
             - match:
                 path: /com.example.Things/DoThing
-              name: grpcroute/default/backend/rule/0/match/0-www.grpc-example.com
+              name: grpcroute/default/backend/rule/0/match/0/www.grpc-example.com
               route:
                 cluster: grpcroute/default/backend/rule/0

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -853,13 +853,13 @@
                     "domains": [
                       "www.example.com"
                     ],
-                    "name": "default/eg/http/www.example.com",
+                    "name": "default/eg/http/www_example_com",
                     "routes": [
                       {
                         "match": {
                           "prefix": "/"
                         },
-                        "name": "httproute/default/backend/rule/0/match/0/www.example.com",
+                        "name": "httproute/default/backend/rule/0/match/0/www_example_com",
                         "route": {
                           "cluster": "httproute/default/backend/rule/0"
                         }
@@ -879,13 +879,13 @@
                     "domains": [
                       "www.grpc-example.com"
                     ],
-                    "name": "default/eg/grpc/www.grpc-example.com",
+                    "name": "default/eg/grpc/www_grpc-example_com",
                     "routes": [
                       {
                         "match": {
                           "path": "/com.example.Things/DoThing"
                         },
-                        "name": "grpcroute/default/backend/rule/0/match/0/www.grpc-example.com",
+                        "name": "grpcroute/default/backend/rule/0/match/0/www_grpc-example_com",
                         "route": {
                           "cluster": "grpcroute/default/backend/rule/0"
                         }

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -859,7 +859,7 @@
                         "match": {
                           "prefix": "/"
                         },
-                        "name": "httproute/default/backend/rule/0/match/0-www.example.com",
+                        "name": "httproute/default/backend/rule/0/match/0/www.example.com",
                         "route": {
                           "cluster": "httproute/default/backend/rule/0"
                         }
@@ -885,7 +885,7 @@
                         "match": {
                           "path": "/com.example.Things/DoThing"
                         },
-                        "name": "grpcroute/default/backend/rule/0/match/0-www.grpc-example.com",
+                        "name": "grpcroute/default/backend/rule/0/match/0/www.grpc-example.com",
                         "route": {
                           "cluster": "grpcroute/default/backend/rule/0"
                         }

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -513,7 +513,7 @@ xds:
             routes:
             - match:
                 prefix: /
-              name: httproute/default/backend/rule/0/match/0-www.example.com
+              name: httproute/default/backend/rule/0/match/0/www.example.com
               route:
                 cluster: httproute/default/backend/rule/0
       - routeConfig:
@@ -527,6 +527,6 @@ xds:
             routes:
             - match:
                 path: /com.example.Things/DoThing
-              name: grpcroute/default/backend/rule/0/match/0-www.grpc-example.com
+              name: grpcroute/default/backend/rule/0/match/0/www.grpc-example.com
               route:
                 cluster: grpcroute/default/backend/rule/0

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -509,11 +509,11 @@ xds:
           virtualHosts:
           - domains:
             - www.example.com
-            name: default/eg/http/www.example.com
+            name: default/eg/http/www_example_com
             routes:
             - match:
                 prefix: /
-              name: httproute/default/backend/rule/0/match/0/www.example.com
+              name: httproute/default/backend/rule/0/match/0/www_example_com
               route:
                 cluster: httproute/default/backend/rule/0
       - routeConfig:
@@ -523,10 +523,10 @@ xds:
           virtualHosts:
           - domains:
             - www.grpc-example.com
-            name: default/eg/grpc/www.grpc-example.com
+            name: default/eg/grpc/www_grpc-example_com
             routes:
             - match:
                 path: /com.example.Things/DoThing
-              name: grpcroute/default/backend/rule/0/match/0/www.grpc-example.com
+              name: grpcroute/default/backend/rule/0/match/0/www_grpc-example_com
               route:
                 cluster: grpcroute/default/backend/rule/0

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
@@ -13,7 +13,7 @@ xds:
           routes:
           - match:
               prefix: /
-            name: httproute/default/backend/rule/0/match/0-www.example.com
+            name: httproute/default/backend/rule/0/match/0/www.example.com
             route:
               cluster: httproute/default/backend/rule/0
     - routeConfig:
@@ -27,6 +27,6 @@ xds:
           routes:
           - match:
               path: /com.example.Things/DoThing
-            name: grpcroute/default/backend/rule/0/match/0-www.grpc-example.com
+            name: grpcroute/default/backend/rule/0/match/0/www.grpc-example.com
             route:
               cluster: grpcroute/default/backend/rule/0

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.route.yaml
@@ -9,11 +9,11 @@ xds:
         virtualHosts:
         - domains:
           - www.example.com
-          name: default/eg/http/www.example.com
+          name: default/eg/http/www_example_com
           routes:
           - match:
               prefix: /
-            name: httproute/default/backend/rule/0/match/0/www.example.com
+            name: httproute/default/backend/rule/0/match/0/www_example_com
             route:
               cluster: httproute/default/backend/rule/0
     - routeConfig:
@@ -23,10 +23,10 @@ xds:
         virtualHosts:
         - domains:
           - www.grpc-example.com
-          name: default/eg/grpc/www.grpc-example.com
+          name: default/eg/grpc/www_grpc-example_com
           routes:
           - match:
               path: /com.example.Things/DoThing
-            name: grpcroute/default/backend/rule/0/match/0/www.grpc-example.com
+            name: grpcroute/default/backend/rule/0/match/0/www_grpc-example_com
             route:
               cluster: grpcroute/default/backend/rule/0

--- a/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
+++ b/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
@@ -19,7 +19,7 @@
                     "match": {
                       "prefix": "/"
                     },
-                    "name": "httproute/default/backend/rule/0/match/0-www.example.com",
+                    "name": "httproute/default/backend/rule/0/match/0/www.example.com",
                     "route": {
                       "cluster": "httproute/default/backend/rule/0"
                     }
@@ -50,7 +50,7 @@
                     "match": {
                       "prefix": "/v2/"
                     },
-                    "name": "httproute/default/backend/rule/0/match/0-www.example2.com",
+                    "name": "httproute/default/backend/rule/0/match/0/www.example2.com",
                     "route": {
                       "cluster": "httproute/default/backend/rule/0"
                     }

--- a/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
+++ b/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
@@ -13,13 +13,13 @@
                 "domains": [
                   "www.example.com"
                 ],
-                "name": "default/eg/http/www.example.com",
+                "name": "default/eg/http/www_example_com",
                 "routes": [
                   {
                     "match": {
                       "prefix": "/"
                     },
-                    "name": "httproute/default/backend/rule/0/match/0/www.example.com",
+                    "name": "httproute/default/backend/rule/0/match/0/www_example_com",
                     "route": {
                       "cluster": "httproute/default/backend/rule/0"
                     }
@@ -44,13 +44,13 @@
                 "domains": [
                   "www.example2.com"
                 ],
-                "name": "default/eg2/http/www.example2.com",
+                "name": "default/eg2/http/www_example2_com",
                 "routes": [
                   {
                     "match": {
                       "prefix": "/v2/"
                     },
-                    "name": "httproute/default/backend/rule/0/match/0/www.example2.com",
+                    "name": "httproute/default/backend/rule/0/match/0/www_example2_com",
                     "route": {
                       "cluster": "httproute/default/backend/rule/0"
                     }

--- a/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
@@ -9,10 +9,10 @@ xds:
         virtualHosts:
         - domains:
           - www.example.com
-          name: envoy-gateway-system/eg/http/www.example.com
+          name: envoy-gateway-system/eg/http/www_example_com
           routes:
           - match:
               prefix: /
-            name: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com
+            name: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com
             route:
               cluster: httproute/envoy-gateway-system/backend/rule/0

--- a/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/quickstart.route.yaml
@@ -13,6 +13,6 @@ xds:
           routes:
           - match:
               prefix: /
-            name: httproute/envoy-gateway-system/backend/rule/0/match/0-www.example.com
+            name: httproute/envoy-gateway-system/backend/rule/0/match/0/www.example.com
             route:
               cluster: httproute/envoy-gateway-system/backend/rule/0

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.json
@@ -440,7 +440,7 @@
                         "match": {
                           "prefix": "/"
                         },
-                        "name": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example",
+                        "name": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example",
                         "route": {
                           "cluster": "httproute/envoy-gateway-system/http-ratelimit/rule/0",
                           "rateLimits": [
@@ -448,8 +448,8 @@
                               "actions": [
                                 {
                                   "headerValueMatch": {
-                                    "descriptorKey": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example-key-rule-0-match-0",
-                                    "descriptorValue": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example-value-rule-0-match-0",
+                                    "descriptorKey": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-key-rule-0-match-0",
+                                    "descriptorValue": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-value-rule-0-match-0",
                                     "expectMatch": true,
                                     "headers": [
                                       {

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.json
@@ -434,13 +434,13 @@
                     "domains": [
                       "ratelimit.example"
                     ],
-                    "name": "envoy-gateway-system/eg/http/ratelimit.example",
+                    "name": "envoy-gateway-system/eg/http/ratelimit_example",
                     "routes": [
                       {
                         "match": {
                           "prefix": "/"
                         },
-                        "name": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example",
+                        "name": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit_example",
                         "route": {
                           "cluster": "httproute/envoy-gateway-system/http-ratelimit/rule/0",
                           "rateLimits": [
@@ -448,8 +448,8 @@
                               "actions": [
                                 {
                                   "headerValueMatch": {
-                                    "descriptorKey": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-key-rule-0-match-0",
-                                    "descriptorValue": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-value-rule-0-match-0",
+                                    "descriptorKey": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit_example-key-rule-0-match-0",
+                                    "descriptorValue": "httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit_example-value-rule-0-match-0",
                                     "expectMatch": true,
                                     "headers": [
                                       {

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.yaml
@@ -259,14 +259,14 @@ xds:
             routes:
             - match:
                 prefix: /
-              name: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example
+              name: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example
               route:
                 cluster: httproute/envoy-gateway-system/http-ratelimit/rule/0
                 rateLimits:
                 - actions:
                   - headerValueMatch:
-                      descriptorKey: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example-key-rule-0-match-0
-                      descriptorValue: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example-value-rule-0-match-0
+                      descriptorKey: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-key-rule-0-match-0
+                      descriptorValue: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-value-rule-0-match-0
                       expectMatch: true
                       headers:
                       - name: x-user-id

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.all.yaml
@@ -255,18 +255,18 @@ xds:
           virtualHosts:
           - domains:
             - ratelimit.example
-            name: envoy-gateway-system/eg/http/ratelimit.example
+            name: envoy-gateway-system/eg/http/ratelimit_example
             routes:
             - match:
                 prefix: /
-              name: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example
+              name: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit_example
               route:
                 cluster: httproute/envoy-gateway-system/http-ratelimit/rule/0
                 rateLimits:
                 - actions:
                   - headerValueMatch:
-                      descriptorKey: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-key-rule-0-match-0
-                      descriptorValue: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-value-rule-0-match-0
+                      descriptorKey: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit_example-key-rule-0-match-0
+                      descriptorValue: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit_example-value-rule-0-match-0
                       expectMatch: true
                       headers:
                       - name: x-user-id

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.route.yaml
@@ -9,18 +9,18 @@ xds:
         virtualHosts:
         - domains:
           - ratelimit.example
-          name: envoy-gateway-system/eg/http/ratelimit.example
+          name: envoy-gateway-system/eg/http/ratelimit_example
           routes:
           - match:
               prefix: /
-            name: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example
+            name: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit_example
             route:
               cluster: httproute/envoy-gateway-system/http-ratelimit/rule/0
               rateLimits:
               - actions:
                 - headerValueMatch:
-                    descriptorKey: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-key-rule-0-match-0
-                    descriptorValue: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-value-rule-0-match-0
+                    descriptorKey: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit_example-key-rule-0-match-0
+                    descriptorValue: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit_example-value-rule-0-match-0
                     expectMatch: true
                     headers:
                     - name: x-user-id

--- a/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/rate-limit-filter-single-route-single-match-to-xds.route.yaml
@@ -13,14 +13,14 @@ xds:
           routes:
           - match:
               prefix: /
-            name: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example
+            name: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example
             route:
               cluster: httproute/envoy-gateway-system/http-ratelimit/rule/0
               rateLimits:
               - actions:
                 - headerValueMatch:
-                    descriptorKey: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example-key-rule-0-match-0
-                    descriptorValue: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0-ratelimit.example-value-rule-0-match-0
+                    descriptorKey: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-key-rule-0-match-0
+                    descriptorValue: httproute/envoy-gateway-system/http-ratelimit/rule/0/match/0/ratelimit.example-value-rule-0-match-0
                     expectMatch: true
                     headers:
                     - name: x-user-id

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -518,7 +518,7 @@ func (t *Translator) processHTTPRouteParentRefListener(route RouteContext, route
 				}
 
 				hostRoute := &ir.HTTPRoute{
-					Name:                  fmt.Sprintf("%s-%s", routeRoute.Name, host),
+					Name:                  fmt.Sprintf("%s/%s", routeRoute.Name, host),
 					Hostname:              host,
 					PathMatch:             routeRoute.PathMatch,
 					HeaderMatches:         routeRoute.HeaderMatches,

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -516,9 +516,11 @@ func (t *Translator) processHTTPRouteParentRefListener(route RouteContext, route
 					// if the redirect scheme is empty, the redirect port must be the Gateway Listener port.
 					routeRoute.Redirect.Port = &redirectPort
 				}
-
+				// Remove dots from the hostname before appending it to the IR Route name
+				// since dots are special chars used in stats tag extraction in Envoy
+				underscoredHost := strings.ReplaceAll(host, ".", "_")
 				hostRoute := &ir.HTTPRoute{
-					Name:                  fmt.Sprintf("%s/%s", routeRoute.Name, host),
+					Name:                  fmt.Sprintf("%s/%s", routeRoute.Name, underscoredHost),
 					Hostname:              host,
 					PathMatch:             routeRoute.PathMatch,
 					HeaderMatches:         routeRoute.HeaderMatches,

--- a/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
@@ -127,7 +127,7 @@ xdsIR:
             spec:
               data: stuff
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
@@ -127,7 +127,7 @@ xdsIR:
             spec:
               data: stuff
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
@@ -107,7 +107,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-1/rule/0
         hostname: '*'
-        name: httproute/envoy-gateway/httproute-1/rule/0/match/0-*
+        name: httproute/envoy-gateway/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -114,7 +114,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
@@ -175,7 +175,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo.bar.com
-        name: httproute/default/httproute-1/rule/0/match/0-foo.bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo.bar.com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
@@ -175,7 +175,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo.bar.com
-        name: httproute/default/httproute-1/rule/0/match/0/foo.bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo_bar_com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration-with-same-algorithm-different-fqdn.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration-with-same-algorithm-different-fqdn.out.yaml
@@ -116,7 +116,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration.out.yaml
@@ -116,7 +116,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
@@ -113,7 +113,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-preexisting-status-condition.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-preexisting-status-condition.out.yaml
@@ -107,7 +107,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-stale-status-condition.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-stale-status-condition.out.yaml
@@ -113,7 +113,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
@@ -171,7 +171,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-2/rule/0
         hostname: foo.com
-        name: httproute/default/httproute-2/rule/0/match/0/foo.com
+        name: httproute/default/httproute-2/rule/0/match/0/foo_com
         pathMatch:
           distinct: false
           name: ""
@@ -186,7 +186,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo.com
-        name: httproute/default/httproute-1/rule/0/match/0/foo.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo_com
         pathMatch:
           distinct: false
           name: ""
@@ -208,7 +208,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-2/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-2/rule/0/match/0/bar.com
+        name: httproute/default/httproute-2/rule/0/match/0/bar_com
         pathMatch:
           distinct: false
           name: ""
@@ -223,7 +223,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-1/rule/0/match/0/bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar_com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
@@ -171,7 +171,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-2/rule/0
         hostname: foo.com
-        name: httproute/default/httproute-2/rule/0/match/0-foo.com
+        name: httproute/default/httproute-2/rule/0/match/0/foo.com
         pathMatch:
           distinct: false
           name: ""
@@ -186,7 +186,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo.com
-        name: httproute/default/httproute-1/rule/0/match/0-foo.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo.com
         pathMatch:
           distinct: false
           name: ""
@@ -208,7 +208,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-2/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-2/rule/0/match/0-bar.com
+        name: httproute/default/httproute-2/rule/0/match/0/bar.com
         pathMatch:
           distinct: false
           name: ""
@@ -223,7 +223,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-1/rule/0/match/0-bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar.com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
@@ -166,7 +166,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
@@ -166,7 +166,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/grpcroute-with-header-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-header-match.out.yaml
@@ -115,4 +115,4 @@ xdsIR:
           exact: foo
           name: magic
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/0-*
+        name: grpcroute/default/grpcroute-1/rule/0/match/0/*

--- a/internal/gatewayapi/testdata/grpcroute-with-method-and-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-method-and-service-match.out.yaml
@@ -115,7 +115,7 @@ xdsIR:
             weight: 1
           name: grpcroute/default/grpcroute-1/rule/0
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/0-*
+        name: grpcroute/default/grpcroute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /com.example/Example
@@ -130,7 +130,7 @@ xdsIR:
             weight: 1
           name: grpcroute/default/grpcroute-1/rule/0
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/1-*
+        name: grpcroute/default/grpcroute-1/rule/0/match/1/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/grpcroute-with-method-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-method-match.out.yaml
@@ -113,7 +113,7 @@ xdsIR:
             weight: 1
           name: grpcroute/default/grpcroute-1/rule/0
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/1-*
+        name: grpcroute/default/grpcroute-1/rule/0/match/1/*
         pathMatch:
           distinct: false
           name: ""
@@ -132,4 +132,4 @@ xdsIR:
           name: :path
           suffix: /ExampleExact
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/0-*
+        name: grpcroute/default/grpcroute-1/rule/0/match/0/*

--- a/internal/gatewayapi/testdata/grpcroute-with-request-header-modifier.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-request-header-modifier.out.yaml
@@ -116,4 +116,4 @@ xdsIR:
             weight: 1
           name: grpcroute/default/grpcroute-1/rule/0
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/-1-*
+        name: grpcroute/default/grpcroute-1/rule/0/match/-1/*

--- a/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
@@ -113,7 +113,7 @@ xdsIR:
             weight: 1
           name: grpcroute/default/grpcroute-1/rule/0
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/1-*
+        name: grpcroute/default/grpcroute-1/rule/0/match/1/*
         pathMatch:
           distinct: false
           name: ""
@@ -128,7 +128,7 @@ xdsIR:
             weight: 1
           name: grpcroute/default/grpcroute-1/rule/0
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/0-*
+        name: grpcroute/default/grpcroute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/grpcroute-with-valid-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-valid-authenfilter.out.yaml
@@ -112,7 +112,7 @@ xdsIR:
             weight: 1
           name: grpcroute/default/grpcroute-1/rule/0
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/-1-*
+        name: grpcroute/default/grpcroute-1/rule/0/match/-1/*
         requestAuthentication:
           jwt:
             providers:

--- a/internal/gatewayapi/testdata/grpcroute-with-valid-ratelimitfilter.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-valid-ratelimitfilter.out.yaml
@@ -112,7 +112,7 @@ xdsIR:
             weight: 1
           name: grpcroute/default/grpcroute-1/rule/0
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/-1-*
+        name: grpcroute/default/grpcroute-1/rule/0/match/-1/*
         rateLimit:
           global:
             rules:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
@@ -311,7 +311,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo.com
-        name: httproute/default/httproute-1/rule/0/match/0-foo.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo.com
         pathMatch:
           distinct: false
           name: ""
@@ -333,7 +333,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-1/rule/0/match/0-bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar.com
         pathMatch:
           distinct: false
           name: ""
@@ -355,7 +355,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo1.com
-        name: httproute/default/httproute-1/rule/0/match/0-foo1.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo1.com
         pathMatch:
           distinct: false
           name: ""
@@ -377,7 +377,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar1.com
-        name: httproute/default/httproute-1/rule/0/match/0-bar1.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar1.com
         pathMatch:
           distinct: false
           name: ""
@@ -399,7 +399,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo2.com
-        name: httproute/default/httproute-1/rule/0/match/0-foo2.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo2.com
         pathMatch:
           distinct: false
           name: ""
@@ -421,7 +421,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar2.com
-        name: httproute/default/httproute-1/rule/0/match/0-bar2.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar2.com
         pathMatch:
           distinct: false
           name: ""
@@ -443,7 +443,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo3.com
-        name: httproute/default/httproute-1/rule/0/match/0-foo3.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo3.com
         pathMatch:
           distinct: false
           name: ""
@@ -465,7 +465,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar3.com
-        name: httproute/default/httproute-1/rule/0/match/0-bar3.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar3.com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
@@ -311,7 +311,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo.com
-        name: httproute/default/httproute-1/rule/0/match/0/foo.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo_com
         pathMatch:
           distinct: false
           name: ""
@@ -333,7 +333,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-1/rule/0/match/0/bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar_com
         pathMatch:
           distinct: false
           name: ""
@@ -355,7 +355,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo1.com
-        name: httproute/default/httproute-1/rule/0/match/0/foo1.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo1_com
         pathMatch:
           distinct: false
           name: ""
@@ -377,7 +377,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar1.com
-        name: httproute/default/httproute-1/rule/0/match/0/bar1.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar1_com
         pathMatch:
           distinct: false
           name: ""
@@ -399,7 +399,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo2.com
-        name: httproute/default/httproute-1/rule/0/match/0/foo2.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo2_com
         pathMatch:
           distinct: false
           name: ""
@@ -421,7 +421,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar2.com
-        name: httproute/default/httproute-1/rule/0/match/0/bar2.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar2_com
         pathMatch:
           distinct: false
           name: ""
@@ -443,7 +443,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo3.com
-        name: httproute/default/httproute-1/rule/0/match/0/foo3.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo3_com
         pathMatch:
           distinct: false
           name: ""
@@ -465,7 +465,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar3.com
-        name: httproute/default/httproute-1/rule/0/match/0/bar3.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar3_com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
@@ -283,7 +283,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo.com
-        name: httproute/default/httproute-1/rule/0/match/0/foo.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo_com
         pathMatch:
           distinct: false
           name: ""
@@ -305,7 +305,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-1/rule/0/match/0/bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar_com
         pathMatch:
           distinct: false
           name: ""
@@ -327,7 +327,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo1.com
-        name: httproute/default/httproute-1/rule/0/match/0/foo1.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo1_com
         pathMatch:
           distinct: false
           name: ""
@@ -349,7 +349,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar1.com
-        name: httproute/default/httproute-1/rule/0/match/0/bar1.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar1_com
         pathMatch:
           distinct: false
           name: ""
@@ -371,7 +371,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo2.com
-        name: httproute/default/httproute-1/rule/0/match/0/foo2.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo2_com
         pathMatch:
           distinct: false
           name: ""
@@ -393,7 +393,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar2.com
-        name: httproute/default/httproute-1/rule/0/match/0/bar2.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar2_com
         pathMatch:
           distinct: false
           name: ""
@@ -415,7 +415,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo3.com
-        name: httproute/default/httproute-1/rule/0/match/0/foo3.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo3_com
         pathMatch:
           distinct: false
           name: ""
@@ -437,7 +437,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar3.com
-        name: httproute/default/httproute-1/rule/0/match/0/bar3.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar3_com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
@@ -283,7 +283,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo.com
-        name: httproute/default/httproute-1/rule/0/match/0-foo.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo.com
         pathMatch:
           distinct: false
           name: ""
@@ -305,7 +305,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-1/rule/0/match/0-bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar.com
         pathMatch:
           distinct: false
           name: ""
@@ -327,7 +327,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo1.com
-        name: httproute/default/httproute-1/rule/0/match/0-foo1.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo1.com
         pathMatch:
           distinct: false
           name: ""
@@ -349,7 +349,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar1.com
-        name: httproute/default/httproute-1/rule/0/match/0-bar1.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar1.com
         pathMatch:
           distinct: false
           name: ""
@@ -371,7 +371,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo2.com
-        name: httproute/default/httproute-1/rule/0/match/0-foo2.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo2.com
         pathMatch:
           distinct: false
           name: ""
@@ -393,7 +393,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar2.com
-        name: httproute/default/httproute-1/rule/0/match/0-bar2.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar2.com
         pathMatch:
           distinct: false
           name: ""
@@ -415,7 +415,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo3.com
-        name: httproute/default/httproute-1/rule/0/match/0-foo3.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo3.com
         pathMatch:
           distinct: false
           name: ""
@@ -437,7 +437,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar3.com
-        name: httproute/default/httproute-1/rule/0/match/0-bar3.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar3.com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
@@ -141,7 +141,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""
@@ -163,7 +163,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -133,7 +133,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo.com
-        name: httproute/default/httproute-1/rule/0/match/0/foo.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo_com
         pathMatch:
           distinct: false
           name: ""
@@ -155,7 +155,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-1/rule/0/match/0/bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar_com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -133,7 +133,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: foo.com
-        name: httproute/default/httproute-1/rule/0/match/0-foo.com
+        name: httproute/default/httproute-1/rule/0/match/0/foo.com
         pathMatch:
           distinct: false
           name: ""
@@ -155,7 +155,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-1/rule/0/match/0-bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar.com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
@@ -107,7 +107,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-matching-port.out.yaml
@@ -111,7 +111,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -141,7 +141,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-1/rule/0/match/0-bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar.com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -141,7 +141,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: bar.com
-        name: httproute/default/httproute-1/rule/0/match/0/bar.com
+        name: httproute/default/httproute-1/rule/0/match/0/bar_com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref.out.yaml
@@ -111,7 +111,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
@@ -109,7 +109,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
@@ -117,7 +117,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -120,7 +120,7 @@ xdsIR:
             weight: 3
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -109,7 +109,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-backendref-serviceimport-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-serviceimport-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -111,7 +111,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-distinct-sourcecidr-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-distinct-sourcecidr-ratelimit.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-distinct-sourcecidr-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-distinct-sourcecidr-ratelimit.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
@@ -106,4 +106,4 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/-1-*
+        name: httproute/default/httproute-1/rule/0/match/-1/*

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -137,7 +137,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -137,7 +137,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -153,7 +153,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -153,7 +153,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -123,7 +123,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -123,7 +123,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
@@ -128,7 +128,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
@@ -128,7 +128,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -115,7 +115,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -115,7 +115,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
@@ -119,7 +119,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
@@ -119,7 +119,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
@@ -104,7 +104,7 @@ xdsIR:
         directResponse:
           statusCode: 500
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
@@ -108,7 +108,7 @@ xdsIR:
         directResponse:
           statusCode: 500
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
@@ -105,7 +105,7 @@ xdsIR:
         directResponse:
           statusCode: 500
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
@@ -104,7 +104,7 @@ xdsIR:
         directResponse:
           statusCode: 500
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.import.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.import.out.yaml
@@ -106,7 +106,7 @@ xdsIR:
         directResponse:
           statusCode: 500
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
@@ -104,7 +104,7 @@ xdsIR:
         directResponse:
           statusCode: 500
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -105,7 +105,7 @@ xdsIR:
         directResponse:
           statusCode: 500
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
@@ -131,7 +131,7 @@ xdsIR:
             port: 8080
             weight: 1
           name: httproute/default/httproute-1/rule/0-mirror
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
@@ -131,7 +131,7 @@ xdsIR:
             port: 8080
             weight: 1
           name: httproute/default/httproute-1/rule/0-mirror
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
@@ -134,7 +134,7 @@ xdsIR:
             port: 8080
             weight: 1
           name: httproute/default/httproute-1/rule/0-mirror
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
@@ -134,7 +134,7 @@ xdsIR:
             port: 8080
             weight: 1
           name: httproute/default/httproute-1/rule/0-mirror
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
@@ -119,7 +119,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
@@ -119,7 +119,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
@@ -119,7 +119,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
@@ -119,7 +119,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
@@ -125,7 +125,7 @@ xdsIR:
             port: 8080
             weight: 1
           name: httproute/default/httproute-1/rule/0-mirror
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
@@ -125,7 +125,7 @@ xdsIR:
             port: 8080
             weight: 1
           name: httproute/default/httproute-1/rule/0-mirror
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -114,7 +114,7 @@ xdsIR:
           invalid: 0
           valid: 0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -114,7 +114,7 @@ xdsIR:
           invalid: 0
           valid: 0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -112,7 +112,7 @@ xdsIR:
           invalid: 0
           valid: 0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -112,7 +112,7 @@ xdsIR:
           invalid: 0
           valid: 0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -115,7 +115,7 @@ xdsIR:
           invalid: 0
           valid: 0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -115,7 +115,7 @@ xdsIR:
           invalid: 0
           valid: 0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
@@ -149,7 +149,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
@@ -149,7 +149,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -137,7 +137,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -137,7 +137,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
@@ -153,7 +153,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
@@ -153,7 +153,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -123,7 +123,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -123,7 +123,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
@@ -128,7 +128,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
@@ -128,7 +128,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
@@ -115,7 +115,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
@@ -115,7 +115,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
@@ -119,7 +119,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
@@ -119,7 +119,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
@@ -108,7 +108,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
@@ -110,4 +110,4 @@ xdsIR:
           exact: POST
           name: :method
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
@@ -142,7 +142,7 @@ xdsIR:
           name: Header-1
           safeRegex: '*regex*'
         hostname: '*'
-        name: httproute/default/httproute-1/rule/2/match/0-*
+        name: httproute/default/httproute-1/rule/2/match/0/*
         pathMatch:
           distinct: false
           name: ""
@@ -161,7 +161,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/1
         hostname: '*'
-        name: httproute/default/httproute-1/rule/1/match/0-*
+        name: httproute/default/httproute-1/rule/1/match/0/*
         pathMatch:
           distinct: false
           name: ""
@@ -180,7 +180,7 @@ xdsIR:
           exact: exact
           name: Header-1
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
@@ -119,7 +119,7 @@ xdsIR:
           exact: Val-2
           name: Header-2
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
@@ -112,7 +112,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*'
-        name: httproute/default/httproute-1/rule/0/match/0-*
+        name: httproute/default/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           exact: /exact

--- a/internal/gatewayapi/testdata/httproute-with-sourcecidr-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-sourcecidr-ratelimit.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-sourcecidr-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-sourcecidr-ratelimit.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -110,7 +110,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -110,7 +110,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -111,7 +111,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""
@@ -126,7 +126,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: whales.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-whales.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/whales.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -111,7 +111,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""
@@ -126,7 +126,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: whales.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/whales.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/whales_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
@@ -119,7 +119,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
@@ -119,7 +119,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
@@ -116,7 +116,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
@@ -116,7 +116,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
@@ -116,7 +116,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
@@ -116,7 +116,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-valid-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-authenfilter.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-valid-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-authenfilter.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-valid-multi-match-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-multi-match-authenfilter.out.yaml
@@ -132,7 +132,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           exact: /test/path/1
@@ -154,7 +154,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/1
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/1/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/1/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           exact: /test/path/2

--- a/internal/gatewayapi/testdata/httproute-with-valid-multi-match-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-multi-match-authenfilter.out.yaml
@@ -132,7 +132,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           exact: /test/path/1
@@ -154,7 +154,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/1
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/1/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/1/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           exact: /test/path/2

--- a/internal/gatewayapi/testdata/httproute-with-valid-multi-match-multi-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-multi-match-multi-authenfilter.out.yaml
@@ -132,7 +132,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           exact: /test/path/1
@@ -154,7 +154,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/1
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/1/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/1/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           exact: /test/path/2

--- a/internal/gatewayapi/testdata/httproute-with-valid-multi-match-multi-authenfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-multi-match-multi-authenfilter.out.yaml
@@ -132,7 +132,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           exact: /test/path/1
@@ -154,7 +154,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/1
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/1/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/1/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           exact: /test/path/2

--- a/internal/gatewayapi/testdata/httproute-with-valid-ratelimitfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-ratelimitfilter.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-valid-ratelimitfilter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-valid-ratelimitfilter.out.yaml
@@ -118,7 +118,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: gateway.envoyproxy.io
-        name: httproute/default/httproute-1/rule/0/match/0-gateway.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/gateway.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
@@ -109,7 +109,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*.envoyproxy.io'
-        name: httproute/default/httproute-1/rule/0/match/0-*.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/*.envoyproxy.io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
@@ -109,7 +109,7 @@ xdsIR:
             weight: 1
           name: httproute/default/httproute-1/rule/0
         hostname: '*.envoyproxy.io'
-        name: httproute/default/httproute-1/rule/0/match/0/*.envoyproxy.io
+        name: httproute/default/httproute-1/rule/0/match/0/*_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
@@ -294,7 +294,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-2/rule/0
         hostname: example.com
-        name: httproute/envoy-gateway/httproute-2/rule/0/match/0/example.com
+        name: httproute/envoy-gateway/httproute-2/rule/0/match/0/example_com
         pathMatch:
           distinct: false
           name: ""
@@ -313,7 +313,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-3/rule/0
         hostname: example.com
-        name: httproute/envoy-gateway/httproute-3/rule/0/match/0/example.com
+        name: httproute/envoy-gateway/httproute-3/rule/0/match/0/example_com
         pathMatch:
           distinct: false
           name: ""
@@ -332,7 +332,7 @@ xdsIR:
           exact: one
           name: version
         hostname: example.net
-        name: httproute/envoy-gateway/httproute-4/rule/0/match/0/example.net
+        name: httproute/envoy-gateway/httproute-4/rule/0/match/0/example_net
         pathMatch:
           distinct: false
           name: ""
@@ -347,7 +347,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-5/rule/0
         hostname: example.net
-        name: httproute/envoy-gateway/httproute-5/rule/0/match/0/example.net
+        name: httproute/envoy-gateway/httproute-5/rule/0/match/0/example_net
         pathMatch:
           distinct: false
           name: ""
@@ -362,7 +362,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-1/rule/0
         hostname: '*.com'
-        name: httproute/envoy-gateway/httproute-1/rule/0/match/0/*.com
+        name: httproute/envoy-gateway/httproute-1/rule/0/match/0/*_com
         pathMatch:
           distinct: false
           name: ""
@@ -377,7 +377,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-1/rule/0
         hostname: '*.net'
-        name: httproute/envoy-gateway/httproute-1/rule/0/match/0/*.net
+        name: httproute/envoy-gateway/httproute-1/rule/0/match/0/*_net
         pathMatch:
           distinct: false
           name: ""

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
@@ -294,7 +294,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-2/rule/0
         hostname: example.com
-        name: httproute/envoy-gateway/httproute-2/rule/0/match/0-example.com
+        name: httproute/envoy-gateway/httproute-2/rule/0/match/0/example.com
         pathMatch:
           distinct: false
           name: ""
@@ -313,7 +313,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-3/rule/0
         hostname: example.com
-        name: httproute/envoy-gateway/httproute-3/rule/0/match/0-example.com
+        name: httproute/envoy-gateway/httproute-3/rule/0/match/0/example.com
         pathMatch:
           distinct: false
           name: ""
@@ -332,7 +332,7 @@ xdsIR:
           exact: one
           name: version
         hostname: example.net
-        name: httproute/envoy-gateway/httproute-4/rule/0/match/0-example.net
+        name: httproute/envoy-gateway/httproute-4/rule/0/match/0/example.net
         pathMatch:
           distinct: false
           name: ""
@@ -347,7 +347,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-5/rule/0
         hostname: example.net
-        name: httproute/envoy-gateway/httproute-5/rule/0/match/0-example.net
+        name: httproute/envoy-gateway/httproute-5/rule/0/match/0/example.net
         pathMatch:
           distinct: false
           name: ""
@@ -362,7 +362,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-1/rule/0
         hostname: '*.com'
-        name: httproute/envoy-gateway/httproute-1/rule/0/match/0-*.com
+        name: httproute/envoy-gateway/httproute-1/rule/0/match/0/*.com
         pathMatch:
           distinct: false
           name: ""
@@ -377,7 +377,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-1/rule/0
         hostname: '*.net'
-        name: httproute/envoy-gateway/httproute-1/rule/0/match/0-*.net
+        name: httproute/envoy-gateway/httproute-1/rule/0/match/0/*.net
         pathMatch:
           distinct: false
           name: ""
@@ -392,7 +392,7 @@ xdsIR:
             weight: 1
           name: httproute/envoy-gateway/httproute-1/rule/0
         hostname: '*'
-        name: httproute/envoy-gateway/httproute-1/rule/0/match/0-*
+        name: httproute/envoy-gateway/httproute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""

--- a/internal/xds/translator/authentication.go
+++ b/internal/xds/translator/authentication.go
@@ -135,7 +135,7 @@ func buildJwtAuthn(irListener *ir.HTTPListener) (*jwtauthnv3.JwtAuthentication, 
 					ClaimToHeaders:      claimToHeaders,
 				}
 
-				providerKey := fmt.Sprintf("%s-%s", route.Name, irProvider.Name)
+				providerKey := fmt.Sprintf("%s/%s", route.Name, irProvider.Name)
 				jwtProviders[providerKey] = jwtProvider
 				reqs = append(reqs, &jwtauthnv3.JwtRequirement{
 					RequiresType: &jwtauthnv3.JwtRequirement_ProviderName{

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-multi-provider.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              first-route-www.test.com-example:
+              first-route-www.test.com/example:
                 audiences:
                 - foo.com
                 claimToHeaders:
@@ -34,7 +34,7 @@
                     timeout: 5s
                     uri: https://localhost/jwt/public-key/jwks.json
                   retryPolicy: {}
-              first-route-www.test.com-example2:
+              first-route-www.test.com/example2:
                 audiences:
                 - one.foo.com
                 - two.foo.com
@@ -53,7 +53,7 @@
                     timeout: 5s
                     uri: https://192.168.1.250:8080/jwt/public-key/jwks.json
                   retryPolicy: {}
-              second-route-www.test.com-example:
+              second-route-www.test.com/example:
                 audiences:
                 - foo.com
                 claimToHeaders:
@@ -69,7 +69,7 @@
                     timeout: 5s
                     uri: https://localhost/jwt/public-key/jwks.json
                   retryPolicy: {}
-              second-route-www.test.com-example2:
+              second-route-www.test.com/example2:
                 audiences:
                 - one.foo.com
                 - two.foo.com
@@ -87,13 +87,13 @@
               first-route-www.test.com:
                 requiresAny:
                   requirements:
-                  - providerName: first-route-www.test.com-example
-                  - providerName: first-route-www.test.com-example2
+                  - providerName: first-route-www.test.com/example
+                  - providerName: first-route-www.test.com/example2
               second-route-www.test.com:
                 requiresAny:
                   requirements:
-                  - providerName: second-route-www.test.com-example
-                  - providerName: second-route-www.test.com-example2
+                  - providerName: second-route-www.test.com/example
+                  - providerName: second-route-www.test.com/example2
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-multi-route-single-provider.listeners.yaml
@@ -40,7 +40,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              first-route-example:
+              first-route/example:
                 audiences:
                 - foo.com
                 claimToHeaders:
@@ -56,7 +56,7 @@
                     timeout: 5s
                     uri: https://localhost/jwt/public-key/jwks.json
                   retryPolicy: {}
-              second-route-example:
+              second-route/example:
                 audiences:
                 - foo.com
                 issuer: https://www.example.com
@@ -71,9 +71,9 @@
                   retryPolicy: {}
             requirementMap:
               first-route:
-                providerName: first-route-example
+                providerName: first-route/example
               second-route:
-                providerName: second-route-example
+                providerName: second-route/example
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-ratelimit.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              first-route-example:
+              first-route/example:
                 audiences:
                 - foo.com
                 issuer: https://www.example.com
@@ -33,7 +33,7 @@
                   retryPolicy: {}
             requirementMap:
               first-route:
-                providerName: first-route-example
+                providerName: first-route/example
         - name: envoy.filters.http.ratelimit
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit

--- a/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authn-single-route-single-match.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              first-route-example:
+              first-route/example:
                 audiences:
                 - foo.com
                 issuer: https://www.example.com
@@ -33,7 +33,7 @@
                   retryPolicy: {}
             requirementMap:
               first-route:
-                providerName: first-route-example
+                providerName: first-route/example
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - example.com
-    name: first-listener/example.com
+    name: first-listener/example_com
     routes:
     - match:
         pathSeparatedPrefix: /v1/example
@@ -21,7 +21,7 @@
         cluster: second-route-dest
   - domains:
     - example.net
-    name: first-listener/example.net
+    name: first-listener/example_net
     routes:
     - match:
         headers:
@@ -39,7 +39,7 @@
         cluster: fourth-route-dest
   - domains:
     - '*.com'
-    name: first-listener/*.com
+    name: first-listener/*_com
     routes:
     - match:
         pathSeparatedPrefix: /foo
@@ -48,7 +48,7 @@
         cluster: fifth-route-dest
   - domains:
     - '*.net'
-    name: first-listener/*.net
+    name: first-listener/*_net
     routes:
     - match:
         pathSeparatedPrefix: /foo

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - gateway.envoyproxy.io
-    name: first-listener/gateway.envoyproxy.io
+    name: first-listener/gateway_envoyproxy_io
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - gateway.envoyproxy.io
-    name: first-listener/gateway.envoyproxy.io
+    name: first-listener/gateway_envoyproxy_io
     routes:
     - match:
         pathSeparatedPrefix: /origin

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - gateway.envoyproxy.io
-    name: first-listener/gateway.envoyproxy.io
+    name: first-listener/gateway_envoyproxy_io
     routes:
     - match:
         headers:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - gateway.envoyproxy.io
-    name: first-listener/gateway.envoyproxy.io
+    name: first-listener/gateway_envoyproxy_io
     routes:
     - match:
         headers:

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -8,6 +8,7 @@ package translator
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -164,9 +165,12 @@ func (t *Translator) processHTTPListenerXdsTranslation(tCtx *types.ResourceVersi
 			// 1:1 between IR HTTPRoute Hostname and xDS VirtualHost.
 			vHost := vHosts[httpRoute.Hostname]
 			if vHost == nil {
+				// Remove dots from the hostname before appending it to the virtualHost name
+				// since dots are special chars used in stats tag extraction in Envoy
+				underscoredHostname := strings.ReplaceAll(httpRoute.Hostname, ".", "_")
 				// Allocate virtual host for this httpRoute.
 				vHost = &routev3.VirtualHost{
-					Name:    fmt.Sprintf("%s/%s", httpListener.Name, httpRoute.Hostname),
+					Name:    fmt.Sprintf("%s/%s", httpListener.Name, underscoredHostname),
 					Domains: []string{httpRoute.Hostname},
 				}
 				vHosts[httpRoute.Hostname] = vHost


### PR DESCRIPTION
* also use `/` instead of `-` in Authentication Filter naming 
* also replaced hostname dots to workaround https://github.com/envoyproxy/envoy/issues/4357