### PR TITLE
feat(translator): set min retry limit of 100

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -679,6 +679,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -700,6 +701,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -726,6 +728,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -747,6 +750,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -768,6 +772,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s

--- a/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
@@ -97,6 +97,7 @@ xds:
           - retryBudget:
               budgetPercent:
                 value: 100
+              minRetryConcurrency: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -376,7 +376,8 @@
                       "retryBudget": {
                         "budgetPercent": {
                           "value": 100
-                        }
+                        },
+                        "minRetryConcurrency": 100
                       }
                     }
                   ]
@@ -409,7 +410,8 @@
                       "retryBudget": {
                         "budgetPercent": {
                           "value": 100
-                        }
+                        },
+                        "minRetryConcurrency": 100
                       }
                     }
                   ]
@@ -450,7 +452,8 @@
                       "retryBudget": {
                         "budgetPercent": {
                           "value": 100
-                        }
+                        },
+                        "minRetryConcurrency": 100
                       }
                     }
                   ]
@@ -483,7 +486,8 @@
                       "retryBudget": {
                         "budgetPercent": {
                           "value": 100
-                        }
+                        },
+                        "minRetryConcurrency": 100
                       }
                     }
                   ]
@@ -516,7 +520,8 @@
                       "retryBudget": {
                         "budgetPercent": {
                           "value": 100
-                        }
+                        },
+                        "minRetryConcurrency": 100
                       }
                     }
                   ]

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -205,6 +205,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -226,6 +227,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -252,6 +254,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -273,6 +276,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -294,6 +298,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
@@ -9,6 +9,7 @@ xds:
           - retryBudget:
               budgetPercent:
                 value: 100
+              minRetryConcurrency: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s
@@ -30,6 +31,7 @@ xds:
           - retryBudget:
               budgetPercent:
                 value: 100
+              minRetryConcurrency: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s
@@ -56,6 +58,7 @@ xds:
           - retryBudget:
               budgetPercent:
                 value: 100
+              minRetryConcurrency: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s
@@ -77,6 +80,7 @@ xds:
           - retryBudget:
               budgetPercent:
                 value: 100
+              minRetryConcurrency: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s
@@ -98,6 +102,7 @@ xds:
           - retryBudget:
               budgetPercent:
                 value: 100
+              minRetryConcurrency: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -268,7 +268,8 @@
                       "retryBudget": {
                         "budgetPercent": {
                           "value": 100
-                        }
+                        },
+                        "minRetryConcurrency": 100
                       }
                     }
                   ]
@@ -301,7 +302,8 @@
                       "retryBudget": {
                         "budgetPercent": {
                           "value": 100
-                        }
+                        },
+                        "minRetryConcurrency": 100
                       }
                     }
                   ]

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -149,6 +149,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s
@@ -170,6 +171,7 @@ xds:
             - retryBudget:
                 budgetPercent:
                   value: 100
+                minRetryConcurrency: 100
           commonLbConfig:
             localityWeightedLbConfig: {}
           connectTimeout: 10s

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
@@ -9,6 +9,7 @@ xds:
           - retryBudget:
               budgetPercent:
                 value: 100
+              minRetryConcurrency: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s
@@ -30,6 +31,7 @@ xds:
           - retryBudget:
               budgetPercent:
                 value: 100
+              minRetryConcurrency: 100
         commonLbConfig:
           localityWeightedLbConfig: {}
         connectTimeout: 10s

--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -276,8 +276,12 @@ func buildXdsClusterCircuitBreaker(circuitBreaker *ir.CircuitBreaker) *clusterv3
 	// related to pod restarts
 	cbt := &clusterv3.CircuitBreakers_Thresholds{
 		Priority: corev3.RoutingPriority_DEFAULT,
+		// concurrent retries limit = max(100, current-active-requests)
 		RetryBudget: &clusterv3.CircuitBreakers_Thresholds_RetryBudget{
 			BudgetPercent: &xdstype.Percent{
+				Value: 100,
+			},
+			MinRetryConcurrency: &wrapperspb.UInt32Value{
 				Value: 100,
 			},
 		},

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.clusters.yaml
@@ -6,6 +6,7 @@
       retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/cors.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/cors.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -60,6 +63,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/fault-injection.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/fault-injection.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -60,6 +63,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -79,6 +83,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/health-check.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -39,6 +40,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -73,6 +75,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -105,6 +108,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -60,6 +63,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -79,6 +83,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -98,6 +103,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -117,6 +123,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -32,6 +33,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http1-trailers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-trailers.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http10.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http10.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/http3.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http3.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -70,6 +73,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -60,6 +63,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -88,6 +92,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -60,6 +63,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -21,6 +22,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -40,6 +42,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -59,6 +62,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -78,6 +82,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -100,6 +105,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -60,6 +63,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -79,6 +83,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -98,6 +103,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -60,6 +63,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -79,6 +83,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -79,6 +82,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/path-settings.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/path-settings.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -60,6 +63,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -60,6 +63,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -79,6 +83,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -41,6 +43,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -60,6 +63,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/timeout.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 31s

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s
@@ -22,6 +23,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.clusters.yaml
@@ -3,6 +3,7 @@
     - retryBudget:
         budgetPercent:
           value: 100
+        minRetryConcurrency: 100
   commonLbConfig:
     localityWeightedLbConfig: {}
   connectTimeout: 10s


### PR DESCRIPTION
**What this PR does / why we need it**:
In addition to #2757, set a default minimum value of `100` for the limit on concurrent retries. Since the concurrent budget is calculated based on the current active requests, the dynamic retry limit may be too low when the volume of traffic is not significant and there are many upstream failures.

In the future, we should make these options configurable, so that users can tune them to their needs. 

**Which issue(s) this PR fixes**:
Fixes #2754
