### PR TITLE
e2e: fix retry logic for e2e udp route

### DIFF
--- a/test/e2e/tests/udproute.go
+++ b/test/e2e/tests/udproute.go
@@ -54,7 +54,8 @@ var UDPRouteTest = suite.ConformanceTest{
 					t.Logf("performing DNS query %s on %s", domain, gwAddr)
 					_, err = dns.Exchange(msg, gwAddr)
 					if err != nil {
-						return false, err
+						t.Logf("failed to perform a UDP query: %v", err)
+						return false, nil
 					}
 					return true, nil
 				}); err != nil {
@@ -64,7 +65,7 @@ var UDPRouteTest = suite.ConformanceTest{
 	},
 }
 
-// GatewayRef is a tiny type for specifying an UDP Route ParentRef without
+// GatewayRef is a tiny type for specifying a UDP Route ParentRef without
 // relying on a specific api version.
 type GatewayRef struct {
 	types.NamespacedName


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
-->

e2e bug fix

**What this PR does / why we need it**:

`dns.Exchange` method should not return its error directly, nor it will end `PollUntilContextTimeout` immediately without any retry.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2266
