### PR TITLE
Use go standard errors instead of multierror

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	github.com/telepresenceio/watchable v0.0.0-20220726211108-9bb86f92afa7
-	github.com/tetratelabs/multierror v1.1.1
 	github.com/tsaarni/certyaml v0.9.2
 	go.opentelemetry.io/otel v1.21.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.44.0
@@ -77,7 +76,6 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
@@ -465,8 +463,6 @@ github.com/telepresenceio/telepresence/rpc/v2 v2.6.8 h1:q5V85LBT9bA/c4YPa/kMvJGy
 github.com/telepresenceio/telepresence/rpc/v2 v2.6.8/go.mod h1:VlgfRoXaW6Tl8IZbHmMWhITne8HY09/wOFtABHGj3ic=
 github.com/telepresenceio/watchable v0.0.0-20220726211108-9bb86f92afa7 h1:GMw3nEaOVyi+tNiGko5kAeRtoiEIpXNHmISyZ7fpw14=
 github.com/telepresenceio/watchable v0.0.0-20220726211108-9bb86f92afa7/go.mod h1:ihJ97e2gsd8GuzFF/I3B1qcik3XZLpXjumQifXi8Slg=
-github.com/tetratelabs/multierror v1.1.1 h1:84JfJvfmnYC5y4877Ag3c4PkCUmQwq6sGI6iRfBATKI=
-github.com/tetratelabs/multierror v1.1.1/go.mod h1:hAyQ/XifPOPdb0x3GsowbjsjCPgT9Fsxjety9TxmuGY=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/cmd/egctl/config.go
+++ b/internal/cmd/egctl/config.go
@@ -8,13 +8,13 @@ package egctl
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"sync"
 
 	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
-	"github.com/tetratelabs/multierror"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	corev1 "k8s.io/api/core/v1"
@@ -81,12 +81,12 @@ func retrieveConfigDump(args []string, includeEds bool, configType envoyConfigTy
 		go func() {
 			fw, err := portForwarder(cli, pod)
 			if err != nil {
-				errs = multierror.Append(errs, err)
+				errs = errors.Join(errs, err)
 				return
 			}
 
 			if err := fw.Start(); err != nil {
-				errs = multierror.Append(errs, err)
+				errs = errors.Join(errs, err)
 				return
 			}
 			defer fw.Stop()
@@ -94,7 +94,7 @@ func retrieveConfigDump(args []string, includeEds bool, configType envoyConfigTy
 
 			configDump, err := extractConfigDump(fw, includeEds, configType)
 			if err != nil {
-				errs = multierror.Append(errs, err)
+				errs = errors.Join(errs, err)
 				return
 			}
 

--- a/internal/cmd/egctl/envoy_stats.go
+++ b/internal/cmd/egctl/envoy_stats.go
@@ -7,13 +7,13 @@ package egctl
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"sync"
 
 	"github.com/spf13/cobra"
-	"github.com/tetratelabs/multierror"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 
@@ -74,7 +74,7 @@ func newEnvoyStatsCmd() *cobra.Command {
 					go func(pod types.NamespacedName) {
 						stats[pod.Namespace+"/"+pod.Name], err = setupEnvoyServerStatsConfig(kubeClient, pod.Name, pod.Namespace, outputFormat)
 						if err != nil {
-							errs = multierror.Append(errs, err)
+							errs = errors.Join(errs, err)
 						}
 						wg.Done()
 					}(pod)
@@ -87,7 +87,7 @@ func newEnvoyStatsCmd() *cobra.Command {
 					go func(pod types.NamespacedName) {
 						stats[pod.Namespace+"/"+pod.Name], err = setupEnvoyClusterStatsConfig(kubeClient, pod.Name, pod.Namespace, outputFormat)
 						if err != nil {
-							errs = multierror.Append(errs, err)
+							errs = errors.Join(errs, err)
 						}
 						wg.Done()
 					}(pod)

--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -7,6 +7,7 @@ package gatewayapi
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/netip"
@@ -21,8 +22,6 @@ import (
 	"k8s.io/utils/ptr"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	"github.com/tetratelabs/multierror"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/ir"
@@ -283,13 +282,13 @@ func (t *Translator) translateSecurityPolicyForRoute(
 
 	if policy.Spec.OIDC != nil {
 		if oidc, err = t.buildOIDC(policy, resources); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
 	if policy.Spec.BasicAuth != nil {
 		if basicAuth, err = t.buildBasicAuth(policy, resources); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
@@ -337,13 +336,13 @@ func (t *Translator) translateSecurityPolicyForGateway(
 
 	if policy.Spec.OIDC != nil {
 		if oidc, err = t.buildOIDC(policy, resources); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
 	if policy.Spec.BasicAuth != nil {
 		if basicAuth, err = t.buildBasicAuth(policy, resources); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 

--- a/internal/xds/translator/basicauth.go
+++ b/internal/xds/translator/basicauth.go
@@ -13,7 +13,6 @@ import (
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	basicauthv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/basic_auth/v3"
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/tetratelabs/multierror"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/envoyproxy/gateway/internal/ir"
@@ -54,7 +53,7 @@ func (*basicAuth) patchHCM(mgr *hcmv3.HttpConnectionManager, irListener *ir.HTTP
 
 		filter, err := buildHCMBasicAuthFilter(route)
 		if err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 			continue
 		}
 
@@ -148,7 +147,7 @@ func (*basicAuth) patchRouteConfig(routeCfg *routev3.RouteConfiguration, irListe
 		if _, ok := filterCfg[filterName]; ok {
 			// This should not happen since this is the only place where the basicAuth
 			// filter is added in a route.
-			errs = multierror.Append(errs, fmt.Errorf(
+			errs = errors.Join(errs, fmt.Errorf(
 				"route config already contains basicAuth config: %+v", route))
 			continue
 		}
@@ -157,7 +156,7 @@ func (*basicAuth) patchRouteConfig(routeCfg *routev3.RouteConfiguration, irListe
 		// per-route in the typePerFilterConfig of the route.
 		routeCfgAny, err := anypb.New(&routev3.FilterConfig{Disabled: true})
 		if err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 			continue
 		}
 

--- a/internal/xds/translator/jsonpatch.go
+++ b/internal/xds/translator/jsonpatch.go
@@ -6,6 +6,7 @@
 package translator
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -15,7 +16,6 @@ import (
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	jsonpatchv5 "github.com/evanphx/json-patch/v5"
-	"github.com/tetratelabs/multierror"
 	"google.golang.org/protobuf/encoding/protojson"
 	"sigs.k8s.io/yaml"
 
@@ -135,7 +135,7 @@ func processJSONPatches(tCtx *types.ResourceVersionTable, envoyPatchPolicies []*
 
 				if resourceJSON, err = m.Marshal(listener); err != nil {
 					err := fmt.Errorf("unable to marshal xds resource %s: %s, err: %w", p.Type, p.Name, err)
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 					continue
 				}
 
@@ -148,7 +148,7 @@ func processJSONPatches(tCtx *types.ResourceVersionTable, envoyPatchPolicies []*
 
 				if resourceJSON, err = m.Marshal(routeConfig); err != nil {
 					err = fmt.Errorf("unable to marshal xds resource %s: %s, err: %w", p.Type, p.Name, err)
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 					continue
 				}
 
@@ -161,7 +161,7 @@ func processJSONPatches(tCtx *types.ResourceVersionTable, envoyPatchPolicies []*
 
 				if resourceJSON, err = m.Marshal(cluster); err != nil {
 					err = fmt.Errorf("unable to marshal xds resource %s: %s, err: %w", p.Type, p.Name, err)
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 					continue
 				}
 			case string(resourcev3.EndpointType):
@@ -172,7 +172,7 @@ func processJSONPatches(tCtx *types.ResourceVersionTable, envoyPatchPolicies []*
 				}
 				if resourceJSON, err = m.Marshal(endpoint); err != nil {
 					err = fmt.Errorf("unable to marshal xds resource %s: %s, err: %w", p.Type, p.Name, err)
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 					continue
 				}
 			}
@@ -227,7 +227,7 @@ func processJSONPatches(tCtx *types.ResourceVersionTable, envoyPatchPolicies []*
 				}
 				if err = deepCopyPtr(temp, listener); err != nil {
 					err := fmt.Errorf("unable to copy xds resource %s, err: %w", string(modifiedJSON), err)
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 					continue
 				}
 			case string(resourcev3.RouteType):
@@ -244,7 +244,7 @@ func processJSONPatches(tCtx *types.ResourceVersionTable, envoyPatchPolicies []*
 				}
 				if err = deepCopyPtr(temp, routeConfig); err != nil {
 					err := fmt.Errorf("unable to copy xds resource %s, err: %w", string(modifiedJSON), err)
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 					continue
 				}
 			case string(resourcev3.ClusterType):
@@ -261,7 +261,7 @@ func processJSONPatches(tCtx *types.ResourceVersionTable, envoyPatchPolicies []*
 				}
 				if err = deepCopyPtr(temp, cluster); err != nil {
 					err := fmt.Errorf("unable to copy xds resource %s, err: %w", string(modifiedJSON), err)
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 					continue
 				}
 			case string(resourcev3.EndpointType):
@@ -278,7 +278,7 @@ func processJSONPatches(tCtx *types.ResourceVersionTable, envoyPatchPolicies []*
 				}
 				if err = deepCopyPtr(temp, endpoint); err != nil {
 					err := fmt.Errorf("unable to copy xds resource %s, err: %w", string(modifiedJSON), err)
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 					continue
 				}
 			}

--- a/internal/xds/translator/jwt.go
+++ b/internal/xds/translator/jwt.go
@@ -15,7 +15,6 @@ import (
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/tetratelabs/multierror"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"k8s.io/utils/ptr"
@@ -267,7 +266,7 @@ func (*jwt) patchResources(tCtx *types.ResourceVersionTable, routes []*ir.HTTPRo
 			provider := route.JWT.Providers[i]
 			jwks, err = url2Cluster(provider.RemoteJWKS.URI, false)
 			if err != nil {
-				errs = multierror.Append(errs, err)
+				errs = errors.Join(errs, err)
 				continue
 			}
 
@@ -284,14 +283,14 @@ func (*jwt) patchResources(tCtx *types.ResourceVersionTable, routes []*ir.HTTPRo
 			if jwks.tls {
 				tSocket, err = buildXdsUpstreamTLSSocket()
 				if err != nil {
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 					continue
 				}
 				clusterArgs.tSocket = tSocket
 			}
 
 			if err = addXdsCluster(tCtx, clusterArgs); err != nil && !errors.Is(err, ErrXdsClusterExists) {
-				errs = multierror.Append(errs, err)
+				errs = errors.Join(errs, err)
 			}
 		}
 	}

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -19,7 +19,6 @@ import (
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"github.com/tetratelabs/multierror"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	extensionTypes "github.com/envoyproxy/gateway/internal/extension/types"
@@ -79,32 +78,32 @@ func (t *Translator) Translate(ir *ir.Xds) (*types.ResourceVersionTable, error) 
 	var errs error
 	if err := t.processHTTPListenerXdsTranslation(
 		tCtx, ir.HTTP, ir.AccessLog, ir.Tracing, ir.Metrics); err != nil {
-		errs = multierror.Append(errs, err)
+		errs = errors.Join(errs, err)
 	}
 
 	if err := processTCPListenerXdsTranslation(tCtx, ir.TCP, ir.AccessLog); err != nil {
-		errs = multierror.Append(errs, err)
+		errs = errors.Join(errs, err)
 	}
 
 	if err := processUDPListenerXdsTranslation(tCtx, ir.UDP, ir.AccessLog); err != nil {
-		errs = multierror.Append(errs, err)
+		errs = errors.Join(errs, err)
 	}
 
 	if err := processJSONPatches(tCtx, ir.EnvoyPatchPolicies); err != nil {
-		errs = multierror.Append(errs, err)
+		errs = errors.Join(errs, err)
 	}
 
 	if err := processClusterForAccessLog(tCtx, ir.AccessLog); err != nil {
-		errs = multierror.Append(errs, err)
+		errs = errors.Join(errs, err)
 	}
 	if err := processClusterForTracing(tCtx, ir.Tracing); err != nil {
-		errs = multierror.Append(errs, err)
+		errs = errors.Join(errs, err)
 	}
 
 	// Check if an extension want to inject any clusters/secrets
 	// If no extension exists (or it doesn't subscribe to this hook) then this is a quick no-op
 	if err := processExtensionPostTranslationHook(tCtx, t.ExtensionManager); err != nil {
-		errs = multierror.Append(errs, err)
+		errs = errors.Join(errs, err)
 	}
 
 	return tCtx, errs
@@ -139,7 +138,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 			if err := tCtx.AddXdsResource(resourcev3.ListenerType, xdsListener); err != nil {
 				// skip this listener if failed to add xds listener to the
 				// resource version table. Normally, this should not happen.
-				errs = multierror.Append(errs, err)
+				errs = errors.Join(errs, err)
 				continue
 			}
 		} else if httpListener.TLS == nil {
@@ -154,7 +153,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 				xdsRouteCfg = findXdsRouteConfig(tCtx, routeName)
 				if xdsRouteCfg == nil {
 					// skip this listener if failed to find xds route config
-					errs = multierror.Append(errs, errors.New("unable to find xds route config"))
+					errs = errors.Join(errs, errors.New("unable to find xds route config"))
 					continue
 				}
 			}
@@ -179,7 +178,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 			}
 
 			if err := tCtx.AddXdsResource(resourcev3.RouteType, xdsRouteCfg); err != nil {
-				errs = multierror.Append(errs, err)
+				errs = errors.Join(errs, err)
 			}
 		}
 
@@ -188,7 +187,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 			for t := range httpListener.TLS.Certificates {
 				secret := buildXdsDownstreamTLSSecret(httpListener.TLS.Certificates[t])
 				if err := tCtx.AddXdsResource(resourcev3.SecretType, secret); err != nil {
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 				}
 			}
 		}
@@ -238,7 +237,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 			xdsRoute, err := buildXdsRoute(httpRoute)
 			if err != nil {
 				// skip this route if failed to build xds route
-				errs = multierror.Append(errs, err)
+				errs = errors.Join(errs, err)
 				continue
 			}
 
@@ -246,7 +245,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 			// If no extension exists (or it doesn't subscribe to this hook) then this is a quick no-op.
 			if err = processExtensionPostRouteHook(xdsRoute, vHost, httpRoute, t.ExtensionManager); err != nil {
 				if err != nil {
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 				}
 			}
 
@@ -261,7 +260,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 
 			if httpRoute.Destination != nil {
 				if err = processXdsCluster(tCtx, httpRoute); err != nil {
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 				}
 			}
 
@@ -273,7 +272,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 						tSocket:      nil,
 						endpointType: EndpointTypeStatic,
 					}); err != nil && !errors.Is(err, ErrXdsClusterExists) {
-						errs = multierror.Append(errs, err)
+						errs = errors.Join(errs, err)
 					}
 				}
 			}
@@ -283,14 +282,14 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 			// Check if an extension want to modify the Virtual Host we just generated
 			// If no extension exists (or it doesn't subscribe to this hook) then this is a quick no-op.
 			if err := processExtensionPostVHostHook(vHost, t.ExtensionManager); err != nil {
-				errs = multierror.Append(errs, err)
+				errs = errors.Join(errs, err)
 			}
 		}
 		xdsRouteCfg.VirtualHosts = append(xdsRouteCfg.VirtualHosts, vHostsList...)
 
 		// Add per-route filter configs to the route config.
 		if err := patchRouteCfgWithPerRouteConfig(xdsRouteCfg, httpListener); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 
 		// Add all the other needed resources referenced by this filter to the
@@ -303,13 +302,13 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 		// rate limit server configuration.
 		// Check if a ratelimit cluster exists, if not, add it, if it's needed.
 		if err := t.createRateLimitServiceCluster(tCtx, httpListener); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 
 		// Check if an extension want to modify the listener that was just configured/created
 		// If no extension exists (or it doesn't subscribe to this hook) then this is a quick no-op
 		if err := processExtensionPostListenerHook(tCtx, xdsListener, t.ExtensionManager); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
@@ -337,13 +336,13 @@ func processTCPListenerXdsTranslation(tCtx *types.ResourceVersionTable, tcpListe
 			xdsListener = buildXdsTCPListener(tcpListener.Name, tcpListener.Address, tcpListener.Port, tcpListener.TCPKeepalive, accesslog)
 			if err := tCtx.AddXdsResource(resourcev3.ListenerType, xdsListener); err != nil {
 				// skip this listener if failed to add xds listener to the
-				errs = multierror.Append(errs, err)
+				errs = errors.Join(errs, err)
 				continue
 			}
 		}
 
 		if err := addXdsTCPFilterChain(xdsListener, tcpListener, tcpListener.Destination.Name, accesslog); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 
 		// 1:1 between IR TCPListener and xDS Cluster
@@ -353,14 +352,14 @@ func processTCPListenerXdsTranslation(tCtx *types.ResourceVersionTable, tcpListe
 			tSocket:      nil,
 			endpointType: EndpointTypeStatic,
 		}); err != nil && !errors.Is(err, ErrXdsClusterExists) {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 
 		if tcpListener.TLS != nil && tcpListener.TLS.Terminate != nil {
 			for _, s := range tcpListener.TLS.Terminate.Certificates {
 				secret := buildXdsDownstreamTLSSecret(s)
 				if err := tCtx.AddXdsResource(resourcev3.SecretType, secret); err != nil {
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 				}
 			}
 		}
@@ -379,12 +378,12 @@ func processUDPListenerXdsTranslation(tCtx *types.ResourceVersionTable, udpListe
 		xdsListener, err := buildXdsUDPListener(udpListener.Destination.Name, udpListener, accesslog)
 		if err != nil {
 			// skip this listener if failed to build xds listener
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 			continue
 		}
 		if err := tCtx.AddXdsResource(resourcev3.ListenerType, xdsListener); err != nil {
 			// skip this listener if failed to add xds listener to the resource version table
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 			continue
 		}
 
@@ -395,7 +394,7 @@ func processUDPListenerXdsTranslation(tCtx *types.ResourceVersionTable, udpListe
 			tSocket:      nil,
 			endpointType: EndpointTypeStatic,
 		}); err != nil && !errors.Is(err, ErrXdsClusterExists) {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 	return errs

--- a/tools/linter/golangci-lint/.golangci.yml
+++ b/tools/linter/golangci-lint/.golangci.yml
@@ -32,6 +32,8 @@ linters-settings:
             desc: "use sigs.k8s.io/yaml instead"
           - pkg: k8s.io/utils/pointer
             desc: "use k8s.io/utils/ptr instead"
+          - pkg: github.com/tetratelabs/multierror
+            desc: "use errors instead"
   gci:
     sections:
       # Captures all standard packages if they do not match another section.


### PR DESCRIPTION
**What type of PR is this?**
* chore: use go standard errors instead of multierror

**What this PR does / why we need it**:

standard errors now supports Joining list of errors so there is no need to rely on custom packages

