### PR TITLE
Change route sorting order to Exact > RegularExpression > PathPrefix

### DIFF
--- a/internal/gatewayapi/sort.go
+++ b/internal/gatewayapi/sort.go
@@ -47,6 +47,7 @@ func (x XdsIRRoutes) Less(i, j int) bool {
 			if x[j].PathMatch.SafeRegex != nil {
 				return true
 			}
+		}
 	}
 	// Equal case
 

--- a/internal/gatewayapi/sort.go
+++ b/internal/gatewayapi/sort.go
@@ -18,24 +18,18 @@ func (x XdsIRRoutes) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
 func (x XdsIRRoutes) Less(i, j int) bool {
 
 	// 1. Sort based on path match type
-	// Exact > PathPrefix > RegularExpression
+	// Exact > RegularExpression > PathPrefix
 	if x[i].PathMatch != nil && x[i].PathMatch.Exact != nil {
 		if x[j].PathMatch != nil {
-			if x[j].PathMatch.Prefix != nil {
-				return false
-			}
-			if x[j].PathMatch.SafeRegex != nil {
+			if x[j].PathMatch.Prefix != nil || x[j].PathMatch.SafeRegex != nil {
 				return false
 			}
 		}
 	}
 	if x[i].PathMatch != nil && x[i].PathMatch.Prefix != nil {
 		if x[j].PathMatch != nil {
-			if x[j].PathMatch.Exact != nil {
+			if x[j].PathMatch.Exact != nil || x[j].PathMatch.SafeRegex != nil {
 				return true
-			}
-			if x[j].PathMatch.SafeRegex != nil {
-				return false
 			}
 		}
 	}
@@ -45,7 +39,7 @@ func (x XdsIRRoutes) Less(i, j int) bool {
 				return true
 			}
 			if x[j].PathMatch.Prefix != nil {
-				return true
+				return false
 			}
 		}
 	}
@@ -96,11 +90,11 @@ func pathMatchCount(pathMatch *ir.StringMatch) int {
 		if pathMatch.Exact != nil {
 			return len(*pathMatch.Exact)
 		}
-		if pathMatch.Prefix != nil {
-			return len(*pathMatch.Prefix)
-		}
 		if pathMatch.SafeRegex != nil {
 			return len(*pathMatch.SafeRegex)
+		}
+		if pathMatch.Prefix != nil {
+			return len(*pathMatch.Prefix)
 		}
 	}
 	return 0

--- a/internal/gatewayapi/sort.go
+++ b/internal/gatewayapi/sort.go
@@ -21,15 +21,11 @@ func (x XdsIRRoutes) Less(i, j int) bool {
 	// Exact > RegularExpression > PathPrefix
 	if x[i].PathMatch != nil && x[i].PathMatch.Exact != nil {
 		if x[j].PathMatch != nil {
-			if x[j].PathMatch.Prefix != nil || x[j].PathMatch.SafeRegex != nil {
+			if x[j].PathMatch.SafeRegex != nil {
 				return false
 			}
-		}
-	}
-	if x[i].PathMatch != nil && x[i].PathMatch.Prefix != nil {
-		if x[j].PathMatch != nil {
-			if x[j].PathMatch.Exact != nil || x[j].PathMatch.SafeRegex != nil {
-				return true
+			if x[j].PathMatch.Prefix != nil {
+				return false
 			}
 		}
 	}
@@ -42,6 +38,15 @@ func (x XdsIRRoutes) Less(i, j int) bool {
 				return false
 			}
 		}
+	}
+	if x[i].PathMatch != nil && x[i].PathMatch.Prefix != nil {
+		if x[j].PathMatch != nil {
+			if x[j].PathMatch.Exact != nil {
+				return true
+			}
+			if x[j].PathMatch.SafeRegex != nil {
+				return true
+			}
 	}
 	// Equal case
 

--- a/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
@@ -126,11 +126,11 @@ xdsIR:
             weight: 1
         hostname: '*'
         isHTTP2: true
-        name: grpcroute/default/grpcroute-1/rule/0/match/0/*
+        name: grpcroute/default/grpcroute-1/rule/0/match/1/*
         pathMatch:
           distinct: false
           name: ""
-          prefix: /com.ExampleExact
+          safeRegex: /com.[A-Z]+/[A-Za-z_][A-Za-z_0-9]*
       - backendWeights:
           invalid: 0
           valid: 0
@@ -145,8 +145,8 @@ xdsIR:
             weight: 1
         hostname: '*'
         isHTTP2: true
-        name: grpcroute/default/grpcroute-1/rule/0/match/1/*
+        name: grpcroute/default/grpcroute-1/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""
-          safeRegex: /com.[A-Z]+/[A-Za-z_][A-Za-z_0-9]*
+          prefix: /com.ExampleExact


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
-->
fix

**What this PR does / why we need it**:

Like <https://github.com/kubernetes-sigs/gateway-api/issues/1770>, I've encountered a case when converting the following ingress definition:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: sentry
  namespace: sentry
spec:
  tls:
    - hosts:
        - sentry.selfhosted.tld
  rules:
    - host: sentry.selfhosted.tld
      http:
        paths:
          - path: /api/store
            pathType: ImplementationSpecific
            backend:
              service:
                name: sentry-relay
                port:
                  number: 3000
          - path: /api/[1-9][0-9]*/(.*)
            pathType: ImplementationSpecific
            backend:
              service:
                name: sentry-relay
                port:
                  number: 3000
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name: sentry-web
                port:
                  number: 9000
```

to

```yaml
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: sentry
  namespace: sentry
spec:
  hostnames:
    - sentry.selfhosted.tld
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: eg
      sectionName: https
  rules:
    - backendRefs:
        - group: ''
          kind: Service
          name: sentry-relay
          port: 3000
          weight: 1
      matches:
        - path:
            type: PathPrefix
            value: /api/store
        - path:
            type: RegularExpression
            value: ^/api/[1-9][0-9]*/.*$
    - backendRefs:
        - group: ''
          kind: Service
          name: sentry-web
          port: 9000
          weight: 1
      matches:
        - path:
            type: PathPrefix
            value: /
```

The RegularExpression is never matched because the PathPrefixes takes precedence

Based on  `Note: The precedence of RegularExpression path matches are implementation-specific.` (<https://github.com/kubernetes-sigs/gateway-api/pull/1855>), I propose in this PR to changes the route precedence order from `Exact > PathPrefix > RegularExpression` to `Exact > RegularExpression > PathPrefix`
