### PR TITLE
fix: use unique container ports in deployment

### DIFF
--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -120,7 +120,7 @@ func expectedProxyContainers(infra *ir.ProxyInfra,
 				return nil, fmt.Errorf("invalid protocol %q", p.Protocol)
 			}
 			port := corev1.ContainerPort{
-				Name:          fmt.Sprintf("%s-%d", protocol, p.ContainerPort),
+				Name:          strings.ToLower(fmt.Sprintf("%s-%d", protocol, p.ContainerPort)),
 				ContainerPort: p.ContainerPort,
 				Protocol:      protocol,
 			}

--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -120,7 +120,7 @@ func expectedProxyContainers(infra *ir.ProxyInfra,
 				return nil, fmt.Errorf("invalid protocol %q", p.Protocol)
 			}
 			port := corev1.ContainerPort{
-				Name:          fmt.Sprintf("port-%d-%s", p.ContainerPort, protocol),
+				Name:          fmt.Sprintf("%s-%d", protocol, p.ContainerPort),
 				ContainerPort: p.ContainerPort,
 				Protocol:      protocol,
 			}

--- a/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
@@ -106,6 +106,20 @@ func TestDeployment(t *testing.T) {
 			deploy:   nil,
 		},
 		{
+			caseName: "duplicate-listeners",
+			infra: func() *ir.Infra {
+				infra := newTestInfra()
+				infra.Proxy.Listeners[0].Ports = append(infra.Proxy.Listeners[0].Ports,
+					ir.ListenerPort{
+						Name:          "Envoy-second-https-listener",
+						Protocol:      ir.TCPProtocolType,
+						ContainerPort: envoyHTTPSPort,
+					})
+				return infra
+			}(),
+			deploy: nil,
+		},
+		{
 			caseName: "custom",
 			infra:    newTestInfra(),
 			deploy: &egv1a1.KubernetesDeploymentSpec{

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -68,10 +68,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -68,10 +68,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -68,10 +68,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -69,10 +69,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -69,10 +69,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -69,10 +69,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -194,10 +194,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -194,10 +194,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -194,10 +194,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -194,10 +194,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -194,10 +194,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -194,10 +194,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -192,10 +192,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -192,10 +192,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -192,10 +192,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -165,10 +165,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         readinessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -165,10 +165,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         readinessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -165,10 +165,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         readinessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/duplicate-listeners.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/duplicate-listeners.yaml
@@ -1,0 +1,293 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/managed-by: envoy-gateway
+    app.kubernetes.io/name: envoy
+    gateway.envoyproxy.io/owning-gateway-name: default
+    gateway.envoyproxy.io/owning-gateway-namespace: default
+  name: envoy-default-37a8eec1
+  namespace: envoy-gateway-system
+spec:
+  progressDeadlineSeconds: 600
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: proxy
+      app.kubernetes.io/managed-by: envoy-gateway
+      app.kubernetes.io/name: envoy
+      gateway.envoyproxy.io/owning-gateway-name: default
+      gateway.envoyproxy.io/owning-gateway-namespace: default
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "19001"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: proxy
+        app.kubernetes.io/managed-by: envoy-gateway
+        app.kubernetes.io/name: envoy
+        gateway.envoyproxy.io/owning-gateway-name: default
+        gateway.envoyproxy.io/owning-gateway-namespace: default
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --service-cluster default
+        - --service-node $(ENVOY_POD_NAME)
+        - |
+          --config-yaml admin:
+            access_log:
+            - name: envoy.access_loggers.file
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                path: /dev/null
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 19000
+          layered_runtime:
+            layers:
+            - name: global_config
+              static_layer:
+                envoy.restart_features.use_eds_cache_for_ads: true
+                re2.max_program_size.error_level: 4294967295
+                re2.max_program_size.warn_level: 1000
+          dynamic_resources:
+            ads_config:
+              api_type: DELTA_GRPC
+              transport_api_version: V3
+              grpc_services:
+              - envoy_grpc:
+                  cluster_name: xds_cluster
+              set_node_on_first_message_only: true
+            lds_config:
+              ads: {}
+              resource_api_version: V3
+            cds_config:
+              ads: {}
+              resource_api_version: V3
+          static_resources:
+            listeners:
+            - name: envoy-gateway-proxy-ready-0.0.0.0-19001
+              address:
+                socket_address:
+                  address: 0.0.0.0
+                  port_value: 19001
+                  protocol: TCP
+              filter_chains:
+              - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: eg-ready-http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                      - name: prometheus_stats
+                        domains:
+                        - "*"
+                        routes:
+                        - match:
+                            prefix: /stats/prometheus
+                          route:
+                            cluster: prometheus_stats
+                    http_filters:
+                    - name: envoy.filters.http.health_check
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                        pass_through_mode: false
+                        headers:
+                        - name: ":path"
+                          string_match:
+                            exact: /ready
+                    - name: envoy.filters.http.router
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            clusters:
+            - name: prometheus_stats
+              connect_timeout: 0.250s
+              type: STATIC
+              lb_policy: ROUND_ROBIN
+              load_assignment:
+                cluster_name: prometheus_stats
+                endpoints:
+                - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 19000
+            - connect_timeout: 10s
+              load_assignment:
+                cluster_name: xds_cluster
+                endpoints:
+                - load_balancing_weight: 1
+                  lb_endpoints:
+                  - load_balancing_weight: 1
+                    endpoint:
+                      address:
+                        socket_address:
+                          address: envoy-gateway
+                          port_value: 18000
+              typed_extension_protocol_options:
+                envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                  "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+                  explicit_http_config:
+                    http2_protocol_options:
+                      connection_keepalive:
+                        interval: 30s
+                        timeout: 5s
+              name: xds_cluster
+              type: STRICT_DNS
+              transport_socket:
+                name: envoy.transport_sockets.tls
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+                  common_tls_context:
+                    tls_params:
+                      tls_maximum_protocol_version: TLSv1_3
+                    tls_certificate_sds_secret_configs:
+                    - name: xds_certificate
+                      sds_config:
+                        path_config_source:
+                          path: "/sds/xds-certificate.json"
+                        resource_api_version: V3
+                    validation_context_sds_secret_config:
+                      name: xds_trusted_ca
+                      sds_config:
+                        path_config_source:
+                          path: "/sds/xds-trusted-ca.json"
+                        resource_api_version: V3
+        - --log-level warn
+        - --cpuset-threads
+        command:
+        - envoy
+        env:
+        - name: ENVOY_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: envoyproxy/envoy:distroless-dev
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /shutdown/ready
+              port: 19002
+              scheme: HTTP
+        name: envoy
+        ports:
+        - containerPort: 8080
+          name: TCP-8080
+          protocol: TCP
+        - containerPort: 8443
+          name: TCP-8443
+          protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 19001
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /certs
+          name: certs
+          readOnly: true
+        - mountPath: /sds
+          name: sds
+      - args:
+        - envoy
+        - shutdown-manager
+        command:
+        - envoy-gateway
+        env:
+        - name: ENVOY_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: envoyproxy/gateway-dev:latest
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - envoy-gateway
+              - envoy
+              - shutdown
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 19002
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: shutdown-manager
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 19002
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      serviceAccountName: envoy-default-37a8eec1
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - name: certs
+        secret:
+          defaultMode: 420
+          secretName: envoy
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: xds-trusted-ca.json
+            path: xds-trusted-ca.json
+          - key: xds-certificate.json
+            path: xds-certificate.json
+          name: envoy-default-37a8eec1
+          optional: false
+        name: sds
+status: {}

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/duplicate-listeners.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/duplicate-listeners.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -196,10 +196,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -196,10 +196,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -196,10 +196,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -202,10 +202,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -202,10 +202,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -202,10 +202,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -192,10 +192,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -192,10 +192,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -192,10 +192,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -196,10 +196,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -196,10 +196,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -196,10 +196,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -196,10 +196,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -196,10 +196,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -196,10 +196,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -69,10 +69,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -69,10 +69,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -69,10 +69,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -193,10 +193,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -193,10 +193,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -193,10 +193,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: port-8080-TCP
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: port-8443-TCP
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: TCP-8080
+          name: tcp-8080
           protocol: TCP
         - containerPort: 8443
-          name: TCP-8443
+          name: tcp-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -191,10 +191,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: port-8080-TCP
+          name: TCP-8080
           protocol: TCP
         - containerPort: 8443
-          name: port-8443-TCP
+          name: TCP-8443
           protocol: TCP
         - containerPort: 19001
           name: metrics


### PR DESCRIPTION
**What type of PR is this?**
fix: use unique ports in deployment

**What this PR does / why we need it**:

Kubernetes requires that container port numbers are unique. So those can exist only once. Current implementation is adding duplicate ports if there are like two listeners listening port 443.

This PR also reduces the amount of restarts needed for deployments https://github.com/envoyproxy/gateway/issues/2965 because it will not modify deployment configuration anymore that often when listeners are modifierd. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2964
