### PR TITLE
fix: allow passing empty metrics config

### DIFF
--- a/api/v1alpha1/envoygateway_helpers.go
+++ b/api/v1alpha1/envoygateway_helpers.go
@@ -104,11 +104,11 @@ func DefaultEnvoyGatewayLogging() *EnvoyGatewayLogging {
 // GetEnvoyGatewayTelemetry returns the EnvoyGatewayTelemetry of EnvoyGateway or a default EnvoyGatewayTelemetry if unspecified.
 func (e *EnvoyGateway) GetEnvoyGatewayTelemetry() *EnvoyGatewayTelemetry {
 	if e.Telemetry != nil {
-		if e.Telemetry.Metrics.Prometheus == nil {
-			e.Telemetry.Metrics.Prometheus = DefaultEnvoyGatewayPrometheus()
-		}
 		if e.Telemetry.Metrics == nil {
 			e.Telemetry.Metrics = DefaultEnvoyGatewayMetrics()
+		}
+		if e.Telemetry.Metrics.Prometheus == nil {
+			e.Telemetry.Metrics.Prometheus = DefaultEnvoyGatewayPrometheus()
 		}
 		return e.Telemetry
 	}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
-->
- fix: allow passing empty metrics fields in config

**What this PR does / why we need it**:

When using the following EnvoyGateway setup, envoy does not start due to invalid handing of nil values.

Config passed:
```yaml
data:
  envoy-gateway.yaml: |
    apiVersion: gateway.envoyproxy.io/v1alpha1
    kind: EnvoyGateway
    gateway:
      controllerName: gateway.envoyproxy.io/gatewayclass-controller
    logging:
      level:
        default: warn
    provider:
      kubernetes:
        overwrite_control_plane_certs: false
      type: Kubernetes
    telemetry:
      tracing:
        provider:
          host: otelcol-gateway-collector.observability
          port: 6831
          type: OpenTelemetry
```

Envoy logs:
```
2024-02-23T08:33:08.765Z	INFO	admin	admin/server.go:39	starting admin server	{"address": "127.0.0.1:19000", "enablePprof": false}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x108bb28]

goroutine 1 [running]:
github.com/envoyproxy/gateway/api/v1alpha1.(*EnvoyGateway).GetEnvoyGatewayTelemetry(0x40006b3a40)
	/home/runner/work/gateway/gateway/api/v1alpha1/envoygateway_helpers.go:107 +0x28
github.com/envoyproxy/gateway/api/v1alpha1.(*EnvoyGateway).DisablePrometheus(...)
	/home/runner/work/gateway/gateway/api/v1alpha1/envoygateway_helpers.go:122
github.com/envoyproxy/gateway/internal/metrics.newOptions(0x40007d7c20)
	/home/runner/work/gateway/gateway/internal/metrics/register.go:79 +0x124
github.com/envoyproxy/gateway/internal/metrics.Init(0x40007d7c20?)
	/home/runner/work/gateway/gateway/internal/metrics/register.go:35 +0x24
github.com/envoyproxy/gateway/internal/cmd.server()
	/home/runner/work/gateway/gateway/internal/cmd/server.go:59 +0x48
github.com/envoyproxy/gateway/internal/cmd.getServerCommand.func1(0x40006cf000?, {0x1fd2ab7?, 0x4?, 0x1fd29d3?})
	/home/runner/work/gateway/gateway/internal/cmd/server.go:38 +0x1c
github.com/spf13/cobra.(*Command).execute(0x4000764f00, {0x40002b4910, 0x1, 0x1})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x4000764c00)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(0x40000a0728?)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x1c
main.main()
	/home/runner/work/gateway/gateway/cmd/envoy-gateway/main.go:16 +0x20
```

Now, passing a config with both metrics and tracing works as expected:
```yaml
  gateway-helm:
    config:
      envoyGateway:
        logging:
          level:
            default: warn
        telemetry:
          metrics:
            prometheus:
              disable: false
          tracing:
            provider:
              type: OpenTelemetry
              host: otelcol-gateway-collector.observability
              port: 6831
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
