### PR TITLE
Run certgen when upgrading

### DIFF
--- a/charts/gateway-helm/templates/certgen.yaml
+++ b/charts/gateway-helm/templates/certgen.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
   {{- include "eg.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
   {{- if .Values.certgen.job.annotations }}
     {{- toYaml .Values.certgen.job.annotations | nindent 4 -}}
   {{- end }}


### PR DESCRIPTION
Run certgen when upgrading EG helm chart because a new secret(HMAC) has been added after v0.0.6, and more may be added later. 

Fix https://github.com/envoyproxy/gateway/issues/2930