### PR TITLE
fix: LoadBalancerIP validation to prevent trailing period

### DIFF
--- a/api/v1alpha1/envoyproxy_types.go
+++ b/api/v1alpha1/envoyproxy_types.go
@@ -130,18 +130,12 @@ type EnvoyProxyKubernetesProvider struct {
 	// are applied.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:message="allocateLoadBalancerNodePorts can only be set for LoadBalancer type",rule="!has(self.allocateLoadBalancerNodePorts) || self.type == 'LoadBalancer'"
-	// +kubebuilder:validation:XValidation:message="loadBalancerIP can only be set for LoadBalancer type",rule="!has(self.loadBalancerIP) || self.type == 'LoadBalancer'"
-	// +kubebuilder:validation:XValidation:message="loadBalancerIP must be a valid IPv4 address",rule="!has(self.loadBalancerIP) || self.loadBalancerIP.matches(r\"^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\\.|$)){4})\")"
 	EnvoyService *KubernetesServiceSpec `json:"envoyService,omitempty"`
 
 	// EnvoyHpa defines the Horizontal Pod Autoscaler settings for Envoy Proxy Deployment.
 	// Once the HPA is being set, Replicas field from EnvoyDeployment will be ignored.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:message="minReplicas must be greater than 0",rule="!has(self.minReplicas) || self.minReplicas > 0"
-	// +kubebuilder:validation:XValidation:message="maxReplicas must be greater than 0",rule="!has(self.maxReplicas) || self.maxReplicas > 0"
-	// +kubebuilder:validation:XValidation:message="maxReplicas cannot be less than minReplicas",rule="!has(self.minReplicas) || self.maxReplicas >= self.minReplicas"
 	EnvoyHpa *KubernetesHorizontalPodAutoscalerSpec `json:"envoyHpa,omitempty"`
 }
 

--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -210,6 +210,8 @@ const (
 )
 
 // KubernetesServiceSpec defines the desired state of the Kubernetes service resource.
+// +kubebuilder:validation:XValidation:message="allocateLoadBalancerNodePorts can only be set for LoadBalancer type",rule="!has(self.allocateLoadBalancerNodePorts) || self.type == 'LoadBalancer'"
+// +kubebuilder:validation:XValidation:message="loadBalancerIP can only be set for LoadBalancer type",rule="!has(self.loadBalancerIP) || self.type == 'LoadBalancer'"
 type KubernetesServiceSpec struct {
 	// Annotations that should be appended to the service.
 	// By default, no annotations are appended.
@@ -243,6 +245,8 @@ type KubernetesServiceSpec struct {
 	// may be ignored if the load balancer provider does not support this feature.
 	// This field has been deprecated in Kubernetes, but it is still used for setting the IP Address in some cloud
 	// providers such as GCP.
+	//
+	// +kubebuilder:validation:XValidation:message="loadBalancerIP must be a valid IPv4 address",rule="self.matches(r\"^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\\.|$)){4})\")"
 	// +optional
 	LoadBalancerIP *string `json:"loadBalancerIP,omitempty"`
 
@@ -328,16 +332,20 @@ const (
 
 // KubernetesHorizontalPodAutoscalerSpec defines Kubernetes Horizontal Pod Autoscaler settings of Envoy Proxy Deployment.
 // See k8s.io.autoscaling.v2.HorizontalPodAutoScalerSpec.
+//
+// +kubebuilder:validation:XValidation:message="maxReplicas cannot be less than minReplicas",rule="!has(self.minReplicas) || self.maxReplicas >= self.minReplicas"
 type KubernetesHorizontalPodAutoscalerSpec struct {
 	// minReplicas is the lower limit for the number of replicas to which the autoscaler
 	// can scale down. It defaults to 1 replica.
 	//
+	// +kubebuilder:validation:XValidation:message="minReplicas must be greater than 0",rule="self > 0"
 	// +optional
 	MinReplicas *int32 `json:"minReplicas,omitempty"`
 
 	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
 	// It cannot be less that minReplicas.
 	//
+	// +kubebuilder:validation:XValidation:message="maxReplicas must be greater than 0",rule="self > 0"
 	MaxReplicas *int32 `json:"maxReplicas"`
 
 	// metrics contains the specifications for which to use to calculate the

--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -246,7 +246,7 @@ type KubernetesServiceSpec struct {
 	// This field has been deprecated in Kubernetes, but it is still used for setting the IP Address in some cloud
 	// providers such as GCP.
 	//
-	// +kubebuilder:validation:XValidation:message="loadBalancerIP must be a valid IPv4 address",rule="self.matches(r\"^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\\.|$)){4})\")"
+	// +kubebuilder:validation:XValidation:message="loadBalancerIP must be a valid IPv4 address",rule="self.matches(r\"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$\")"
 	// +optional
 	LoadBalancerIP *string `json:"loadBalancerIP,omitempty"`
 

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
@@ -5981,6 +5981,9 @@ spec:
                               cannot be less that minReplicas.
                             format: int32
                             type: integer
+                            x-kubernetes-validations:
+                            - message: maxReplicas must be greater than 0
+                              rule: self > 0
                           metrics:
                             description: metrics contains the specifications for which
                               to use to calculate the desired replica count (the maximum
@@ -6516,14 +6519,13 @@ spec:
                               It defaults to 1 replica.
                             format: int32
                             type: integer
+                            x-kubernetes-validations:
+                            - message: minReplicas must be greater than 0
+                              rule: self > 0
                         required:
                         - maxReplicas
                         type: object
                         x-kubernetes-validations:
-                        - message: minReplicas must be greater than 0
-                          rule: '!has(self.minReplicas) || self.minReplicas > 0'
-                        - message: maxReplicas must be greater than 0
-                          rule: '!has(self.maxReplicas) || self.maxReplicas > 0'
                         - message: maxReplicas cannot be less than minReplicas
                           rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
                       envoyService:
@@ -6574,6 +6576,9 @@ spec:
                               but it is still used for setting the IP Address in some
                               cloud providers such as GCP.
                             type: string
+                            x-kubernetes-validations:
+                            - message: loadBalancerIP must be a valid IPv4 address
+                              rule: self.matches(r"^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})")
                           type:
                             default: LoadBalancer
                             description: Type determines how the Service is exposed.
@@ -6598,8 +6603,6 @@ spec:
                         - message: loadBalancerIP can only be set for LoadBalancer
                             type
                           rule: '!has(self.loadBalancerIP) || self.type == ''LoadBalancer'''
-                        - message: loadBalancerIP must be a valid IPv4 address
-                          rule: '!has(self.loadBalancerIP) || self.loadBalancerIP.matches(r"^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})")'
                     type: object
                   type:
                     description: Type is the type of resource provider to use. A resource

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
@@ -6578,7 +6578,7 @@ spec:
                             type: string
                             x-kubernetes-validations:
                             - message: loadBalancerIP must be a valid IPv4 address
-                              rule: self.matches(r"^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})")
+                              rule: self.matches(r"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
                           type:
                             default: LoadBalancer
                             description: Type determines how the Service is exposed.

--- a/test/cel-validation/envoyproxy_test.go
+++ b/test/cel-validation/envoyproxy_test.go
@@ -161,6 +161,23 @@ func TestEnvoyProxyProvider(t *testing.T) {
 						Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
 							EnvoyService: &egv1a1.KubernetesServiceSpec{
 								Type:           ptr.To(egv1a1.ServiceTypeLoadBalancer),
+								LoadBalancerIP: ptr.To("1.2.3.4."),
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{"loadBalancerIP must be a valid IPv4 address"},
+		},
+		{
+			desc: "ServiceTypeLoadBalancer-with-invalid-IP",
+			mutate: func(envoy *egv1a1.EnvoyProxy) {
+				envoy.Spec = egv1a1.EnvoyProxySpec{
+					Provider: &egv1a1.EnvoyProxyProvider{
+						Type: egv1a1.ProviderTypeKubernetes,
+						Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
+							EnvoyService: &egv1a1.KubernetesServiceSpec{
+								Type:           ptr.To(egv1a1.ServiceTypeLoadBalancer),
 								LoadBalancerIP: ptr.To("a.b.c.d"),
 							},
 						},


### PR DESCRIPTION
**What type of PR is this?**

fix: LoadBalancerIP validation to prevent trailing period

**What this PR does / why we need it**:

Current validation allowed `loadBalancerIP` to have a trailing period. This corrects the match expression to reject values such as `1.2.3.4.` and moves the validation rules for shared types to reside with the objects they are validating.