### PR TITLE
fix: Address race condition disrupting graceful shutdown process

### DIFF
--- a/internal/cmd/envoy/shutdown_manager.go
+++ b/internal/cmd/envoy/shutdown_manager.go
@@ -34,8 +34,8 @@ const (
 	ShutdownManagerHealthCheckPath = "/healthz"
 	// ShutdownManagerReadyPath is the path used to indicate shutdown readiness.
 	ShutdownManagerReadyPath = "/shutdown/ready"
-	// ShutdownActiveFile is the file used to indicate shutdown readiness.
-	ShutdownActiveFile = "/tmp/shutdown-active"
+	// ShutdownReadyFile is the file used to indicate shutdown readiness.
+	ShutdownReadyFile = "/tmp/shutdown-ready"
 )
 
 // ShutdownManager serves shutdown manager process for Envoy proxies.
@@ -44,7 +44,7 @@ func ShutdownManager(readyTimeout time.Duration) error {
 	handler := http.NewServeMux()
 	handler.HandleFunc(ShutdownManagerHealthCheckPath, func(_ http.ResponseWriter, _ *http.Request) {})
 	handler.HandleFunc(ShutdownManagerReadyPath, func(w http.ResponseWriter, _ *http.Request) {
-		shutdownReadyHandler(w, readyTimeout, ShutdownActiveFile)
+		shutdownReadyHandler(w, readyTimeout, ShutdownReadyFile)
 	})
 
 	// Setup HTTP server
@@ -85,24 +85,12 @@ func ShutdownManager(readyTimeout time.Duration) error {
 }
 
 // shutdownReadyHandler handles the endpoint used by a preStop hook on the Envoy
-// container to block until ready to terminate. When the graceful drain process
-// has begun a file will be written to indicate shutdown is in progress. This
-// handler will poll for the file and block until it is removed.
-func shutdownReadyHandler(w http.ResponseWriter, readyTimeout time.Duration, activeFile string) {
+// container to block until ready to terminate. After the graceful drain process
+// has completed a file will be written to indicate shutdown readiness.
+func shutdownReadyHandler(w http.ResponseWriter, readyTimeout time.Duration, readyFile string) {
 	var startTime = time.Now()
 
 	logger.Info("received shutdown ready request")
-
-	// Since we cannot establish order between preStop hooks, wait a bit giving the exec
-	// preStop hook a chance to touch the signaling file before starting to poll for it.
-	time.Sleep(2 * time.Second)
-
-	// Exit early if active file failed to show up
-	if _, err := os.Stat(activeFile); os.IsNotExist(err) {
-		logger.Info("shutdown active file not found")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
 
 	// Poll for shutdown readiness
 	for {
@@ -114,15 +102,15 @@ func shutdownReadyHandler(w http.ResponseWriter, readyTimeout time.Duration, act
 			return
 		}
 
-		_, err := os.Stat(activeFile)
+		_, err := os.Stat(readyFile)
 		switch {
 		case os.IsNotExist(err):
-			logger.Info("shutdown readiness detected")
-			return
+			time.Sleep(1 * time.Second)
 		case err != nil:
 			logger.Error(err, "error checking for shutdown readiness")
 		case err == nil:
-			time.Sleep(1 * time.Second)
+			logger.Info("shutdown readiness detected")
+			return
 		}
 	}
 }
@@ -137,12 +125,6 @@ func Shutdown(drainTimeout time.Duration, minDrainDuration time.Duration, exitAt
 	// Reconfigure logger to write to stdout of main process if running in Kubernetes
 	if _, k8s := os.LookupEnv("KUBERNETES_SERVICE_HOST"); k8s && os.Getpid() != 1 {
 		logger = logging.FileLogger("/proc/1/fd/1", "shutdown-manager", v1alpha1.LogLevelInfo)
-	}
-
-	// Signal to shutdownReadyHandler that drain process is started
-	if _, err := os.Create(ShutdownActiveFile); err != nil {
-		logger.Error(err, "error creating shutdown active file")
-		return err
 	}
 
 	logger.Info(fmt.Sprintf("initiating graceful drain with %.0f second minimum drain period and %.0f second timeout",
@@ -185,8 +167,8 @@ func Shutdown(drainTimeout time.Duration, minDrainDuration time.Duration, exitAt
 	}
 
 	// Signal to shutdownReadyHandler that drain process is complete
-	if err := os.Remove(ShutdownActiveFile); err != nil {
-		logger.Error(err, "error removing shutdown active file")
+	if _, err := os.Create(ShutdownReadyFile); err != nil {
+		logger.Error(err, "error creating shutdown ready file")
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR resolves a race condition created when the original implementation of `/shutdown/ready` [was altered](https://github.com/envoyproxy/gateway/pull/2633#discussion_r1499870618) in an attempt to safeguard against CPU usage from excessive polling if a malicious actor issued a large number of requests to the `/shutdown/ready` endpoint of active proxy pods. In reality that is likely a very low risk compared to the tradeoff of the race condition.

Given this change has been proven to result in a race condition that causes real harm (breaks the graceful drain), I'm proposing we revert to the original implementation where `/shutdown/ready` blocks until the readiness indicator turns up or until it's timeout is reached preventing the race condition.

More than a few times now on clusters with small nodes but which are practically idle I've witnessed the process fail due to the exec in the preStop taking longer than 2 seconds to start and touch the shutdown active file. This can be seen in logs where the message `shutdown active file not found` turns up and Envoy receives the SIGTERM early. Effects are that Envoy doesn't exit gracefully and the pod doesn't completely terminate until the graceful drain timeout elapses.

```
envoy [2024-03-09 21:02:51.657][1][warning][main] [source/server/server.cc:881] caught ENVOY_SIGTERM
envoy [2024-03-09 21:02:51.914][1][warning][config] [./source/extensions/config_subscription/grpc/grpc_stream.h:155] DeltaAggregatedResources gRPC config stream to xds_cluster closed: 13, 
shutdown-manager 2024-03-09T21:02:49.561Z    INFO    shutdown-manager    envoy/shutdown_manager.go:94    received shutdown ready request
shutdown-manager 2024-03-09T21:02:51.619Z    INFO    shutdown-manager    envoy/shutdown_manager.go:102    shutdown active file not found
shutdown-manager 2024-03-09T21:02:51.663Z    INFO    shutdown-manager    envoy/shutdown_manager.go:148    initiating graceful drain with 5 second minimum drain period and 600 second timeout
shutdown-manager 2024-03-09T21:02:51.931Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:153    error failing active health checks    {"error": "Post \"http://127.0.0.1:19000/healthcheck/fail\": read tcp 127.0.0.1:58214->127.0.0.1:19000: read: connection reset by peer"}
shutdown-manager 2024-03-09T21:02:51.933Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:158    error initiating graceful drain    {"error": "Post \"http://127.0.0.1:19000/drain_listeners?graceful&skip_exit\": dial tcp 127.0.0.1:19000: connect: connection refused"}
shutdown-manager 2024-03-09T21:02:51.933Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:168    error getting total connections    {"error": "Get \"http://127.0.0.1:19000//stats?filter=^server\\\\.total_connections$&format=json\": dial tcp 127.0.0.1:19000: connect: connection refused"}
shutdown-manager 2024-03-09T21:02:52.935Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:168    error getting total connections    {"error": "Get \"http://127.0.0.1:19000//stats?filter=^server\\\\.total_connections$&format=json\": dial tcp 127.0.0.1:19000: connect: connection refused"}
shutdown-manager 2024-03-09T21:02:53.936Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:168    error getting total connections    {"error": "Get \"http://127.0.0.1:19000//stats?filter=^server\\\\.total_connections$&format=json\": dial tcp 127.0.0.1:19000: connect: connection refused"}
shutdown-manager 2024-03-09T21:02:54.936Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:168    error getting total connections    {"error": "Get \"http://127.0.0.1:19000//stats?filter=^server\\\\.total_connections$&format=json\": dial tcp 127.0.0.1:19000: connect: connection refused"}
shutdown-manager 2024-03-09T21:02:55.937Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:168    error getting total connections    {"error": "Get \"http://127.0.0.1:19000//stats?filter=^server\\\\.total_connections$&format=json\": dial tcp 127.0.0.1:19000: connect: connection refused"}
shutdown-manager 2024-03-09T21:02:56.938Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:168    error getting total connections    {"error": "Get \"http://127.0.0.1:19000//stats?filter=^server\\\\.total_connections$&format=json\": dial tcp 127.0.0.1:19000: connect: connection refused"}
shutdown-manager 2024-03-09T21:02:56.938Z    INFO    shutdown-manager    envoy/shutdown_manager.go:172    minimum drain period reached; will exit when total connections reaches 0
shutdown-manager 2024-03-09T21:02:57.939Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:168    error getting total connections    {"error": "Get \"http://127.0.0.1:19000//stats?filter=^server\\\\.total_connections$&format=json\": dial tcp 127.0.0.1:19000: connect: connection refused"}
shutdown-manager 2024-03-09T21:02:58.941Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:168    error getting total connections    {"error": "Get \"http://127.0.0.1:19000//stats?filter=^server\\\\.total_connections$&format=json\": dial tcp 127.0.0.1:19000: connect: connection refused"}
shutdown-manager 2024-03-09T21:02:59.941Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:168    error getting total connections    {"error": "Get \"http://127.0.0.1:19000//stats?filter=^server\\\\.total_connections$&format=json\": dial tcp 127.0.0.1:19000: connect: connection refused"}
shutdown-manager 2024-03-09T21:03:00.942Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:168    error getting total connections    {"error": "Get \"http://127.0.0.1:19000//stats?filter=^server\\\\.total_connections$&format=json\": dial tcp 127.0.0.1:19000: connect: connection refused"}
shutdown-manager 2024-03-09T21:03:01.944Z    ERROR    shutdown-manager    envoy/shutdown_manager.go:168    error getting total connections    {"error": "Get \"http://127.0.0.1:19000//stats?filter=^server\\\\.total_connections$&format=json\": dial tcp 127.0.0.1:19000: connect: connection refused"}
```