### PR TITLE
fix docs string for access logs

### DIFF
--- a/api/config/v1alpha1/accesslogging_types.go
+++ b/api/config/v1alpha1/accesslogging_types.go
@@ -33,6 +33,7 @@ const (
 )
 
 // ProxyAccessLogFormat defines the format of accesslog.
+// By default accesslogs are written to standard output.
 // +union
 type ProxyAccessLogFormat struct {
 	// Type defines the type of accesslog format.
@@ -40,7 +41,6 @@ type ProxyAccessLogFormat struct {
 	// +unionDiscriminator
 	Type ProxyAccessLogFormatType `json:"type,omitempty"`
 	// Text defines the text accesslog format, following Envoy accesslog formatting,
-	// empty value results in proxy's default access log format.
 	// It's required when the format type is "Text".
 	// Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be used in the format.
 	// The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings) provides more information.
@@ -79,7 +79,7 @@ type ProxyAccessLogSink struct {
 
 type FileEnvoyProxyAccessLog struct {
 	// Path defines the file path used to expose envoy access log(e.g. /dev/stdout).
-	// Empty value disables accesslog.
+	// +kubebuilder:validation:MinLength=1
 	Path string `json:"path,omitempty"`
 }
 

--- a/charts/gateway-helm/crds/generated/config.gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-helm/crds/generated/config.gateway.envoyproxy.io_envoyproxies.yaml
@@ -3864,10 +3864,9 @@ spec:
                                   type: object
                                 text:
                                   description: Text defines the text accesslog format,
-                                    following Envoy accesslog formatting, empty value
-                                    results in proxy's default access log format.
-                                    It's required when the format type is "Text".
-                                    Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)
+                                    following Envoy accesslog formatting, It's required
+                                    when the format type is "Text". Envoy [command
+                                    operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)
                                     may be used in the format. The [format string
                                     documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings)
                                     provides more information.
@@ -3890,7 +3889,7 @@ spec:
                                       path:
                                         description: Path defines the file path used
                                           to expose envoy access log(e.g. /dev/stdout).
-                                          Empty value disables accesslog.
+                                        minLength: 1
                                         type: string
                                     type: object
                                   openTelemetry:

--- a/docs/latest/api/config_types.md
+++ b/docs/latest/api/config_types.md
@@ -426,7 +426,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `path` _string_ | Path defines the file path used to expose envoy access log(e.g. /dev/stdout). Empty value disables accesslog. |
+| `path` _string_ | Path defines the file path used to expose envoy access log(e.g. /dev/stdout). |
 
 
 ## Gateway
@@ -729,7 +729,7 @@ _Appears in:_
 
 
 
-ProxyAccessLogFormat defines the format of accesslog.
+ProxyAccessLogFormat defines the format of accesslog. By default accesslogs are written to standard output.
 
 _Appears in:_
 - [ProxyAccessLogSetting](#proxyaccesslogsetting)
@@ -737,7 +737,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `type` _[ProxyAccessLogFormatType](#proxyaccesslogformattype)_ | Type defines the type of accesslog format. |
-| `text` _string_ | Text defines the text accesslog format, following Envoy accesslog formatting, empty value results in proxy's default access log format. It's required when the format type is "Text". Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be used in the format. The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings) provides more information. |
+| `text` _string_ | Text defines the text accesslog format, following Envoy accesslog formatting, It's required when the format type is "Text". Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be used in the format. The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings) provides more information. |
 | `json` _object (keys:string, values:string)_ | JSON is additional attributes that describe the specific event occurrence. Structured format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) can be used as values for fields within the Struct. It's required when the format type is "JSON". |
 
 


### PR DESCRIPTION
make sure user specifies a file name when sink is set to file
