### PR TITLE
Trigger a reconcile of SecurityPolicy when OIDC or Basic Auth secrets…

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -189,7 +189,7 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 
 	// Update status for all gateway classes
 	for _, gc := range cc.notAcceptedClasses() {
-		if err := r.gatewayClassUpdater(ctx, gc, false, string(status.ReasonOlderGatewayClassExists),
+		if err := r.updateStatusForGatewayClass(ctx, gc, false, string(status.ReasonOlderGatewayClassExists),
 			status.MsgOlderGatewayClassExists); err != nil {
 			r.resources.GatewayAPIResources.Delete(acceptedGC.Name)
 			return reconcile.Result{}, err
@@ -347,7 +347,7 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 	if acceptedGC.Spec.ParametersRef != nil && acceptedGC.DeletionTimestamp == nil {
 		if err := r.processParamsRef(ctx, acceptedGC, resourceTree); err != nil {
 			msg := fmt.Sprintf("%s: %v", status.MsgGatewayClassInvalidParams, err)
-			if err := r.gatewayClassUpdater(ctx, acceptedGC, false, string(gwapiv1.GatewayClassReasonInvalidParameters), msg); err != nil {
+			if err := r.updateStatusForGatewayClass(ctx, acceptedGC, false, string(gwapiv1.GatewayClassReasonInvalidParameters), msg); err != nil {
 				r.log.Error(err, "unable to update GatewayClass status")
 			}
 			r.log.Error(err, "failed to process parametersRef for gatewayclass", "name", acceptedGC.Name)
@@ -359,7 +359,7 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 		r.mergeGateways = *resourceTree.EnvoyProxy.Spec.MergeGateways
 	}
 
-	if err := r.gatewayClassUpdater(ctx, acceptedGC, true, string(gwapiv1.GatewayClassReasonAccepted), status.MsgValidGatewayClass); err != nil {
+	if err := r.updateStatusForGatewayClass(ctx, acceptedGC, true, string(gwapiv1.GatewayClassReasonAccepted), status.MsgValidGatewayClass); err != nil {
 		r.log.Error(err, "unable to update GatewayClass status")
 		return reconcile.Result{}, err
 	}
@@ -491,31 +491,6 @@ func (r *gatewayAPIReconciler) processSecretRef(
 	return nil
 }
 
-func (r *gatewayAPIReconciler) gatewayClassUpdater(ctx context.Context, gc *gwapiv1.GatewayClass, accepted bool, reason, msg string) error {
-	if r.statusUpdater != nil {
-		r.statusUpdater.Send(status.Update{
-			NamespacedName: types.NamespacedName{Name: gc.Name},
-			Resource:       &gwapiv1.GatewayClass{},
-			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-				gc, ok := obj.(*gwapiv1.GatewayClass)
-				if !ok {
-					panic(fmt.Sprintf("unsupported object type %T", obj))
-				}
-
-				return status.SetGatewayClassAccepted(gc.DeepCopy(), accepted, reason, msg)
-			}),
-		})
-	} else {
-		// this branch makes testing easier by not going through the status.Updater.
-		duplicate := status.SetGatewayClassAccepted(gc.DeepCopy(), accepted, reason, msg)
-
-		if err := r.client.Status().Update(ctx, duplicate); err != nil && !kerrors.IsNotFound(err) {
-			return fmt.Errorf("error updating status of gatewayclass %s: %w", duplicate.Name, err)
-		}
-	}
-	return nil
-}
-
 func (r *gatewayAPIReconciler) getNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
 	nsKey := types.NamespacedName{Name: name}
 	ns := new(corev1.Namespace)
@@ -524,50 +499,6 @@ func (r *gatewayAPIReconciler) getNamespace(ctx context.Context, name string) (*
 		return nil, err
 	}
 	return ns, nil
-}
-
-func (r *gatewayAPIReconciler) statusUpdateForGateway(ctx context.Context, gtw *gwapiv1.Gateway) {
-	// nil check for unit tests.
-	if r.statusUpdater == nil {
-		return
-	}
-
-	// Get deployment
-	deploy, err := r.envoyDeploymentForGateway(ctx, gtw)
-	if err != nil {
-		r.log.Info("failed to get Deployment for gateway",
-			"namespace", gtw.Namespace, "name", gtw.Name)
-	}
-
-	// Get service
-	svc, err := r.envoyServiceForGateway(ctx, gtw)
-	if err != nil {
-		r.log.Info("failed to get Service for gateway",
-			"namespace", gtw.Namespace, "name", gtw.Name)
-	}
-	// update accepted condition
-	status.UpdateGatewayStatusAcceptedCondition(gtw, true)
-	// update address field and programmed condition
-	status.UpdateGatewayStatusProgrammedCondition(gtw, svc, deploy, r.store.listNodeAddresses()...)
-
-	key := utils.NamespacedName(gtw)
-
-	// publish status
-	r.statusUpdater.Send(status.Update{
-		NamespacedName: key,
-		Resource:       new(gwapiv1.Gateway),
-		Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-			g, ok := obj.(*gwapiv1.Gateway)
-			if !ok {
-				panic(fmt.Sprintf("unsupported object type %T", obj))
-			}
-			gCopy := g.DeepCopy()
-			gCopy.Status.Conditions = gtw.Status.Conditions
-			gCopy.Status.Addresses = gtw.Status.Addresses
-			gCopy.Status.Listeners = gtw.Status.Listeners
-			return gCopy
-		}),
-	})
 }
 
 func (r *gatewayAPIReconciler) findReferenceGrant(ctx context.Context, from, to ObjectKindNamespacedName) (*gwapiv1b1.ReferenceGrant, error) {
@@ -1037,303 +968,6 @@ func (r *gatewayAPIReconciler) addFinalizer(ctx context.Context, gc *gwapiv1.Gat
 		}
 	}
 	return nil
-}
-
-// subscribeAndUpdateStatus subscribes to gateway API object status updates and
-// writes it into the Kubernetes API Server.
-func (r *gatewayAPIReconciler) subscribeAndUpdateStatus(ctx context.Context) {
-	// Gateway object status updater
-	go func() {
-		message.HandleSubscription(message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "gateway-status"}, r.resources.GatewayStatuses.Subscribe(ctx),
-			func(update message.Update[types.NamespacedName, *gwapiv1.GatewayStatus], errChan chan error) {
-				// skip delete updates.
-				if update.Delete {
-					return
-				}
-				// Get gateway object
-				gtw := new(gwapiv1.Gateway)
-				if err := r.client.Get(ctx, update.Key, gtw); err != nil {
-					r.log.Error(err, "gateway not found", "namespace", gtw.Namespace, "name", gtw.Name)
-					errChan <- err
-					return
-				}
-				// Set the updated Status and call the status update
-				gtw.Status = *update.Value
-				r.statusUpdateForGateway(ctx, gtw)
-			},
-		)
-		r.log.Info("gateway status subscriber shutting down")
-	}()
-
-	// HTTPRoute object status updater
-	go func() {
-		message.HandleSubscription(message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "httproute-status"}, r.resources.HTTPRouteStatuses.Subscribe(ctx),
-			func(update message.Update[types.NamespacedName, *gwapiv1.HTTPRouteStatus], errChan chan error) {
-				// skip delete updates.
-				if update.Delete {
-					return
-				}
-				key := update.Key
-				val := update.Value
-				r.statusUpdater.Send(status.Update{
-					NamespacedName: key,
-					Resource:       new(gwapiv1.HTTPRoute),
-					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-						h, ok := obj.(*gwapiv1.HTTPRoute)
-						if !ok {
-							err := fmt.Errorf("unsupported object type %T", obj)
-							errChan <- err
-							panic(err)
-						}
-						hCopy := h.DeepCopy()
-						hCopy.Status.Parents = val.Parents
-						return hCopy
-					}),
-				})
-			},
-		)
-		r.log.Info("httpRoute status subscriber shutting down")
-	}()
-
-	// GRPCRoute object status updater
-	go func() {
-		message.HandleSubscription(message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "grpcroute-status"}, r.resources.GRPCRouteStatuses.Subscribe(ctx),
-			func(update message.Update[types.NamespacedName, *gwapiv1a2.GRPCRouteStatus], errChan chan error) {
-				// skip delete updates.
-				if update.Delete {
-					return
-				}
-				key := update.Key
-				val := update.Value
-				r.statusUpdater.Send(status.Update{
-					NamespacedName: key,
-					Resource:       new(gwapiv1a2.GRPCRoute),
-					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-						h, ok := obj.(*gwapiv1a2.GRPCRoute)
-						if !ok {
-							err := fmt.Errorf("unsupported object type %T", obj)
-							errChan <- err
-							panic(err)
-						}
-						hCopy := h.DeepCopy()
-						hCopy.Status.Parents = val.Parents
-						return hCopy
-					}),
-				})
-			},
-		)
-		r.log.Info("grpcRoute status subscriber shutting down")
-	}()
-
-	// TLSRoute object status updater
-	go func() {
-		message.HandleSubscription(message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "tlsroute-status"}, r.resources.TLSRouteStatuses.Subscribe(ctx),
-			func(update message.Update[types.NamespacedName, *gwapiv1a2.TLSRouteStatus], errChan chan error) {
-				// skip delete updates.
-				if update.Delete {
-					return
-				}
-				key := update.Key
-				val := update.Value
-				r.statusUpdater.Send(status.Update{
-					NamespacedName: key,
-					Resource:       new(gwapiv1a2.TLSRoute),
-					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-						t, ok := obj.(*gwapiv1a2.TLSRoute)
-						if !ok {
-							err := fmt.Errorf("unsupported object type %T", obj)
-							errChan <- err
-							panic(err)
-						}
-						tCopy := t.DeepCopy()
-						tCopy.Status.Parents = val.Parents
-						return tCopy
-					}),
-				})
-			},
-		)
-		r.log.Info("tlsRoute status subscriber shutting down")
-	}()
-
-	// TCPRoute object status updater
-	go func() {
-		message.HandleSubscription(message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "tcproute-status"}, r.resources.TCPRouteStatuses.Subscribe(ctx),
-			func(update message.Update[types.NamespacedName, *gwapiv1a2.TCPRouteStatus], errChan chan error) {
-				// skip delete updates.
-				if update.Delete {
-					return
-				}
-				key := update.Key
-				val := update.Value
-				r.statusUpdater.Send(status.Update{
-					NamespacedName: key,
-					Resource:       new(gwapiv1a2.TCPRoute),
-					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-						t, ok := obj.(*gwapiv1a2.TCPRoute)
-						if !ok {
-							err := fmt.Errorf("unsupported object type %T", obj)
-							errChan <- err
-							panic(err)
-						}
-						tCopy := t.DeepCopy()
-						tCopy.Status.Parents = val.Parents
-						return tCopy
-					}),
-				})
-			},
-		)
-		r.log.Info("tcpRoute status subscriber shutting down")
-	}()
-
-	// UDPRoute object status updater
-	go func() {
-		message.HandleSubscription(message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "udproute-status"}, r.resources.UDPRouteStatuses.Subscribe(ctx),
-			func(update message.Update[types.NamespacedName, *gwapiv1a2.UDPRouteStatus], errChan chan error) {
-				// skip delete updates.
-				if update.Delete {
-					return
-				}
-				key := update.Key
-				val := update.Value
-				r.statusUpdater.Send(status.Update{
-					NamespacedName: key,
-					Resource:       new(gwapiv1a2.UDPRoute),
-					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-						t, ok := obj.(*gwapiv1a2.UDPRoute)
-						if !ok {
-							err := fmt.Errorf("unsupported object type %T", obj)
-							errChan <- err
-							panic(err)
-						}
-						tCopy := t.DeepCopy()
-						tCopy.Status.Parents = val.Parents
-						return tCopy
-					}),
-				})
-			},
-		)
-		r.log.Info("udpRoute status subscriber shutting down")
-	}()
-
-	// EnvoyPatchPolicy object status updater
-	go func() {
-		message.HandleSubscription(message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "envoypatchpolicy-status"}, r.resources.EnvoyPatchPolicyStatuses.Subscribe(ctx),
-			func(update message.Update[types.NamespacedName, *v1alpha1.EnvoyPatchPolicyStatus], errChan chan error) {
-				// skip delete updates.
-				if update.Delete {
-					return
-				}
-				key := update.Key
-				val := update.Value
-				r.statusUpdater.Send(status.Update{
-					NamespacedName: key,
-					Resource:       new(v1alpha1.EnvoyPatchPolicy),
-					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-						t, ok := obj.(*v1alpha1.EnvoyPatchPolicy)
-						if !ok {
-							err := fmt.Errorf("unsupported object type %T", obj)
-							errChan <- err
-							panic(err)
-						}
-						tCopy := t.DeepCopy()
-						tCopy.Status = *val
-						return tCopy
-					}),
-				})
-			},
-		)
-		r.log.Info("envoyPatchPolicy status subscriber shutting down")
-	}()
-
-	// ClientTrafficPolicy object status updater
-	go func() {
-		message.HandleSubscription(message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "clienttrafficpolicy-status"}, r.resources.ClientTrafficPolicyStatuses.Subscribe(ctx),
-			func(update message.Update[types.NamespacedName, *v1alpha1.ClientTrafficPolicyStatus], errChan chan error) {
-				// skip delete updates.
-				if update.Delete {
-					return
-				}
-				key := update.Key
-				val := update.Value
-				r.statusUpdater.Send(status.Update{
-					NamespacedName: key,
-					Resource:       new(v1alpha1.ClientTrafficPolicy),
-					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-						t, ok := obj.(*v1alpha1.ClientTrafficPolicy)
-						if !ok {
-							err := fmt.Errorf("unsupported object type %T", obj)
-							errChan <- err
-							panic(err)
-						}
-						tCopy := t.DeepCopy()
-						tCopy.Status = *val
-						return tCopy
-					}),
-				})
-			},
-		)
-		r.log.Info("clientTrafficPolicy status subscriber shutting down")
-	}()
-
-	// BackendTrafficPolicy object status updater
-	go func() {
-		message.HandleSubscription(message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "backendtrafficpolicy-status"}, r.resources.BackendTrafficPolicyStatuses.Subscribe(ctx),
-			func(update message.Update[types.NamespacedName, *v1alpha1.BackendTrafficPolicyStatus], errChan chan error) {
-				// skip delete updates.
-				if update.Delete {
-					return
-				}
-				key := update.Key
-				val := update.Value
-				r.statusUpdater.Send(status.Update{
-					NamespacedName: key,
-					Resource:       new(v1alpha1.BackendTrafficPolicy),
-					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-						t, ok := obj.(*v1alpha1.BackendTrafficPolicy)
-						if !ok {
-							err := fmt.Errorf("unsupported object type %T", obj)
-							errChan <- err
-							panic(err)
-						}
-						tCopy := t.DeepCopy()
-						tCopy.Status = *val
-						return tCopy
-					}),
-				})
-			},
-		)
-		r.log.Info("backendTrafficPolicy status subscriber shutting down")
-	}()
-
-	// SecurityPolicy object status updater
-	go func() {
-		message.HandleSubscription(message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "securitypolicy-status"}, r.resources.SecurityPolicyStatuses.Subscribe(ctx),
-			func(update message.Update[types.NamespacedName, *v1alpha1.SecurityPolicyStatus], errChan chan error) {
-				// skip delete updates.
-				if update.Delete {
-					return
-				}
-				key := update.Key
-				val := update.Value
-				r.statusUpdater.Send(status.Update{
-					NamespacedName: key,
-					Resource:       new(v1alpha1.SecurityPolicy),
-					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-						t, ok := obj.(*v1alpha1.SecurityPolicy)
-						if !ok {
-							err := fmt.Errorf("unsupported object type %T", obj)
-							errChan <- err
-							panic(err)
-						}
-						tCopy := t.DeepCopy()
-						tCopy.Status = *val
-						return tCopy
-					}),
-				})
-			},
-		)
-		r.log.Info("securityPolicy status subscriber shutting down")
-	}()
 }
 
 // watchResources watches gateway api resources.

--- a/internal/provider/kubernetes/predicates.go
+++ b/internal/provider/kubernetes/predicates.go
@@ -180,7 +180,7 @@ func (r *gatewayAPIReconciler) validateServiceForReconcile(obj client.Object) bo
 	// Check if the Service belongs to a Gateway, if so, update the Gateway status.
 	gtw := r.findOwningGateway(ctx, labels)
 	if gtw != nil {
-		r.statusUpdateForGateway(ctx, gtw)
+		r.updateStatusForGateway(ctx, gtw)
 		return false
 	}
 
@@ -191,7 +191,7 @@ func (r *gatewayAPIReconciler) validateServiceForReconcile(obj client.Object) bo
 		if res != nil && len(res.Gateways) > 0 {
 			for _, gw := range res.Gateways {
 				gw := gw
-				r.statusUpdateForGateway(ctx, gw)
+				r.updateStatusForGateway(ctx, gw)
 			}
 		}
 
@@ -315,7 +315,7 @@ func (r *gatewayAPIReconciler) validateDeploymentForReconcile(obj client.Object)
 		// Check if the deployment belongs to a Gateway, if so, update the Gateway status.
 		gtw := r.findOwningGateway(ctx, labels)
 		if gtw != nil {
-			r.statusUpdateForGateway(ctx, gtw)
+			r.updateStatusForGateway(ctx, gtw)
 			return false
 		}
 	}
@@ -327,7 +327,7 @@ func (r *gatewayAPIReconciler) validateDeploymentForReconcile(obj client.Object)
 		if res != nil && len(res.Gateways) > 0 {
 			for _, gw := range res.Gateways {
 				gw := gw
-				r.statusUpdateForGateway(ctx, gw)
+				r.updateStatusForGateway(ctx, gw)
 			}
 		}
 		return false

--- a/internal/provider/kubernetes/predicates_test.go
+++ b/internal/provider/kubernetes/predicates_test.go
@@ -12,10 +12,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/envoygateway"
@@ -208,7 +210,67 @@ func TestValidateSecretForReconcile(t *testing.T) {
 			expect: false,
 		},
 		{
-			name: "gateway does not exist",
+			name: "references SecurityPolicy OIDC",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", v1alpha1.GatewayControllerName),
+				test.GetGateway(types.NamespacedName{Name: "scheduled-status-test"}, "test-gc"),
+				&v1alpha1.SecurityPolicy{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "oidc",
+					},
+					Spec: v1alpha1.SecurityPolicySpec{
+						TargetRef: gwapiv1a2.PolicyTargetReferenceWithSectionName{
+							PolicyTargetReference: gwapiv1a2.PolicyTargetReference{
+								Kind: "Gateway",
+								Name: "scheduled-status-test",
+							},
+						},
+						OIDC: &v1alpha1.OIDC{
+							Provider: v1alpha1.OIDCProvider{
+								Issuer:                "https://accounts.google.com",
+								AuthorizationEndpoint: ptr.To("https://accounts.google.com/o/oauth2/v2/auth"),
+								TokenEndpoint:         ptr.To("https://oauth2.googleapis.com/token"),
+							},
+							ClientID: "client-id",
+							ClientSecret: gwapiv1b1.SecretObjectReference{
+								Name: "secret",
+							},
+						},
+					},
+				},
+			},
+			secret: test.GetSecret(types.NamespacedName{Name: "secret"}),
+			expect: true,
+		},
+		{
+			name: "references SecurityPolicy Basic Auth",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", v1alpha1.GatewayControllerName),
+				test.GetGateway(types.NamespacedName{Name: "scheduled-status-test"}, "test-gc"),
+				&v1alpha1.SecurityPolicy{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "basic-auth",
+					},
+					Spec: v1alpha1.SecurityPolicySpec{
+						TargetRef: gwapiv1a2.PolicyTargetReferenceWithSectionName{
+							PolicyTargetReference: gwapiv1a2.PolicyTargetReference{
+								Kind: "Gateway",
+								Name: "scheduled-status-test",
+							},
+						},
+						BasicAuth: &v1alpha1.BasicAuth{
+							Users: gwapiv1b1.SecretObjectReference{
+								Name: "secret",
+							},
+						},
+					},
+				},
+			},
+			secret: test.GetSecret(types.NamespacedName{Name: "secret"}),
+			expect: true,
+		},
+		{
+			name: "secret is not referenced by any EG CRs",
 			configs: []client.Object{
 				test.GetGatewayClass("test-gc", v1alpha1.GatewayControllerName),
 			},
@@ -231,6 +293,7 @@ func TestValidateSecretForReconcile(t *testing.T) {
 			WithScheme(envoygateway.GetScheme()).
 			WithObjects(tc.configs...).
 			WithIndex(&gwapiv1.Gateway{}, secretGatewayIndex, secretGatewayIndexFunc).
+			WithIndex(&v1alpha1.SecurityPolicy{}, secretSecurityPolicyIndex, secretSecurityPolicyIndexFunc).
 			Build()
 		t.Run(tc.name, func(t *testing.T) {
 			res := r.validateSecretForReconcile(tc.secret)

--- a/internal/provider/kubernetes/status.go
+++ b/internal/provider/kubernetes/status.go
@@ -1,0 +1,411 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/message"
+	"github.com/envoyproxy/gateway/internal/provider/utils"
+	"github.com/envoyproxy/gateway/internal/status"
+)
+
+// subscribeAndUpdateStatus subscribes to gateway API object status updates and
+// writes it into the Kubernetes API Server.
+func (r *gatewayAPIReconciler) subscribeAndUpdateStatus(ctx context.Context) {
+	// Gateway object status updater
+	go func() {
+		message.HandleSubscription(
+			message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "gateway-status"},
+			r.resources.GatewayStatuses.Subscribe(ctx),
+			func(update message.Update[types.NamespacedName, *gwapiv1.GatewayStatus], errChan chan error) {
+				// skip delete updates.
+				if update.Delete {
+					return
+				}
+				// Get gateway object
+				gtw := new(gwapiv1.Gateway)
+				if err := r.client.Get(ctx, update.Key, gtw); err != nil {
+					r.log.Error(err, "gateway not found", "namespace", gtw.Namespace, "name", gtw.Name)
+					errChan <- err
+					return
+				}
+				// Set the updated Status and call the status update
+				gtw.Status = *update.Value
+				r.updateStatusForGateway(ctx, gtw)
+			},
+		)
+		r.log.Info("gateway status subscriber shutting down")
+	}()
+
+	// HTTPRoute object status updater
+	go func() {
+		message.HandleSubscription(
+			message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "httproute-status"},
+			r.resources.HTTPRouteStatuses.Subscribe(ctx),
+			func(update message.Update[types.NamespacedName, *gwapiv1.HTTPRouteStatus], errChan chan error) {
+				// skip delete updates.
+				if update.Delete {
+					return
+				}
+				key := update.Key
+				val := update.Value
+				r.statusUpdater.Send(status.Update{
+					NamespacedName: key,
+					Resource:       new(gwapiv1.HTTPRoute),
+					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+						h, ok := obj.(*gwapiv1.HTTPRoute)
+						if !ok {
+							err := fmt.Errorf("unsupported object type %T", obj)
+							errChan <- err
+							panic(err)
+						}
+						hCopy := h.DeepCopy()
+						hCopy.Status.Parents = val.Parents
+						return hCopy
+					}),
+				})
+			},
+		)
+		r.log.Info("httpRoute status subscriber shutting down")
+	}()
+
+	// GRPCRoute object status updater
+	go func() {
+		message.HandleSubscription(message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "grpcroute-status"}, r.resources.GRPCRouteStatuses.Subscribe(ctx),
+			func(update message.Update[types.NamespacedName, *gwapiv1a2.GRPCRouteStatus], errChan chan error) {
+				// skip delete updates.
+				if update.Delete {
+					return
+				}
+				key := update.Key
+				val := update.Value
+				r.statusUpdater.Send(status.Update{
+					NamespacedName: key,
+					Resource:       new(gwapiv1a2.GRPCRoute),
+					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+						h, ok := obj.(*gwapiv1a2.GRPCRoute)
+						if !ok {
+							err := fmt.Errorf("unsupported object type %T", obj)
+							errChan <- err
+							panic(err)
+						}
+						hCopy := h.DeepCopy()
+						hCopy.Status.Parents = val.Parents
+						return hCopy
+					}),
+				})
+			},
+		)
+		r.log.Info("grpcRoute status subscriber shutting down")
+	}()
+
+	// TLSRoute object status updater
+	go func() {
+		message.HandleSubscription(
+			message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "tlsroute-status"},
+			r.resources.TLSRouteStatuses.Subscribe(ctx),
+			func(update message.Update[types.NamespacedName, *gwapiv1a2.TLSRouteStatus], errChan chan error) {
+				// skip delete updates.
+				if update.Delete {
+					return
+				}
+				key := update.Key
+				val := update.Value
+				r.statusUpdater.Send(status.Update{
+					NamespacedName: key,
+					Resource:       new(gwapiv1a2.TLSRoute),
+					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+						t, ok := obj.(*gwapiv1a2.TLSRoute)
+						if !ok {
+							err := fmt.Errorf("unsupported object type %T", obj)
+							errChan <- err
+							panic(err)
+						}
+						tCopy := t.DeepCopy()
+						tCopy.Status.Parents = val.Parents
+						return tCopy
+					}),
+				})
+			},
+		)
+		r.log.Info("tlsRoute status subscriber shutting down")
+	}()
+
+	// TCPRoute object status updater
+	go func() {
+		message.HandleSubscription(
+			message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "tcproute-status"},
+			r.resources.TCPRouteStatuses.Subscribe(ctx),
+			func(update message.Update[types.NamespacedName, *gwapiv1a2.TCPRouteStatus], errChan chan error) {
+				// skip delete updates.
+				if update.Delete {
+					return
+				}
+				key := update.Key
+				val := update.Value
+				r.statusUpdater.Send(status.Update{
+					NamespacedName: key,
+					Resource:       new(gwapiv1a2.TCPRoute),
+					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+						t, ok := obj.(*gwapiv1a2.TCPRoute)
+						if !ok {
+							err := fmt.Errorf("unsupported object type %T", obj)
+							errChan <- err
+							panic(err)
+						}
+						tCopy := t.DeepCopy()
+						tCopy.Status.Parents = val.Parents
+						return tCopy
+					}),
+				})
+			},
+		)
+		r.log.Info("tcpRoute status subscriber shutting down")
+	}()
+
+	// UDPRoute object status updater
+	go func() {
+		message.HandleSubscription(
+			message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "udproute-status"},
+			r.resources.UDPRouteStatuses.Subscribe(ctx),
+			func(update message.Update[types.NamespacedName, *gwapiv1a2.UDPRouteStatus], errChan chan error) {
+				// skip delete updates.
+				if update.Delete {
+					return
+				}
+				key := update.Key
+				val := update.Value
+				r.statusUpdater.Send(status.Update{
+					NamespacedName: key,
+					Resource:       new(gwapiv1a2.UDPRoute),
+					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+						t, ok := obj.(*gwapiv1a2.UDPRoute)
+						if !ok {
+							err := fmt.Errorf("unsupported object type %T", obj)
+							errChan <- err
+							panic(err)
+						}
+						tCopy := t.DeepCopy()
+						tCopy.Status.Parents = val.Parents
+						return tCopy
+					}),
+				})
+			},
+		)
+		r.log.Info("udpRoute status subscriber shutting down")
+	}()
+
+	// EnvoyPatchPolicy object status updater
+	go func() {
+		message.HandleSubscription(
+			message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "envoypatchpolicy-status"},
+			r.resources.EnvoyPatchPolicyStatuses.Subscribe(ctx),
+			func(update message.Update[types.NamespacedName, *v1alpha1.EnvoyPatchPolicyStatus], errChan chan error) {
+				// skip delete updates.
+				if update.Delete {
+					return
+				}
+				key := update.Key
+				val := update.Value
+				r.statusUpdater.Send(status.Update{
+					NamespacedName: key,
+					Resource:       new(v1alpha1.EnvoyPatchPolicy),
+					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+						t, ok := obj.(*v1alpha1.EnvoyPatchPolicy)
+						if !ok {
+							err := fmt.Errorf("unsupported object type %T", obj)
+							errChan <- err
+							panic(err)
+						}
+						tCopy := t.DeepCopy()
+						tCopy.Status = *val
+						return tCopy
+					}),
+				})
+			},
+		)
+		r.log.Info("envoyPatchPolicy status subscriber shutting down")
+	}()
+
+	// ClientTrafficPolicy object status updater
+	go func() {
+		message.HandleSubscription(
+			message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "clienttrafficpolicy-status"},
+			r.resources.ClientTrafficPolicyStatuses.Subscribe(ctx),
+			func(update message.Update[types.NamespacedName, *v1alpha1.ClientTrafficPolicyStatus], errChan chan error) {
+				// skip delete updates.
+				if update.Delete {
+					return
+				}
+				key := update.Key
+				val := update.Value
+				r.statusUpdater.Send(status.Update{
+					NamespacedName: key,
+					Resource:       new(v1alpha1.ClientTrafficPolicy),
+					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+						t, ok := obj.(*v1alpha1.ClientTrafficPolicy)
+						if !ok {
+							err := fmt.Errorf("unsupported object type %T", obj)
+							errChan <- err
+							panic(err)
+						}
+						tCopy := t.DeepCopy()
+						tCopy.Status = *val
+						return tCopy
+					}),
+				})
+			},
+		)
+		r.log.Info("clientTrafficPolicy status subscriber shutting down")
+	}()
+
+	// BackendTrafficPolicy object status updater
+	go func() {
+		message.HandleSubscription(
+			message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "backendtrafficpolicy-status"},
+			r.resources.BackendTrafficPolicyStatuses.Subscribe(ctx),
+			func(update message.Update[types.NamespacedName, *v1alpha1.BackendTrafficPolicyStatus], errChan chan error) {
+				// skip delete updates.
+				if update.Delete {
+					return
+				}
+				key := update.Key
+				val := update.Value
+				r.statusUpdater.Send(status.Update{
+					NamespacedName: key,
+					Resource:       new(v1alpha1.BackendTrafficPolicy),
+					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+						t, ok := obj.(*v1alpha1.BackendTrafficPolicy)
+						if !ok {
+							err := fmt.Errorf("unsupported object type %T", obj)
+							errChan <- err
+							panic(err)
+						}
+						tCopy := t.DeepCopy()
+						tCopy.Status = *val
+						return tCopy
+					}),
+				})
+			},
+		)
+		r.log.Info("backendTrafficPolicy status subscriber shutting down")
+	}()
+
+	// SecurityPolicy object status updater
+	go func() {
+		message.HandleSubscription(
+			message.Metadata{Runner: string(v1alpha1.LogComponentProviderRunner), Message: "securitypolicy-status"},
+			r.resources.SecurityPolicyStatuses.Subscribe(ctx),
+			func(update message.Update[types.NamespacedName, *v1alpha1.SecurityPolicyStatus], errChan chan error) {
+				// skip delete updates.
+				if update.Delete {
+					return
+				}
+				key := update.Key
+				val := update.Value
+				r.statusUpdater.Send(status.Update{
+					NamespacedName: key,
+					Resource:       new(v1alpha1.SecurityPolicy),
+					Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+						t, ok := obj.(*v1alpha1.SecurityPolicy)
+						if !ok {
+							err := fmt.Errorf("unsupported object type %T", obj)
+							errChan <- err
+							panic(err)
+						}
+						tCopy := t.DeepCopy()
+						tCopy.Status = *val
+						return tCopy
+					}),
+				})
+			},
+		)
+		r.log.Info("securityPolicy status subscriber shutting down")
+	}()
+}
+
+func (r *gatewayAPIReconciler) updateStatusForGateway(ctx context.Context, gtw *gwapiv1.Gateway) {
+	// nil check for unit tests.
+	if r.statusUpdater == nil {
+		return
+	}
+
+	// Get deployment
+	deploy, err := r.envoyDeploymentForGateway(ctx, gtw)
+	if err != nil {
+		r.log.Info("failed to get Deployment for gateway",
+			"namespace", gtw.Namespace, "name", gtw.Name)
+	}
+
+	// Get service
+	svc, err := r.envoyServiceForGateway(ctx, gtw)
+	if err != nil {
+		r.log.Info("failed to get Service for gateway",
+			"namespace", gtw.Namespace, "name", gtw.Name)
+	}
+	// update accepted condition
+	status.UpdateGatewayStatusAcceptedCondition(gtw, true)
+	// update address field and programmed condition
+	status.UpdateGatewayStatusProgrammedCondition(gtw, svc, deploy, r.store.listNodeAddresses()...)
+
+	key := utils.NamespacedName(gtw)
+
+	// publish status
+	r.statusUpdater.Send(status.Update{
+		NamespacedName: key,
+		Resource:       new(gwapiv1.Gateway),
+		Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+			g, ok := obj.(*gwapiv1.Gateway)
+			if !ok {
+				panic(fmt.Sprintf("unsupported object type %T", obj))
+			}
+			gCopy := g.DeepCopy()
+			gCopy.Status.Conditions = gtw.Status.Conditions
+			gCopy.Status.Addresses = gtw.Status.Addresses
+			gCopy.Status.Listeners = gtw.Status.Listeners
+			return gCopy
+		}),
+	})
+}
+
+func (r *gatewayAPIReconciler) updateStatusForGatewayClass(
+	ctx context.Context,
+	gc *gwapiv1.GatewayClass,
+	accepted bool,
+	reason,
+	msg string) error {
+	if r.statusUpdater != nil {
+		r.statusUpdater.Send(status.Update{
+			NamespacedName: types.NamespacedName{Name: gc.Name},
+			Resource:       &gwapiv1.GatewayClass{},
+			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
+				gc, ok := obj.(*gwapiv1.GatewayClass)
+				if !ok {
+					panic(fmt.Sprintf("unsupported object type %T", obj))
+				}
+
+				return status.SetGatewayClassAccepted(gc.DeepCopy(), accepted, reason, msg)
+			}),
+		})
+	} else {
+		// this branch makes testing easier by not going through the status.Updater.
+		duplicate := status.SetGatewayClassAccepted(gc.DeepCopy(), accepted, reason, msg)
+
+		if err := r.client.Status().Update(ctx, duplicate); err != nil && !kerrors.IsNotFound(err) {
+			return fmt.Errorf("error updating status of gatewayclass %s: %w", duplicate.Name, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR does the following:
* Adds Indexing to `SecurityPolicy` to allow searching for `SecurityPolicies` by Secrets in OIDC and Basic Auth configurations
* Trigger a reconciliation on `SecurityPolicy` when a referenced Secret is updated
* Move Status Updating to a separate file to shrink the huge controller.go
Fix: https://github.com/envoyproxy/gateway/issues/2497

