### PR TITLE
WIP: Updates Gateway Listener AttachedRoutes Calculation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/envoyproxy/gateway
 
 go 1.20
 
+replace sigs.k8s.io/gateway-api => ../../../sigs.k8s.io/gateway-api
+
 require (
 	github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4
 	github.com/davecgh/go-spew v1.1.1

--- a/internal/gatewayapi/contexts.go
+++ b/internal/gatewayapi/contexts.go
@@ -90,6 +90,10 @@ func (l *ListenerContext) SetSupportedKinds(kinds ...v1beta1.RouteGroupKind) {
 	l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds = kinds
 }
 
+func (l *ListenerContext) GetSupportedKinds() []v1beta1.RouteGroupKind {
+	return l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds
+}
+
 func (l *ListenerContext) IncrementAttachedRoutes() {
 	l.gateway.Status.Listeners[l.listenerStatusIdx].AttachedRoutes++
 }

--- a/internal/gatewayapi/validate.go
+++ b/internal/gatewayapi/validate.go
@@ -209,12 +209,16 @@ func (t *Translator) validateListenerConditions(listener *ListenerContext) (isRe
 	if !(lConditions[0].Type == string(v1beta1.ListenerConditionProgrammed) && lConditions[0].Status == metav1.ConditionTrue) {
 		hasProgrammedCond := false
 		hasRefsCond := false
+		hasAcceptedCond := false
 		for _, existing := range lConditions {
 			if existing.Type == string(v1beta1.ListenerConditionProgrammed) {
 				hasProgrammedCond = true
 			}
 			if existing.Type == string(v1beta1.ListenerConditionResolvedRefs) {
 				hasRefsCond = true
+			}
+			if existing.Type == string(v1beta1.ListenerConditionAccepted) {
+				hasAcceptedCond = true
 			}
 		}
 		// set "Programmed: false" if it's not set already.
@@ -233,6 +237,15 @@ func (t *Translator) validateListenerConditions(listener *ListenerContext) (isRe
 				metav1.ConditionTrue,
 				v1beta1.ListenerReasonResolvedRefs,
 				"Listener references have been resolved",
+			)
+		}
+		// set "Accepted: true" if it's not set already.
+		if !hasAcceptedCond {
+			listener.SetCondition(
+				v1beta1.ListenerConditionAccepted,
+				metav1.ConditionTrue,
+				v1beta1.ListenerReasonAccepted,
+				"Listener has been successfully translated",
 			)
 		}
 		// skip computing IR

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -531,7 +531,7 @@ func (r *gatewayAPIReconciler) processGateways(ctx context.Context, acceptedGC *
 						)
 						if err != nil && !kerrors.IsNotFound(err) {
 							r.log.Error(err, "unable to find Secret")
-							return err
+							continue
 						}
 
 						r.log.Info("processing Secret", "namespace", secretNamespace, "name", string(certRef.Name))

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -48,7 +48,13 @@ func TestGatewayAPIConformance(t *testing.T) {
 		SkipTests:            []string{},
 		ExemptFeatures:       suite.MeshCoreFeatures,
 	})
-	cSuite.Setup(t)
-	cSuite.Run(t, tests.ConformanceTests)
 
+	cSuite.Setup(t)
+
+	tests := []suite.ConformanceTest{
+		tests.GatewayWithAttachedRoutes,
+	}
+
+	cSuite.Run(t, tests)
+	//cSuite.Run(t, tests.ConformanceTests)
 }


### PR DESCRIPTION
**What type of PR is this?**
Updates the GW API translator so that successful attachment of a Route to a Listener is based solely on the combination of the AllowedRoutes field on the corresponding Listener and the Route's ParentRefs field.

**What this PR does / why we need it**:
Required for GW API conformance.

**Which issue(s) this PR fixes**:
xref #1916
