### PR TITLE
docs: fix typo in bootstrap example

### DIFF
--- a/site/content/en/latest/user/customize-envoyproxy.md
+++ b/site/content/en/latest/user/customize-envoyproxy.md
@@ -236,7 +236,7 @@ metadata:
 spec:
   bootstrap:
     type: Replace
-    bootstrap: |
+    value: |
       admin:
         access_log:
         - name: envoy.access_loggers.file


### PR DESCRIPTION
The example to customize the bootstrap config is wrong and leads to an error:

```
cat eg.yaml| egctl x translate --from gateway-api --to xds  -f - 
Error: proto: syntax error (line 1:10): unexpected token [
proto: syntax error (line 1:10): unexpected token [
```
