### PR TITLE
fix: Remove ErrHTTPRouteMatchEmpty check for Xds IR

### DIFF
--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -31,7 +31,6 @@ var (
 	ErrTLSPrivateKey                 = errors.New("field PrivateKey must be specified")
 	ErrHTTPRouteNameEmpty            = errors.New("field Name must be specified")
 	ErrHTTPRouteHostnameEmpty        = errors.New("field Hostname must be specified")
-	ErrHTTPRouteMatchEmpty           = errors.New("either PathMatch, HeaderMatches or QueryParamMatches fields must be specified")
 	ErrDestinationNameEmpty          = errors.New("field Name must be specified")
 	ErrDestEndpointHostInvalid       = errors.New("field Address must be a valid IP address")
 	ErrDestEndpointPortInvalid       = errors.New("field Port specified is invalid")
@@ -316,9 +315,6 @@ func (h HTTPRoute) Validate() error {
 	}
 	if h.Hostname == "" {
 		errs = multierror.Append(errs, ErrHTTPRouteHostnameEmpty)
-	}
-	if h.PathMatch == nil && (len(h.HeaderMatches) == 0) && (len(h.QueryParamMatches) == 0) {
-		errs = multierror.Append(errs, ErrHTTPRouteMatchEmpty)
 	}
 	if h.PathMatch != nil {
 		if err := h.PathMatch.Validate(); err != nil {

--- a/internal/ir/xds_test.go
+++ b/internal/ir/xds_test.go
@@ -43,13 +43,6 @@ var (
 		Hostnames: []string{"example.com"},
 		Routes:    []*HTTPRoute{&happyHTTPRoute},
 	}
-	invalidRouteMatchHTTPListener = HTTPListener{
-		Name:      "invalid-route-match",
-		Address:   "0.0.0.0",
-		Port:      80,
-		Hostnames: []string{"example.com"},
-		Routes:    []*HTTPRoute{&emptyMatchHTTPRoute},
-	}
 	invalidBackendHTTPListener = HTTPListener{
 		Name:      "invalid-backend-match",
 		Address:   "0.0.0.0",
@@ -144,11 +137,6 @@ var (
 		PathMatch: &StringMatch{
 			Exact: ptrTo("example"),
 		},
-		Destination: &happyRouteDestination,
-	}
-	emptyMatchHTTPRoute = HTTPRoute{
-		Name:        "empty-match",
-		Hostname:    "*",
 		Destination: &happyRouteDestination,
 	}
 	invalidBackendHTTPRoute = HTTPRoute{
@@ -510,9 +498,9 @@ func TestValidateXds(t *testing.T) {
 		{
 			name: "invalid listener",
 			input: Xds{
-				HTTP: []*HTTPListener{&happyHTTPListener, &invalidAddrHTTPListener, &invalidRouteMatchHTTPListener},
+				HTTP: []*HTTPListener{&happyHTTPListener, &invalidAddrHTTPListener},
 			},
-			want: []error{ErrListenerAddressInvalid, ErrHTTPRouteMatchEmpty},
+			want: []error{ErrListenerAddressInvalid},
 		},
 		{
 			name: "invalid backend",
@@ -578,11 +566,6 @@ func TestValidateHTTPListener(t *testing.T) {
 				Routes:  []*HTTPRoute{&happyHTTPRoute},
 			},
 			want: []error{ErrListenerPortInvalid, ErrHTTPListenerHostnamesEmpty},
-		},
-		{
-			name:  "invalid route match",
-			input: invalidRouteMatchHTTPListener,
-			want:  []error{ErrHTTPRouteMatchEmpty},
 		},
 	}
 	for _, test := range tests {
@@ -836,11 +819,6 @@ func TestValidateHTTPRoute(t *testing.T) {
 				Destination: &happyRouteDestination,
 			},
 			want: []error{ErrHTTPRouteHostnameEmpty},
-		},
-		{
-			name:  "empty match",
-			input: emptyMatchHTTPRoute,
-			want:  []error{ErrHTTPRouteMatchEmpty},
 		},
 		{
 			name:  "invalid backend",


### PR DESCRIPTION
Empty matches are supported in the gateway api spec e.g. https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1alpha2.GRPCRouteRule and we are also tranlating it correctly in the gateway-api layer e.g. https://github.com/envoyproxy/gateway/blob/76704d1124eccaf06b81634a96390c95722a0554/internal/gatewayapi/route.go#L212 but the IR layer is rejecting this valid config

Relates to https://github.com/envoyproxy/gateway/issues/1958#issuecomment-1760149916