### PR TITLE
expose redirect uri to oidc API

### DIFF
--- a/api/v1alpha1/oidc_types.go
+++ b/api/v1alpha1/oidc_types.go
@@ -30,6 +30,13 @@ type OIDC struct {
 	// +kubebuilder:validation:Required
 	ClientSecret gwapiv1b1.SecretObjectReference `json:"clientSecret"`
 
+	// The redirect URI to be used in the OIDC
+	// [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+	//
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
+	RedirectURI string `json:"redirectURI"`
+
 	// The OIDC scopes to be used in the
 	// [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
 	// The "openid" scope is always added to the list of scopes if not already

--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -467,12 +467,32 @@ func (t *Translator) buildOIDC(
 	}
 	scopes := appendOpenidScopeIfNotExist(oidc.Scopes)
 
+	redirectPathMatcher := redirectPath(oidc.RedirectURI)
+	if redirectPathMatcher == "" {
+		return nil, fmt.Errorf("invalid redirect URI: %s", oidc.RedirectURI)
+	}
+
 	return &ir.OIDC{
-		Provider:     *provider,
-		ClientID:     oidc.ClientID,
-		ClientSecret: clientSecretBytes,
-		Scopes:       scopes,
+		Provider:            *provider,
+		ClientID:            oidc.ClientID,
+		ClientSecret:        clientSecretBytes,
+		RedirectURI:         oidc.RedirectURI,
+		RedirectPathMatcher: redirectPathMatcher,
+		Scopes:              scopes,
 	}, nil
+}
+
+func redirectPath(redirectURI string) string {
+	count := 0
+	for i, char := range redirectURI {
+		if char == '/' {
+			count++
+			if count == 3 {
+				return redirectURI[i:]
+			}
+		}
+	}
+	return ""
 }
 
 // appendOpenidScopeIfNotExist appends the openid scope to the provided scopes

--- a/internal/gatewayapi/securitypolicy_test.go
+++ b/internal/gatewayapi/securitypolicy_test.go
@@ -1,0 +1,37 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package gatewayapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_redirectPathMatcher(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		redirectURI string
+		want        string
+	}{
+		{
+			name:        "redirectURI with path",
+			redirectURI: "https://example.com/test/oauth2/callback",
+			want:        "/test/oauth2/callback",
+		},
+		{
+			name:        "redirectURI with header tokens",
+			redirectURI: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/test/oauth2/callback",
+			want:        "/test/oauth2/callback",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, redirectPath(tt.redirectURI), "redirectPathMatcher(%v)", tt.redirectURI)
+		})
+	}
+}

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-and-invalid-oidc.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-and-invalid-oidc.in.yaml
@@ -81,6 +81,7 @@ securityPolicies:
       clientID: "client1.apps.googleusercontent.com"
       clientSecret:
         name: "client1-secret"
+      redirectURI: "https://www.example.com/oauth2/callback"
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: SecurityPolicy
   metadata:
@@ -109,3 +110,4 @@ securityPolicies:
       clientID: "client1.apps.googleusercontent.com"
       clientSecret:
         name: "client2-secret"
+      redirectURI: "https://www.example.com/oauth2/callback"

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-and-invalid-oidc.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-and-invalid-oidc.out.yaml
@@ -159,6 +159,7 @@ securityPolicies:
         name: client2-secret
       provider:
         issuer: https://accounts.google.com
+      redirectURI: https://www.example.com/oauth2/callback
     targetRef:
       group: gateway.networking.k8s.io
       kind: HTTPRoute
@@ -197,6 +198,7 @@ securityPolicies:
         name: client1-secret
       provider:
         issuer: https://accounts.google.com
+      redirectURI: https://www.example.com/oauth2/callback
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.in.yaml
@@ -38,3 +38,4 @@ securityPolicies:
       clientID: "client1.apps.foo.bar.com"
       clientSecret:
         name: "client1-secret"
+      redirectURI: "https://www.example.com/oauth2/callback"

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.out.yaml
@@ -71,6 +71,7 @@ securityPolicies:
         name: client1-secret
       provider:
         issuer: https://httpbin.org/
+      redirectURI: https://www.example.com/oauth2/callback
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-secretref.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-secretref.in.yaml
@@ -76,6 +76,7 @@ securityPolicies:
       clientID: "client1.apps.googleusercontent.com"
       clientSecret:
         name: "client1-secret"
+      redirectURI: "https://www.example.com/oauth2/callback"
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: SecurityPolicy
   metadata:
@@ -95,6 +96,7 @@ securityPolicies:
       clientSecret:
         namespace: envoy-gateway
         name: "client2-secret"
+      redirectURI: "https://www.example.com/oauth2/callback"
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: SecurityPolicy
   metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-secretref.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-secretref.out.yaml
@@ -183,6 +183,7 @@ securityPolicies:
         authorizationEndpoint: https://accounts.google.com/o/oauth2/v2/auth
         issuer: https://accounts.google.com
         tokenEndpoint: https://oauth2.googleapis.com/token
+      redirectURI: https://www.example.com/oauth2/callback
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway
@@ -212,6 +213,7 @@ securityPolicies:
         authorizationEndpoint: https://accounts.google.com/o/oauth2/v2/auth
         issuer: https://accounts.google.com
         tokenEndpoint: https://oauth2.googleapis.com/token
+      redirectURI: https://www.example.com/oauth2/callback
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway
@@ -241,6 +243,7 @@ securityPolicies:
         authorizationEndpoint: https://accounts.google.com/o/oauth2/v2/auth
         issuer: https://accounts.google.com
         tokenEndpoint: https://oauth2.googleapis.com/token
+      redirectURI: ""
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc.in.yaml
@@ -107,6 +107,7 @@ securityPolicies:
       clientID: "client1.apps.googleusercontent.com"
       clientSecret:
         name: "client1-secret"
+      redirectURI: "https://www.example.com/bar/oauth2/callback"
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: SecurityPolicy
   metadata:
@@ -126,6 +127,7 @@ securityPolicies:
       clientID: "client2.oauth.foo.com"
       clientSecret:
         name: "client2-secret"
+      redirectURI: "https://www.example.com/foo/oauth2/callback"
       scopes: ["openid", "email", "profile"]
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: SecurityPolicy

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc.out.yaml
@@ -184,6 +184,7 @@ securityPolicies:
         authorizationEndpoint: https://oauth.foo.com/oauth2/v2/auth
         issuer: https://oauth.foo.com
         tokenEndpoint: https://oauth.foo.com/token
+      redirectURI: https://www.example.com/foo/oauth2/callback
       scopes:
       - openid
       - email
@@ -218,6 +219,7 @@ securityPolicies:
         authorizationEndpoint: https://oauth.bar.com/oauth2/v2/auth
         issuer: https://oauth.bar.com
         tokenEndpoint: https://oauth.bar.com/token
+      redirectURI: ""
     targetRef:
       group: gateway.networking.k8s.io
       kind: GRPCRoute
@@ -225,9 +227,9 @@ securityPolicies:
   status:
     conditions:
     - lastTransitionTime: null
-      message: SecurityPolicy has been accepted.
-      reason: Accepted
-      status: "True"
+      message: 'Invalid redirect URI: '
+      reason: Invalid
+      status: "False"
       type: Accepted
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: SecurityPolicy
@@ -244,6 +246,7 @@ securityPolicies:
         name: client1-secret
       provider:
         issuer: https://accounts.google.com
+      redirectURI: https://www.example.com/bar/oauth2/callback
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway
@@ -289,6 +292,8 @@ xdsIR:
           provider:
             authorizationEndpoint: https://oauth.foo.com/oauth2/v2/auth
             tokenEndpoint: https://oauth.foo.com/token
+          redirectPathMatcher: /foo/oauth2/callback
+          redirectURI: https://www.example.com/foo/oauth2/callback
           scopes:
           - openid
           - email
@@ -317,6 +322,8 @@ xdsIR:
           provider:
             authorizationEndpoint: https://accounts.google.com/o/oauth2/v2/auth
             tokenEndpoint: https://oauth2.googleapis.com/token
+          redirectPathMatcher: /bar/oauth2/callback
+          redirectURI: https://www.example.com/bar/oauth2/callback
           scopes:
           - openid
         pathMatch:
@@ -338,10 +345,12 @@ xdsIR:
         hostname: '*'
         name: grpcroute/default/grpcroute-1/rule/0/match/-1/*
         oidc:
-          clientID: client3.bar.foo.com
+          clientID: client1.apps.googleusercontent.com
           clientSecret: Y2xpZW50MTpzZWNyZXQK
           provider:
-            authorizationEndpoint: https://oauth.bar.com/oauth2/v2/auth
-            tokenEndpoint: https://oauth.bar.com/token
+            authorizationEndpoint: https://accounts.google.com/o/oauth2/v2/auth
+            tokenEndpoint: https://oauth2.googleapis.com/token
+          redirectPathMatcher: /bar/oauth2/callback
+          redirectURI: https://www.example.com/bar/oauth2/callback
           scopes:
           - openid

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -365,8 +365,14 @@ type OIDC struct {
 	// [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
 	//
 	// This is an Opaque secret. The client secret should be stored in the key "client-secret".
+	ClientSecret []byte `json:"clientSecret" yaml:"clientSecret"`
 
-	ClientSecret []byte `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	// The redirect URI to be used in the
+	// [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+	RedirectURI string `json:"redirectURI" yaml:"redirectURI"`
+
+	// Matching rule for the redirect path.
+	RedirectPathMatcher string `json:"redirectPathMatcher" yaml:"redirectPathMatcher"`
 
 	// The OIDC scopes to be used in the
 	// [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).

--- a/internal/xds/translator/oidc.go
+++ b/internal/xds/translator/oidc.go
@@ -28,8 +28,6 @@ import (
 const (
 	oauth2Filter                = "envoy.filters.http.oauth2"
 	defaultTokenEndpointTimeout = 10
-	redirectURL                 = "%REQ(x-forwarded-proto)%://%REQ(:authority)%/oauth2/callback"
-	redirectPathMatcher         = "/oauth2/callback"
 	defaultSignoutPath          = "/signout"
 )
 
@@ -131,12 +129,12 @@ func oauth2Config(route *ir.HTTPRoute) (*oauth2v3.OAuth2, error) {
 				},
 			},
 			AuthorizationEndpoint: route.OIDC.Provider.AuthorizationEndpoint,
-			RedirectUri:           redirectURL,
+			RedirectUri:           route.OIDC.RedirectURI,
 			RedirectPathMatcher: &matcherv3.PathMatcher{
 				Rule: &matcherv3.PathMatcher_Path{
 					Path: &matcherv3.StringMatcher{
 						MatchPattern: &matcherv3.StringMatcher_Exact{
-							Exact: redirectPathMatcher,
+							Exact: route.OIDC.RedirectPathMatcher,
 						},
 					},
 				},

--- a/internal/xds/translator/testdata/in/xds-ir/oidc.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/oidc.yaml
@@ -18,6 +18,8 @@ http:
     oidc:
       clientID: client.oauth.foo.com
       clientSecret: Y2xpZW50MTpzZWNyZXQK
+      redirectURI: "https://www.example.com/foo/oauth2/callback"
+      redirectPathMatcher: "/foo/oauth2/callback"
       provider:
         authorizationEndpoint: https://oauth.foo.com/oauth2/v2/auth
         tokenEndpoint: https://oauth.foo.com/token
@@ -38,6 +40,8 @@ http:
     oidc:
       clientID: client.oauth.bar.com
       clientSecret: Y2xpZW50MTpzZWNyZXQK
+      redirectURI: "https://www.example.com/bar/oauth2/callback"
+      redirectPathMatcher: "/bar/oauth2/callback"
       provider:
         authorizationEndpoint: https://oauth.bar.com/oauth2/v2/auth
         tokenEndpoint: https://oauth.bar.com/token
@@ -58,6 +62,8 @@ http:
     oidc:
       clientID: test.oauth.bar.com
       clientSecret: Y2xpZW50MTpzZWNyZXQK
+      redirectURI: "https://www.example.com/test/oauth2/callback"
+      redirectPathMatcher: "/test/oauth2/callback"
       provider:
         authorizationEndpoint: https://oauth.bar.com/oauth2/v2/auth
         tokenEndpoint: https://oauth.bar.com/token

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.listeners.yaml
@@ -39,8 +39,8 @@
               forwardBearerToken: true
               redirectPathMatcher:
                 path:
-                  exact: /oauth2/callback
-              redirectUri: '%REQ(x-forwarded-proto)%://%REQ(:authority)%/oauth2/callback'
+                  exact: /foo/oauth2/callback
+              redirectUri: https://www.example.com/foo/oauth2/callback
               signoutPath:
                 path:
                   exact: /signout
@@ -73,8 +73,8 @@
               forwardBearerToken: true
               redirectPathMatcher:
                 path:
-                  exact: /oauth2/callback
-              redirectUri: '%REQ(x-forwarded-proto)%://%REQ(:authority)%/oauth2/callback'
+                  exact: /bar/oauth2/callback
+              redirectUri: https://www.example.com/bar/oauth2/callback
               signoutPath:
                 path:
                   exact: /signout
@@ -107,8 +107,8 @@
               forwardBearerToken: true
               redirectPathMatcher:
                 path:
-                  exact: /oauth2/callback
-              redirectUri: '%REQ(x-forwarded-proto)%://%REQ(:authority)%/oauth2/callback'
+                  exact: /test/oauth2/callback
+              redirectUri: https://www.example.com/test/oauth2/callback
               signoutPath:
                 path:
                   exact: /signout

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -1245,6 +1245,7 @@ _Appears in:_
 | `clientID` _string_ | The client ID to be used in the OIDC [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest). |
 | `clientSecret` _[SecretObjectReference](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.SecretObjectReference)_ | The Kubernetes secret which contains the OIDC client secret to be used in the [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest). 
  This is an Opaque secret. The client secret should be stored in the key "client-secret". |
+| `redirectURI` _string_ | The redirect URI to be used in the OIDC [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest). |
 | `scopes` _string array_ | The OIDC scopes to be used in the [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest). The "openid" scope is always added to the list of scopes if not already specified. |
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The current OIDC implementation uses a fixed redirect url: `/oauth2/callback`. It causes problem if this url doesn't match the HTTPRoute because the oauth2 filter can not receive the callback form the OIDC provider.

This PR exposes redirect uri to oidc API to make it possible to set the redirect uri to match the HTTPRoute url. For example:

HTTPRoute
```yaml
kind: HTTPRoute
metadata:
  name: backend
spec:
  hostnames:
  - www.example.com
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: eg
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /    # the current default redirect uri will be caught by this route, which has no oauth2 filter in its configuration.
    backendRefs:
    - group: ""
      kind: Service
      name: backend
      port: 3000
  - matches:
    - path:
        type: PathPrefix
        value: /secret-page
    backendRefs:
    - group: ""
      kind: Service
      name: backend
      port: 3000
```
SecurityPolicy
```yaml
apiVersion: gateway.envoyproxy.io/v1alpha1
kind: SecurityPolicy
metadata:
  name: oidc-example
spec:
  oidc:
    # set redirect_uri to `/secret-page/oauth2/callback` to make sure the redirect from the OIDC provider can reach the correct HTTPRoute 
    redirect_uri: /secret-page/oauth2/callback 
    clientID: 250344188863-uve9br9mtrj05j2tfn8ls7n3fhemg3sr.apps.googleusercontent.com
    clientSecret:
      group: ""
      kind: Secret
      name: my-app-client-secret
    provider:
      issuer: https://accounts.google.com
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: backend
  ```

fix: https://github.com/envoyproxy/gateway/issues/2326