### PR TITLE
fix: update outdated image in grpc routing docs

### DIFF
--- a/examples/kubernetes/grpc-routing.yaml
+++ b/examples/kubernetes/grpc-routing.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: grpcsrv
-          image: quay.io/mhausenblas/yages:0.1.0
+          image: ghcr.io/projectcontour/yages:v0.1.0
           ports:
             - containerPort: 9000
               protocol: TCP


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
-->

**What this PR does / why we need it**:
Deploying yages with `quay.io/mhausenblas/yages:0.1.0` resulted in `Error: ErrImagePull`.
```bash
Warning Failed 9s kubelet Failed to pull image "quay.io/mhausenblas/yages:0.1.0": rpc error: 
code = Unknown desc = Error response from daemon: application/vnd.docker.distribution.manifest.v1+prettyjws not supported
 ```
Propose: change image `quay.io/mhausenblas/yages` to forked and updated `ghcr.io/projectcontour/yages`.

