### PR TITLE
Fix: requests not matching defined routes trigger per-route filters

### DIFF
--- a/internal/gatewayapi/testdata/securitypolicy-with-basic-auth.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-basic-auth.out.yaml
@@ -155,14 +155,3 @@ xdsIR:
           distinct: false
           name: ""
           prefix: /foo
-      - backendWeights:
-          invalid: 0
-          valid: 0
-        directResponse:
-          statusCode: 404
-        hostname: gateway.envoyproxy.io
-        name: gateway_envoyproxy_io/catch-all-return-404
-        pathMatch:
-          distinct: false
-          name: ""
-          prefix: /

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth.out.yaml
@@ -272,25 +272,3 @@ xdsIR:
           distinct: false
           name: ""
           prefix: /bar
-      - backendWeights:
-          invalid: 0
-          valid: 0
-        directResponse:
-          statusCode: 404
-        hostname: www.foo.com
-        name: www_foo_com/catch-all-return-404
-        pathMatch:
-          distinct: false
-          name: ""
-          prefix: /
-      - backendWeights:
-          invalid: 0
-          valid: 0
-        directResponse:
-          statusCode: 404
-        hostname: www.bar.com
-        name: www_bar_com/catch-all-return-404
-        pathMatch:
-          distinct: false
-          name: ""
-          prefix: /

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc.in.yaml
@@ -62,7 +62,7 @@ httpRoutes:
     name: httproute-2
   spec:
     hostnames:
-    - www.foo.com
+    - www.example.com
     parentRefs:
     - namespace: envoy-gateway
       name: gateway-1
@@ -70,7 +70,7 @@ httpRoutes:
     rules:
     - matches:
       - path:
-          value: "/"
+          value: "/bar"
       backendRefs:
       - name: service-1
         port: 8080

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc.out.yaml
@@ -86,7 +86,7 @@ httpRoutes:
     namespace: default
   spec:
     hostnames:
-    - www.foo.com
+    - www.example.com
     parentRefs:
     - name: gateway-1
       namespace: envoy-gateway
@@ -97,7 +97,7 @@ httpRoutes:
         port: 8080
       matches:
       - path:
-          value: /
+          value: /bar
   status:
     parents:
     - conditions:
@@ -256,8 +256,8 @@ xdsIR:
               port: 8080
             protocol: HTTP
             weight: 1
-        hostname: www.foo.com
-        name: httproute/default/httproute-2/rule/0/match/0/www_foo_com
+        hostname: www.example.com
+        name: httproute/default/httproute-2/rule/0/match/0/www_example_com
         oidc:
           clientID: client1.apps.googleusercontent.com
           clientSecret: Y2xpZW50MTpzZWNyZXQK
@@ -272,15 +272,4 @@ xdsIR:
         pathMatch:
           distinct: false
           name: ""
-          prefix: /
-      - backendWeights:
-          invalid: 0
-          valid: 0
-        directResponse:
-          statusCode: 404
-        hostname: www.example.com
-        name: www_example_com/catch-all-return-404
-        pathMatch:
-          distinct: false
-          name: ""
-          prefix: /
+          prefix: /bar

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -6,12 +6,8 @@
 package gatewayapi
 
 import (
-	"fmt"
-	"strings"
-
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -207,59 +203,10 @@ func (t *Translator) Translate(resources *Resources) *TranslateResult {
 	// Sort xdsIR based on the Gateway API spec
 	sortXdsIRMap(xdsIR)
 
-	// Add a catch-all route for each HTTP listener if needed
-	addCatchAllRoute(xdsIR)
-
 	return newTranslateResult(gateways, httpRoutes, grpcRoutes, tlsRoutes,
 		tcpRoutes, udpRoutes, clientTrafficPolicies, backendTrafficPolicies,
 		securityPolicies, xdsIR, infraIR)
 
-}
-
-// For filters without native per-route support, we need to add a catch-all route
-// to ensure that these filters are disabled for non-matching requests.
-// https://github.com/envoyproxy/gateway/issues/2507
-func addCatchAllRoute(xdsIR map[string]*ir.Xds) {
-	for _, i := range xdsIR {
-		for _, http := range i.HTTP {
-			var needCatchAllRoutePerHost = make(map[string]bool)
-			for _, r := range http.Routes {
-				if r.ExtAuth != nil || r.BasicAuth != nil || r.OIDC != nil {
-					needCatchAllRoutePerHost[r.Hostname] = true
-				}
-			}
-
-			// skip if there is already a catch-all route
-			for host := range needCatchAllRoutePerHost {
-				for _, r := range http.Routes {
-					if (r.Hostname == host &&
-						r.PathMatch != nil &&
-						r.PathMatch.Prefix != nil &&
-						*r.PathMatch.Prefix == "/") &&
-						len(r.HeaderMatches) == 0 &&
-						len(r.QueryParamMatches) == 0 {
-						delete(needCatchAllRoutePerHost, host)
-					}
-				}
-			}
-
-			for host, needCatchAllRoute := range needCatchAllRoutePerHost {
-				if needCatchAllRoute {
-					underscoredHost := strings.ReplaceAll(host, ".", "_")
-					http.Routes = append(http.Routes, &ir.HTTPRoute{
-						Name: fmt.Sprintf("%s/catch-all-return-404", underscoredHost),
-						PathMatch: &ir.StringMatch{
-							Prefix: ptr.To("/"),
-						},
-						DirectResponse: &ir.DirectResponse{
-							StatusCode: 404,
-						},
-						Hostname: host,
-					})
-				}
-			}
-		}
-	}
 }
 
 // GetRelevantGateways returns GatewayContexts, containing a copy of the original

--- a/internal/xds/translator/basicauth.go
+++ b/internal/xds/translator/basicauth.go
@@ -7,7 +7,6 @@ package translator
 
 import (
 	"errors"
-	"fmt"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -35,6 +34,7 @@ var _ httpFilter = &basicAuth{}
 // patchHCM builds and appends the basic_auth Filters to the HTTP Connection Manager
 // if applicable, and it does not already exist.
 // Note: this method creates an basic_auth filter for each route that contains an BasicAuth config.
+// The filter is disabled by default. It is enabled on the route level.
 func (*basicAuth) patchHCM(mgr *hcmv3.HttpConnectionManager, irListener *ir.HTTPListener) error {
 	var errs error
 
@@ -77,7 +77,8 @@ func buildHCMBasicAuthFilter(route *ir.HTTPRoute) (*hcmv3.HttpFilter, error) {
 	}
 
 	return &hcmv3.HttpFilter{
-		Name: basicAuthFilterName(route),
+		Name:     basicAuthFilterName(route),
+		Disabled: true,
 		ConfigType: &hcmv3.HttpFilter_TypedConfig{
 			TypedConfig: basicAuthAny,
 		},
@@ -114,52 +115,6 @@ func routeContainsBasicAuth(irRoute *ir.HTTPRoute) bool {
 
 func (*basicAuth) patchResources(*types.ResourceVersionTable, []*ir.HTTPRoute) error {
 	return nil
-}
-
-// patchRouteCfg patches the provided route configuration with the basicAuth filter
-// if applicable.
-// Note: this method disables all the basicAuth filters by default. The filter will
-// be enabled per-route in the typePerFilterConfig of the route.
-func (*basicAuth) patchRouteConfig(routeCfg *routev3.RouteConfiguration, irListener *ir.HTTPListener) error {
-	if routeCfg == nil {
-		return errors.New("route configuration is nil")
-	}
-	if irListener == nil {
-		return errors.New("ir listener is nil")
-	}
-
-	var errs error
-	for _, route := range irListener.Routes {
-		if !routeContainsBasicAuth(route) {
-			continue
-		}
-
-		filterName := basicAuthFilterName(route)
-		filterCfg := routeCfg.TypedPerFilterConfig
-
-		if _, ok := filterCfg[filterName]; ok {
-			// This should not happen since this is the only place where the basicAuth
-			// filter is added in a route.
-			errs = errors.Join(errs, fmt.Errorf(
-				"route config already contains basicAuth config: %+v", route))
-			continue
-		}
-
-		// Disable all the filters by default. The filter will be enabled
-		// per-route in the typePerFilterConfig of the route.
-		routeCfgAny, err := anypb.New(&routev3.FilterConfig{Disabled: true})
-		if err != nil {
-			errs = errors.Join(errs, err)
-			continue
-		}
-
-		if filterCfg == nil {
-			routeCfg.TypedPerFilterConfig = make(map[string]*anypb.Any)
-		}
-
-		routeCfg.TypedPerFilterConfig[filterName] = routeCfgAny
-	}
-	return errs
 }
 
 // patchRoute patches the provided route with the basicAuth config if applicable.

--- a/internal/xds/translator/cors.go
+++ b/internal/xds/translator/cors.go
@@ -165,10 +165,6 @@ func (*cors) patchRoute(route *routev3.Route, irRoute *ir.HTTPRoute) error {
 	return nil
 }
 
-func (*cors) patchRouteConfig(*routev3.RouteConfiguration, *ir.HTTPListener) error {
-	return nil
-}
-
 func (c *cors) patchResources(*types.ResourceVersionTable, []*ir.HTTPRoute) error {
 	return nil
 }

--- a/internal/xds/translator/fault.go
+++ b/internal/xds/translator/fault.go
@@ -121,10 +121,6 @@ func (*fault) patchResources(*types.ResourceVersionTable, []*ir.HTTPRoute) error
 	return nil
 }
 
-func (*fault) patchRouteConfig(routeCfg *routev3.RouteConfiguration, irListener *ir.HTTPListener) error {
-	return nil
-}
-
 // patchRoute patches the provided route with the fault config if applicable.
 // Note: this method enables the corresponding fault filter for the provided route.
 func (*fault) patchRoute(route *routev3.Route, irRoute *ir.HTTPRoute) error {

--- a/internal/xds/translator/httpfilters.go
+++ b/internal/xds/translator/httpfilters.go
@@ -39,9 +39,8 @@ func registerHTTPFilter(filter httpFilter) {
 //   - patchHCM: EG adds a filter for each route in the HCM filter chain, the
 //     filter name is prefixed with the filter's type name, for example,
 //     "envoy.filters.http.oauth2", and suffixed with the route name. Each filter
-//     is configured with the route's per-route configuration.
-//   - patchRouteConfig: EG disables all the filters of this type in the
-//     typedFilterConfig of the route config.
+//     is configured with the route's per-route configuration. The filter is
+//     disabled by default and is enabled on the route level.
 //   - PatchRouteWithPerRouteConfig: EG enables the corresponding filter for each
 //     route in the typedFilterConfig of that route.
 //
@@ -51,10 +50,6 @@ func registerHTTPFilter(filter httpFilter) {
 type httpFilter interface {
 	// patchHCM patches the HttpConnectionManager with the filter.
 	patchHCM(mgr *hcmv3.HttpConnectionManager, irListener *ir.HTTPListener) error
-
-	// patchRouteConfig patches the provided RouteConfiguration with a filter's
-	// RouteConfiguration level configuration.
-	patchRouteConfig(rc *routev3.RouteConfiguration, irListener *ir.HTTPListener) error
 
 	// patchRoute patches the provide Route with a filter's Route level configuration.
 	patchRoute(route *routev3.Route, irRoute *ir.HTTPRoute) error
@@ -176,23 +171,6 @@ func (t *Translator) patchHCMWithFilters(
 
 	// Sort the filters in the correct order.
 	mgr.HttpFilters = sortHTTPFilters(mgr.HttpFilters)
-	return nil
-}
-
-// patchRouteCfgWithPerRouteConfig appends per-route filter configurations to the
-// provided listener's RouteConfiguration.
-// This method is used to disable the filters without native per-route support.
-// The disabled filters will be enabled by route in the patchRouteWithPerRouteConfig
-// method.
-func patchRouteCfgWithPerRouteConfig(
-	routeCfg *routev3.RouteConfiguration,
-	irListener *ir.HTTPListener) error {
-	// Only supports the oauth2 filter for now, other filters will be added later.
-	for _, filter := range httpFilters {
-		if err := filter.patchRouteConfig(routeCfg, irListener); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/internal/xds/translator/jwt.go
+++ b/internal/xds/translator/jwt.go
@@ -333,10 +333,6 @@ func routeContainsJWTAuthn(irRoute *ir.HTTPRoute) bool {
 	return false
 }
 
-func (*jwt) patchRouteConfig(*routev3.RouteConfiguration, *ir.HTTPListener) error {
-	return nil
-}
-
 // buildJwtFromHeaders returns a list of JwtHeader transformed from JWTFromHeader struct
 func buildJwtFromHeaders(headers []v1alpha1.JWTHeaderExtractor) []*jwtauthnv3.JwtHeader {
 	jwtHeaders := make([]*jwtauthnv3.JwtHeader, 0, len(headers))

--- a/internal/xds/translator/local_ratelimit.go
+++ b/internal/xds/translator/local_ratelimit.go
@@ -110,10 +110,6 @@ func (*localRateLimit) patchResources(*types.ResourceVersionTable,
 	return nil
 }
 
-func (*localRateLimit) patchRouteConfig(*routev3.RouteConfiguration, *ir.HTTPListener) error {
-	return nil
-}
-
 func (*localRateLimit) patchRoute(route *routev3.Route, irRoute *ir.HTTPRoute) error {
 	routeAction := route.GetRoute()
 

--- a/internal/xds/translator/oidc.go
+++ b/internal/xds/translator/oidc.go
@@ -40,6 +40,7 @@ var _ httpFilter = &oidc{}
 // patchHCM builds and appends the oauth2 Filters to the HTTP Connection Manager
 // if applicable, and it does not already exist.
 // Note: this method creates an oauth2 filter for each route that contains an OIDC config.
+// the filter is disabled by default. It is enabled on the route level.
 func (*oidc) patchHCM(mgr *hcmv3.HttpConnectionManager, irListener *ir.HTTPListener) error {
 	var errs error
 
@@ -85,7 +86,8 @@ func buildHCMOAuth2Filter(route *ir.HTTPRoute) (*hcmv3.HttpFilter, error) {
 	}
 
 	return &hcmv3.HttpFilter{
-		Name: oauth2FilterName(route),
+		Name:     oauth2FilterName(route),
+		Disabled: true,
 		ConfigType: &hcmv3.HttpFilter_TypedConfig{
 			TypedConfig: OAuth2Any,
 		},
@@ -339,52 +341,6 @@ func generateHMACSecretKey() ([]byte, error) {
 	}
 
 	return key, nil
-}
-
-// patchRouteCfg patches the provided route configuration with the oauth2 filter
-// if applicable.
-// Note: this method disables all the oauth2 filters by default. The filter will
-// be enabled per-route in the typePerFilterConfig of the route.
-func (*oidc) patchRouteConfig(routeCfg *routev3.RouteConfiguration, irListener *ir.HTTPListener) error {
-	if routeCfg == nil {
-		return errors.New("route configuration is nil")
-	}
-	if irListener == nil {
-		return errors.New("ir listener is nil")
-	}
-
-	var errs error
-	for _, route := range irListener.Routes {
-		if !routeContainsOIDC(route) {
-			continue
-		}
-
-		filterName := oauth2FilterName(route)
-		filterCfg := routeCfg.TypedPerFilterConfig
-
-		if _, ok := filterCfg[filterName]; ok {
-			// This should not happen since this is the only place where the oauth2
-			// filter is added in a route.
-			errs = errors.Join(errs, fmt.Errorf(
-				"route config already contains oauth2 config: %+v", route))
-			continue
-		}
-
-		// Disable all the filters by default. The filter will be enabled
-		// per-route in the typePerFilterConfig of the route.
-		routeCfgAny, err := anypb.New(&routev3.FilterConfig{Disabled: true})
-		if err != nil {
-			errs = errors.Join(errs, err)
-			continue
-		}
-
-		if filterCfg == nil {
-			routeCfg.TypedPerFilterConfig = make(map[string]*anypb.Any)
-		}
-
-		routeCfg.TypedPerFilterConfig[filterName] = routeCfgAny
-	}
-	return errs
 }
 
 // patchRoute patches the provided route with the oauth2 config if applicable.

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth.listeners.yaml
@@ -14,7 +14,8 @@
           initialStreamWindowSize: 65536
           maxConcurrentStreams: 100
         httpFilters:
-        - name: envoy.filters.http.basic_auth_first-route
+        - disabled: true
+          name: envoy.filters.http.basic_auth_first-route
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuth
             users:

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth.routes.yaml
@@ -1,9 +1,5 @@
 - ignorePortInHostMatching: true
   name: first-listener
-  typedPerFilterConfig:
-    envoy.filters.http.basic_auth_first-route:
-      '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-      disabled: true
   virtualHosts:
   - domains:
     - '*'

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.listeners.yaml
@@ -14,7 +14,8 @@
           initialStreamWindowSize: 65536
           maxConcurrentStreams: 100
         httpFilters:
-        - name: envoy.filters.http.ext_authz_httproute/default/httproute-1/rule/0/match/0/www_example_com
+        - disabled: true
+          name: envoy.filters.http.ext_authz_httproute/default/httproute-1/rule/0/match/0/www_example_com
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
             httpService:
@@ -27,7 +28,8 @@
                 cluster: securitypolicy/default/policy-for-first-route/http-backend
                 timeout: 10s
                 uri: http://http-backend.envoy-gateway:80/auth
-        - name: envoy.filters.http.ext_authz_httproute/default/httproute-2/rule/0/match/0/www_example_com
+        - disabled: true
+          name: envoy.filters.http.ext_authz_httproute/default/httproute-2/rule/0/match/0/www_example_com
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
             allowedHeaders:

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.routes.yaml
@@ -1,12 +1,5 @@
 - ignorePortInHostMatching: true
   name: first-listener
-  typedPerFilterConfig:
-    envoy.filters.http.ext_authz_httproute/default/httproute-1/rule/0/match/0/www_example_com:
-      '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-      disabled: true
-    envoy.filters.http.ext_authz_httproute/default/httproute-2/rule/0/match/0/www_example_com:
-      '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-      disabled: true
   virtualHosts:
   - domains:
     - '*'

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.listeners.yaml
@@ -14,7 +14,8 @@
           initialStreamWindowSize: 65536
           maxConcurrentStreams: 100
         httpFilters:
-        - name: envoy.filters.http.oauth2_first-route
+        - disabled: true
+          name: envoy.filters.http.oauth2_first-route
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2
             config:
@@ -48,7 +49,8 @@
                 cluster: oauth_foo_com_443
                 timeout: 10s
                 uri: https://oauth.foo.com/token
-        - name: envoy.filters.http.oauth2_second-route
+        - disabled: true
+          name: envoy.filters.http.oauth2_second-route
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2
             config:

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.routes.yaml
@@ -1,12 +1,5 @@
 - ignorePortInHostMatching: true
   name: first-listener
-  typedPerFilterConfig:
-    envoy.filters.http.oauth2_first-route:
-      '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-      disabled: true
-    envoy.filters.http.oauth2_second-route:
-      '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-      disabled: true
   virtualHosts:
   - domains:
     - '*'

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -294,11 +294,6 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 		}
 		xdsRouteCfg.VirtualHosts = append(xdsRouteCfg.VirtualHosts, vHostsList...)
 
-		// Add per-route filter configs to the route config.
-		if err := patchRouteCfgWithPerRouteConfig(xdsRouteCfg, httpListener); err != nil {
-			errs = errors.Join(errs, err)
-		}
-
 		// Add all the other needed resources referenced by this filter to the
 		// resource version table.
 		if err := patchResources(tCtx, httpListener.Routes); err != nil {

--- a/site/content/en/latest/user/oidc.md
+++ b/site/content/en/latest/user/oidc.md
@@ -3,12 +3,12 @@ title: "OIDC Authentication"
 ---
 
 This guide provides instructions for configuring [OpenID Connect (OIDC)][oidc] authentication.
-OpenID Connect (OIDC) is an authentication standard built on top of OAuth 2.0. 
-It enables client applications to rely on authentication that is performed by an OpenID Connect Provider (OP) 
+OpenID Connect (OIDC) is an authentication standard built on top of OAuth 2.0.
+It enables client applications to rely on authentication that is performed by an OpenID Connect Provider (OP)
 to verify the identity of a user.
 
-Envoy Gateway introduces a new CRD called [SecurityPolicy][SecurityPolicy] that allows the user to configure OIDC 
-authentication. 
+Envoy Gateway introduces a new CRD called [SecurityPolicy][SecurityPolicy] that allows the user to configure OIDC
+authentication.
 This instantiated resource can be linked to a [Gateway][Gateway] and [HTTPRoute][HTTPRoute] resource.
 
 ## Prerequisites
@@ -17,7 +17,7 @@ Follow the steps from the [Quickstart](../quickstart) guide to install Envoy Gat
 Before proceeding, you should be able to query the example backend using HTTP.
 
 OIDC authentication requires the redirect URL to be HTTPS. Follow the [Secure Gateways](../secure-gateways) guide
- to generate the TLS certificates and update the Gateway configuration to add an HTTPS listener.
+to generate the TLS certificates and update the Gateway configuration to add an HTTPS listener.
 
 Verify the Gateway status:
 
@@ -34,7 +34,11 @@ providers, including Auth0, Azure AD, Keycloak, Okta, OneLogin, Salesforce, UAA,
 
 Follow the steps in the [Google OIDC documentation][google-oidc] to register an OIDC application. Please make sure the
 redirect URL is set to the one you configured in the SecurityPolicy that you will create in the step below. If you don't
-specify a redirect URL in the SecurityPolicy, the default redirect URL is `https://<gateway-hostname>/oauth2/callback`.
+specify a redirect URL in the SecurityPolicy, the default redirect URL is `https://${GATEWAY_HOST}/oauth2/callback`.
+Please notice that the `redirectURL` and `logoutPath` must be caught by the target HTTPRoute. For example, if the
+HTTPRoute is configured to match the host `www.example.com` and the path `/foo`, the `redirectURL` must
+be prefixed with `https://www.example.com/foo`, and `logoutPath` must be prefixed with`/foo`, for example,
+`https://www.example.com/foo/oauth2/callback` and `/foo/logout`, otherwise the OIDC authentication will fail.
 
 After registering the application, you should have the following information:
 * Client ID: The client ID of the OIDC application.
@@ -73,6 +77,8 @@ spec:
     clientID: "${CLIENT_ID}.apps.googleusercontent.com"
     clientSecret:
       name: "my-app-client-secret"
+    redirectURI: "https://www.example.com/oauth2/callback"
+    logoutPath: "/logout"
 EOF
 ```
 

--- a/site/content/en/latest/user/oidc.md
+++ b/site/content/en/latest/user/oidc.md
@@ -34,11 +34,7 @@ providers, including Auth0, Azure AD, Keycloak, Okta, OneLogin, Salesforce, UAA,
 
 Follow the steps in the [Google OIDC documentation][google-oidc] to register an OIDC application. Please make sure the
 redirect URL is set to the one you configured in the SecurityPolicy that you will create in the step below. If you don't
-specify a redirect URL in the SecurityPolicy, the default redirect URL is `https://${GATEWAY_HOST}/oauth2/callback`.
-Please notice that the `redirectURL` and `logoutPath` must be caught by the target HTTPRoute. For example, if the 
-HTTPRoute is configured to match the host `www.example.com` and the path `/foo`, the `redirectURL` must
-be prefixed with `https://www.example.com/foo`, and `logoutPath` must be prefixed with`/foo`, for example,
-`https://www.example.com/foo/oauth2/callback` and `/foo/logout`, otherwise the OIDC authentication will fail.
+specify a redirect URL in the SecurityPolicy, the default redirect URL is `https://<gateway-hostname>/oauth2/callback`.
 
 After registering the application, you should have the following information:
 * Client ID: The client ID of the OIDC application.
@@ -77,8 +73,6 @@ spec:
     clientID: "${CLIENT_ID}.apps.googleusercontent.com"
     clientSecret:
       name: "my-app-client-secret"
-    redirectURI: "https://www.example.com/oauth2/callback"
-    logoutPath: "/logout"
 EOF
 ```
 

--- a/test/e2e/tests/basic-auth.go
+++ b/test/e2e/tests/basic-auth.go
@@ -156,35 +156,6 @@ var BasicAuthTest = suite.ConformanceTest{
 				t.Errorf("failed to compare request and response: %v", err)
 			}
 		})
-
-		// https://github.com/envoyproxy/gateway/issues/2507
-		t.Run("request without matching routes ", func(t *testing.T) {
-			ns := "gateway-conformance-infra"
-			routeNN := types.NamespacedName{Name: "http-with-basic-auth-1", Namespace: ns}
-			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
-			SecurityPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "basic-auth-1", Namespace: ns})
-			// TODO: We should wait for the `programmed` condition to be true before sending traffic.
-			expectedResponse := http.ExpectedResponse{
-				Request: http.Request{
-					Path: "/not-matching-route",
-				},
-				Response: http.Response{
-					StatusCode: 404,
-				},
-				Namespace: ns,
-			}
-
-			req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
-			cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
-			if err != nil {
-				t.Errorf("failed to get expected response: %v", err)
-			}
-
-			if err := http.CompareRequest(t, &req, cReq, cResp, expectedResponse); err != nil {
-				t.Errorf("failed to compare request and response: %v", err)
-			}
-		})
 	},
 }
 


### PR DESCRIPTION
This PR disables per-route filters in `http_filters`, and removes the filter configuration in the `route_config`.
This fixes https://github.com/envoyproxy/gateway/issues/2606 without needing to add a `catch-all-return-404` route.

Fix https://github.com/envoyproxy/gateway/issues/2606
Related: https://github.com/envoyproxy/envoy/issues/32484
