### PR TITLE
fix a typo: disabled -> disable

### DIFF
--- a/docs/latest/design/accesslog.md
+++ b/docs/latest/design/accesslog.md
@@ -133,7 +133,7 @@ metadata:
 spec:
   telemetry:
     accessLog:
-      disabled: true
+      disable: true
 ```
 
 2. The following is an example with text format access log.

--- a/docs/latest/user/proxy-observability.md
+++ b/docs/latest/user/proxy-observability.md
@@ -93,7 +93,7 @@ Verify logs from loki:
 curl -s "http://$LOKI_IP:3100/loki/api/v1/query_range" --data-urlencode "query={job=\"fluentbit\"}" | jq '.data.result[0].values'
 ```
 
-If you want to disable it, set the `telemetry.accesslog.disabled` to `true` in the `EnvoyProxy` CRD.
+If you want to disable it, set the `telemetry.accesslog.disable` to `true` in the `EnvoyProxy` CRD.
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/envoyproxy/gateway/latest/examples/kubernetes/accesslog/disable-accesslog.yaml

--- a/docs/v0.5.0/design/accesslog.md
+++ b/docs/v0.5.0/design/accesslog.md
@@ -133,7 +133,7 @@ metadata:
 spec:
   telemetry:
     accessLog:
-      disabled: true
+      disable: true
 ```
 
 2. The following is an example with text format access log.

--- a/docs/v0.5.0/user/proxy-observability.md
+++ b/docs/v0.5.0/user/proxy-observability.md
@@ -93,7 +93,7 @@ Verify logs from loki:
 curl -s "http://$LOKI_IP:3100/loki/api/v1/query_range" --data-urlencode "query={job=\"fluentbit\"}" | jq '.data.result[0].values'
 ```
 
-If you want to disable it, set the `telemetry.accesslog.disabled` to `true` in the `EnvoyProxy` CRD.
+If you want to disable it, set the `telemetry.accesslog.disable` to `true` in the `EnvoyProxy` CRD.
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/envoyproxy/gateway/latest/examples/kubernetes/accesslog/disable-accesslog.yaml

--- a/examples/kubernetes/accesslog/disable-accesslog.yaml
+++ b/examples/kubernetes/accesslog/disable-accesslog.yaml
@@ -18,4 +18,4 @@ metadata:
 spec:
   telemetry:
     accessLog:
-      disabled: true
+      disable: true


### PR DESCRIPTION
**What type of PR is this?**

* docs: fix a typo: disabled -> disable, the API actually is `telemetry.accesslog.disable` not `telemetry.accesslog.disabled`. I fixed the typo in the docs and example YAML files. See the [API types](https://gateway.envoyproxy.io/latest/design/accesslog.html#proxyaccesslog-api-type).