### PR TITLE
add the missing required field type

### DIFF
--- a/examples/kubernetes/tracing/default.yaml
+++ b/examples/kubernetes/tracing/default.yaml
@@ -23,6 +23,7 @@ spec:
       provider:
         host: otel-collector.monitoring.svc.cluster.local
         port: 4317
+        type: OpenTelemetry
       customTags:
         # This is an example of using a literal as a tag value
         key1:


### PR DESCRIPTION
Fix the tracing example configuration error: missing the required field "type", see the [TracingProvider](https://gateway.envoyproxy.io/latest/api/config_types.html#tracingprovider).