### PR TITLE
Enable HTTPRouteRewritePath test

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
+++ b/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
@@ -48,7 +48,7 @@
                 "routes": [
                   {
                     "match": {
-                      "prefix": "/v2/"
+                      "pathSeparatedPrefix": "/v2/"
                     },
                     "name": "httproute/default/backend/rule/0/match/0/www_example2_com",
                     "route": {

--- a/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
+++ b/internal/cmd/egctl/testdata/translate/out/multiple-xds.route.json
@@ -48,7 +48,7 @@
                 "routes": [
                   {
                     "match": {
-                      "pathSeparatedPrefix": "/v2/"
+                      "pathSeparatedPrefix": "/v2"
                     },
                     "name": "httproute/default/backend/rule/0/match/0/www_example2_com",
                     "route": {

--- a/internal/gatewayapi/sort.go
+++ b/internal/gatewayapi/sort.go
@@ -16,7 +16,42 @@ type XdsIRRoutes []*ir.HTTPRoute
 func (x XdsIRRoutes) Len() int      { return len(x) }
 func (x XdsIRRoutes) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
 func (x XdsIRRoutes) Less(i, j int) bool {
-	// 1. Sort based on characters in a matching path.
+
+	// 1. Sort based on path match type
+	// Exact > PathPrefix > RegularExpression
+	if x[i].PathMatch != nil && x[i].PathMatch.Exact != nil {
+		if x[j].PathMatch != nil {
+			if x[j].PathMatch.Prefix != nil {
+				return false
+			}
+			if x[j].PathMatch.SafeRegex != nil {
+				return false
+			}
+		}
+	}
+	if x[i].PathMatch != nil && x[i].PathMatch.Prefix != nil {
+		if x[j].PathMatch != nil {
+			if x[j].PathMatch.Exact != nil {
+				return true
+			}
+			if x[j].PathMatch.SafeRegex != nil {
+				return false
+			}
+		}
+	}
+	if x[i].PathMatch != nil && x[i].PathMatch.SafeRegex != nil {
+		if x[j].PathMatch != nil {
+			if x[j].PathMatch.Exact != nil {
+				return true
+			}
+			if x[j].PathMatch.Prefix != nil {
+				return true
+			}
+		}
+	}
+	// Equal case
+
+	// 2. Sort based on characters in a matching path.
 	pCountI := pathMatchCount(x[i].PathMatch)
 	pCountJ := pathMatchCount(x[j].PathMatch)
 	if pCountI < pCountJ {
@@ -27,7 +62,7 @@ func (x XdsIRRoutes) Less(i, j int) bool {
 	}
 	// Equal case
 
-	// 2. Sort based on the number of Header matches.
+	// 3. Sort based on the number of Header matches.
 	hCountI := len(x[i].HeaderMatches)
 	hCountJ := len(x[j].HeaderMatches)
 	if hCountI < hCountJ {
@@ -38,7 +73,7 @@ func (x XdsIRRoutes) Less(i, j int) bool {
 	}
 	// Equal case
 
-	// 3. Sort based on the number of Query param matches.
+	// 4. Sort based on the number of Query param matches.
 	qCountI := len(x[i].QueryParamMatches)
 	qCountJ := len(x[j].QueryParamMatches)
 	return qCountI < qCountJ

--- a/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
@@ -119,11 +119,11 @@ xdsIR:
               port: 8080
             weight: 1
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/1/*
+        name: grpcroute/default/grpcroute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""
-          safeRegex: /com.[A-Z]+/[A-Za-z_][A-Za-z_0-9]*
+          prefix: /com.ExampleExact
       - backendWeights:
           invalid: 0
           valid: 0
@@ -135,8 +135,8 @@ xdsIR:
               port: 8080
             weight: 1
         hostname: '*'
-        name: grpcroute/default/grpcroute-1/rule/0/match/0/*
+        name: grpcroute/default/grpcroute-1/rule/0/match/1/*
         pathMatch:
           distinct: false
           name: ""
-          prefix: /com.ExampleExact
+          safeRegex: /com.[A-Z]+/[A-Za-z_][A-Za-z_0-9]*

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
@@ -137,46 +137,6 @@ xdsIR:
           invalid: 0
           valid: 0
         destination:
-          name: httproute/default/httproute-1/rule/2
-          settings:
-          - endpoints:
-            - host: 7.7.7.7
-              port: 8080
-            weight: 1
-        headerMatches:
-        - distinct: false
-          name: Header-1
-          safeRegex: '*regex*'
-        hostname: '*'
-        name: httproute/default/httproute-1/rule/2/match/0/*
-        pathMatch:
-          distinct: false
-          name: ""
-          safeRegex: '*regex*'
-        queryParamMatches:
-        - distinct: false
-          name: QueryParam-1
-          safeRegex: '*regex*'
-      - backendWeights:
-          invalid: 0
-          valid: 0
-        destination:
-          name: httproute/default/httproute-1/rule/1
-          settings:
-          - endpoints:
-            - host: 7.7.7.7
-              port: 8080
-            weight: 1
-        hostname: '*'
-        name: httproute/default/httproute-1/rule/1/match/0/*
-        pathMatch:
-          distinct: false
-          name: ""
-          prefix: /prefix
-      - backendWeights:
-          invalid: 0
-          valid: 0
-        destination:
           name: httproute/default/httproute-1/rule/0
           settings:
           - endpoints:
@@ -197,3 +157,43 @@ xdsIR:
         - distinct: false
           exact: exact
           name: QueryParam-1
+      - backendWeights:
+          invalid: 0
+          valid: 0
+        destination:
+          name: httproute/default/httproute-1/rule/1
+          settings:
+          - endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            weight: 1
+        hostname: '*'
+        name: httproute/default/httproute-1/rule/1/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /prefix
+      - backendWeights:
+          invalid: 0
+          valid: 0
+        destination:
+          name: httproute/default/httproute-1/rule/2
+          settings:
+          - endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            weight: 1
+        headerMatches:
+        - distinct: false
+          name: Header-1
+          safeRegex: '*regex*'
+        hostname: '*'
+        name: httproute/default/httproute-1/rule/2/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          safeRegex: '*regex*'
+        queryParamMatches:
+        - distinct: false
+          name: QueryParam-1
+          safeRegex: '*regex*'

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -107,9 +107,9 @@ func buildXdsRouteMatch(pathMatch *ir.StringMatch, headerMatches []*ir.StringMat
 				}
 			} else {
 				// Remove trailing /
-				*pathMatch.Prefix = strings.TrimSuffix(*pathMatch.Prefix, "/")
+				trimmedPrefix := strings.TrimSuffix(*pathMatch.Prefix, "/")
 				outMatch.PathSpecifier = &routev3.RouteMatch_PathSeparatedPrefix{
-					PathSeparatedPrefix: *pathMatch.Prefix,
+					PathSeparatedPrefix: trimmedPrefix,
 				}
 			}
 		} else if pathMatch.SafeRegex != nil {

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -277,9 +277,9 @@ func buildXdsURLRewriteAction(destName string, urlRewrite *ir.URLRewrite, pathMa
 				(*urlRewrite.Path.PrefixMatchReplace == "" || *urlRewrite.Path.PrefixMatchReplace == "/") {
 				routeAction.RegexRewrite = &matcherv3.RegexMatchAndSubstitute{
 					Pattern: &matcherv3.RegexMatcher{
-						Regex: "^" + *pathMatch.Prefix,
+						Regex: "^" + *pathMatch.Prefix + `\/*`,
 					},
-					Substitution: "",
+					Substitution: "/",
 				}
 			} else {
 				routeAction.PrefixRewrite = *urlRewrite.Path.PrefixMatchReplace

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -107,7 +107,7 @@ func buildXdsRouteMatch(pathMatch *ir.StringMatch, headerMatches []*ir.StringMat
 				}
 			} else {
 				// Remove trailing /
-				strings.TrimSuffix(*pathMatch.Prefix, "/")
+				*pathMatch.Prefix = strings.TrimSuffix(*pathMatch.Prefix, "/")
 				outMatch.PathSpecifier = &routev3.RouteMatch_PathSeparatedPrefix{
 					PathSeparatedPrefix: *pathMatch.Prefix,
 				}

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -6,6 +6,8 @@
 package translator
 
 import (
+	"strings"
+
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
@@ -104,6 +106,8 @@ func buildXdsRouteMatch(pathMatch *ir.StringMatch, headerMatches []*ir.StringMat
 					Prefix: "/",
 				}
 			} else {
+				// Remove trailing /
+				strings.TrimSuffix(*pathMatch.Prefix, "/")
 				outMatch.PathSpecifier = &routev3.RouteMatch_PathSeparatedPrefix{
 					PathSeparatedPrefix: *pathMatch.Prefix,
 				}

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -6,8 +6,6 @@
 package translator
 
 import (
-	"strings"
-
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
@@ -101,10 +99,9 @@ func buildXdsRouteMatch(pathMatch *ir.StringMatch, headerMatches []*ir.StringMat
 				Path: *pathMatch.Exact,
 			}
 		} else if pathMatch.Prefix != nil {
-			// when the prefix ends with "/", use RouteMatch_Prefix
-			if strings.HasSuffix(*pathMatch.Prefix, "/") {
+			if *pathMatch.Prefix == "/" {
 				outMatch.PathSpecifier = &routev3.RouteMatch_Prefix{
-					Prefix: *pathMatch.Prefix,
+					Prefix: "/",
 				}
 			} else {
 				outMatch.PathSpecifier = &routev3.RouteMatch_PathSeparatedPrefix{
@@ -271,6 +268,7 @@ func buildXdsURLRewriteAction(destName string, urlRewrite *ir.URLRewrite, pathMa
 			// Circumvent the case of "//" when the replace string is "/"
 			// An empty replace string does not seem to solve the issue so we are using
 			// a regex match and replace instead
+			// Remove this workaround once https://github.com/envoyproxy/envoy/issues/26055 is fixed
 			if pathMatch != nil && pathMatch.Prefix != nil &&
 				(*urlRewrite.Path.PrefixMatchReplace == "" || *urlRewrite.Path.PrefixMatchReplace == "/") {
 				routeAction.RegexRewrite = &matcherv3.RegexMatchAndSubstitute{

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
@@ -10,10 +10,10 @@
         - name: :authority
           stringMatch:
             exact: gateway.envoyproxy.io
-        pathSeparatedPrefix: /origin/
+        pathSeparatedPrefix: /origin
       name: rewrite-route
       route:
         cluster: rewrite-route-dest
         regexRewrite:
           pattern:
-            regex: ^/origin/
+            regex: ^/origin

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
@@ -10,7 +10,7 @@
         - name: :authority
           stringMatch:
             exact: gateway.envoyproxy.io
-        prefix: /origin/
+        pathSeparatedPrefix: /origin/
       name: rewrite-route
       route:
         cluster: rewrite-route-dest

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
@@ -16,4 +16,4 @@
         cluster: rewrite-route-dest
         regexRewrite:
           pattern:
-            regex: ^/origin
+            regex: ^/origin/

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
@@ -14,4 +14,6 @@
       name: rewrite-route
       route:
         cluster: rewrite-route-dest
-        prefixRewrite: /
+        regexRewrite:
+          pattern:
+            regex: ^/origin/

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.routes.yaml
@@ -16,4 +16,5 @@
         cluster: rewrite-route-dest
         regexRewrite:
           pattern:
-            regex: ^/origin/
+            regex: ^/origin/\/*
+          substitution: /

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -48,7 +48,6 @@ func TestGatewayAPIConformance(t *testing.T) {
 		CleanupBaseResources: *flags.CleanupBaseResources,
 		SupportedFeatures:    suite.AllFeatures,
 		SkipTests: []string{
-			tests.HTTPRouteRewritePath.ShortName,
 			tests.GatewayStaticAddresses.ShortName,
 			tests.GatewayWithAttachedRoutes.ShortName,
 			tests.HTTPRouteBackendProtocolH2C.ShortName,

--- a/test/conformance/experimental_conformance_test.go
+++ b/test/conformance/experimental_conformance_test.go
@@ -97,7 +97,6 @@ func experimentalConformance(t *testing.T) {
 				CleanupBaseResources: *flags.CleanupBaseResources,
 				SupportedFeatures:    suite.AllFeatures,
 				SkipTests: []string{
-					tests.HTTPRouteRewritePath.ShortName,
 					tests.GatewayStaticAddresses.ShortName,
 					tests.GatewayWithAttachedRoutes.ShortName,
 					tests.HTTPRouteBackendProtocolH2C.ShortName,


### PR DESCRIPTION
* Addresses this conformance test https://github.com/kubernetes-sigs/gateway-api/blob/8f1b718543caae927bb4f57dfb538aff1efc8159/conformance/tests/httproute-rewrite-path.yaml#L32 by using a regex match and replace instead of a prefix replace, since a prefix replace adds a double slash
* tries to implement https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPPathModifier
* reverts #1125 which tried to solve the same problem
* trim the `/` suffix when it comes to prefix matches because Gateway API recommends ignoring the trailing `/` and envoy errors out when the trailing char is `/` for path separated prefix
* enhance IR sorting function so preference is given to exact match over path prefix match, this is needed when exact match of `/match` and path prefix match of `/match/` exists which need to reordered in envoy to make sure path prefix is not selected

Fixes: https://github.com/envoyproxy/gateway/issues/2004