### PR TITLE
fix circuitbreaker BTP

### DIFF
--- a/test/e2e/testdata/circuitbreaker.yaml
+++ b/test/e2e/testdata/circuitbreaker.yaml
@@ -11,7 +11,7 @@ spec:
     namespace: gateway-conformance-infra
   circuitBreaker:
     maxConnections: 0
-    maxRequests: 0
+    maxParallelRequests: 0
     maxPendingRequests: 0
 ---
 apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
not sure why there's no error, looks like there's a field named `maxRequests`, got following error:
```console
Error from server (BadRequest): error when creating "BackendTrafficPolicy/circuitbreaker.yaml": BackendTrafficPolicy in version "v1alpha1" cannot be handled as a BackendTrafficPolicy: strict decoding error: unknown field "spec.circuitBreaker.maxRequests"
```