### PR TITLE
chore: Update Envoy proxy image to envoy:distroless-dev in main

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -19,7 +19,7 @@ const (
 	// DefaultDeploymentMemoryResourceRequests for deployment memory resource
 	DefaultDeploymentMemoryResourceRequests = "512Mi"
 	// DefaultEnvoyProxyImage is the default image used by envoyproxy
-	DefaultEnvoyProxyImage = "envoyproxy/envoy-dev:latest"
+	DefaultEnvoyProxyImage = "envoyproxy/envoy:distroless-dev"
 	// DefaultRateLimitImage is the default image used by ratelimit.
 	DefaultRateLimitImage = "envoyproxy/ratelimit:master"
 	// HTTPProtocol is the common-used http protocol.

--- a/internal/gatewayapi/testdata/disable-accesslog.in.yaml
+++ b/internal/gatewayapi/testdata/disable-accesslog.in.yaml
@@ -21,7 +21,7 @@ envoyproxy:
               value: env_a_value
             - name: env_b
               value: env_b_name
-            image: "envoyproxy/envoy-dev:latest"
+            image: "envoyproxy/envoy:distroless-dev"
             resources:
               requests:
                 cpu: 100m

--- a/internal/gatewayapi/testdata/disable-accesslog.out.yaml
+++ b/internal/gatewayapi/testdata/disable-accesslog.out.yaml
@@ -60,7 +60,7 @@ infraIR:
                     value: env_a_value
                   - name: env_b
                     value: env_b_name
-                  image: envoyproxy/envoy-dev:latest
+                  image: envoyproxy/envoy:distroless-dev
                   resources:
                     requests:
                       cpu: 100m

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json-no-format.in.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json-no-format.in.yaml
@@ -27,7 +27,7 @@ envoyproxy:
               value: env_a_value
             - name: env_b
               value: env_b_name
-            image: "envoyproxy/envoy-dev:latest"
+            image: "envoyproxy/envoy:distroless-dev"
             resources:
               requests:
                 cpu: 100m

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json-no-format.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json-no-format.out.yaml
@@ -60,7 +60,7 @@ infraIR:
                     value: env_a_value
                   - name: env_b
                     value: env_b_name
-                  image: envoyproxy/envoy-dev:latest
+                  image: envoyproxy/envoy:distroless-dev
                   resources:
                     requests:
                       cpu: 100m

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json.in.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json.in.yaml
@@ -30,7 +30,7 @@ envoyproxy:
               value: env_a_value
             - name: env_b
               value: env_b_name
-            image: "envoyproxy/envoy-dev:latest"
+            image: "envoyproxy/envoy:distroless-dev"
             resources:
               requests:
                 cpu: 100m

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json.out.yaml
@@ -60,7 +60,7 @@ infraIR:
                     value: env_a_value
                   - name: env_b
                     value: env_b_name
-                  image: envoyproxy/envoy-dev:latest
+                  image: envoyproxy/envoy:distroless-dev
                   resources:
                     requests:
                       cpu: 100m

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-with-bad-sinks.in.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-with-bad-sinks.in.yaml
@@ -28,7 +28,7 @@ envoyproxy:
               value: env_a_value
             - name: env_b
               value: env_b_name
-            image: "envoyproxy/envoy-dev:latest"
+            image: "envoyproxy/envoy:distroless-dev"
             resources:
               requests:
                 cpu: 100m

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-with-bad-sinks.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-with-bad-sinks.out.yaml
@@ -60,7 +60,7 @@ infraIR:
                     value: env_a_value
                   - name: env_b
                     value: env_b_name
-                  image: envoyproxy/envoy-dev:latest
+                  image: envoyproxy/envoy:distroless-dev
                   resources:
                     requests:
                       cpu: 100m

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog.in.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog.in.yaml
@@ -35,7 +35,7 @@ envoyproxy:
               value: env_a_value
             - name: env_b
               value: env_b_name
-            image: "envoyproxy/envoy-dev:latest"
+            image: "envoyproxy/envoy:distroless-dev"
             resources:
               requests:
                 cpu: 100m

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog.out.yaml
@@ -60,7 +60,7 @@ infraIR:
                     value: env_a_value
                   - name: env_b
                     value: env_b_name
-                  image: envoyproxy/envoy-dev:latest
+                  image: envoyproxy/envoy:distroless-dev
                   resources:
                     requests:
                       cpu: 100m

--- a/internal/gatewayapi/testdata/envoyproxy-valid.in.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-valid.in.yaml
@@ -18,7 +18,7 @@ envoyproxy:
               value: env_a_value
             - name: env_b
               value: env_b_name
-            image: "envoyproxy/envoy-dev:latest"
+            image: "envoyproxy/envoy:distroless-dev"
             resources:
               requests:
                 cpu: 100m

--- a/internal/gatewayapi/testdata/envoyproxy-valid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-valid.out.yaml
@@ -60,7 +60,7 @@ infraIR:
                     value: env_a_value
                   - name: env_b
                     value: env_b_name
-                  image: envoyproxy/envoy-dev:latest
+                  image: envoyproxy/envoy:distroless-dev
                   resources:
                     requests:
                       cpu: 100m

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:distroless-dev
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -51,7 +51,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:distroless-dev
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -151,7 +151,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:distroless-dev
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/enable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/enable-prometheus.yaml
@@ -177,7 +177,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:distroless-dev
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -163,7 +163,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:distroless-dev
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -157,7 +157,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:distroless-dev
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -51,7 +51,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:distroless-dev
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -153,7 +153,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:distroless-dev
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -151,7 +151,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:distroless-dev
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -151,7 +151,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:distroless-dev
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -151,7 +151,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-          image: envoyproxy/envoy-dev:latest
+          image: envoyproxy/envoy:distroless-dev
           imagePullPolicy: IfNotPresent
           name: envoy
           ports:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the Envoy proxy image used to distroless dev builds for the `main` branch.