### PR TITLE
fix: Envoy rejects XDS at runtime losing all routes on restart

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -22,6 +22,8 @@ envoyProxy:
           - name: global_config
             static_layer:
               envoy.restart_features.use_eds_cache_for_ads: true
+              re2.max_program_size.error_level: 4294967295
+              re2.max_program_size.warn_level: 1000
         dynamic_resources:
           ads_config:
             api_type: DELTA_GRPC
@@ -504,6 +506,8 @@ xds:
           - name: global_config
             staticLayer:
               envoy.restart_features.use_eds_cache_for_ads: true
+              re2.max_program_size.error_level: 4294967295
+              re2.max_program_size.warn_level: 1000
         staticResources:
           clusters:
           - connectTimeout: 0.250s

--- a/internal/cmd/egctl/testdata/translate/out/envoy-patch-policy.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/envoy-patch-policy.all.yaml
@@ -32,6 +32,8 @@ xds:
           - name: global_config
             staticLayer:
               envoy.restart_features.use_eds_cache_for_ads: true
+              re2.max_program_size.error_level: 4294967295
+              re2.max_program_size.warn_level: 1000
         staticResources:
           clusters:
           - connectTimeout: 0.250s

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -49,7 +49,9 @@
                 {
                   "name": "global_config",
                   "staticLayer": {
-                    "envoy.restart_features.use_eds_cache_for_ads": true
+                    "envoy.restart_features.use_eds_cache_for_ads": true,
+                    "re2.max_program_size.error_level": 4294967295,
+                    "re2.max_program_size.warn_level": 1000
                   }
                 }
               ]

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -32,6 +32,8 @@ xds:
           - name: global_config
             staticLayer:
               envoy.restart_features.use_eds_cache_for_ads: true
+              re2.max_program_size.error_level: 4294967295
+              re2.max_program_size.warn_level: 1000
         staticResources:
           clusters:
           - connectTimeout: 0.250s

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.bootstrap.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.bootstrap.yaml
@@ -31,6 +31,8 @@ xds:
         - name: global_config
           staticLayer:
             envoy.restart_features.use_eds_cache_for_ads: true
+            re2.max_program_size.error_level: 4294967295
+            re2.max_program_size.warn_level: 1000
       staticResources:
         clusters:
         - connectTimeout: 0.250s

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -49,7 +49,9 @@
                 {
                   "name": "global_config",
                   "staticLayer": {
-                    "envoy.restart_features.use_eds_cache_for_ads": true
+                    "envoy.restart_features.use_eds_cache_for_ads": true,
+                    "re2.max_program_size.error_level": 4294967295,
+                    "re2.max_program_size.warn_level": 1000
                   }
                 }
               ]

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -32,6 +32,8 @@ xds:
           - name: global_config
             staticLayer:
               envoy.restart_features.use_eds_cache_for_ads: true
+              re2.max_program_size.error_level: 4294967295
+              re2.max_program_size.warn_level: 1000
         staticResources:
           clusters:
           - connectTimeout: 0.250s

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.bootstrap.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.bootstrap.yaml
@@ -31,6 +31,8 @@ xds:
         - name: global_config
           staticLayer:
             envoy.restart_features.use_eds_cache_for_ads: true
+            re2.max_program_size.error_level: 4294967295
+            re2.max_program_size.warn_level: 1000
       staticResources:
         clusters:
         - connectTimeout: 0.250s

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -55,6 +55,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -54,6 +54,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -52,6 +52,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -50,6 +50,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/enable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/enable-prometheus.yaml
@@ -54,6 +54,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -52,6 +52,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -62,6 +62,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -52,6 +52,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -56,6 +56,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -50,6 +50,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -50,6 +50,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -50,6 +50,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -50,6 +50,8 @@ spec:
                 - name: global_config
                   static_layer:
                     envoy.restart_features.use_eds_cache_for_ads: true
+                    re2.max_program_size.error_level: 4294967295
+                    re2.max_program_size.warn_level: 1000
               dynamic_resources:
                 ads_config:
                   api_type: DELTA_GRPC

--- a/internal/xds/bootstrap/bootstrap.yaml.tpl
+++ b/internal/xds/bootstrap/bootstrap.yaml.tpl
@@ -33,6 +33,8 @@ layered_runtime:
   - name: global_config
     static_layer:
       envoy.restart_features.use_eds_cache_for_ads: true
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 dynamic_resources:
   ads_config:
     api_type: DELTA_GRPC

--- a/internal/xds/bootstrap/testdata/custom-stats-matcher.yaml
+++ b/internal/xds/bootstrap/testdata/custom-stats-matcher.yaml
@@ -24,6 +24,8 @@ layered_runtime:
   - name: global_config
     static_layer:
       envoy.restart_features.use_eds_cache_for_ads: true
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 dynamic_resources:
   ads_config:
     api_type: DELTA_GRPC

--- a/internal/xds/bootstrap/testdata/disable-prometheus.yaml
+++ b/internal/xds/bootstrap/testdata/disable-prometheus.yaml
@@ -13,6 +13,8 @@ layered_runtime:
   - name: global_config
     static_layer:
       envoy.restart_features.use_eds_cache_for_ads: true
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 dynamic_resources:
   ads_config:
     api_type: DELTA_GRPC

--- a/internal/xds/bootstrap/testdata/enable-prometheus.yaml
+++ b/internal/xds/bootstrap/testdata/enable-prometheus.yaml
@@ -13,6 +13,8 @@ layered_runtime:
   - name: global_config
     static_layer:
       envoy.restart_features.use_eds_cache_for_ads: true
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 dynamic_resources:
   ads_config:
     api_type: DELTA_GRPC

--- a/internal/xds/bootstrap/testdata/otel-metrics.yaml
+++ b/internal/xds/bootstrap/testdata/otel-metrics.yaml
@@ -13,6 +13,8 @@ layered_runtime:
   - name: global_config
     static_layer:
       envoy.restart_features.use_eds_cache_for_ads: true
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 dynamic_resources:
   ads_config:
     api_type: DELTA_GRPC


### PR DESCRIPTION
**What type of PR is this?**

fix: Envoy rejects XDS at runtime losing all routes on restart

**What this PR does / why we need it**:

By default Envoy rejects regex routes with a max program size > 100, which is very easy to trigger with simple regex matches:

```
rejected: regex '^/api/v1/object/[\w]{32}/action$' RE2 program size of 107 > max program size of 100
```

When envoy restarts, it loses all it's config resulting in 404 responses to all requests. This change lifts the deprecated validation done by `max_program_size` leaving in place a warning threshold which can be used to monitor for high complexity regex routes without putting stability of the system at risk. See thread on the related issue for full details.

**Which issue(s) this PR fixes**:

Relates #2543 
