### PR TITLE
fix: Deprecated field error when using RequestHeaderModifier filter

### DIFF
--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -329,12 +329,20 @@ func buildXdsAddedHeaders(headersToAdd []ir.AddHeader) []*corev3.HeaderValueOpti
 	headerValueOptions := make([]*corev3.HeaderValueOption, len(headersToAdd))
 
 	for i, header := range headersToAdd {
+		var appendAction corev3.HeaderValueOption_HeaderAppendAction
+
+		if header.Append {
+			appendAction = corev3.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD
+		} else {
+			appendAction = corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD
+		}
+
 		headerValueOptions[i] = &corev3.HeaderValueOption{
 			Header: &corev3.HeaderValue{
 				Key:   header.Name,
 				Value: header.Value,
 			},
-			Append: &wrapperspb.BoolValue{Value: header.Append},
+			AppendAction: appendAction,
 		}
 
 		// Allow empty headers to be set, but don't add the config to do so unless necessary

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.routes.yaml
@@ -9,23 +9,21 @@
         prefix: /
       name: request-header-route
       requestHeadersToAdd:
-      - append: true
-        header:
+      - header:
           key: some-header
           value: some-value
-      - append: true
-        header:
+      - header:
           key: some-header-2
           value: some-value
-      - append: false
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
         header:
           key: some-header3
           value: some-value
-      - append: false
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
         header:
           key: some-header4
           value: some-value
-      - append: false
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
         header:
           key: empty-header
         keepEmptyValue: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.routes.yaml
@@ -9,23 +9,21 @@
         prefix: /
       name: response-header-route
       responseHeadersToAdd:
-      - append: true
-        header:
+      - header:
           key: some-header
           value: some-value
-      - append: true
-        header:
+      - header:
           key: some-header-2
           value: some-value
-      - append: false
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
         header:
           key: some-header3
           value: some-value
-      - append: false
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
         header:
           key: some-header4
           value: some-value
-      - append: false
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
         header:
           key: empty-header
         keepEmptyValue: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.routes.yaml
@@ -9,23 +9,21 @@
         prefix: /
       name: response-header-route
       responseHeadersToAdd:
-      - append: true
-        header:
+      - header:
           key: some-header
           value: some-value
-      - append: true
-        header:
+      - header:
           key: some-header-2
           value: some-value
-      - append: false
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
         header:
           key: some-header3
           value: some-value
-      - append: false
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
         header:
           key: some-header4
           value: some-value
-      - append: false
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
         header:
           key: empty-header
         keepEmptyValue: true


### PR DESCRIPTION
**What type of PR is this?**

fix: Deprecated field error when using RequestHeaderModifier filter

**What this PR does / why we need it**:

Applying the attached `HTTPRoute` currently results in envoy logging a warning:

```
4-02-07 15:09:47.684][1][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.core.v3.HeaderValueOption Using deprecated option 'envoy.config.core.v3.HeaderValueOption.append' from file base.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
```

<details>
  <summary><code>HTTPRoute</code> which triggers the warning</summary>

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: backend
  namespace: default
spec:
  hostnames:
  - www.example.com
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: eg
  rules:
  - backendRefs:
    - kind: Service
      name: backend
      port: 3000
    matches:
    - path:
        type: PathPrefix
        value: /
    filters:
    - type: RequestHeaderModifier
      requestHeaderModifier:
        add:
        - name: X-Lorem
          value: dolor
```

</details>

This change updates the route translator to use the `AppendAction` enum which replaces the deprecated boolean field.