### PR TITLE
bug: use contents:write permission for release actions

### DIFF
--- a/.github/workflows/latest_release.yaml
+++ b/.github/workflows/latest_release.yaml
@@ -8,7 +8,7 @@ on:
     - "**/*.png"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   latest-release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
     tags:
       - "v*.*.*"
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   release:


### PR DESCRIPTION
defualted all base permissions to contents: read using https://github.com/envoyproxy/gateway/pull/2398
which broke the latest release action
https://github.com/envoyproxy/gateway/actions/runs/7415213672/job/20179669381