### PR TITLE
chore: reuse validateSecretRef for TLS secret validation

### DIFF
--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -443,7 +443,7 @@ func (t *Translator) buildOIDC(
 		namespace: policy.Namespace,
 	}
 	if clientSecret, err = t.validateSecretRef(
-		false, from, oidc.ClientSecret, resources); err != nil {
+		oidc.ClientSecret, false, from, resources); err != nil {
 		return nil, err
 	}
 
@@ -576,7 +576,7 @@ func (t *Translator) buildBasicAuth(
 		namespace: policy.Namespace,
 	}
 	if usersSecret, err = t.validateSecretRef(
-		false, from, basicAuth.Users, resources); err != nil {
+		basicAuth.Users, false, from, resources); err != nil {
 		return nil, err
 	}
 

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
@@ -28,7 +28,7 @@ gateways:
       - lastTransitionTime: null
         message: Certificate ref to secret default/tls-secret-1 not permitted by any
           ReferenceGrant.
-        reason: RefNotPermitted
+        reason: InvalidCertificateRef
         status: "False"
         type: ResolvedRefs
       - lastTransitionTime: null


### PR DESCRIPTION
This is a small refactor to remove duplicated secret validation code.