### PR TITLE
feat(translator): add default retry budget and retry host predicate

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -674,6 +674,11 @@ xds:
       dynamicActiveClusters:
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -690,6 +695,11 @@ xds:
           type: EDS
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -711,6 +721,11 @@ xds:
                 http2ProtocolOptions: {}
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -727,6 +742,11 @@ xds:
           type: EDS
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -743,6 +763,11 @@ xds:
           type: EDS
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s

--- a/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
@@ -92,6 +92,11 @@ xds:
     dynamicActiveClusters:
     - cluster:
         '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+        circuitBreakers:
+          thresholds:
+          - retryBudget:
+              budgetPercent:
+                value: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -370,6 +370,17 @@
             {
               "cluster": {
                 "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+                "circuitBreakers": {
+                  "thresholds": [
+                    {
+                      "retryBudget": {
+                        "budgetPercent": {
+                          "value": 100
+                        }
+                      }
+                    }
+                  ]
+                },
                 "commonLbConfig": {
                   "localityWeightedLbConfig": {}
                 },
@@ -392,6 +403,17 @@
             {
               "cluster": {
                 "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+                "circuitBreakers": {
+                  "thresholds": [
+                    {
+                      "retryBudget": {
+                        "budgetPercent": {
+                          "value": 100
+                        }
+                      }
+                    }
+                  ]
+                },
                 "commonLbConfig": {
                   "localityWeightedLbConfig": {}
                 },
@@ -422,6 +444,17 @@
             {
               "cluster": {
                 "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+                "circuitBreakers": {
+                  "thresholds": [
+                    {
+                      "retryBudget": {
+                        "budgetPercent": {
+                          "value": 100
+                        }
+                      }
+                    }
+                  ]
+                },
                 "commonLbConfig": {
                   "localityWeightedLbConfig": {}
                 },
@@ -444,6 +477,17 @@
             {
               "cluster": {
                 "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+                "circuitBreakers": {
+                  "thresholds": [
+                    {
+                      "retryBudget": {
+                        "budgetPercent": {
+                          "value": 100
+                        }
+                      }
+                    }
+                  ]
+                },
                 "commonLbConfig": {
                   "localityWeightedLbConfig": {}
                 },
@@ -466,6 +510,17 @@
             {
               "cluster": {
                 "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+                "circuitBreakers": {
+                  "thresholds": [
+                    {
+                      "retryBudget": {
+                        "budgetPercent": {
+                          "value": 100
+                        }
+                      }
+                    }
+                  ]
+                },
                 "commonLbConfig": {
                   "localityWeightedLbConfig": {}
                 },

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -200,6 +200,11 @@ xds:
       dynamicActiveClusters:
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -216,6 +221,11 @@ xds:
           type: EDS
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -237,6 +247,11 @@ xds:
                 http2ProtocolOptions: {}
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -253,6 +268,11 @@ xds:
           type: EDS
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -269,6 +289,11 @@ xds:
           type: EDS
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
@@ -4,6 +4,11 @@ xds:
     dynamicActiveClusters:
     - cluster:
         '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+        circuitBreakers:
+          thresholds:
+          - retryBudget:
+              budgetPercent:
+                value: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s
@@ -20,6 +25,11 @@ xds:
         type: EDS
     - cluster:
         '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+        circuitBreakers:
+          thresholds:
+          - retryBudget:
+              budgetPercent:
+                value: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s
@@ -41,6 +51,11 @@ xds:
               http2ProtocolOptions: {}
     - cluster:
         '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+        circuitBreakers:
+          thresholds:
+          - retryBudget:
+              budgetPercent:
+                value: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s
@@ -57,6 +72,11 @@ xds:
         type: EDS
     - cluster:
         '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+        circuitBreakers:
+          thresholds:
+          - retryBudget:
+              budgetPercent:
+                value: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s
@@ -73,6 +93,11 @@ xds:
         type: EDS
     - cluster:
         '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+        circuitBreakers:
+          thresholds:
+          - retryBudget:
+              budgetPercent:
+                value: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -262,6 +262,17 @@
             {
               "cluster": {
                 "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+                "circuitBreakers": {
+                  "thresholds": [
+                    {
+                      "retryBudget": {
+                        "budgetPercent": {
+                          "value": 100
+                        }
+                      }
+                    }
+                  ]
+                },
                 "commonLbConfig": {
                   "localityWeightedLbConfig": {}
                 },
@@ -284,6 +295,17 @@
             {
               "cluster": {
                 "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+                "circuitBreakers": {
+                  "thresholds": [
+                    {
+                      "retryBudget": {
+                        "budgetPercent": {
+                          "value": 100
+                        }
+                      }
+                    }
+                  ]
+                },
                 "commonLbConfig": {
                   "localityWeightedLbConfig": {}
                 },

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -144,6 +144,11 @@ xds:
       dynamicActiveClusters:
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -160,6 +165,11 @@ xds:
           type: EDS
       - cluster:
           '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+          circuitBreakers:
+            thresholds:
+            - retryBudget:
+                budgetPercent:
+                  value: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
@@ -4,6 +4,11 @@ xds:
     dynamicActiveClusters:
     - cluster:
         '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+        circuitBreakers:
+          thresholds:
+          - retryBudget:
+              budgetPercent:
+                value: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s
@@ -20,6 +25,11 @@ xds:
         type: EDS
     - cluster:
         '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+        circuitBreakers:
+          thresholds:
+          - retryBudget:
+              budgetPercent:
+                value: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s

--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -144,9 +144,9 @@ func buildXdsCluster(args *xdsClusterArgs) *clusterv3.Cluster {
 		cluster.OutlierDetection = buildXdsOutlierDetection(args.healthCheck.Passive)
 
 	}
-	if args.circuitBreaker != nil {
-		cluster.CircuitBreakers = buildXdsClusterCircuitBreaker(args.circuitBreaker)
-	}
+
+	cluster.CircuitBreakers = buildXdsClusterCircuitBreaker(args.circuitBreaker)
+
 	if args.tcpkeepalive != nil {
 		cluster.UpstreamConnectionOptions = buildXdsClusterUpstreamOptions(args.tcpkeepalive)
 	}
@@ -272,25 +272,34 @@ func buildHealthCheckPayload(irLoad *ir.HealthCheckPayload) *corev3.HealthCheck_
 }
 
 func buildXdsClusterCircuitBreaker(circuitBreaker *ir.CircuitBreaker) *clusterv3.CircuitBreakers {
+	// Always allow the same amount of retries as regular requests to handle surges in retries
+	// related to pod restarts
 	cbt := &clusterv3.CircuitBreakers_Thresholds{
 		Priority: corev3.RoutingPriority_DEFAULT,
+		RetryBudget: &clusterv3.CircuitBreakers_Thresholds_RetryBudget{
+			BudgetPercent: &xdstype.Percent{
+				Value: 100,
+			},
+		},
 	}
 
-	if circuitBreaker.MaxConnections != nil {
-		cbt.MaxConnections = &wrapperspb.UInt32Value{
-			Value: *circuitBreaker.MaxConnections,
+	if circuitBreaker != nil {
+		if circuitBreaker.MaxConnections != nil {
+			cbt.MaxConnections = &wrapperspb.UInt32Value{
+				Value: *circuitBreaker.MaxConnections,
+			}
 		}
-	}
 
-	if circuitBreaker.MaxPendingRequests != nil {
-		cbt.MaxPendingRequests = &wrapperspb.UInt32Value{
-			Value: *circuitBreaker.MaxPendingRequests,
+		if circuitBreaker.MaxPendingRequests != nil {
+			cbt.MaxPendingRequests = &wrapperspb.UInt32Value{
+				Value: *circuitBreaker.MaxPendingRequests,
+			}
 		}
-	}
 
-	if circuitBreaker.MaxParallelRequests != nil {
-		cbt.MaxRequests = &wrapperspb.UInt32Value{
-			Value: *circuitBreaker.MaxParallelRequests,
+		if circuitBreaker.MaxParallelRequests != nil {
+			cbt.MaxRequests = &wrapperspb.UInt32Value{
+				Value: *circuitBreaker.MaxParallelRequests,
+			}
 		}
 	}
 

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.clusters.yaml
@@ -3,6 +3,9 @@
     - maxConnections: 1
       maxPendingRequests: 1
       maxRequests: 1
+      retryBudget:
+        budgetPercent:
+          value: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/cors.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/cors.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -40,7 +55,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/fault-injection.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/fault-injection.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -40,7 +55,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -54,7 +74,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/health-check.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -29,7 +34,12 @@
     maxEjectionPercent: 100
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -58,7 +68,12 @@
     maxEjectionPercent: 100
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -85,7 +100,12 @@
     maxEjectionPercent: 100
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -40,7 +55,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -54,7 +74,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -68,7 +93,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -82,7 +112,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -22,7 +27,12 @@
               name: preserve_case
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http1-trailers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-trailers.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http10.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http10.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/http3.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http3.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -50,7 +65,12 @@
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -40,7 +55,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -63,7 +83,12 @@
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: 192.168.1.250
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -40,7 +55,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -11,7 +16,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -25,7 +35,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -39,7 +54,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -53,7 +73,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -70,7 +95,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -40,7 +55,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -54,7 +74,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -68,7 +93,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -40,7 +55,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -54,7 +74,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -59,7 +74,12 @@
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: oauth.foo.com
   type: STRICT_DNS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/path-settings.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/path-settings.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -40,7 +55,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -40,7 +55,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -54,7 +74,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -26,7 +36,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -40,7 +55,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.routes.yaml
@@ -11,6 +11,7 @@
       route:
         cluster: first-route-dest
         retryPolicy:
+          hostSelectionRetryMaxAttempts: "5"
           numRetries: 5
           perTryTimeout: 0.250s
           retriableStatusCodes:
@@ -19,6 +20,10 @@
           retryBackOff:
             baseInterval: 0.100s
             maxInterval: 10s
+          retryHostPredicate:
+          - name: envoy.retry_host_predicates.previous_hosts
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
           retryOn: connect-failure,retriable-status-codes
         upgradeConfigs:
         - upgradeType: websocket
@@ -32,9 +37,14 @@
       route:
         cluster: first-route-dest
         retryPolicy:
+          hostSelectionRetryMaxAttempts: "5"
           numRetries: 2
           retriableStatusCodes:
           - 503
+          retryHostPredicate:
+          - name: envoy.retry_host_predicates.previous_hosts
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
           retryOn: connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes
         upgradeConfigs:
         - upgradeType: websocket

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/timeout.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 31s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
@@ -12,7 +17,12 @@
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY

--- a/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.clusters.yaml
@@ -1,4 +1,9 @@
-- commonLbConfig:
+- circuitBreakers:
+    thresholds:
+    - retryBudget:
+        budgetPercent:
+          value: 100
+  commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets default values for:
-  retry budgets on any cluster: set to 100% of the configured max parallel request 
-  retry host predicate on any route that enables retries: omits previously-host hosts for retries

These values are inspired by envoy and istio recommendations, and intended to improve the overall success of retries when the backend is going through a rolling restart. 

**Which issue(s) this PR fixes**:
Fixes #2754
