### PR TITLE
remove cors, jwt, rl assignment from route translator

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -554,9 +554,6 @@ func (t *Translator) processHTTPRouteParentRefListener(route RouteContext, route
 					DirectResponse:        routeRoute.DirectResponse,
 					URLRewrite:            routeRoute.URLRewrite,
 					Mirrors:               routeRoute.Mirrors,
-					RateLimit:             routeRoute.RateLimit,
-					CORS:                  routeRoute.CORS,
-					JWT:                   routeRoute.JWT,
 					Timeout:               routeRoute.Timeout,
 					ExtensionRefs:         routeRoute.ExtensionRefs,
 				}


### PR DESCRIPTION
All the translations and assignments now happen in the policy translators