### PR TITLE
dont run docs GHA on release branches

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,13 +3,11 @@ on:
   push:
     branches:
     - "main"
-    - "release/v*"
     paths-ignore:
     - "**/*.png"
   pull_request:
     branches:
     - "main"
-    - "release/v*"
     paths-ignore:
     - "**/*.png"
 


### PR DESCRIPTION
Docs GHA only runs on `main`

Fixes this error https://github.com/envoyproxy/gateway/actions/runs/6673931411/job/18140221080
