### PR TITLE
fix: BadRequest error applying JSON access log example

### DIFF
--- a/examples/kubernetes/accesslog/json-accesslog.yaml
+++ b/examples/kubernetes/accesslog/json-accesslog.yaml
@@ -20,11 +20,11 @@ spec:
     accessLog:
       settings:
         - format:
-          type: JSON
-          json:
-            status: "%RESPONSE_CODE%"
-            message: "%LOCAL_REPLY_BODY%"
-      sinks:
-        - type: File
-          file:
-            path: /dev/stdout
+            type: JSON
+            json:
+              status: "%RESPONSE_CODE%"
+              message: "%LOCAL_REPLY_BODY%"
+          sinks:
+            - type: File
+              file:
+                path: /dev/stdout


### PR DESCRIPTION
**What type of PR is this?**

Resolves an error encountered applying one of the examples:

```
$ kubectl apply -f examples/kubernetes/accesslog/json-accesslog.yaml 
gatewayclass.gateway.networking.k8s.io/eg configured
Error from server (BadRequest): error when creating "examples/kubernetes/accesslog/json-accesslog.yaml": EnvoyProxy in version "v1alpha1" cannot be handled as a EnvoyProxy: strict decoding error: unknown field "spec.telemetry.accessLog.settings[0].json", unknown field "spec.telemetry.accessLog.settings[0].type", unknown field "spec.telemetry.accessLog.sinks"
```