### PR TITLE
fix: Incorrect conversion between integer types

### DIFF
--- a/internal/xds/translator/ratelimit.go
+++ b/internal/xds/translator/ratelimit.go
@@ -461,7 +461,7 @@ func (t *Translator) createRateLimitServiceCluster(tCtx *types.ResourceVersionTa
 	ds := &ir.DestinationSetting{
 		Weight:    ptr.To[uint32](1),
 		Protocol:  ir.GRPC,
-		Endpoints: []*ir.DestinationEndpoint{ir.NewDestEndpoint(host, uint32(port))},
+		Endpoints: []*ir.DestinationEndpoint{ir.NewDestEndpoint(host, port)},
 	}
 
 	tSocket, err := buildRateLimitTLSocket()
@@ -498,14 +498,14 @@ func getRateLimitDomain(irListener *ir.HTTPListener) string {
 	return irListener.Name
 }
 
-func (t *Translator) getRateLimitServiceGrpcHostPort() (string, int) {
+func (t *Translator) getRateLimitServiceGrpcHostPort() (string, uint32) {
 	u, err := url.Parse(t.GlobalRateLimit.ServiceURL)
 	if err != nil {
 		panic(err)
 	}
-	p, err := strconv.Atoi(u.Port())
+	p, err := strconv.ParseUint(u.Port(), 10, 32)
 	if err != nil {
 		panic(err)
 	}
-	return u.Hostname(), p
+	return u.Hostname(), uint32(p)
 }

--- a/internal/xds/translator/utils.go
+++ b/internal/xds/translator/utils.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	defaultHTTPSPort = 443
-	defaultHTTPPort  = 80
+	defaultHTTPSPort uint64 = 443
+	defaultHTTPPort  uint64 = 80
 )
 
 // urlCluster is a cluster that is created from a URL.
@@ -47,7 +47,7 @@ func url2Cluster(strURL string, secure bool) (*urlCluster, error) {
 		return nil, fmt.Errorf("unsupported URI scheme %s", u.Scheme)
 	}
 
-	var port int
+	var port uint64
 	if u.Scheme == "https" {
 		port = defaultHTTPSPort
 	} else {
@@ -55,7 +55,7 @@ func url2Cluster(strURL string, secure bool) (*urlCluster, error) {
 	}
 
 	if u.Port() != "" {
-		port, err = strconv.Atoi(u.Port())
+		port, err = strconv.ParseUint(u.Port(), 10, 32)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
use `strconv.ParseUint` instead of `strconv.Atoi` since `Atoi` can lead to unexpected errors - if a string is parsed into an int, and that int is converted into another integer type of a smaller size (uint32 in this case), the result can produce unexpected values.