### PR TITLE
use wildcard to match alloworigins

### DIFF
--- a/api/v1alpha1/cors_types.go
+++ b/api/v1alpha1/cors_types.go
@@ -7,11 +7,27 @@ package v1alpha1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+// Origin is defined by the scheme (protocol), hostname (domain), and port of
+// the URL used to access it. The hostname can be “precise” which is just the
+// domain name or “wildcard” which is a domain name prefixed with a single
+// wildcard label such as “*.example.com”.
+//
+// For example, the following are valid origins:
+// - https://foo.example.com
+// - https://*.example.com
+// - http://foo.example.com:8080
+// - http://*.example.com:8080
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^https?:\/\/(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[0-9]+)?$`
+type Origin string
+
 // CORS defines the configuration for Cross-Origin Resource Sharing (CORS).
 type CORS struct {
 	// AllowOrigins defines the origins that are allowed to make requests.
 	// +kubebuilder:validation:MinItems=1
-	AllowOrigins []StringMatch `json:"allowOrigins,omitempty" yaml:"allowOrigins"`
+	AllowOrigins []Origin `json:"allowOrigins,omitempty" yaml:"allowOrigins"`
 	// AllowMethods defines the methods that are allowed to make requests.
 	// +kubebuilder:validation:MinItems=1
 	AllowMethods []string `json:"allowMethods,omitempty" yaml:"allowMethods"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -166,10 +166,8 @@ func (in *CORS) DeepCopyInto(out *CORS) {
 	*out = *in
 	if in.AllowOrigins != nil {
 		in, out := &in.AllowOrigins, &out.AllowOrigins
-		*out = make([]StringMatch, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = make([]Origin, len(*in))
+		copy(*out, *in)
 	}
 	if in.AllowMethods != nil {
 		in, out := &in.AllowMethods, &out.AllowMethods

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -123,28 +123,17 @@ spec:
                     description: AllowOrigins defines the origins that are allowed
                       to make requests.
                     items:
-                      description: StringMatch defines how to match any strings. This
-                        is a general purpose match condition that can be used by other
-                        EG APIs that need to match against a string.
-                      properties:
-                        type:
-                          default: Exact
-                          description: Type specifies how to match against a string.
-                          enum:
-                          - Exact
-                          - Prefix
-                          - Suffix
-                          - RegularExpression
-                          type: string
-                        value:
-                          description: Value specifies the string value that the match
-                            must have.
-                          maxLength: 1024
-                          minLength: 1
-                          type: string
-                      required:
-                      - value
-                      type: object
+                      description: "Origin is defined by the scheme (protocol), hostname
+                        (domain), and port of the URL used to access it. The hostname
+                        can be “precise” which is just the domain name or “wildcard”
+                        which is a domain name prefixed with a single wildcard label
+                        such as “*.example.com”. \n For example, the following are
+                        valid origins: - https://foo.example.com - https://*.example.com
+                        - http://foo.example.com:8080 - http://*.example.com:8080"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^https?:\/\/(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[0-9]+)?$
+                      type: string
                     minItems: 1
                     type: array
                   exposeHeaders:

--- a/internal/gatewayapi/securitypolicy_test.go
+++ b/internal/gatewayapi/securitypolicy_test.go
@@ -1,0 +1,76 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package gatewayapi
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_wildcard2regex(t *testing.T) {
+	tests := []struct {
+		name     string
+		wildcard string
+		origin   string
+		want     int
+	}{
+		{
+			name:     "test1",
+			wildcard: "http://*.example.com",
+			origin:   "http://foo.example.com",
+			want:     1,
+		},
+		{
+			name:     "test2",
+			wildcard: "http://*.example.com",
+			origin:   "http://foo.bar.example.com",
+			want:     1,
+		},
+		{
+			name:     "test3",
+			wildcard: "http://*.example.com",
+			origin:   "http://foo.bar.com",
+			want:     0,
+		},
+		{
+			name:     "test4",
+			wildcard: "http://*.example.com",
+			origin:   "https://foo.example.com",
+			want:     0,
+		},
+		{
+			name:     "test5",
+			wildcard: "http://*.example.com:8080",
+			origin:   "http://foo.example.com:8080",
+			want:     1,
+		},
+		{
+			name:     "test6",
+			wildcard: "http://*.example.com:8080",
+			origin:   "http://foo.bar.example.com:8080",
+			want:     1,
+		},
+		{
+			name:     "test7",
+			wildcard: "http://*.example.com:8080",
+			origin:   "http://foo.example.com",
+			want:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			regexStr := wildcard2regex(tt.wildcard)
+			regex, err := regexp.Compile(regexStr)
+			require.Nil(t, err)
+			finds := regex.FindAllString(tt.origin, -1)
+			assert.Equalf(t, tt.want, len(finds), "wildcard2regex(%v)", tt.wildcard)
+		})
+	}
+}

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors.in.yaml
@@ -76,10 +76,8 @@ securityPolicies:
       namespace: envoy-gateway
     cors:
       allowOrigins:
-      - type: RegularExpression
-        value: "FooBar[0-9]+"
-      - type: Exact
-        value: foo.bar.com
+      - "http://*.example.com"
+      - "http://foo.bar.com"
       allowMethods:
       - GET
       - POST
@@ -103,10 +101,8 @@ securityPolicies:
       namespace: default
     cors:
       allowOrigins:
-      - type: Prefix
-        value: example
-      - type: Suffix
-        value: bar.org
+      - "https://*.test.com:8080"
+      - "https://www.test.org:8080"
       allowMethods:
       - GET
       - POST

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
@@ -199,10 +199,8 @@ securityPolicies:
       - GET
       - POST
       allowOrigins:
-      - type: Prefix
-        value: example
-      - type: Suffix
-        value: bar.org
+      - https://*.test.com:8080
+      - https://www.test.org:8080
       exposeHeaders:
       - x-header-7
       - x-header-8
@@ -234,10 +232,8 @@ securityPolicies:
       - GET
       - POST
       allowOrigins:
-      - type: RegularExpression
-        value: FooBar[0-9]+
-      - type: Exact
-        value: foo.bar.com
+      - http://*.example.com
+      - http://foo.bar.com
       exposeHeaders:
       - x-header-3
       - x-header-4
@@ -280,9 +276,9 @@ xdsIR:
           allowOrigins:
           - distinct: false
             name: ""
-            safeRegex: FooBar[0-9]+
+            safeRegex: http://.*\.example\.com
           - distinct: false
-            exact: foo.bar.com
+            exact: http://foo.bar.com
             name: ""
           exposeHeaders:
           - x-header-3
@@ -324,10 +320,10 @@ xdsIR:
           allowOrigins:
           - distinct: false
             name: ""
-            prefix: example
+            safeRegex: https://.*\.test\.com:8080
           - distinct: false
+            exact: https://www.test.org:8080
             name: ""
-            suffix: bar.org
           exposeHeaders:
           - x-header-7
           - x-header-8

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -131,7 +131,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `allowOrigins` _[StringMatch](#stringmatch) array_ | AllowOrigins defines the origins that are allowed to make requests. |
+| `allowOrigins` _Origin array_ | AllowOrigins defines the origins that are allowed to make requests. |
 | `allowMethods` _string array_ | AllowMethods defines the methods that are allowed to make requests. |
 | `allowHeaders` _string array_ | AllowHeaders defines the headers that are allowed to be sent with requests. |
 | `exposeHeaders` _string array_ | ExposeHeaders defines the headers that can be exposed in the responses. |
@@ -1833,7 +1833,6 @@ _Appears in:_
 StringMatch defines how to match any strings. This is a general purpose match condition that can be used by other EG APIs that need to match against a string.
 
 _Appears in:_
-- [CORS](#cors)
 - [ProxyMetrics](#proxymetrics)
 
 | Field | Description |

--- a/site/content/en/latest/user/cors.md
+++ b/site/content/en/latest/user/cors.md
@@ -31,8 +31,8 @@ spec:
     name: backend
   cors:
     allowOrigins:
-    - type: RegularExpression
-      value: .*\.foo\.com
+    - "http://*.foo.com"
+    - "http://*.foo.com:80"
     allowMethods:
     - GET
     - POST
@@ -93,6 +93,19 @@ curl -H "Origin: http://www.bar.com" \
 ```
 
 You won't see any CORS headers in the response, indicating that the request from `http://www.bar.com` was not allowed.
+
+If you try to send a request from `http://www.foo.com:8080`, you should also see similar response because the port number 
+`8080` is not included in the allowed origins.
+
+```shell
+```shell
+curl -H "Origin: http://www.foo.com:8080" \
+  -H "Host: www.example.com" \
+  -H "Access-Control-Request-Method: GET" \
+  -X OPTIONS -v -s \
+  http://$GATEWAY_HOST \
+  1> /dev/null
+```
 
 Note: CORS specification requires that the browsers to send a preflight request to the server to ask if it's allowed
 to access the limited resource in another domains. The browsers are supposed to follow the response from the server to

--- a/test/e2e/testdata/cors.yaml
+++ b/test/e2e/testdata/cors.yaml
@@ -11,12 +11,9 @@ spec:
     namespace: gateway-conformance-infra
   cors:
     allowOrigins:
-    - type: Exact
-      value: "https://www.foo.com"
-    - type: Exact
-      value: "https://www.bar.com"
-    - type: RegularExpression
-      value: "https://[a-zA-Z0-9]+.foobar.com"
+    - "https://www.foo.com"
+    - "https://www.bar.com"
+    - "https://*.foobar.com"
     allowMethods:
     - GET
     - POST


### PR DESCRIPTION
The current CORS api uses regex to match the allowed origins. This PR changes this behavior to use wildcard matching instead. Using wildcard matching is more intuitive and easier to use, and also aligns with the gateway api hostname matching.

before:

```yaml
apiVersion: gateway.envoyproxy.io/v1alpha1
kind: SecurityPolicy
metadata:
  name: cors
spec:
  cors:
    allowMethods:
    - GET
    - HEAD
    - PUT
    - PATCH
    - POST
    - DELETE
    allowOrigins:
    - type: RegularExpression
      value: .*\.example\.com
    allowCredentials: true
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: backend
```

after:

```yaml
apiVersion: gateway.envoyproxy.io/v1alpha1
kind: SecurityPolicy
metadata:
  name: cors
spec:
  cors:
    allowMethods:
    - GET
    - HEAD
    - PUT
    - PATCH
    - POST
    - DELETE
    allowOrigins:
    - https://*.example.com
    allowCredentials: true
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: backend
```

related: 
https://github.com/envoyproxy/gateway/discussions/2350
https://github.com/envoyproxy/gateway/issues/2312