### PR TITLE
chore: pin Docker images versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@
 
 version: 2
 updates:
+  - package-ecosystem: docker
+    directory: /tools/docker/envoy-gateway/
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /site
+    schedule:
+      interval: weekly
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,4 +1,4 @@
-FROM klakegg/hugo:ext-alpine
+FROM klakegg/hugo:ext-alpine@sha256:536dd4805d0493ee13bf1f3df3852ed1f26d1625983507c8c56242fc029b44c7
 
 RUN apk add git && \
   git config --global --add safe.directory /src

--- a/tools/docker/envoy-gateway/Dockerfile
+++ b/tools/docker/envoy-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:112a87f19e83c83711cc81ce8ed0b4d79acd65789682a6a272df57c4a0858534
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/envoy-gateway /usr/local/bin/
 


### PR DESCRIPTION
**What type of PR is this?**
* chore : pin Dockerfile images version
* Setup dependabot accordingly

**What this PR does / why we need it**:
Improve OSSF score

**Which issue(s) this PR fixes**:

