### PR TITLE
fix: set path prefix for http ext auth service

### DIFF
--- a/internal/xds/translator/extauth.go
+++ b/internal/xds/translator/extauth.go
@@ -147,8 +147,12 @@ func httpService(http *ir.HTTPExtAuthService) *extauthv3.HttpService {
 	var (
 		uri              string
 		headersToBackend []*matcherv3.StringMatcher
-		service          = new(extauthv3.HttpService)
+		service          *extauthv3.HttpService
 	)
+
+	service = &extauthv3.HttpService{
+		PathPrefix: http.Path,
+	}
 
 	u := url.URL{
 		// scheme should be decided by the TLS setting, but we don't have that info now.

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.listeners.yaml
@@ -39,6 +39,7 @@
                   patterns:
                   - exact: header1
                   - exact: header2
+              pathPrefix: /auth
               serverUri:
                 cluster: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
                 timeout: 10s


### PR DESCRIPTION
fix: [can't configure pathPrefix for extAuth.](https://github.com/envoyproxy/gateway/issues/3016)