### PR TITLE
e2e: use default shutdown mgr settings in upgrade test suite

### DIFF
--- a/test/config/gatewayclass.yaml
+++ b/test/config/gatewayclass.yaml
@@ -81,8 +81,6 @@ metadata:
   name: upgrade-config
   namespace: envoy-gateway-system
 spec:
-  shutdown:
-    drainTimeout: 15s
   provider:
     type: Kubernetes
     kubernetes:


### PR DESCRIPTION
**What type of PR is this?**
Use default shutdown manager settings in the upgrade suite, allowing connections to gracefully close over a longer period of time. 

**What this PR does / why we need it**:
relates to #2937 
