### PR TITLE
Allow policy target namespace to be optional

### DIFF
--- a/internal/gatewayapi/clienttrafficpolicy.go
+++ b/internal/gatewayapi/clienttrafficpolicy.go
@@ -17,6 +17,7 @@ import (
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/status"
+	"github.com/envoyproxy/gateway/internal/utils/ptr"
 )
 
 const (
@@ -170,16 +171,9 @@ func ProcessClientTrafficPolicies(clientTrafficPolicies []*egv1a1.ClientTrafficP
 
 func getGatewayTargetRef(policy *egv1a1.ClientTrafficPolicy, gateways []*GatewayContext) *GatewayContext {
 	targetNs := policy.Spec.TargetRef.Namespace
-
-	// Ensure Namespace is set
+	// If empty, default to namespace of policy
 	if targetNs == nil {
-		status.SetClientTrafficPolicyCondition(policy,
-			gwv1a2.PolicyConditionAccepted,
-			metav1.ConditionFalse,
-			gwv1a2.PolicyReasonInvalid,
-			"TargetRef.Namespace must be set",
-		)
-		return nil
+		targetNs = ptr.To(gwv1b1.Namespace(policy.Namespace))
 	}
 
 	// Ensure policy can only target a Gateway


### PR DESCRIPTION
* Defaults to the policy namespace as recommend by upstream
https://github.com/kubernetes-sigs/gateway-api/blob/d38e6c81ba3d3f137012ceeec8262ab40ad0cd81/apis/v1alpha2/policy_types.go#L47
