### PR TITLE
fix: Configure idle timeout when timeout is set on HTTPRoute

### DIFF
--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -8,6 +8,7 @@ package translator
 import (
 	"errors"
 	"strings"
+	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -62,7 +63,7 @@ func buildXdsRoute(httpRoute *ir.HTTPRoute) (*routev3.Route, error) {
 			// If there are invalid backends then a weighted cluster is required for the route
 			routeAction = buildXdsWeightedRouteAction(httpRoute)
 		} else {
-			routeAction = buildXdsRouteAction(httpRoute.Destination.Name)
+			routeAction = buildXdsRouteAction(httpRoute)
 		}
 		if httpRoute.Mirrors != nil {
 			routeAction.RequestMirrorPolicies = buildXdsRequestMirrorPolicies(httpRoute.Mirrors)
@@ -207,11 +208,12 @@ func buildXdsStringMatcher(irMatch *ir.StringMatch) *matcherv3.StringMatcher {
 	return stringMatcher
 }
 
-func buildXdsRouteAction(destName string) *routev3.RouteAction {
+func buildXdsRouteAction(httpRoute *ir.HTTPRoute) *routev3.RouteAction {
 	return &routev3.RouteAction{
 		ClusterSpecifier: &routev3.RouteAction_Cluster{
-			Cluster: destName,
+			Cluster: httpRoute.Destination.Name,
 		},
+		IdleTimeout: idleTimeout(httpRoute),
 	}
 }
 
@@ -239,7 +241,25 @@ func buildXdsWeightedRouteAction(httpRoute *ir.HTTPRoute) *routev3.RouteAction {
 				Clusters: clusters,
 			},
 		},
+		IdleTimeout: idleTimeout(httpRoute),
 	}
+}
+
+func idleTimeout(httpRoute *ir.HTTPRoute) *durationpb.Duration {
+	if httpRoute.Timeout != nil && httpRoute.Timeout.HTTP != nil {
+		if httpRoute.Timeout.HTTP.RequestTimeout != nil {
+			var timeout time.Duration
+
+			// If request timeout is other than zero, use request timeout + 30 so
+			// idle timeout will not interfere with configured request timeout.
+			if httpRoute.Timeout.HTTP.RequestTimeout.Duration != 0 {
+				timeout = httpRoute.Timeout.HTTP.RequestTimeout.Duration + time.Second*30
+			}
+
+			return durationpb.New(timeout)
+		}
+	}
+	return nil
 }
 
 func buildXdsRedirectAction(redirection *ir.Redirect) *routev3.RedirectAction {

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-timeout.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-timeout.yaml
@@ -27,10 +27,21 @@ http:
     hostname: "*"
     timeout:
       http:
-        requestTimeout: 0s
+        requestTimeout: 4000s
     destination:
       name: "second-route-dest"
       settings:
       - endpoints:
         - host: "1.2.3.4"
           port: 50001
+  - name: "third-route"
+    hostname: "*"
+    timeout:
+      http:
+        requestTimeout: 0s
+    destination:
+      name: "third-route-dest"
+      settings:
+      - endpoints:
+        - host: "1.2.3.4"
+          port: 50002

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-timeout.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-timeout.yaml
@@ -23,3 +23,14 @@ http:
       - endpoints:
         - host: "1.2.3.4"
           port: 50000
+  - name: "second-route"
+    hostname: "*"
+    timeout:
+      http:
+        requestTimeout: 0s
+    destination:
+      name: "second-route-dest"
+      settings:
+      - endpoints:
+        - host: "1.2.3.4"
+          port: 50001

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
@@ -12,3 +12,17 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_ONLY
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: second-route-dest
+  lbPolicy: LEAST_REQUEST
+  name: second-route-dest
+  outlierDetection: {}
+  perConnectionBufferLimitBytes: 32768
+  type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
@@ -26,3 +26,17 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_ONLY
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: third-route-dest
+  lbPolicy: LEAST_REQUEST
+  name: third-route-dest
+  outlierDetection: {}
+  perConnectionBufferLimitBytes: 32768
+  type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.endpoints.yaml
@@ -10,3 +10,15 @@
     loadBalancingWeight: 1
     locality:
       region: first-route-dest/backend/0
+- clusterName: second-route-dest
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 1.2.3.4
+            portValue: 50001
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: second-route-dest/backend/0

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.endpoints.yaml
@@ -22,3 +22,15 @@
     loadBalancingWeight: 1
     locality:
       region: second-route-dest/backend/0
+- clusterName: third-route-dest
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 1.2.3.4
+            portValue: 50002
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: third-route-dest/backend/0

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.routes.yaml
@@ -14,6 +14,16 @@
       name: first-route
       route:
         cluster: first-route-dest
+        idleTimeout: 35s
         timeout: 5s
+        upgradeConfigs:
+        - upgradeType: websocket
+    - match:
+        prefix: /
+      name: second-route
+      route:
+        cluster: second-route-dest
+        idleTimeout: 0s
+        timeout: 0s
         upgradeConfigs:
         - upgradeType: websocket

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.routes.yaml
@@ -14,7 +14,7 @@
       name: first-route
       route:
         cluster: first-route-dest
-        idleTimeout: 35s
+        idleTimeout: 3600s
         timeout: 5s
         upgradeConfigs:
         - upgradeType: websocket
@@ -23,6 +23,15 @@
       name: second-route
       route:
         cluster: second-route-dest
+        idleTimeout: 4000s
+        timeout: 4000s
+        upgradeConfigs:
+        - upgradeType: websocket
+    - match:
+        prefix: /
+      name: third-route
+      route:
+        cluster: third-route-dest
         idleTimeout: 0s
         timeout: 0s
         upgradeConfigs:


### PR DESCRIPTION
**What type of PR is this?**

Fixes bug where default `stream_idle_timeout` in connection manager interferes with request timeouts set on HTTPRoute when set greater than 5 minutes preventing high request timeouts from being used without patching connection manager settings.

**What this PR does**:

If an HTTP request `timeout` is configured on the route and is non-zero, the `idle_timeout` will be set to the greater of 1hr or the configured request timeout. If the `timeout` on the HTTPRoute is set to `0` the `idle_timeout` is also set to `0` disabling both timeouts on the route.

**How to reproduce**:

1. Deploy demo into kind cluster and set a fault injection delay of 500s:

```yaml
apiVersion: gateway.envoyproxy.io/v1alpha1
kind: BackendTrafficPolicy
metadata:
  name: fault-injection-delay
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: backend
  faultInjection:
    delay:
      fixedDelay: 500s
```

2. Configure timeout on HTTPRoute:

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: backend
spec:
  hostnames:
  - www.example.com
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: eg
  rules:
  - backendRefs:
    - kind: Service
      name: backend
      port: 3000
    matches:
    - path:
        type: PathPrefix
        value: /
    timeouts:
      request: 600s
```

3. Issue request via `curl` noting the 504 response code at the 5 minute mark

```bash
$ time curl -sv -H "Host: www.example.com" http://172.18.255.200/
*   Trying 172.18.255.200:80...
* Connected to 172.18.255.200 (172.18.255.200) port 80
> GET / HTTP/1.1
> Host: www.example.com
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/1.1 504 Gateway Timeout
< content-length: 14
< content-type: text/plain
< date: Mon, 26 Feb 2024 18:20:32 GMT
< 
* Connection #0 to host 172.18.255.200 left intact
stream timeout
real	5m0.072s
user	0m0.017s
sys	0m0.023s
```

4. Note the reason for the early timeout in the request log:

```
"response_code":"504","response_flags":"DI,SI","response_code_details":"stream_idle_timeout"
```

