### PR TITLE
move "/" to route prefix

### DIFF
--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -263,7 +263,7 @@ func (t *Translator) translateBackendTrafficPolicyForRoute(policy *egv1a1.Backen
 	}
 
 	// Apply IR to all relevant routes
-	prefix := irRoutePrefix(route) + "/" // Prevent mismatching routes with the same prefix
+	prefix := irRoutePrefix(route)
 	for _, ir := range xdsIR {
 		for _, http := range ir.HTTP {
 			for _, r := range http.Routes {

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -378,15 +378,17 @@ func irUDPListenerName(listener *ListenerContext, udpRoute *UDPRouteContext) str
 }
 
 func irRoutePrefix(route RouteContext) string {
-	return fmt.Sprintf("%s/%s/%s", strings.ToLower(string(GetRouteType(route))), route.GetNamespace(), route.GetName())
+	// add a "/" at the end of the prefix to prevent mismatching routes with the
+	// same prefix. For example, route prefix "/foo/" should not match a route "/foobar".
+	return fmt.Sprintf("%s/%s/%s/", strings.ToLower(string(GetRouteType(route))), route.GetNamespace(), route.GetName())
 }
 
 func irRouteName(route RouteContext, ruleIdx, matchIdx int) string {
-	return fmt.Sprintf("%s/rule/%d/match/%d", irRoutePrefix(route), ruleIdx, matchIdx)
+	return fmt.Sprintf("%srule/%d/match/%d", irRoutePrefix(route), ruleIdx, matchIdx)
 }
 
 func irRouteDestinationName(route RouteContext, ruleIdx int) string {
-	return fmt.Sprintf("%s/rule/%d", irRoutePrefix(route), ruleIdx)
+	return fmt.Sprintf("%srule/%d", irRoutePrefix(route), ruleIdx)
 }
 
 func irTLSConfigs(tlsSecrets []*v1.Secret) []*ir.TLSListenerConfig {

--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -293,7 +293,7 @@ func (t *Translator) translateSecurityPolicyForRoute(
 	// Apply IR to all relevant routes
 	// Note: there are multiple features in a security policy, even if some of them
 	// are invalid, we still want to apply the valid ones.
-	prefix := irRoutePrefix(route) + "/" // Prevent mismatching routes with the same prefix
+	prefix := irRoutePrefix(route)
 	for _, ir := range xdsIR {
 		for _, http := range ir.HTTP {
 			for _, r := range http.Routes {


### PR DESCRIPTION
This is a small change to move "/" to route prefix so we can reuse the `irRoutePrefix` function and avoid duplicating code. 