### PR TITLE
register for v1beta1 gateway api

### DIFF
--- a/internal/envoygateway/scheme.go
+++ b/internal/envoygateway/scheme.go
@@ -10,6 +10,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapi "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -35,6 +36,9 @@ func init() {
 	}
 	// Add Gateway API types.
 	if err := gwapiv1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	if err := gwapiv1b1.AddToScheme(scheme); err != nil {
 		panic(err)
 	}
 	if err := gwapiv1a2.AddToScheme(scheme); err != nil {

--- a/internal/gatewayapi/resource.go
+++ b/internal/gatewayapi/resource.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapi "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -33,7 +34,7 @@ type Resources struct {
 	TLSRoutes             []*gwapiv1a2.TLSRoute          `json:"tlsRoutes,omitempty" yaml:"tlsRoutes,omitempty"`
 	TCPRoutes             []*gwapiv1a2.TCPRoute          `json:"tcpRoutes,omitempty" yaml:"tcpRoutes,omitempty"`
 	UDPRoutes             []*gwapiv1a2.UDPRoute          `json:"udpRoutes,omitempty" yaml:"udpRoutes,omitempty"`
-	ReferenceGrants       []*gwapiv1a2.ReferenceGrant    `json:"referenceGrants,omitempty" yaml:"referenceGrants,omitempty"`
+	ReferenceGrants       []*gwapiv1b1.ReferenceGrant    `json:"referenceGrants,omitempty" yaml:"referenceGrants,omitempty"`
 	Namespaces            []*v1.Namespace                `json:"namespaces,omitempty" yaml:"namespaces,omitempty"`
 	Services              []*v1.Service                  `json:"services,omitempty" yaml:"services,omitempty"`
 	ServiceImports        []*mcsapi.ServiceImport        `json:"serviceImports,omitempty" yaml:"serviceImports,omitempty"`
@@ -56,7 +57,7 @@ func NewResources() *Resources {
 		Services:              []*v1.Service{},
 		EndpointSlices:        []*discoveryv1.EndpointSlice{},
 		Secrets:               []*v1.Secret{},
-		ReferenceGrants:       []*gwapiv1a2.ReferenceGrant{},
+		ReferenceGrants:       []*gwapiv1b1.ReferenceGrant{},
 		Namespaces:            []*v1.Namespace{},
 		RateLimitFilters:      []*egv1a1.RateLimitFilter{},
 		AuthenticationFilters: []*egv1a1.AuthenticationFilter{},

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/yaml"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -537,7 +537,7 @@ func TestIsValidCrossNamespaceRef(t *testing.T) {
 		name           string
 		from           crossNamespaceFrom
 		to             crossNamespaceTo
-		referenceGrant *v1alpha2.ReferenceGrant
+		referenceGrant *v1beta1.ReferenceGrant
 		want           bool
 	}
 
@@ -559,20 +559,20 @@ func TestIsValidCrossNamespaceRef(t *testing.T) {
 				namespace: "default",
 				name:      "tls-secret-1",
 			},
-			referenceGrant: &v1alpha2.ReferenceGrant{
+			referenceGrant: &v1beta1.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "referencegrant-1",
 					Namespace: "default",
 				},
-				Spec: v1alpha2.ReferenceGrantSpec{
-					From: []v1alpha2.ReferenceGrantFrom{
+				Spec: v1beta1.ReferenceGrantSpec{
+					From: []v1beta1.ReferenceGrantFrom{
 						{
 							Group:     "gateway.networking.k8s.io",
 							Kind:      "Gateway",
 							Namespace: "envoy-gateway-system",
 						},
 					},
-					To: []v1alpha2.ReferenceGrantTo{
+					To: []v1beta1.ReferenceGrantTo{
 						{
 							Group: "",
 							Kind:  "Secret",
@@ -642,7 +642,7 @@ func TestIsValidCrossNamespaceRef(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			var referenceGrants []*v1alpha2.ReferenceGrant
+			var referenceGrants []*v1beta1.ReferenceGrant
 			if tc.referenceGrant != nil {
 				referenceGrants = append(referenceGrants, tc.referenceGrant)
 			}

--- a/internal/gatewayapi/validate.go
+++ b/internal/gatewayapi/validate.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func (t *Translator) validateBackendRef(backendRef *gwapiv1a2.BackendRef, parentRef *RouteParentContext, route RouteContext,
@@ -629,7 +630,7 @@ func (t *Translator) validateConflictedLayer4Listeners(gateways []*GatewayContex
 	}
 }
 
-func (t *Translator) validateCrossNamespaceRef(from crossNamespaceFrom, to crossNamespaceTo, referenceGrants []*gwapiv1a2.ReferenceGrant) bool {
+func (t *Translator) validateCrossNamespaceRef(from crossNamespaceFrom, to crossNamespaceTo, referenceGrants []*gwapiv1b1.ReferenceGrant) bool {
 	for _, referenceGrant := range referenceGrants {
 		// The ReferenceGrant must be defined in the namespace of
 		// the "to" (the referent).

--- a/internal/gatewayapi/zz_generated.deepcopy.go
+++ b/internal/gatewayapi/zz_generated.deepcopy.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -95,11 +96,11 @@ func (in *Resources) DeepCopyInto(out *Resources) {
 	}
 	if in.ReferenceGrants != nil {
 		in, out := &in.ReferenceGrants, &out.ReferenceGrants
-		*out = make([]*v1alpha2.ReferenceGrant, len(*in))
+		*out = make([]*v1beta1.ReferenceGrant, len(*in))
 		for i := range *in {
 			if (*in)[i] != nil {
 				in, out := &(*in)[i], &(*out)[i]
-				*out = new(v1alpha2.ReferenceGrant)
+				*out = new(v1beta1.ReferenceGrant)
 				(*in).DeepCopyInto(*out)
 			}
 		}

--- a/site/content/en/latest/user/secure-gateways.md
+++ b/site/content/en/latest/user/secure-gateways.md
@@ -173,7 +173,7 @@ namespace to reference Secrets in the "envoy-gateway-system" namespace:
 
 ```console
 $ cat <<EOF | kubectl apply -f -
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: example

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -47,7 +47,6 @@ func TestGatewayAPIConformance(t *testing.T) {
 		SupportedFeatures:    suite.AllFeatures,
 		SkipTests: []string{
 			tests.GatewaySecretInvalidReferenceGrant.ShortName,
-			tests.HTTPRouteReferenceGrant.ShortName,
 			tests.HTTPRouteRewritePath.ShortName,
 			tests.GatewayStaticAddresses.ShortName,
 		},

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/tests"
 	"sigs.k8s.io/gateway-api/conformance/utils/flags"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
@@ -36,6 +37,7 @@ func TestGatewayAPIConformance(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, v1alpha2.AddToScheme(client.Scheme()))
+	require.NoError(t, v1beta1.AddToScheme(client.Scheme()))
 	require.NoError(t, v1.AddToScheme(client.Scheme()))
 
 	cSuite := suite.New(suite.Options{

--- a/test/conformance/experimental_conformance_test.go
+++ b/test/conformance/experimental_conformance_test.go
@@ -54,7 +54,7 @@ func TestExperimentalConformance(t *testing.T) {
 
 	err = v1alpha2.AddToScheme(mgrClient.Scheme())
 	assert.NoError(t, err)
-	err = v1beta1.AddToScheme(client.Scheme())
+	err = v1beta1.AddToScheme(mgrClient.Scheme())
 	assert.NoError(t, err)
 	err = v1.AddToScheme(mgrClient.Scheme())
 	assert.NoError(t, err)

--- a/test/conformance/experimental_conformance_test.go
+++ b/test/conformance/experimental_conformance_test.go
@@ -22,6 +22,7 @@ import (
 
 	"sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	confv1a1 "sigs.k8s.io/gateway-api/conformance/apis/v1alpha1"
 	"sigs.k8s.io/gateway-api/conformance/tests"
 	"sigs.k8s.io/gateway-api/conformance/utils/flags"
@@ -52,6 +53,8 @@ func TestExperimentalConformance(t *testing.T) {
 	}
 
 	err = v1alpha2.AddToScheme(mgrClient.Scheme())
+	assert.NoError(t, err)
+	err = v1beta1.AddToScheme(client.Scheme())
 	assert.NoError(t, err)
 	err = v1.AddToScheme(mgrClient.Scheme())
 	assert.NoError(t, err)

--- a/test/conformance/experimental_conformance_test.go
+++ b/test/conformance/experimental_conformance_test.go
@@ -94,7 +94,6 @@ func experimentalConformance(t *testing.T) {
 				CleanupBaseResources: *flags.CleanupBaseResources,
 				SkipTests: []string{
 					tests.GatewaySecretInvalidReferenceGrant.ShortName,
-					tests.HTTPRouteReferenceGrant.ShortName,
 					tests.HTTPRouteRewritePath.ShortName,
 					tests.GatewayStaticAddresses.ShortName,
 				},


### PR DESCRIPTION
* `ReferenceGrant` is still on v1beta1

Fixes: https://github.com/envoyproxy/gateway/issues/2005