### PR TITLE
Fix the description for BackendTrafficPolicy

### DIFF
--- a/api/v1alpha1/backendtrafficpolicy_types.go
+++ b/api/v1alpha1/backendtrafficpolicy_types.go
@@ -22,7 +22,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 //
 // BackendTrafficPolicy allows the user to configure the behavior of the connection
-// between the downstream client and Envoy Proxy listener.
+// between the Envoy Proxy listener and the backend service.
 type BackendTrafficPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -27,7 +27,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: BackendTrafficPolicy allows the user to configure the behavior
-          of the connection between the downstream client and Envoy Proxy listener.
+          of the connection between the Envoy Proxy listener and the backend service.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -42,7 +42,7 @@ _Appears in:_
 
 
 
-BackendTrafficPolicy allows the user to configure the behavior of the connection between the downstream client and Envoy Proxy listener.
+BackendTrafficPolicy allows the user to configure the behavior of the connection between the Envoy Proxy listener and the backend service.
 
 _Appears in:_
 - [BackendTrafficPolicyList](#backendtrafficpolicylist)


### PR DESCRIPTION
**What type of PR is this?**
* "docs: fix the wrong description"

**What this PR does / why we need it**:
According the description of https://github.com/envoyproxy/gateway/issues/1821, the BackendTrafficPolicy is about the policy of the connection between Envoy Proxy listener and backend service.

**Which issue(s) this PR fixes**:
n/a
