### PR TITLE
fix: allow envoyHpa maxReplicas to be equal to minReplicas

### DIFF
--- a/api/v1alpha1/envoyproxy_types.go
+++ b/api/v1alpha1/envoyproxy_types.go
@@ -134,7 +134,7 @@ type EnvoyProxyKubernetesProvider struct {
 	// +optional
 	// +kubebuilder:validation:XValidation:message="minReplicas must be greater than 0",rule="!has(self.minReplicas) || self.minReplicas > 0"
 	// +kubebuilder:validation:XValidation:message="maxReplicas must be greater than 0",rule="!has(self.maxReplicas) || self.maxReplicas > 0"
-	// +kubebuilder:validation:XValidation:message="maxReplicas cannot be less than or equal to minReplicas",rule="!has(self.minReplicas) || self.maxReplicas > self.minReplicas"
+	// +kubebuilder:validation:XValidation:message="maxReplicas cannot be less than minReplicas",rule="!has(self.minReplicas) || self.maxReplicas >= self.minReplicas"
 	EnvoyHpa *KubernetesHorizontalPodAutoscalerSpec `json:"envoyHpa,omitempty"`
 }
 

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
@@ -6272,8 +6272,8 @@ spec:
                           rule: '!has(self.minReplicas) || self.minReplicas > 0'
                         - message: maxReplicas must be greater than 0
                           rule: '!has(self.maxReplicas) || self.maxReplicas > 0'
-                        - message: maxReplicas cannot be less than or equal to minReplicas
-                          rule: '!has(self.minReplicas) || self.maxReplicas > self.minReplicas'
+                        - message: maxReplicas cannot be less than minReplicas
+                          rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
                       envoyService:
                         description: EnvoyService defines the desired state of the
                           Envoy service resource. If unspecified, default settings

--- a/test/cel-validation/envoyproxy_test.go
+++ b/test/cel-validation/envoyproxy_test.go
@@ -481,7 +481,24 @@ func TestEnvoyProxyProvider(t *testing.T) {
 					},
 				}
 			},
-			wantErrors: []string{"maxReplicas cannot be less than or equal to minReplicas"},
+			wantErrors: []string{"maxReplicas cannot be less than minReplicas"},
+		},
+		{
+			desc: "ProxyHpa-maxReplicas-equals-to-minReplicas",
+			mutate: func(envoy *egv1a1.EnvoyProxy) {
+				envoy.Spec = egv1a1.EnvoyProxySpec{
+					Provider: &egv1a1.EnvoyProxyProvider{
+						Type: egv1a1.ProviderTypeKubernetes,
+						Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
+							EnvoyHpa: &egv1a1.KubernetesHorizontalPodAutoscalerSpec{
+								MinReplicas: ptr.To[int32](2),
+								MaxReplicas: ptr.To[int32](2),
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{},
 		},
 		{
 			desc: "ProxyHpa-valid",


### PR DESCRIPTION
**What this PR does / why we need it**:
According to hpa [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#horizontalpodautoscalerspec-v2-autoscaling) `maxReplicas` cannot be less that `minReplicas`. The current cel validation also forbids it to be equal to `minReplicas`.
This PR fixes the validation to be aligned with the spec and also adds a test.

**Which issue(s) this PR fixes**: N/A

