### PR TITLE
fix: use Patch API for infra-client

### DIFF
--- a/charts/gateway-helm/templates/infra-manager-rbac.yaml
+++ b/charts/gateway-helm/templates/infra-manager-rbac.yaml
@@ -14,7 +14,6 @@ rules:
   verbs:
   - create
   - get
-  - update
   - delete
   - patch
 - apiGroups:
@@ -24,7 +23,6 @@ rules:
   verbs:
   - create
   - get
-  - update
   - delete
   - patch
 - apiGroups:
@@ -34,7 +32,6 @@ rules:
   verbs:
   - create
   - get
-  - update
   - delete
   - patch
 ---

--- a/charts/gateway-helm/templates/infra-manager-rbac.yaml
+++ b/charts/gateway-helm/templates/infra-manager-rbac.yaml
@@ -16,6 +16,7 @@ rules:
   - get
   - update
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -25,6 +26,7 @@ rules:
   - get
   - update
   - delete
+  - patch
 - apiGroups:
   - autoscaling
   resources:
@@ -34,6 +36,7 @@ rules:
   - get
   - update
   - delete
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/internal/infrastructure/kubernetes/infra_client.go
+++ b/internal/infrastructure/kubernetes/infra_client.go
@@ -38,7 +38,6 @@ func (cli *InfraClient) CreateOrUpdate(ctx context.Context, key client.ObjectKey
 			// Since the client.Object does not have a specific Spec field to compare
 			// just perform an update for now.
 			if updateChecker() {
-				specific.SetUID(current.GetUID())
 				opts := []client.PatchOption{client.ForceOwnership, client.FieldOwner("envoy-gateway")}
 				if err := cli.Client.Patch(ctx, specific, client.Apply, opts...); err != nil {
 					return fmt.Errorf("for Update: %w", err)

--- a/internal/infrastructure/kubernetes/infra_client.go
+++ b/internal/infrastructure/kubernetes/infra_client.go
@@ -39,7 +39,8 @@ func (cli *InfraClient) CreateOrUpdate(ctx context.Context, key client.ObjectKey
 			// just perform an update for now.
 			if updateChecker() {
 				specific.SetUID(current.GetUID())
-				if err := cli.Client.Update(ctx, specific); err != nil {
+				opts := []client.PatchOption{client.ForceOwnership, client.FieldOwner("envoy-gateway")}
+				if err := cli.Client.Patch(ctx, specific, client.Apply, opts...); err != nil {
 					return fmt.Errorf("for Update: %w", err)
 				}
 			}

--- a/internal/infrastructure/kubernetes/proxy_configmap_test.go
+++ b/internal/infrastructure/kubernetes/proxy_configmap_test.go
@@ -99,9 +99,16 @@ func TestCreateOrUpdateProxyConfigMap(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var cli client.Client
 			if tc.current != nil {
-				cli = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects(tc.current).Build()
+				cli = fakeclient.NewClientBuilder().
+					WithScheme(envoygateway.GetScheme()).
+					WithObjects(tc.current).
+					WithInterceptorFuncs(interceptorFunc).
+					Build()
 			} else {
-				cli = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build()
+				cli = fakeclient.NewClientBuilder().
+					WithScheme(envoygateway.GetScheme()).
+					WithInterceptorFuncs(interceptorFunc).
+					Build()
 			}
 			kube := NewInfra(cli, cfg)
 			r := proxy.NewResourceRender(kube.Namespace, infra.GetProxyInfra())

--- a/internal/infrastructure/kubernetes/proxy_deployment_test.go
+++ b/internal/infrastructure/kubernetes/proxy_deployment_test.go
@@ -106,9 +106,16 @@ func TestCreateOrUpdateProxyDeployment(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var cli client.Client
 			if tc.current != nil {
-				cli = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects(tc.current).Build()
+				cli = fakeclient.NewClientBuilder().
+					WithScheme(envoygateway.GetScheme()).
+					WithObjects(tc.current).
+					WithInterceptorFuncs(interceptorFunc).
+					Build()
 			} else {
-				cli = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build()
+				cli = fakeclient.NewClientBuilder().
+					WithScheme(envoygateway.GetScheme()).
+					WithInterceptorFuncs(interceptorFunc).
+					Build()
 			}
 
 			kube := NewInfra(cli, cfg)

--- a/internal/infrastructure/kubernetes/proxy_infra_test.go
+++ b/internal/infrastructure/kubernetes/proxy_infra_test.go
@@ -7,6 +7,8 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -14,9 +16,12 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -28,9 +33,41 @@ import (
 )
 
 func newTestInfra(t *testing.T) *Infra {
-	cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build()
+	cli := fakeclient.NewClientBuilder().
+		WithScheme(envoygateway.GetScheme()).
+		WithInterceptorFuncs(interceptorFunc).
+		Build()
 	return newTestInfraWithClient(t, cli)
 }
+
+// Borrowing the interceptor from https://github.com/istio/istio/blob/2f54c6a52a5c6661d5eb9bd2277aab77304fee45/operator/pkg/helmreconciler/apply_test.go#L40
+// Interceptor is used for ApplyPatch as of this patch is not yet supported by the fake client, see https://github.com/kubernetes/kubernetes/issues/99953
+var interceptorFunc = interceptor.Funcs{Patch: func(
+	ctx context.Context,
+	clnt client.WithWatch,
+	obj client.Object,
+	patch client.Patch,
+	opts ...client.PatchOption,
+) error {
+	// Apply patches are supposed to upsert, but fake client fails if the object doesn't exist,
+	// if an apply patch occurs for an object that doesn't yet exist, create it.
+	if patch.Type() != types.ApplyPatchType {
+		return clnt.Patch(ctx, obj, patch, opts...)
+	}
+	check, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return errors.New("could not check for object in fake client")
+	}
+	if err := clnt.Get(ctx, client.ObjectKeyFromObject(obj), check); kerrors.IsNotFound(err) {
+		if err := clnt.Create(ctx, check); err != nil {
+			return fmt.Errorf("could not inject object creation for fake: %w", err)
+		}
+	} else if err != nil {
+		return err
+	}
+	obj.SetResourceVersion(check.GetResourceVersion())
+	return clnt.Update(ctx, obj)
+}}
 
 func TestCmpBytes(t *testing.T) {
 	m1 := map[string][]byte{}

--- a/internal/infrastructure/kubernetes/proxy_serviceaccount_test.go
+++ b/internal/infrastructure/kubernetes/proxy_serviceaccount_test.go
@@ -174,9 +174,16 @@ func TestCreateOrUpdateProxyServiceAccount(t *testing.T) {
 
 			var cli client.Client
 			if tc.current != nil {
-				cli = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects(tc.current).Build()
+				cli = fakeclient.NewClientBuilder().
+					WithScheme(envoygateway.GetScheme()).
+					WithObjects(tc.current).
+					WithInterceptorFuncs(interceptorFunc).
+					Build()
 			} else {
-				cli = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build()
+				cli = fakeclient.NewClientBuilder().
+					WithScheme(envoygateway.GetScheme()).
+					WithInterceptorFuncs(interceptorFunc).
+					Build()
 			}
 
 			kube := NewInfra(cli, cfg)

--- a/internal/infrastructure/kubernetes/ratelimit_deployment_test.go
+++ b/internal/infrastructure/kubernetes/ratelimit_deployment_test.go
@@ -68,9 +68,16 @@ func TestCreateOrUpdateRateLimitDeployment(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var cli client.Client
 			if tc.current != nil {
-				cli = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects(tc.current).Build()
+				cli = fakeclient.NewClientBuilder().
+					WithScheme(envoygateway.GetScheme()).
+					WithObjects(tc.current).
+					WithInterceptorFuncs(interceptorFunc).
+					Build()
 			} else {
-				cli = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build()
+				cli = fakeclient.NewClientBuilder().
+					WithScheme(envoygateway.GetScheme()).
+					WithInterceptorFuncs(interceptorFunc).
+					Build()
 			}
 
 			kube := NewInfra(cli, cfg)

--- a/internal/infrastructure/kubernetes/ratelimit_serviceaccount_test.go
+++ b/internal/infrastructure/kubernetes/ratelimit_serviceaccount_test.go
@@ -92,9 +92,16 @@ func TestCreateOrUpdateRateLimitServiceAccount(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var cli client.Client
 			if tc.current != nil {
-				cli = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).WithObjects(tc.current).Build()
+				cli = fakeclient.NewClientBuilder().
+					WithScheme(envoygateway.GetScheme()).
+					WithObjects(tc.current).
+					WithInterceptorFuncs(interceptorFunc).
+					Build()
 			} else {
-				cli = fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build()
+				cli = fakeclient.NewClientBuilder().
+					WithScheme(envoygateway.GetScheme()).
+					WithInterceptorFuncs(interceptorFunc).
+					Build()
 			}
 
 			cfg, err := config.New()

--- a/test/helm/default.yaml
+++ b/test/helm/default.yaml
@@ -188,6 +188,7 @@ rules:
   - get
   - update
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -197,6 +198,7 @@ rules:
   - get
   - update
   - delete
+  - patch
 - apiGroups:
   - autoscaling
   resources:
@@ -206,6 +208,7 @@ rules:
   - get
   - update
   - delete
+  - patch
 ---
 # Source: gateway-helm/templates/leader-election-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/test/helm/default.yaml
+++ b/test/helm/default.yaml
@@ -186,7 +186,6 @@ rules:
   verbs:
   - create
   - get
-  - update
   - delete
   - patch
 - apiGroups:
@@ -196,7 +195,6 @@ rules:
   verbs:
   - create
   - get
-  - update
   - delete
   - patch
 - apiGroups:
@@ -206,7 +204,6 @@ rules:
   verbs:
   - create
   - get
-  - update
   - delete
   - patch
 ---


### PR DESCRIPTION
**What type of PR is this?**
Instead of utilizing the Update API for the infra-client, this PR changed it to the Patch API with ApplyPatch.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2995 
