### PR TITLE
fix(helm): remove unused RBAC verbs

### DIFF
--- a/charts/gateway-helm/templates/_rbac.tpl
+++ b/charts/gateway-helm/templates/_rbac.tpl
@@ -71,8 +71,6 @@ resources:
 verbs:
 - get
 - list
-- patch
-- update
 - watch
 {{- end }}
 
@@ -102,8 +100,6 @@ resources:
 verbs:
 - get
 - list
-- patch
-- update
 - watch
 {{- end }}
 


### PR DESCRIPTION
**What type of PR is this?**
Helm chart cleanup.

**What this PR does / why we need it**:
Remove unused patch & update RBAC verbs from EG role.

**Which issue(s) this PR fixes**:
Fixes #2449
