### PR TITLE
chore: group k8s gomod depencies together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      k8s.io:
+        patterns:
+          - "k8s.io/*"
   - package-ecosystem: pip
     directory: /tools/src/codespell
     schedule:


### PR DESCRIPTION
inspired from https://github.com/envoyproxy/go-control-plane/pull/774 which reduces the number of dependabot PRs

