### PR TITLE
Address 'helm lint' error <.watch.namespaces>: nil pointer

### DIFF
--- a/charts/gateway-helm/templates/envoy-gateway-rbac.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-rbac.yaml
@@ -1,6 +1,6 @@
 {{ $watchedNamespaces := list }}
 {{ if $kube := .Values.config.envoyGateway.provider.kubernetes }}
-{{ if and $kube.watch $kube.watch.namespaces }}
+{{ if and $kube.watch (gt (len $kube.watch.namespaces) 0) }}
 {{ $watchedNamespaces = $kube.watch.namespaces }}
 {{ end }}
 {{ end }}

--- a/charts/gateway-helm/templates/envoy-gateway-rbac.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-rbac.yaml
@@ -1,9 +1,7 @@
 {{ $watchedNamespaces := list }}
 {{ if $kube := .Values.config.envoyGateway.provider.kubernetes }}
 {{ if $kube.watch }}
-{{ if or (not $kube.watch.namespaces) (eq (len $kube.watch.namespaces) 0) }}
-{{ $watchedNamespaces = list }}
-{{ else }}
+{{ if and $kube.watch.namespaces (gt (len $kube.watch.namespaces) 0) }}
 {{ $watchedNamespaces = $kube.watch.namespaces }}
 {{ end }}
 {{ end }}

--- a/charts/gateway-helm/templates/envoy-gateway-rbac.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-rbac.yaml
@@ -1,9 +1,14 @@
 {{ $watchedNamespaces := list }}
 {{ if $kube := .Values.config.envoyGateway.provider.kubernetes }}
-{{ if and $kube.watch (gt (len $kube.watch.namespaces) 0) }}
+{{ if $kube.watch }}
+{{ if or (not $kube.watch.namespaces) (eq (len $kube.watch.namespaces) 0) }}
+{{ $watchedNamespaces = list }}
+{{ else }}
 {{ $watchedNamespaces = $kube.watch.namespaces }}
 {{ end }}
 {{ end }}
+{{ end }}
+
 {{ if gt (len $watchedNamespaces) 0 }}
 {{ range $_, $ns := $watchedNamespaces }}
 ---

--- a/charts/gateway-helm/templates/envoy-gateway-rbac.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-rbac.yaml
@@ -1,12 +1,14 @@
 {{ $watchedNamespaces := list }}
-{{ if $kube := .Values.config.envoyGateway.provider.kubernetes }}
+{{ if .Values.config.envoyGateway.provider.kubernetes }}
+{{ $kube := .Values.config.envoyGateway.provider.kubernetes }}
 {{ if $kube.watch }}
-{{ if and $kube.watch.namespaces (gt (len $kube.watch.namespaces) 0) }}
+{{ if $kube.watch.namespaces }}
+{{ if gt (len $kube.watch.namespaces) 0 }}
 {{ $watchedNamespaces = $kube.watch.namespaces }}
 {{ end }}
 {{ end }}
 {{ end }}
-
+{{ end }}
 {{ if gt (len $watchedNamespaces) 0 }}
 {{ range $_, $ns := $watchedNamespaces }}
 ---

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -45,7 +45,6 @@ config:
       level:
         default: info
 
-
 envoyGatewayMetricsService:
   ports:
     - name: https

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -41,9 +41,6 @@ config:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
     provider:
       type: Kubernetes
-      kubernetes:
-        watch:
-          namespaces: {}
     logging:
       level:
         default: info

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -41,9 +41,13 @@ config:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
     provider:
       type: Kubernetes
+      kubernetes:
+        watch:
+          namespaces: {}
     logging:
       level:
         default: info
+
 
 envoyGatewayMetricsService:
   ports:


### PR DESCRIPTION
**What type of PR is this?**

helm lint indentifies the following error:
```
templates/: template: gateway-helm/templates/envoy-gateway-rbac.yaml:3:27: executing "gateway-helm/templates/envoy-gateway-rbac.yaml" at <$kube.watch.namespaces>: nil pointer evaluating interface
```

**What this PR does / why we need it**:

two adjustments:
- values now hove the path `config.envoyGateway.provider.kubernetes.watch.namespaces`
- also adjusting logic to handle empty list in `templates.envoy-gateway-rbac.yaml`

