### PR TITLE
chore: clean warning message

### DIFF
--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -11,6 +11,7 @@ WAIT_TIMEOUT ?= 15m
 FLUENT_BIT_CHART_VERSION ?= 0.30.4
 OTEL_COLLECTOR_CHART_VERSION ?= 0.73.1
 TEMPO_CHART_VERSION ?= 1.3.1
+E2E_RUN_TEST ?=
 
 # Set Kubernetes Resources Directory Path
 ifeq ($(origin KUBE_PROVIDER_DIR),undefined)


### PR DESCRIPTION
remove following warning message:
```console
make uninstall-e2e-telemetry
tools/make/kube.mk:121: warning: undefined variable `E2E_RUN_TEST'
```