### PR TITLE
chore: bump gateway api to v0.8.1

### DIFF
--- a/charts/gateway-helm/crds/gatewayapi-crds.yaml
+++ b/charts/gateway-helm/crds/gatewayapi-crds.yaml
@@ -24,7 +24,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
-    gateway.networking.k8s.io/bundle-version: v0.8.0
+    gateway.networking.k8s.io/bundle-version: v0.8.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
@@ -469,7 +469,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
-    gateway.networking.k8s.io/bundle-version: v0.8.0
+    gateway.networking.k8s.io/bundle-version: v0.8.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
@@ -964,7 +964,7 @@ spec:
                     for each listener
                   rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
                     == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
-                    == l2.hostname : true)))'
+                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
             required:
             - gatewayClassName
             - listeners
@@ -1742,7 +1742,7 @@ spec:
                     for each listener
                   rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
                     == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
-                    == l2.hostname : true)))'
+                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
             required:
             - gatewayClassName
             - listeners
@@ -2060,7 +2060,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
-    gateway.networking.k8s.io/bundle-version: v0.8.0
+    gateway.networking.k8s.io/bundle-version: v0.8.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: grpcroutes.gateway.networking.k8s.io
@@ -3765,7 +3765,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
-    gateway.networking.k8s.io/bundle-version: v0.8.0
+    gateway.networking.k8s.io/bundle-version: v0.8.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
@@ -8596,7 +8596,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
-    gateway.networking.k8s.io/bundle-version: v0.8.0
+    gateway.networking.k8s.io/bundle-version: v0.8.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
@@ -8885,7 +8885,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
-    gateway.networking.k8s.io/bundle-version: v0.8.0
+    gateway.networking.k8s.io/bundle-version: v0.8.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tcproutes.gateway.networking.k8s.io
@@ -9501,7 +9501,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
-    gateway.networking.k8s.io/bundle-version: v0.8.0
+    gateway.networking.k8s.io/bundle-version: v0.8.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tlsroutes.gateway.networking.k8s.io
@@ -10166,7 +10166,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2245
-    gateway.networking.k8s.io/bundle-version: v0.8.0
+    gateway.networking.k8s.io/bundle-version: v0.8.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: udproutes.gateway.networking.k8s.io
@@ -10847,7 +10847,7 @@ spec:
     spec:
       containers:
       - name: webhook
-        image: registry.k8s.io/gateway-api/admission-server:v0.8.0
+        image: registry.k8s.io/gateway-api/admission-server:v0.8.1
         imagePullPolicy: IfNotPresent
         args:
         - -logtostderr

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	k8s.io/kubectl v0.28.1
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
 	sigs.k8s.io/controller-runtime v0.16.2
-	sigs.k8s.io/gateway-api v0.8.0
+	sigs.k8s.io/gateway-api v0.8.1
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gE
 sigs.k8s.io/controller-runtime v0.16.2 h1:mwXAVuEk3EQf478PQwQ48zGOXvW27UJc8NHktQVuIPU=
 sigs.k8s.io/controller-runtime v0.16.2/go.mod h1:vpMu3LpI5sYWtujJOa2uPK61nB5rbwlN7BAB8aSLvGU=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/gateway-api v0.8.0 h1:isQQ3Jx2qFP7vaA3ls0846F0Amp9Eq14P08xbSwVbQg=
-sigs.k8s.io/gateway-api v0.8.0/go.mod h1:okOnjPNBFbIS/Rw9kAhuIUaIkLhTKEu+ARIuXk2dgaM=
+sigs.k8s.io/gateway-api v0.8.1 h1:Bo4NMAQFYkQZnHXOfufbYwbPW7b3Ic5NjpbeW6EJxuU=
+sigs.k8s.io/gateway-api v0.8.1/go.mod h1:0PteDrsrgkRmr13nDqFWnev8tOysAVrwnvfFM55tSVg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.8.1/go.mod h1:oNKTxUVPYkV9lWzY6CVMNluVq8cBsyq+UgPJdvA3uu4=

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -46,7 +46,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 		CleanupBaseResources: *flags.CleanupBaseResources,
 		SupportedFeatures:    suite.AllFeatures,
 		SkipTests: []string{
-			// Remove once https://github.com/envoyproxy/gateway/issues/1811 is fixed
+			// TODO: Remove once https://github.com/envoyproxy/gateway/issues/1811 is fixed
 			tests.HTTPRouteRequestMultipleMirrors.ShortName,
 		},
 		ExemptFeatures: suite.MeshCoreFeatures,

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -45,7 +45,11 @@ func TestGatewayAPIConformance(t *testing.T) {
 		Clientset:            clientset,
 		CleanupBaseResources: *flags.CleanupBaseResources,
 		SupportedFeatures:    suite.AllFeatures,
-		ExemptFeatures:       suite.MeshCoreFeatures,
+		SkipTests: []string{
+			// Remove once https://github.com/envoyproxy/gateway/issues/1811 is fixed
+			tests.HTTPRouteRequestMultipleMirrors.ShortName,
+		},
+		ExemptFeatures: suite.MeshCoreFeatures,
 	})
 	cSuite.Setup(t)
 	cSuite.Run(t, tests.ConformanceTests)

--- a/test/conformance/experimental_conformance_test.go
+++ b/test/conformance/experimental_conformance_test.go
@@ -34,7 +34,6 @@ var (
 	mgrClient           client.Client
 	implementation      *confv1a1.Implementation
 	conformanceProfiles sets.Set[suite.ConformanceProfileName]
-	skipTests           []string
 )
 
 func TestExperimentalConformance(t *testing.T) {
@@ -93,8 +92,11 @@ func experimentalConformance(t *testing.T) {
 				GatewayClassName:     *flags.GatewayClassName,
 				Debug:                *flags.ShowDebug,
 				CleanupBaseResources: *flags.CleanupBaseResources,
-				SkipTests:            skipTests,
-				SupportedFeatures:    sets.Set[suite.SupportedFeature]{}.Insert(suite.HTTPRouteExtendedFeatures.UnsortedList()...),
+				SkipTests: []string{
+					// Remove once https://github.com/envoyproxy/gateway/issues/1811 is fixed
+					tests.HTTPRouteRequestMultipleMirrors.ShortName,
+				},
+				SupportedFeatures: sets.Set[suite.SupportedFeature]{}.Insert(suite.HTTPRouteExtendedFeatures.UnsortedList()...),
 			},
 			Implementation:      *implementation,
 			ConformanceProfiles: conformanceProfiles,

--- a/test/conformance/experimental_conformance_test.go
+++ b/test/conformance/experimental_conformance_test.go
@@ -93,7 +93,7 @@ func experimentalConformance(t *testing.T) {
 				Debug:                *flags.ShowDebug,
 				CleanupBaseResources: *flags.CleanupBaseResources,
 				SkipTests: []string{
-					// Remove once https://github.com/envoyproxy/gateway/issues/1811 is fixed
+					// TODO: Remove once https://github.com/envoyproxy/gateway/issues/1811 is fixed
 					tests.HTTPRouteRequestMultipleMirrors.ShortName,
 				},
 				SupportedFeatures: sets.Set[suite.SupportedFeature]{}.Insert(suite.HTTPRouteExtendedFeatures.UnsortedList()...),


### PR DESCRIPTION
https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.8.1