### PR TITLE
update k8s version in compatibility matrix

### DIFF
--- a/site/content/en/blog/compatibility/matrix/matrix.md
+++ b/site/content/en/blog/compatibility/matrix/matrix.md
@@ -13,9 +13,9 @@ release.
 
 | Envoy Gateway version | Envoy Proxy version | Rate Limit version | Gateway API version | Kubernetes version  |
 | --------------------- | ------------------- | ------------------ | ------------------- | ------------------- |
-| v0.6.0                | **distroless-v1.28-latest** | **b9796237** | **v1.0.0**        | v1.25, v1.26, v1.27 |
+| v0.6.0                | **distroless-v1.28-latest** | **b9796237** | **v1.0.0**        | v1.26, v1.27, v1.28 |
 | v0.5.0                | **v1.27-latest**    | **e059638d**       | **v0.7.1**          | v1.25, v1.26, v1.27 |
 | v0.4.0                | **v1.26-latest**    | **542a6047**       | **v0.6.2**          | v1.25, v1.26, v1.27 |
 | v0.3.0                | **v1.25-latest**    | **f28024e3**       | **v0.6.1**          | v1.24, v1.25, v1.26 |
 | v0.2.0                | **v1.23-latest**    |                    | **v0.5.1**          | v1.24               |
-| latest                | **dev-latest**      | **master**         | **v1.0.0**          | v1.25, v1.26, v1.27 |
+| latest                | **dev-latest**      | **master**         | **v1.0.0**          | v1.26, v1.27, v1.28 |


### PR DESCRIPTION
Taken from https://github.com/envoyproxy/gateway/blob/fe12c418119eebf15f51f2e7146797e86410d5bf/.github/workflows/build_and_test.yaml#L107
