### PR TITLE
feat(helm): support affinity configuration for EnvoyGateway pod

### DIFF
--- a/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
@@ -33,6 +33,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.deployment.pod.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args:
         - server

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -20,6 +20,7 @@ deployment:
       targetPort: 18001
   replicas: 1
   pod:
+    affinity: {}
     annotations: {}
     labels: {}
 

--- a/site/content/en/latest/install/api.md
+++ b/site/content/en/latest/install/api.md
@@ -39,6 +39,7 @@ The Helm chart for Envoy Gateway
 | deployment.envoyGateway.resources.limits.memory | string | `"1024Mi"` |  |
 | deployment.envoyGateway.resources.requests.cpu | string | `"100m"` |  |
 | deployment.envoyGateway.resources.requests.memory | string | `"256Mi"` |  |
+| deployment.pod.affinity | object | `{}` |  |
 | deployment.pod.annotations | object | `{}` |  |
 | deployment.pod.labels | object | `{}` |  |
 | deployment.ports[0].name | string | `"grpc"` |  |


### PR DESCRIPTION
**What type of PR is this?**
Feature - Add support for affinity configuration in `EnvoyGateway` pod.

**What this PR does / why we need it**:
A sample use case for affinity configuration is making `EnvoyGateway` HA on different nodes (By adding AntiAffinity rule).

**Which issue(s) this PR fixes**: N/A
