### PR TITLE
fix: Circuit Breaker flaky test

### DIFF
--- a/test/e2e/tests/circuitbreaker.go
+++ b/test/e2e/tests/circuitbreaker.go
@@ -45,15 +45,7 @@ var CircuitBreakerTest = suite.ConformanceTest{
 				Namespace: ns,
 			}
 
-			req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
-			cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
-			if err != nil {
-				t.Errorf("failed to get expected response: %v", err)
-			}
-
-			if err := http.CompareRequest(t, &req, cReq, cResp, expectedResponse); err != nil {
-				t.Errorf("failed to compare request and response: %v", err)
-			}
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 		})
 	},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows responses to converge to a closed circuit breaker, instead of demanding that the first request will already have the circuit breaker enforced. 

**Which issue(s) this PR fixes**:
Fixes #2758
