### PR TITLE
ci: add PR comment and cc reviewers

### DIFF
--- a/.github/workflows/welcome.yaml
+++ b/.github/workflows/welcome.yaml
@@ -26,7 +26,7 @@ jobs:
             - Your PR needs to receive at least two approvals.
             - At least one approval must come from a member of the gateway-maintainers team.
 
-            **NOTE**: Once your PR is under review, ***please do not rebase and force push it***. Otherwise, it will force your reviewers to review the PR from scratch rather than simply look at your latest changes. 
+            **NOTE**: Once your PR is under review, ***please do not rebase and force push it***. Otherwise, it will force your reviewers to review the PR from scratch rather than simply look at your latest changes.
 
             <details>
             <summary> What's more, you can help expedite the processing of your PR by </summary>

--- a/.github/workflows/welcome.yaml
+++ b/.github/workflows/welcome.yaml
@@ -15,26 +15,26 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            🚀 Thank you for contributing to the [Envoy Gateway](https://gateway.envoyproxy.io) project! 🚀
+            🚀 Thank you for contributing to the [Envoy Gateway](https://gateway.envoyproxy.io/) project! 🚀
 
-            Your PR has been successfully submitted, and we greatly appreciate your effort and contribution. Before merging, please ensure to follow the process below:
+            Before merging, please ensure to follow the process below:
 
-            1. **Requesting Reviews**:
-              - cc @envoyproxy/gateway-reviewers team for an initial review.
-              - After the initial review, reviewers should request the @envoyproxy/gateway-maintainers team for further review.
+            1. Requesting Reviews:
+            - cc @envoyproxy/gateway-reviewers team for an initial review.
+            - After the initial review, reviewers should request the @envoyproxy/gateway-maintainers team for further review.
+            2. Review Approval:
+            - Your PR needs to receive at least two approvals.
+            - At least one approval must come from a member of the gateway-maintainers team.
 
-            2. **Review Approval**:
-              - Your PR needs to receive at least **two** approvals.
-              - At least **one** approval must come from a member of the gateway-maintainers team.
+            **NOTE**: Once your PR is under review, ***please do not rebase and force push it***. Otherwise, it will force your reviewers to review the PR from scratch rather than simply look at your latest changes. 
 
-            Our [Build and Test Workflow](https://github.com/envoyproxy/gateway/actions/workflows/build_and_test.yaml) will run a series of checks on your code to ensure it meets our quality standards and coding conventions. In the meantime, you can help expedite the processing of your PR by:
+            <details>
+            <summary> What's more, you can help expedite the processing of your PR by </summary>
+            <br>
+
             - Ensuring you have self-reviewed your work according to the project's [Contribution Guidelines](https://gateway.envoyproxy.io/latest/contributions/develop).
             - If your PR addresses a specific issue, make sure to mention it in the PR description.
             - Respond promptly if there are any test failures or suggestions for improvements that we comment on.
 
-            Envoy Gateway team will review your PR as soon as possible. If all goes well, your code will soon be merged into the main branch. Should further modifications be required or if there are any questions, we will communicate with you in the PR comments.
-
-            Thank you once again for your contribution, we look forward to your excellent code bringing more possibilities to the Envoy Gateway!
-
-            Happy coding!
+            </details>
           reactions: 'heart'

--- a/.github/workflows/welcome.yaml
+++ b/.github/workflows/welcome.yaml
@@ -1,0 +1,40 @@
+name: Welcome
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  comment:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            🚀 Thank you for contributing to the [Envoy Gateway](https://gateway.envoyproxy.io) project! 🚀
+
+            Your PR has been successfully submitted, and we greatly appreciate your effort and contribution. Before merging, please ensure to follow the process below:
+
+            1. **Requesting Reviews**:
+              - cc @envoyproxy/gateway-reviewers team for an initial review.
+              - After the initial review, reviewers should request the @envoyproxy/gateway-maintainers team for further review.
+
+            2. **Review Approval**:
+              - Your PR needs to receive at least **two** approvals.
+              - At least **one** approval must come from a member of the gateway-maintainers team.
+
+            Our [Build and Test Workflow](https://github.com/envoyproxy/gateway/actions/workflows/build_and_test.yaml) will run a series of checks on your code to ensure it meets our quality standards and coding conventions. In the meantime, you can help expedite the processing of your PR by:
+            - Ensuring you have self-reviewed your work according to the project's [Contribution Guidelines](https://gateway.envoyproxy.io/latest/contributions/develop).
+            - If your PR addresses a specific issue, make sure to mention it in the PR description.
+            - Respond promptly if there are any test failures or suggestions for improvements that we comment on.
+
+            Envoy Gateway team will review your PR as soon as possible. If all goes well, your code will soon be merged into the main branch. Should further modifications be required or if there are any questions, we will communicate with you in the PR comments.
+
+            Thank you once again for your contribution, we look forward to your excellent code bringing more possibilities to the Envoy Gateway!
+
+            Happy coding!
+          reactions: 'heart'


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

We tried a couple of ways to auto request reviews from @envoyproxy/gateway-reviewers, but it failed, and I tried it too today, failed again.

So current way is to add a welcome comment to cc @envoyproxy/gateway-maintainers and @envoyproxy/gateway-reviewers, they should get the ping too.

