### PR TITLE
Pin version to v1.0.0 in 1.0.0 docs

### DIFF
--- a/site/content/en/v1.0.0/install/api.md
+++ b/site/content/en/v1.0.0/install/api.md
@@ -3,7 +3,7 @@ title = "gateway-helm"
 +++
 
 
-![Version: v0.0.0-latest](https://img.shields.io/badge/Version-v0.0.0--latest-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: v1.0.0](https://img.shields.io/badge/Version-v1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 The Helm chart for Envoy Gateway
 
@@ -53,4 +53,3 @@ The Helm chart for Envoy Gateway
 | deployment.replicas | int | `1` |  |
 | envoyGatewayMetricsService.port | int | `19001` |  |
 | kubernetesClusterDomain | string | `"cluster.local"` |  |
-

--- a/site/content/en/v1.0.0/install/install-helm.md
+++ b/site/content/en/v1.0.0/install/install-helm.md
@@ -18,7 +18,7 @@ The Envoy Gateway Helm chart is hosted by DockerHub.
 It is published at `oci://docker.io/envoyproxy/gateway-helm`.
 
 {{% alert title="Note" color="primary" %}}
-We use `v0.0.0-latest` as the latest development version.
+We use `v1.0.0` as the latest development version.
 
 You can visit [Envoy Gateway Helm Chart](https://hub.docker.com/r/envoyproxy/gateway-helm/tags) for more releases.
 {{% /alert %}}
@@ -34,7 +34,7 @@ Refer to the [Developer Guide](/latest/contributions/develop) to learn more.
 Install the Gateway API CRDs and Envoy Gateway:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace
+helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.0.0 -n envoy-gateway-system --create-namespace
 ```
 
 Wait for Envoy Gateway to become available:
@@ -66,7 +66,7 @@ Some of the quick ways of using the helm install command for envoy gateway insta
 ### Increase the replicas
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace --set deployment.replicas=2
+helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.0.0 -n envoy-gateway-system --create-namespace --set deployment.replicas=2
 ```
 
 ### Change the kubernetesClusterDomain name
@@ -74,7 +74,7 @@ helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest 
 If you have installed your cluster with different domain name you can use below command.
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace --set kubernetesClusterDomain=<domain name>
+helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.0.0 -n envoy-gateway-system --create-namespace --set kubernetesClusterDomain=<domain name>
 ```
 
 **Note**: Above are some of the ways we can directly use for customization of our installation. But if you are looking for more complex changes [values.yaml](https://helm.sh/docs/chart_template_guide/values_files/) comes to rescue.
@@ -111,7 +111,7 @@ Here we have made three changes to our values.yaml file. Increase the resources 
 You can use the below command to install the envoy gateway using values.yaml file.
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace -f values.yaml
+helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.0.0 -n envoy-gateway-system --create-namespace -f values.yaml
 ```
 
 {{% alert title="Helm Chart Values" color="primary" %}}

--- a/site/content/en/v1.0.0/user/operations/deployment-mode.md
+++ b/site/content/en/v1.0.0/user/operations/deployment-mode.md
@@ -52,7 +52,7 @@ helm install \
 --set config.envoyGateway.provider.kubernetes.watch.type=Namespaces \
 --set config.envoyGateway.provider.kubernetes.watch.namespaces={marketing} \
 eg-marketing oci://docker.io/envoyproxy/gateway-helm \
---version v0.0.0-latest -n marketing --create-namespace
+--version v1.0.0 -n marketing --create-namespace
 ```
 
 Lets create a `GatewayClass` linked to the marketing team's Envoy Gateway controller, and as well other resources linked to it, so the `backend` application operated by this team can be exposed to external clients.
@@ -230,7 +230,7 @@ helm install \
 --set config.envoyGateway.provider.kubernetes.watch.type=Namespaces \
 --set config.envoyGateway.provider.kubernetes.watch.namespaces={product} \
 eg-product oci://docker.io/envoyproxy/gateway-helm \
---version v0.0.0-latest -n product --create-namespace
+--version v1.0.0 -n product --create-namespace
 ```
 
 Lets create a `GatewayClass` linked to the product team's Envoy Gateway controller, and as well other resources linked to it, so the `backend` application operated by this team can be exposed to external clients.

--- a/site/content/en/v1.0.0/user/traffic/multicluster-service.md
+++ b/site/content/en/v1.0.0/user/traffic/multicluster-service.md
@@ -39,7 +39,7 @@ Once the above steps are done and all the pods are up in both the clusters. We a
 Install the Gateway API CRDs and Envoy Gateway in cluster1:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace --kubeconfig output/kubeconfigs/kind-config-cluster1
+helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.0.0 -n envoy-gateway-system --create-namespace --kubeconfig output/kubeconfigs/kind-config-cluster1
 ```
 
 Wait for Envoy Gateway to become available:


### PR DESCRIPTION
Should we use v1.0.0 instead of the latest in the v1.0.0 docs since it's a GA version ? @envoyproxy/gateway-maintainers 