### PR TITLE
chore: add helm-readme-gen to docs-api to generate

### DIFF
--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -27,7 +27,7 @@ docs.clean:
 	rm -rf $(DOCS_OUTPUT_DIR)
 
 .PHONY: docs-api
-docs-api: docs-api-gen docs-api-headings
+docs-api: docs-api-gen helm-readme-gen docs-api-headings
 
 .PHONY: helm-readme-gen
 helm-readme-gen: $(tools/helm-docs)


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

make `generate` does not include `helm-readme-gen`, which makes the lint CI can not check if the helm docs is the latest.
