### PR TITLE
bug: fix deletion of all gatewayclasses

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -52,7 +52,10 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 		func(update message.Update[string, *gatewayapi.GatewayClassResources], errChan chan error) {
 			r.Logger.Info("received an update")
 			val := update.Value
+			// There is only 1 key which is the controller name
+			// so when a delete is triggered, delete all IR keys
 			if update.Delete || val == nil {
+				r.deleteAllIRKeys()
 				return
 			}
 
@@ -163,6 +166,14 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 		},
 	)
 	r.Logger.Info("shutting down")
+}
+
+// deleteAllIRKeys deletes all XdsIR and InfraIR
+func (r *Runner) deleteAllIRKeys() {
+	for key := range r.InfraIR.LoadAll() {
+		r.InfraIR.Delete(key)
+		r.XdsIR.Delete(key)
+	}
 }
 
 // getIRKeysToDelete returns the list of IR keys to delete

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -154,9 +154,6 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 				!slice.ContainsString(gwClass.Finalizers, gatewayClassFinalizer) {
 				r.log.Info("gatewayclass marked for deletion")
 				cc.removeMatch(&gwClass)
-
-				// Delete the gatewayclass from the watchable map.
-				r.resources.GatewayAPIResources.Delete(gwClass.Name)
 				continue
 			}
 
@@ -167,6 +164,7 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 	// The gatewayclass was already deleted/finalized and there are stale queue entries.
 	acceptedGCs := cc.matchedClasses
 	if acceptedGCs == nil {
+		r.resources.GatewayAPIResources.Delete(string(r.classController))
 		r.log.Info("no accepted gatewayclass")
 		return reconcile.Result{}, nil
 	}
@@ -352,13 +350,13 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 				r.log.Error(err, fmt.Sprintf("failed to remove finalizer from gatewayclass %s",
 					acceptedGC.Name))
 				return reconcile.Result{}, err
-			} else {
-				// finalize the accepted GatewayClass.
-				if err := r.addFinalizer(ctx, acceptedGC); err != nil {
-					r.log.Error(err, fmt.Sprintf("failed adding finalizer to gatewayclass %s",
-						acceptedGC.Name))
-					return reconcile.Result{}, err
-				}
+			}
+		} else {
+			// finalize the accepted GatewayClass.
+			if err := r.addFinalizer(ctx, acceptedGC); err != nil {
+				r.log.Error(err, fmt.Sprintf("failed adding finalizer to gatewayclass %s",
+					acceptedGC.Name))
+				return reconcile.Result{}, err
 			}
 		}
 	}


### PR DESCRIPTION
* when no gatewayclasses exist, delete the key from the provider resources and clean all up IRs in the gateway-api layer
* also fixed the finalizer logic
