### PR TITLE
chore: improve docs-serve

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,7 @@
     "_build": "npm run _hugo-dev",
     "_check:links": "echo IMPLEMENTATION PENDING for check-links; echo",
     "_hugo": "hugo --cleanDestinationDir",
-    "_hugo-dev": "npm run _hugo -- -e dev -DFE",
+    "_hugo-dev": "npm run _hugo -- -e dev -DFE --baseURL http://localhost --bind 0.0.0.0",
     "_serve": "npm run _hugo-dev -- --minify serve",
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "npm run _hugo -- --minify",


### PR DESCRIPTION
after:
```shell
Environment: "dev"
Serving pages from memory
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:1313/ (bind address 0.0.0.0)
```