### PR TITLE
Replace the net.ParseIP with netip.ParseAddr for IP address parsing.

### DIFF
--- a/api/v1alpha1/validation/envoyproxy_validate.go
+++ b/api/v1alpha1/validation/envoyproxy_validate.go
@@ -8,7 +8,7 @@ package validation
 import (
 	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"reflect"
 
 	bootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
@@ -103,7 +103,7 @@ func validateService(spec *egv1a1.EnvoyProxySpec) []error {
 				errs = append(errs, fmt.Errorf("loadBalancerIP can only be set for %v type", egv1a1.ServiceTypeLoadBalancer))
 			}
 
-			if ip := net.ParseIP(*serviceLoadBalancerIP); ip == nil || ip.To4() == nil {
+			if ip, err := netip.ParseAddr(*serviceLoadBalancerIP); err != nil || !ip.Unmap().Is4() {
 				errs = append(errs, fmt.Errorf("loadBalancerIP:%s is an invalid IPv4 address", *serviceLoadBalancerIP))
 			}
 		}

--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -8,8 +8,8 @@ package gatewayapi
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"sort"
 	"strconv"
@@ -578,8 +578,8 @@ func validateTokenEndpoint(tokenEndpoint string) error {
 		return fmt.Errorf("token endpoint URL scheme must be https: %s", tokenEndpoint)
 	}
 
-	if ip := net.ParseIP(parsedURL.Hostname()); ip != nil {
-		if v4 := ip.To4(); v4 != nil {
+	if ip, err := netip.ParseAddr(parsedURL.Hostname()); err == nil {
+		if ip.Unmap().Is4() {
 			return fmt.Errorf("token endpoint URL must be a domain name: %s", tokenEndpoint)
 		}
 	}

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -8,8 +8,8 @@ package ir
 import (
 	"cmp"
 	"errors"
-	"net"
 	"net/http"
+	"net/netip"
 	"reflect"
 
 	"github.com/tetratelabs/multierror"
@@ -217,7 +217,7 @@ func (h HTTPListener) Validate() error {
 	if h.Name == "" {
 		errs = multierror.Append(errs, ErrListenerNameEmpty)
 	}
-	if ip := net.ParseIP(h.Address); ip == nil {
+	if _, err := netip.ParseAddr(h.Address); err != nil {
 		errs = multierror.Append(errs, ErrListenerAddressInvalid)
 	}
 	if h.Port == 0 {
@@ -714,9 +714,9 @@ func (d DestinationEndpoint) Validate() error {
 	var errs error
 
 	err := validation.IsDNS1123Subdomain(d.Host)
-	ip := net.ParseIP(d.Host)
+	_, pErr := netip.ParseAddr(d.Host)
 
-	if err != nil && ip == nil {
+	if err != nil && pErr != nil {
 		errs = multierror.Append(errs, ErrDestEndpointHostInvalid)
 	}
 
@@ -941,7 +941,7 @@ func (h TCPListener) Validate() error {
 	if h.Name == "" {
 		errs = multierror.Append(errs, ErrListenerNameEmpty)
 	}
-	if ip := net.ParseIP(h.Address); ip == nil {
+	if _, err := netip.ParseAddr(h.Address); err != nil {
 		errs = multierror.Append(errs, ErrListenerAddressInvalid)
 	}
 	if h.Port == 0 {
@@ -1005,7 +1005,7 @@ func (h UDPListener) Validate() error {
 	if h.Name == "" {
 		errs = multierror.Append(errs, ErrListenerNameEmpty)
 	}
-	if ip := net.ParseIP(h.Address); ip == nil {
+	if _, err := netip.ParseAddr(h.Address); err != nil {
 		errs = multierror.Append(errs, ErrListenerAddressInvalid)
 	}
 	if h.Port == 0 {

--- a/internal/xds/translator/utils.go
+++ b/internal/xds/translator/utils.go
@@ -8,7 +8,7 @@ package translator
 import (
 	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
@@ -63,8 +63,8 @@ func url2Cluster(strURL string, secure bool) (*urlCluster, error) {
 
 	name := fmt.Sprintf("%s_%d", strings.ReplaceAll(u.Hostname(), ".", "_"), port)
 
-	if ip := net.ParseIP(u.Hostname()); ip != nil {
-		if v4 := ip.To4(); v4 != nil {
+	if ip, err := netip.ParseAddr(u.Hostname()); err == nil {
+		if ip.Unmap().Is4() {
 			epType = EndpointTypeStatic
 		}
 	}


### PR DESCRIPTION
Description:
Golang `net/netip` package was imported in Go 1.18, and it defines IP address by [Addr](https://pkg.go.dev/net/netip#Addr) instead of [net.IP](https://pkg.go.dev/net#IP). Compared to the `net.IP` type, `Addr` type takes less memory, is immutable, and is comparable (supports == and being a map key). This project is using `go 1.21`, so I recommend that to change this package.