### PR TITLE
fix(helm): fix incorrect imagePullSecrets indentation

### DIFF
--- a/charts/gateway-helm/templates/certgen.yaml
+++ b/charts/gateway-helm/templates/certgen.yaml
@@ -33,11 +33,11 @@ spec:
           value: {{ .Values.kubernetesClusterDomain }}
         image: {{ .Values.deployment.envoyGateway.image.repository }}:{{ .Values.deployment.envoyGateway.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.deployment.envoyGateway.imagePullPolicy }}
-        {{- with .Values.deployment.envoyGateway.imagePullSecrets }}
-        imagePullSecrets:
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
         name: envoy-gateway-certgen
+      {{- with .Values.deployment.envoyGateway.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       securityContext:
         runAsGroup: 65534

--- a/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
@@ -51,10 +51,6 @@ spec:
           value: {{ .Values.kubernetesClusterDomain }}
         image: {{ .Values.deployment.envoyGateway.image.repository }}:{{ .Values.deployment.envoyGateway.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.deployment.envoyGateway.imagePullPolicy }}
-        {{- with .Values.deployment.envoyGateway.imagePullSecrets }}
-        imagePullSecrets:
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -79,6 +75,10 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
+      {{- with .Values.deployment.envoyGateway.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: envoy-gateway


### PR DESCRIPTION
**What type of PR is this?**
Bug fix. 

**What this PR does / why we need it**:
It fixes wrong indentation of imagePullSecrets in both EG deployment and certgen job - should be under pod spec instead of under container.
Tested by installing chart to kind cluster - once with default values and once with secret ref.

**Which issue(s) this PR fixes**: N/A
