### PR TITLE
chore: Address unused write and tautological nilness checks

### DIFF
--- a/internal/cmd/envoy/shutdown_manager.go
+++ b/internal/cmd/envoy/shutdown_manager.go
@@ -108,7 +108,7 @@ func shutdownReadyHandler(w http.ResponseWriter, readyTimeout time.Duration, rea
 			time.Sleep(1 * time.Second)
 		case err != nil:
 			logger.Error(err, "error checking for shutdown readiness")
-		case err == nil:
+		default:
 			logger.Info("shutdown readiness detected")
 			return
 		}

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -263,12 +263,6 @@ func processTimeout(irRoute *ir.HTTPRoute, rule gwapiv1.HTTPRouteRule) {
 
 func setRequestTimeout(irTimeout *ir.Timeout, d metav1.Duration) {
 	switch {
-	case irTimeout == nil:
-		irTimeout = &ir.Timeout{
-			HTTP: &ir.HTTPTimeout{
-				RequestTimeout: ptr.To(d),
-			},
-		}
 	case irTimeout.HTTP == nil:
 		irTimeout.HTTP = &ir.HTTPTimeout{
 			RequestTimeout: ptr.To(d),

--- a/internal/xds/translator/basicauth.go
+++ b/internal/xds/translator/basicauth.go
@@ -108,15 +108,9 @@ func basicAuthConfig(basicAuth *ir.BasicAuth) *basicauthv3.BasicAuth {
 
 // routeContainsBasicAuth returns true if BasicAuth exists for the provided route.
 func routeContainsBasicAuth(irRoute *ir.HTTPRoute) bool {
-	if irRoute == nil {
-		return false
-	}
-
-	if irRoute != nil &&
-		irRoute.BasicAuth != nil {
+	if irRoute != nil && irRoute.BasicAuth != nil {
 		return true
 	}
-
 	return false
 }
 

--- a/internal/xds/translator/extauth.go
+++ b/internal/xds/translator/extauth.go
@@ -202,15 +202,9 @@ func grpcService(grpc *ir.GRPCExtAuthService) *corev3.GrpcService_EnvoyGrpc {
 
 // routeContainsExtAuth returns true if ExtAuth exists for the provided route.
 func routeContainsExtAuth(irRoute *ir.HTTPRoute) bool {
-	if irRoute == nil {
-		return false
-	}
-
-	if irRoute != nil &&
-		irRoute.ExtAuth != nil {
+	if irRoute != nil && irRoute.ExtAuth != nil {
 		return true
 	}
-
 	return false
 }
 

--- a/internal/xds/translator/fault.go
+++ b/internal/xds/translator/fault.go
@@ -59,7 +59,7 @@ func (*fault) patchHCM(mgr *hcmv3.HttpConnectionManager, irListener *ir.HTTPList
 		}
 	}
 
-	faultFilter, err := buildHCMFaultFilter(irListener)
+	faultFilter, err := buildHCMFaultFilter()
 	if err != nil {
 		return err
 	}
@@ -69,8 +69,8 @@ func (*fault) patchHCM(mgr *hcmv3.HttpConnectionManager, irListener *ir.HTTPList
 }
 
 // buildHCMFaultFilter returns a basic_auth HTTP filter from the provided IR HTTPRoute.
-func buildHCMFaultFilter(irListener *ir.HTTPListener) (*hcmv3.HttpFilter, error) {
-	faultProto := faultConfig(irListener)
+func buildHCMFaultFilter() (*hcmv3.HttpFilter, error) {
+	faultProto := &xdshttpfaultv3.HTTPFault{}
 
 	if err := faultProto.ValidateAll(); err != nil {
 		return nil, err
@@ -89,10 +89,6 @@ func buildHCMFaultFilter(irListener *ir.HTTPListener) (*hcmv3.HttpFilter, error)
 	}, nil
 }
 
-func faultConfig(irListener *ir.HTTPListener) *xdshttpfaultv3.HTTPFault {
-	return &xdshttpfaultv3.HTTPFault{}
-}
-
 // listenerContainsFault returns true if Fault exists for the provided listener.
 func listenerContainsFault(irListener *ir.HTTPListener) bool {
 	for _, route := range irListener.Routes {
@@ -105,15 +101,9 @@ func listenerContainsFault(irListener *ir.HTTPListener) bool {
 
 // routeContainsFault returns true if Fault exists for the provided route.
 func routeContainsFault(irRoute *ir.HTTPRoute) bool {
-	if irRoute == nil {
-		return false
-	}
-
-	if irRoute != nil &&
-		irRoute.FaultInjection != nil {
+	if irRoute != nil && irRoute.FaultInjection != nil {
 		return true
 	}
-
 	return false
 }
 

--- a/internal/xds/translator/jwt.go
+++ b/internal/xds/translator/jwt.go
@@ -323,17 +323,12 @@ func listenerContainsJWTAuthn(irListener *ir.HTTPListener) bool {
 // routeContainsJWTAuthn returns true if JWT authentication exists for the
 // provided route.
 func routeContainsJWTAuthn(irRoute *ir.HTTPRoute) bool {
-	if irRoute == nil {
-		return false
-	}
-
 	if irRoute != nil &&
 		irRoute.JWT != nil &&
 		irRoute.JWT.Providers != nil &&
 		len(irRoute.JWT.Providers) > 0 {
 		return true
 	}
-
 	return false
 }
 

--- a/internal/xds/translator/oidc.go
+++ b/internal/xds/translator/oidc.go
@@ -178,15 +178,9 @@ func oauth2Config(oidc *ir.OIDC) (*oauth2v3.OAuth2, error) {
 
 // routeContainsOIDC returns true if OIDC exists for the provided route.
 func routeContainsOIDC(irRoute *ir.HTTPRoute) bool {
-	if irRoute == nil {
-		return false
-	}
-
-	if irRoute != nil &&
-		irRoute.OIDC != nil {
+	if irRoute != nil && irRoute.OIDC != nil {
 		return true
 	}
-
 	return false
 }
 

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -271,9 +271,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 			// Check if an extension want to modify the route we just generated
 			// If no extension exists (or it doesn't subscribe to this hook) then this is a quick no-op.
 			if err = processExtensionPostRouteHook(xdsRoute, vHost, httpRoute, t.ExtensionManager); err != nil {
-				if err != nil {
-					errs = errors.Join(errs, err)
-				}
+				errs = errors.Join(errs, err)
 			}
 
 			if enabledHTTP3 {

--- a/tools/linter/golangci-lint/.golangci.yml
+++ b/tools/linter/golangci-lint/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - goheader
     - gocritic
     - gosec
+    - govet
     - misspell
     - revive
     - stylecheck
@@ -57,6 +58,11 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/envoyproxy/gateway/
+  govet:
+    enable-all: true
+    disable:
+      - shadow
+      - fieldalignment
   revive:
     rules:
       # TODO: enable if-return check


### PR DESCRIPTION
**What type of PR is this?**

Adds `govet` linter cleaning up unused writes and tautological nilness checks:

```
internal/cmd/envoy/shutdown_manager.go:111:12: nilness: tautological condition: nil == nil (govet)
		case err == nil:
		         ^
internal/xds/translator/basicauth.go:115:13: nilness: tautological condition: non-nil != nil (govet)
	if irRoute != nil &&
	           ^
internal/xds/translator/extauth.go:209:13: nilness: tautological condition: non-nil != nil (govet)
	if irRoute != nil &&
	           ^
internal/xds/translator/fault.go:112:13: nilness: tautological condition: non-nil != nil (govet)
	if irRoute != nil &&
	           ^
internal/xds/translator/jwt.go:330:13: nilness: tautological condition: non-nil != nil (govet)
	if irRoute != nil &&
	           ^
internal/xds/translator/oidc.go:185:13: nilness: tautological condition: non-nil != nil (govet)
	if irRoute != nil &&
	           ^
internal/xds/translator/translator.go:274:12: nilness: tautological condition: non-nil != nil (govet)
				if err != nil {
				       ^
internal/gatewayapi/route.go:268:8: unusedwrite: unused write to field HTTP (govet)
			HTTP: &ir.HTTPTimeout{
			 
```