### PR TITLE
[POC] Add private key provider support

### DIFF
--- a/api/v1alpha1/envoygateway_helpers.go
+++ b/api/v1alpha1/envoygateway_helpers.go
@@ -51,6 +51,9 @@ func (e *EnvoyGateway) SetEnvoyGatewayDefaults() {
 	if e.Telemetry == nil {
 		e.Telemetry = DefaultEnvoyGatewayTelemetry()
 	}
+	if e.PrivateKeyProvider == nil {
+		e.PrivateKeyProvider = DefaultEnvoyPrivateKeyProvider()
+	}
 }
 
 // GetEnvoyGatewayAdmin returns the EnvoyGatewayAdmin of EnvoyGateway or a default EnvoyGatewayAdmin if unspecified.
@@ -166,6 +169,16 @@ func DefaultEnvoyGatewayKubeProvider() *EnvoyGatewayKubernetesProvider {
 	return &EnvoyGatewayKubernetesProvider{
 		RateLimitDeployment: DefaultKubernetesDeployment(DefaultRateLimitImage),
 	}
+}
+
+// GetEnvoyGatewayPrivateKeyProvider returns the EnvoyPrivateKeyProvider of EnvoyGateway or a default EnvoyPrivateKeyProvider if unspecified.
+func (e *EnvoyGateway) GetEnvoyGatewayPrivateKeyProvider() *EnvoyPrivateKeyProvider {
+	if e.PrivateKeyProvider != nil {
+		return e.PrivateKeyProvider
+	}
+	e.PrivateKeyProvider.Default = DefaultEnvoyDefaultPrivateKeyProvider()
+
+	return e.PrivateKeyProvider
 }
 
 // DefaultEnvoyGatewayAdmin returns a new EnvoyGatewayAdmin with default configuration parameters.

--- a/api/v1alpha1/envoygateway_types.go
+++ b/api/v1alpha1/envoygateway_types.go
@@ -88,6 +88,11 @@ type EnvoyGatewaySpec struct {
 	//
 	// +optional
 	ExtensionAPIs *ExtensionAPISettings `json:"extensionApis,omitempty"`
+
+	// PrivateKeyProvider defines the envoy's private key provider used for the TLS.
+	//
+	// +optional
+	PrivateKeyProvider *EnvoyPrivateKeyProvider `json:"privateKeyProvider,omitempty"`
 }
 
 // EnvoyGatewayTelemetry defines telemetry configurations for envoy gateway control plane.

--- a/api/v1alpha1/envoyproxy_types.go
+++ b/api/v1alpha1/envoyproxy_types.go
@@ -74,6 +74,11 @@ type EnvoyProxySpec struct {
 	//
 	// +optional
 	MergeGateways *bool `json:"mergeGateways,omitempty"`
+
+	// PrivateKeyProvider defines the envoy's private key provider used for the TLS.
+	//
+	// +optional
+	PrivateKeyProvider *EnvoyPrivateKeyProvider `json:"privateKeyProvider,omitempty"`
 }
 
 type ProxyTelemetry struct {

--- a/api/v1alpha1/tls_helpers.go
+++ b/api/v1alpha1/tls_helpers.go
@@ -1,0 +1,30 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package v1alpha1
+
+// PrivateKeyProviderType defines the types of private key providers supported by Envoy Gateway.
+//
+// +kubebuilder:validation:Enum=Default;CryptoMB;QAT
+type PrivateKeyProviderType string
+
+const (
+	// PrivateKeyProviderTypeDefault defines the "default" private key provider.
+	PrivateKeyProviderTypeDefault PrivateKeyProviderType = "Default"
+	PrivateKeyProviderTypeCryptoMB PrivateKeyProviderType = "CryptoMB"
+	PrivateKeyProviderTypeQAT PrivateKeyProviderType = "QAT"
+)
+
+// DefaultEnvoyPrivateKeyProvider returns a new EnvoyPrivateKeyProvider with default configuration parameters.
+func DefaultEnvoyPrivateKeyProvider() *EnvoyPrivateKeyProvider {
+	return &EnvoyPrivateKeyProvider{
+		Type: PrivateKeyProviderTypeDefault,
+	}
+}
+
+// DefaultEnvoyDefaultPrivateKeyProvider returns a new EnvoyDefaultPrivateKeyProvider with default settings.
+func DefaultEnvoyDefaultPrivateKeyProvider() *EnvoyDefaultPrivateKeyProvider {
+	return &EnvoyDefaultPrivateKeyProvider{}
+}

--- a/api/v1alpha1/tls_types.go
+++ b/api/v1alpha1/tls_types.go
@@ -5,6 +5,48 @@
 
 package v1alpha1
 
+import (
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// EnvoyPrivateKeyProvider defines the desired configuration of a private key provider.
+// +union
+type EnvoyPrivateKeyProvider struct {
+	// Type is the type of provider to use. Supported types are "Default", "CryptoMB" and "QAT".
+	//
+	// +unionDiscriminator
+	Type PrivateKeyProviderType `json:"type"`
+
+	// Default defines the configuration of the private key provider.
+	//
+	// +optional
+	Default *EnvoyDefaultPrivateKeyProvider `json:"default,omitempty"`
+
+	// CryptoMB defines the configuration of the CryptoMB private key provider.
+	//
+	// +optional
+	CryptoMB *EnvoyCryptoMBPrivateKeyProvider `json:"cryptoMB,omitempty"`
+
+	// QAT defines the configuration of the CryptoMB private key provider.
+	//
+	// +optional
+	QAT *EnvoyQATPrivateKeyProvider `json:"qat,omitempty"`
+}
+
+type EnvoyDefaultPrivateKeyProvider struct {
+
+}
+
+type EnvoyCryptoMBPrivateKeyProvider struct {
+	Interval *gwapiv1.Duration `json:"interval,omitempty"`
+	Fallback bool `json:"fallback,omitempty"`
+}
+
+type EnvoyQATPrivateKeyProvider struct {
+	Interval *gwapiv1.Duration `json:"interval,omitempty"`
+	Fallback bool `json:"fallback,omitempty"`
+}
+
 // +kubebuilder:validation:XValidation:rule="has(self.minVersion) && self.minVersion == '1.3' ? !has(self.ciphers) : true", message="setting ciphers has no effect if the minimum possible TLS version is 1.3"
 // +kubebuilder:validation:XValidation:rule="has(self.minVersion) && has(self.maxVersion) ? {\"Auto\":0,\"1.0\":1,\"1.1\":2,\"1.2\":3,\"1.3\":4}[self.minVersion] <= {\"1.0\":1,\"1.1\":2,\"1.2\":3,\"1.3\":4,\"Auto\":5}[self.maxVersion] : !has(self.minVersion) && has(self.maxVersion) ? 3 <= {\"1.0\":1,\"1.1\":2,\"1.2\":3,\"1.3\":4,\"Auto\":5}[self.maxVersion] : true", message="minVersion must be smaller or equal to maxVersion"
 type TLSSettings struct {

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
@@ -103,6 +103,51 @@ spec:
                   the newer listener (based on timestamp) will be rejected and its
                   status will be updated with a "Accepted=False" condition.
                 type: boolean
+              privateKeyProvider:
+                description: PrivateKeyProvider defines the envoy's private key provider
+                  used for the TLS.
+                properties:
+                  cryptoMB:
+                    description: CryptoMB defines the configuration of the CryptoMB
+                      private key provider.
+                    properties:
+                      fallback:
+                        type: boolean
+                      interval:
+                        description: Duration is a string value representing a duration
+                          in time. The format is as specified in GEP-2257, a strict
+                          subset of the syntax parsed by Golang time.ParseDuration.
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                    type: object
+                  default:
+                    description: Default defines the configuration of the private
+                      key provider.
+                    type: object
+                  qat:
+                    description: QAT defines the configuration of the CryptoMB private
+                      key provider.
+                    properties:
+                      fallback:
+                        type: boolean
+                      interval:
+                        description: Duration is a string value representing a duration
+                          in time. The format is as specified in GEP-2257, a strict
+                          subset of the syntax parsed by Golang time.ParseDuration.
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                    type: object
+                  type:
+                    description: Type is the type of provider to use. Supported types
+                      are "Default", "CryptoMB" and "QAT".
+                    enum:
+                    - Default
+                    - CryptoMB
+                    - QAT
+                    type: string
+                required:
+                - type
+                type: object
               provider:
                 description: Provider defines the desired resource provider and provider-specific
                   configuration. If unspecified, the "Kubernetes" resource provider

--- a/internal/cmd/egctl/translate.go
+++ b/internal/cmd/egctl/translate.go
@@ -316,7 +316,7 @@ func translateGatewayAPIToXds(dnsDomain string, resourceType string, resources *
 				ServiceURL: ratelimit.GetServiceURL("envoy-gateway", dnsDomain),
 			},
 		}
-		xRes, err := xTranslator.Translate(val)
+		xRes, err := xTranslator.Translate(val, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to translate xds ir for key %s value %+v, error:%w", key, val, err)
 		}

--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -41,6 +41,7 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR XdsIRMap
 
 		if resources.EnvoyProxy != nil {
 			infraIR[irKey].Proxy.Config = resources.EnvoyProxy
+			xdsIR[irKey].Config = resources.EnvoyProxy
 		}
 
 		xdsIR[irKey].AccessLog = processAccessLog(infraIR[irKey].Proxy.Config)

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -78,6 +78,8 @@ type Xds struct {
 	UDP []*UDPListener `json:"udp,omitempty" yaml:"udp,omitempty"`
 	// EnvoyPatchPolicies is the intermediate representation of the EnvoyPatchPolicy resource
 	EnvoyPatchPolicies []*EnvoyPatchPolicy `json:"envoyPatchPolicies,omitempty" yaml:"envoyPatchPolicies,omitempty"`
+	// Config defines user-facing configuration of the managed proxy infrastructure.
+	Config *egv1a1.EnvoyProxy `json:"config,omitempty" yaml:"config,omitempty"`
 }
 
 // Equal implements the Comparable interface used by watchable.DeepEqual to skip unnecessary updates.

--- a/internal/xds/translator/runner/runner.go
+++ b/internal/xds/translator/runner/runner.go
@@ -76,8 +76,19 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 						t.GlobalRateLimit.Timeout = r.EnvoyGateway.RateLimit.Timeout.Duration
 					}
 				}
-
-				result, err := t.Translate(val)
+				var privateKeyProvider *v1alpha1.EnvoyPrivateKeyProvider
+				if val.Config != nil {
+					if val.Config.Spec.PrivateKeyProvider != nil {
+						r.Logger.Info("!!!!!!!!!! using dynamic config for private key provider")
+						privateKeyProvider = val.Config.Spec.PrivateKeyProvider
+					}
+				} else {
+					if (r.EnvoyGateway.PrivateKeyProvider != nil) {
+						r.Logger.Info("!!!!!!!!!! using static config for private key provider")
+						privateKeyProvider = r.EnvoyGateway.PrivateKeyProvider
+					}
+				}
+				result, err := t.Translate(val, privateKeyProvider)
 				if err != nil {
 					r.Logger.Error(err, "failed to translate xds ir")
 					errChan <- err


### PR DESCRIPTION
**What type of PR is this?**
new feature's POC

**What this PR does / why we need it**:
The Envoy Private Key Provider (https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-privatekeyprovider) allows implementing different provider which can provide the private key operation acceleration through the hardware or private key protection through the hardware.

Today, there are two private key providers were implemented as Envoy contrib extensions:

CryptoMB in Envoy 1.20 release (https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/private_key_providers/cryptomb/v3alpha/cryptomb.proto )
QAT in Envoy 1.24 release ([ https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/private_key_providers/qat/v3alpha/qat.proto#extensions-private-key-providers-qat-v3alpha-qatprivatekeymethodconfig](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/private_key_providers/qat/v3alpha/qat.proto#extensions-private-key-providers-qat-v3alpha-qatprivatekeymethodconfig) )
This proposal aims to describe how to enable private key provider configuration in the EnvoyGateway through dynamic configuration and static configuration. Also, consider the aspect of envoy image and k8s resource scheduling.

**Which issue(s) this PR fixes**:
Fixes #2456

