### PR TITLE
fix: QUIC listeners should only advertise HTTP/3 over ALPN, and not HTTP/2 and HTTP/1.1

### DIFF
--- a/internal/xds/translator/testdata/out/xds-ir/http3.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http3.listeners.yaml
@@ -40,8 +40,6 @@
         downstreamTlsContext:
           commonTlsContext:
             alpnProtocols:
-            - h2
-            - http/1.1
             - h3
             tlsCertificateSdsSecretConfigs:
             - name: envoy-gateway-tls-secret-1


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #2896 
