### PR TITLE
bug: skip backendRefs with weight set to 0

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -1053,6 +1053,11 @@ func (t *Translator) processDestination(backendRef gwapiv1.BackendRef,
 		return nil, weight
 	}
 
+	// Skip processing backends with 0 weight
+	if weight == 0 {
+		return nil, weight
+	}
+
 	var (
 		endpoints []*ir.DestinationEndpoint
 		addrType  *ir.DestinationAddressType

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.in.yaml
@@ -37,3 +37,6 @@ httpRoutes:
             - name: service-3
               port: 8080
               weight: 3
+            - name: service-4
+              port: 8080
+              weight: 0

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -61,6 +61,9 @@ httpRoutes:
       - name: service-3
         port: 8080
         weight: 3
+      - name: service-4
+        port: 8080
+        weight: 0
       matches:
       - path:
           value: /

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -62,7 +62,7 @@ func TestTranslate(t *testing.T) {
 			}
 
 			// Add common test fixtures
-			for i := 1; i <= 3; i++ {
+			for i := 1; i <= 4; i++ {
 				svcName := "service-" + strconv.Itoa(i)
 				epSliceName := "endpointslice-" + strconv.Itoa(i)
 				resources.Services = append(resources.Services,


### PR DESCRIPTION
* Envoy's `LocalityLbEndpoints.LoadBalancingWeight` only accepts weights greater than 0. So skip such backends/endpoints in the gateway api layer
* From the API spec, no other processing is required for such cases https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.BackendRef
```
If weight is set to 0, no traffic should be forwarded for this entry.
```

Fixes https://github.com/envoyproxy/gateway/issues/2495