### PR TITLE
fix: use unique ports in kubernetes service

### DIFF
--- a/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
@@ -72,11 +72,13 @@ func newTestInfraWithAnnotationsAndLabels(annotations, labels map[string]string)
 					Name:          "EnvoyHTTPPort",
 					Protocol:      ir.TCPProtocolType,
 					ContainerPort: envoyHTTPPort,
+					ServicePort:   envoyHTTPPort,
 				},
 				{
 					Name:          "EnvoyHTTPSPort",
 					Protocol:      ir.TCPProtocolType,
 					ContainerPort: envoyHTTPSPort,
+					ServicePort:   envoyHTTPSPort,
 				},
 			},
 		},

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/clusterIP-custom-addresses.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/clusterIP-custom-addresses.yaml
@@ -14,12 +14,12 @@ spec:
   clusterIPs:
     - 10.102.168.100
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
-      port: 0
+    - name: port-8080
+      port: 8080
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
-      port: 0
+    - name: port-8443
+      port: 8443
       protocol: TCP
       targetPort: 8443
   selector:

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/custom.yaml
@@ -13,12 +13,12 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
-      port: 0
+    - name: port-8080
+      port: 8080
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
-      port: 0
+    - name: port-8443
+      port: 8443
       protocol: TCP
       targetPort: 8443
   selector:

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/default.yaml
@@ -12,12 +12,12 @@ metadata:
 spec:
   externalTrafficPolicy: Local
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
-      port: 0
+    - name: port-8080
+      port: 8080
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
-      port: 0
+    - name: port-8443
+      port: 8443
       protocol: TCP
       targetPort: 8443
   selector:

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/override-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/override-annotations.yaml
@@ -17,12 +17,12 @@ metadata:
 spec:
   externalTrafficPolicy: Local
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
-      port: 0
+    - name: port-8080
+      port: 8080
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
-      port: 0
+    - name: port-8443
+      port: 8443
       protocol: TCP
       targetPort: 8443
   selector:

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/patch-service.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/patch-service.yaml
@@ -12,12 +12,12 @@ metadata:
 spec:
   externalTrafficPolicy: Local
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
-      port: 0
+    - name: port-8080
+      port: 8080
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
-      port: 0
+    - name: port-8443
+      port: 8443
       protocol: TCP
       targetPort: 8443
   selector:

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/with-annotations.yaml
@@ -15,12 +15,12 @@ metadata:
 spec:
   externalTrafficPolicy: Local
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
-      port: 0
+    - name: port-8080
+      port: 8080
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
-      port: 0
+    - name: port-8443
+      port: 8443
       protocol: TCP
       targetPort: 8443
   selector:


### PR DESCRIPTION
**What type of PR is this?**
fix: use unique ports in kubernetes service

**What this PR does / why we need it**:

It is not allowed to have duplicate port numbers in kubernetes service.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2964


Not sure is `port-[port number]` the correct way to fix this. But afaik that port name does not matter in any case because all calls are coming outside of kubernetes?