### PR TITLE
chore: Cleanups for issue #2506

### DIFF
--- a/internal/ir/infra.go
+++ b/internal/ir/infra.go
@@ -79,13 +79,6 @@ type ProxyListener struct {
 type HTTP3Settings struct {
 }
 
-// HTTP1Settings provides HTTP/1 configuration on the listener.
-// +k8s:deepcopy-gen=true
-type HTTP1Settings struct {
-	EnableTrailers     bool `json:"enableTrailers,omitempty" yaml:"enableTrailers,omitempty"`
-	PreserveHeaderCase bool `json:"preserveHeaderCase,omitempty" yaml:"preserveHeaderCase,omitempty"`
-}
-
 // ListenerPort defines a network port of a listener.
 // +k8s:deepcopy-gen=true
 type ListenerPort struct {

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -346,6 +346,13 @@ type BackendWeights struct {
 	Invalid uint32 `json:"invalid" yaml:"invalid"`
 }
 
+// HTTP1Settings provides HTTP/1 configuration on the listener.
+// +k8s:deepcopy-gen=true
+type HTTP1Settings struct {
+	EnableTrailers     bool `json:"enableTrailers,omitempty" yaml:"enableTrailers,omitempty"`
+	PreserveHeaderCase bool `json:"preserveHeaderCase,omitempty" yaml:"preserveHeaderCase,omitempty"`
+}
+
 // HTTPRoute holds the route information associated with the HTTP Route
 // +k8s:deepcopy-gen=true
 type HTTPRoute struct {

--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -48,6 +48,8 @@ func http1ProtocolOptions(opts *ir.HTTP1Settings) *corev3.Http1ProtocolOptions {
 	if !opts.EnableTrailers && !opts.PreserveHeaderCase {
 		return nil
 	}
+	// If PreserveHeaderCase is true and EnableTrailers is false then setting the EnableTrailers field to false
+	// is simply keeping it at its default value of "disabled".
 	r := &corev3.Http1ProtocolOptions{
 		EnableTrailers: opts.EnableTrailers,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes some nits from the review comments for #2506:

1. Move the `HTTP1Settings` struct to `xds.go`
2. Add a comment as requested in the review.
