### PR TITLE
fix: when service type = clusterIP set the address to service.clusterIP

### DIFF
--- a/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
@@ -42,6 +42,13 @@ func newTestInfraWithAnnotations(annotations map[string]string) *ir.Infra {
 	return newTestInfraWithAnnotationsAndLabels(annotations, nil)
 }
 
+func newTestInfraWithAddresses(addresses []string) *ir.Infra {
+	infra := newTestInfraWithAnnotationsAndLabels(nil, nil)
+	infra.Proxy.Addresses = addresses
+
+	return infra
+}
+
 func newTestInfraWithAnnotationsAndLabels(annotations, labels map[string]string) *ir.Infra {
 	i := ir.NewInfra()
 
@@ -546,6 +553,15 @@ func TestService(t *testing.T) {
 				Annotations: map[string]string{
 					"anno1": "value1-override",
 				},
+			},
+		},
+		{
+			caseName: "clusterIP-custom-addresses",
+			infra: newTestInfraWithAddresses([]string{
+				"10.102.168.100",
+			}),
+			service: &egv1a1.KubernetesServiceSpec{
+				Type: &svcType,
 			},
 		},
 	}

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/clusterIP-custom-addresses.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/clusterIP-custom-addresses.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: envoy
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/managed-by: envoy-gateway
+    gateway.envoyproxy.io/owning-gateway-name: default
+    gateway.envoyproxy.io/owning-gateway-namespace: default
+  name: envoy-default-37a8eec1
+  namespace: envoy-gateway-system
+spec:
+  clusterIP: 10.102.168.100
+  clusterIPs:
+    - 10.102.168.100
+  ports:
+    - name: envoy-EnvoyHTTPPort-d76a15e2
+      port: 0
+      protocol: TCP
+      targetPort: 8080
+    - name: envoy-EnvoyHTTPSPort-6658f727
+      port: 0
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/name: envoy
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/managed-by: envoy-gateway
+    gateway.envoyproxy.io/owning-gateway-name: default
+    gateway.envoyproxy.io/owning-gateway-namespace: default
+  sessionAffinity: None
+  type: ClusterIP

--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -28,10 +28,12 @@ func UpdateGatewayStatusProgrammedCondition(gw *gwapiv1.Gateway, svc *corev1.Ser
 		// If the addresses is explicitly set in the Gateway spec by the user, use it
 		// to populate the Status
 		if len(gw.Spec.Addresses) > 0 {
-			// Make sure the addresses have been populated into ExternalIPs
+			// Make sure the addresses have been populated into ExternalIPs/ClusterIPs
 			// and use that value
 			if len(svc.Spec.ExternalIPs) > 0 {
 				addresses = append(addresses, svc.Spec.ExternalIPs...)
+			} else if len(svc.Spec.ClusterIPs) > 0 {
+				addresses = append(addresses, svc.Spec.ClusterIPs...)
 			}
 		} else {
 			if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {


### PR DESCRIPTION
**What type of PR is this?**
fix:  when service type = clusterIP set the address to service.clusterIP 

**What this PR does / why we need it**:

This commit solves the problem that when setting Service Type=ClusterIP and customizing the address for Gateway.spec.addresses, the address is incorrectly set to externalIPs.

I fixed it so that it can be correctly set to the ClusterIP

**Which issue(s) this PR fixes**:

Fixes #2166 
