### PR TITLE
doc: small patch cert-manager doc better experience

### DIFF
--- a/site/content/en/latest/user/tls-cert-manager.md
+++ b/site/content/en/latest/user/tls-cert-manager.md
@@ -182,6 +182,7 @@ spec:
           - kind: Gateway
             name: eg
             namespace: default
+EOF
 ```
 
 The important parts are
@@ -262,6 +263,7 @@ spec:
           - kind: Gateway
             name: eg
             namespace: default
+EOF
 ```
 
 And now you can update the Gateway listener to point to `letsencrypt` instead:

--- a/site/content/en/latest/user/tls-cert-manager.md
+++ b/site/content/en/latest/user/tls-cert-manager.md
@@ -210,7 +210,7 @@ Status:
 Now we're ready to update the Gateway annotation to use this issuer instead:
 
 ```console
-$ kubectl annotate --overwrite gateway/eg cert-manager.io/clusterissuer=letsencrypt-staging
+$ kubectl annotate --overwrite gateway/eg cert-manager.io/cluster-issuer=letsencrypt-staging
 ```
 
 The Gateway should be picked up by cert-manager, which will create a new certificate for you, and replace the Secret.
@@ -269,7 +269,7 @@ EOF
 And now you can update the Gateway listener to point to `letsencrypt` instead:
 
 ```console
-$ kubectl annotate --overwrite gateway/eg cert-manager.io/clusterissuer=letsencrypt
+$ kubectl annotate --overwrite gateway/eg cert-manager.io/cluster-issuer=letsencrypt
 ```
 
 As before, track it by looking at CertificateRequests.

--- a/site/content/en/v0.6.0/user/tls-cert-manager.md
+++ b/site/content/en/v0.6.0/user/tls-cert-manager.md
@@ -182,6 +182,7 @@ spec:
           - kind: Gateway
             name: eg
             namespace: default
+EOF
 ```
 
 The important parts are
@@ -262,6 +263,7 @@ spec:
           - kind: Gateway
             name: eg
             namespace: default
+EOF
 ```
 
 And now you can update the Gateway listener to point to `letsencrypt` instead:

--- a/site/content/en/v0.6.0/user/tls-cert-manager.md
+++ b/site/content/en/v0.6.0/user/tls-cert-manager.md
@@ -210,7 +210,7 @@ Status:
 Now we're ready to update the Gateway annotation to use this issuer instead:
 
 ```console
-$ kubectl annotate --overwrite gateway/eg cert-manager.io/clusterissuer=letsencrypt-staging
+$ kubectl annotate --overwrite gateway/eg cert-manager.io/cluster-issuer=letsencrypt-staging
 ```
 
 The Gateway should be picked up by cert-manager, which will create a new certificate for you, and replace the Secret.
@@ -269,7 +269,7 @@ EOF
 And now you can update the Gateway listener to point to `letsencrypt` instead:
 
 ```console
-$ kubectl annotate --overwrite gateway/eg cert-manager.io/clusterissuer=letsencrypt
+$ kubectl annotate --overwrite gateway/eg cert-manager.io/cluster-issuer=letsencrypt
 ```
 
 As before, track it by looking at CertificateRequests.


### PR DESCRIPTION
Annotation for cluster-issuer was also changed it seems:

Checkout https://cert-manager.io/docs/usage/gateway/#supported-annotations