### PR TITLE
Run CI on k8s v1.29.0

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -76,7 +76,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        version: [ v1.26.6, v1.27.3, v1.28.0 ]
+        version: [ v1.27.3, v1.28.0, v1.29.0 ]
     steps:
     - uses: actions/checkout@v4
     - uses: ./tools/github-actions/setup-deps
@@ -104,7 +104,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        version: [ v1.26.6, v1.27.3, v1.28.0 ]
+        version: [ v1.27.3, v1.28.0, v1.29.0 ]
     steps:
     - uses: actions/checkout@v4
     - uses: ./tools/github-actions/setup-deps


### PR DESCRIPTION
* rm'd v1.26 for now, since we are only running last 3 versions

* k8s support matrix should be revisited pre GA