### PR TITLE
fix: wrong gatewayclass status without paramsRef

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -1629,11 +1629,6 @@ func (r *gatewayAPIReconciler) hasManagedClass(obj client.Object) bool {
 
 // processParamsRef processes the parametersRef of the provided GatewayClass.
 func (r *gatewayAPIReconciler) processParamsRef(ctx context.Context, gc *gwapiv1b1.GatewayClass, resourceTree *gatewayapi.Resources) error {
-	if gc.Spec.ParametersRef != nil {
-		if !refsEnvoyProxy(gc) {
-			return fmt.Errorf("unsupported parametersRef for gatewayclass %s", gc.Name)
-		}
-	}
 	epList := new(egv1a1.EnvoyProxyList)
 	// The EnvoyProxy must be in the same namespace as EG.
 	if err := r.client.List(ctx, epList, &client.ListOptions{Namespace: r.namespace}); err != nil {
@@ -1688,12 +1683,16 @@ func (r *gatewayAPIReconciler) processParamsRef(ctx context.Context, gc *gwapiv1
 		}
 	}
 
-	if !found {
-		return fmt.Errorf("failed to find envoyproxy referenced by gatewayclass: %s", gc.Name)
-	}
-
-	if !valid {
-		return fmt.Errorf("invalid gatewayclass %s: %v", gc.Name, validationErr)
+	if gc.Spec.ParametersRef != nil {
+		if !refsEnvoyProxy(gc) {
+			return fmt.Errorf("unsupported parametersRef for gatewayclass %s", gc.Name)
+		}
+		if !found {
+			return fmt.Errorf("failed to find envoyproxy referenced by gatewayclass: %s", gc.Name)
+		}
+		if !valid {
+			return fmt.Errorf("invalid gatewayclass %s: %v", gc.Name, validationErr)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing the bug: 
Providing GatewayClass without paramsRef
```bash
apiVersion: gateway.networking.k8s.io/v1beta1
kind: GatewayClass
metadata:
  name: example-class
spec:
  controllerName: gateway.envoyproxy.io/gatewayclass-controller
```
results in error in the provider, not accepting the GatewayClass.
```bash
ERROR provider kubernetes/controller.go:330 failed to process parametersRef for gatewayclass
{"runner": "provider", "name": "example-class", "error": "failed to find envoyproxy referenced by gatewayclass: example-class"}
```
```bash
  status:
    conditions:
    - message: 'Invalid parametersRef: failed to find envoyproxy referenced by gatewayclass:
        example-class'
      observedGeneration: 2
      reason: InvalidParameters
      status: "False"
      type: Accepted
 
NAME            CONTROLLER                                      ACCEPTED   AGE
example-class   gateway.envoyproxy.io/gatewayclass-controller   False      2m
```

