### PR TITLE
use ADS cache to ensure the rule order

### DIFF
--- a/internal/xds/server/runner/runner.go
+++ b/internal/xds/server/runner/runner.go
@@ -83,7 +83,7 @@ func (r *Runner) Start(ctx context.Context) (err error) {
 		PermitWithoutStream: true,
 	}))
 
-	r.cache = cache.NewSnapshotCache(false, r.Logger)
+	r.cache = cache.NewSnapshotCache(true, r.Logger)
 	registerServer(serverv3.NewServer(ctx, r.cache, r.cache), r.grpc)
 
 	// Start and listen xDS gRPC Server.


### PR DESCRIPTION
**What type of PR is this?**
fix: modifies gateway to use ADS mode

**What this PR does / why we need it**:

This pr will ensure that the delta watches are sent in correct order (see https://github.com/envoyproxy/go-control-plane/blob/main/pkg/cache/v3/simple.go#L301-L304)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2521

Like mentioned in issue, after this modification everything works great! and I can run my go script to verify it:

```
% go run main.go 
httproute.gateway.networking.k8s.io/echoserver-ext configured
2024/02/16 23:41:06 fetching code
securitypolicy.gateway.envoyproxy.io/echoserver-ext-oidc created
2024/02/16 23:41:06 fetching code
2024/02/16 23:41:07 fetching code
securitypolicy.gateway.envoyproxy.io "echoserver-ext-oidc" deleted
httproute.gateway.networking.k8s.io "echoserver-ext" deleted
httproute.gateway.networking.k8s.io/echoserver-ext created
2024/02/16 23:41:10 fetching code
2024/02/16 23:41:11 fetching code
securitypolicy.gateway.envoyproxy.io/echoserver-ext-oidc created
2024/02/16 23:41:11 fetching code
2024/02/16 23:41:12 fetching code
securitypolicy.gateway.envoyproxy.io "echoserver-ext-oidc" deleted
httproute.gateway.networking.k8s.io "echoserver-ext" deleted
First failure count: 0
Second failure count: 0
Total executions: 2
```
