### PR TITLE
chore: use v1.0.0 as default for upgrade test

### DIFF
--- a/test/e2e/tests/eg_upgrade.go
+++ b/test/e2e/tests/eg_upgrade.go
@@ -34,7 +34,7 @@ var EGUpgradeTest = suite.ConformanceTest{
 			depNS := "envoy-gateway-system"
 			lastVersionTag := os.Getenv("last_version_tag")
 			if lastVersionTag == "" {
-				lastVersionTag = "v0.6.0" // Default version tag if not specified
+				lastVersionTag = "v1.0.0" // Default version tag if not specified
 			}
 
 			ns := "gateway-upgrade-infra"


### PR DESCRIPTION
**What this PR does / why we need it**:
Now that v1.0.0 is released, we should use it a baseline for upgrade tests in CI. 
