### PR TITLE
feat: configure overload manager

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -130,6 +130,13 @@ envoyProxy:
                       path_config_source:
                         path: "/sds/xds-trusted-ca.json"
                       resource_api_version: V3
+        overload_manager:
+          refresh_interval: 0.25s
+          resource_monitors:
+          - name: "envoy.resource_monitors.global_downstream_max_connections"
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+              max_active_downstream_connections: 50000
     logging: {}
   status: {}
 gatewayClass:
@@ -508,6 +515,13 @@ xds:
               envoy.restart_features.use_eds_cache_for_ads: true
               re2.max_program_size.error_level: 4294967295
               re2.max_program_size.warn_level: 1000
+        overloadManager:
+          refreshInterval: 0.250s
+          resourceMonitors:
+          - name: envoy.resource_monitors.global_downstream_max_connections
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+              maxActiveDownstreamConnections: "50000"
         staticResources:
           clusters:
           - connectTimeout: 0.250s

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -56,6 +56,18 @@
                 }
               ]
             },
+            "overloadManager": {
+              "refreshInterval": "0.250s",
+              "resourceMonitors": [
+                {
+                  "name": "envoy.resource_monitors.global_downstream_max_connections",
+                  "typedConfig": {
+                    "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+                    "maxActiveDownstreamConnections": "50000"
+                  }
+                }
+              ]
+            },
             "staticResources": {
               "clusters": [
                 {

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -34,6 +34,13 @@ xds:
               envoy.restart_features.use_eds_cache_for_ads: true
               re2.max_program_size.error_level: 4294967295
               re2.max_program_size.warn_level: 1000
+        overloadManager:
+          refreshInterval: 0.250s
+          resourceMonitors:
+          - name: envoy.resource_monitors.global_downstream_max_connections
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+              maxActiveDownstreamConnections: "50000"
         staticResources:
           clusters:
           - connectTimeout: 0.250s

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.bootstrap.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.bootstrap.yaml
@@ -33,6 +33,13 @@ xds:
             envoy.restart_features.use_eds_cache_for_ads: true
             re2.max_program_size.error_level: 4294967295
             re2.max_program_size.warn_level: 1000
+      overloadManager:
+        refreshInterval: 0.250s
+        resourceMonitors:
+        - name: envoy.resource_monitors.global_downstream_max_connections
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+            maxActiveDownstreamConnections: "50000"
       staticResources:
         clusters:
         - connectTimeout: 0.250s

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -56,6 +56,18 @@
                 }
               ]
             },
+            "overloadManager": {
+              "refreshInterval": "0.250s",
+              "resourceMonitors": [
+                {
+                  "name": "envoy.resource_monitors.global_downstream_max_connections",
+                  "typedConfig": {
+                    "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+                    "maxActiveDownstreamConnections": "50000"
+                  }
+                }
+              ]
+            },
             "staticResources": {
               "clusters": [
                 {

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -34,6 +34,13 @@ xds:
               envoy.restart_features.use_eds_cache_for_ads: true
               re2.max_program_size.error_level: 4294967295
               re2.max_program_size.warn_level: 1000
+        overloadManager:
+          refreshInterval: 0.250s
+          resourceMonitors:
+          - name: envoy.resource_monitors.global_downstream_max_connections
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+              maxActiveDownstreamConnections: "50000"
         staticResources:
           clusters:
           - connectTimeout: 0.250s

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.bootstrap.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.bootstrap.yaml
@@ -33,6 +33,13 @@ xds:
             envoy.restart_features.use_eds_cache_for_ads: true
             re2.max_program_size.error_level: 4294967295
             re2.max_program_size.warn_level: 1000
+      overloadManager:
+        refreshInterval: 0.250s
+        resourceMonitors:
+        - name: envoy.resource_monitors.global_downstream_max_connections
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+            maxActiveDownstreamConnections: "50000"
       staticResources:
         clusters:
         - connectTimeout: 0.250s

--- a/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
@@ -497,6 +497,19 @@ func TestDeployment(t *testing.T) {
 			infra:     newTestInfra(),
 			extraArgs: []string{"--key1 val1", "--key2 val2"},
 		},
+		{
+			caseName: "with-empty-memory-limits",
+			infra:    newTestInfra(),
+			deploy: &egv1a1.KubernetesDeploymentSpec{
+				Container: &egv1a1.KubernetesContainerSpec{
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("400m"),
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.caseName, func(t *testing.T) {

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -168,6 +168,28 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 1717986918
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -168,6 +168,28 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 1717986918
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -166,6 +166,28 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 1717986918
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -165,6 +165,13 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -139,6 +139,13 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -166,6 +166,28 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 1717986918
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -176,6 +176,13 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -165,6 +165,13 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -165,6 +165,13 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
         - --drain-time-s 30

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -166,6 +166,28 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 1717986918
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -170,6 +170,13 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -1,0 +1,299 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/managed-by: envoy-gateway
+    app.kubernetes.io/name: envoy
+    gateway.envoyproxy.io/owning-gateway-name: default
+    gateway.envoyproxy.io/owning-gateway-namespace: default
+  name: envoy-default-37a8eec1
+  namespace: envoy-gateway-system
+spec:
+  progressDeadlineSeconds: 600
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: proxy
+      app.kubernetes.io/managed-by: envoy-gateway
+      app.kubernetes.io/name: envoy
+      gateway.envoyproxy.io/owning-gateway-name: default
+      gateway.envoyproxy.io/owning-gateway-namespace: default
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "19001"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: proxy
+        app.kubernetes.io/managed-by: envoy-gateway
+        app.kubernetes.io/name: envoy
+        gateway.envoyproxy.io/owning-gateway-name: default
+        gateway.envoyproxy.io/owning-gateway-namespace: default
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --service-cluster default
+        - --service-node $(ENVOY_POD_NAME)
+        - |
+          --config-yaml admin:
+            access_log:
+            - name: envoy.access_loggers.file
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                path: /dev/null
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 19000
+          layered_runtime:
+            layers:
+            - name: global_config
+              static_layer:
+                envoy.restart_features.use_eds_cache_for_ads: true
+                re2.max_program_size.error_level: 4294967295
+                re2.max_program_size.warn_level: 1000
+          dynamic_resources:
+            ads_config:
+              api_type: DELTA_GRPC
+              transport_api_version: V3
+              grpc_services:
+              - envoy_grpc:
+                  cluster_name: xds_cluster
+              set_node_on_first_message_only: true
+            lds_config:
+              ads: {}
+              resource_api_version: V3
+            cds_config:
+              ads: {}
+              resource_api_version: V3
+          static_resources:
+            listeners:
+            - name: envoy-gateway-proxy-ready-0.0.0.0-19001
+              address:
+                socket_address:
+                  address: 0.0.0.0
+                  port_value: 19001
+                  protocol: TCP
+              filter_chains:
+              - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: eg-ready-http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                      - name: prometheus_stats
+                        domains:
+                        - "*"
+                        routes:
+                        - match:
+                            prefix: /stats/prometheus
+                          route:
+                            cluster: prometheus_stats
+                    http_filters:
+                    - name: envoy.filters.http.health_check
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                        pass_through_mode: false
+                        headers:
+                        - name: ":path"
+                          string_match:
+                            exact: /ready
+                    - name: envoy.filters.http.router
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            clusters:
+            - name: prometheus_stats
+              connect_timeout: 0.250s
+              type: STATIC
+              lb_policy: ROUND_ROBIN
+              load_assignment:
+                cluster_name: prometheus_stats
+                endpoints:
+                - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 19000
+            - connect_timeout: 10s
+              load_assignment:
+                cluster_name: xds_cluster
+                endpoints:
+                - load_balancing_weight: 1
+                  lb_endpoints:
+                  - load_balancing_weight: 1
+                    endpoint:
+                      address:
+                        socket_address:
+                          address: envoy-gateway
+                          port_value: 18000
+              typed_extension_protocol_options:
+                envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                  "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+                  explicit_http_config:
+                    http2_protocol_options:
+                      connection_keepalive:
+                        interval: 30s
+                        timeout: 5s
+              name: xds_cluster
+              type: STRICT_DNS
+              transport_socket:
+                name: envoy.transport_sockets.tls
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+                  common_tls_context:
+                    tls_params:
+                      tls_maximum_protocol_version: TLSv1_3
+                    tls_certificate_sds_secret_configs:
+                    - name: xds_certificate
+                      sds_config:
+                        path_config_source:
+                          path: "/sds/xds-certificate.json"
+                        resource_api_version: V3
+                    validation_context_sds_secret_config:
+                      name: xds_trusted_ca
+                      sds_config:
+                        path_config_source:
+                          path: "/sds/xds-trusted-ca.json"
+                        resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
+        - --log-level warn
+        - --cpuset-threads
+        command:
+        - envoy
+        env:
+        - name: ENVOY_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: envoyproxy/envoy:distroless-dev
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /shutdown/ready
+              port: 19002
+              scheme: HTTP
+        name: envoy
+        ports:
+        - containerPort: 8080
+          name: EnvoyH-d76a15e2
+          protocol: TCP
+        - containerPort: 8443
+          name: EnvoyH-6658f727
+          protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 19001
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 400m
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /certs
+          name: certs
+          readOnly: true
+        - mountPath: /sds
+          name: sds
+      - args:
+        - envoy
+        - shutdown-manager
+        command:
+        - envoy-gateway
+        env:
+        - name: ENVOY_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: envoyproxy/gateway-dev:latest
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - envoy-gateway
+              - envoy
+              - shutdown
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 19002
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: shutdown-manager
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 19002
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      serviceAccountName: envoy-default-37a8eec1
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - name: certs
+        secret:
+          defaultMode: 420
+          secretName: envoy
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: xds-trusted-ca.json
+            path: xds-trusted-ca.json
+          - key: xds-certificate.json
+            path: xds-certificate.json
+          name: envoy-default-37a8eec1
+          optional: false
+        name: sds
+status: {}

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -165,6 +165,13 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
         - --key1 val1

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -165,6 +165,13 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -165,6 +165,13 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -165,6 +165,13 @@ spec:
                         path_config_source:
                           path: "/sds/xds-trusted-ca.json"
                         resource_api_version: V3
+          overload_manager:
+            refresh_interval: 0.25s
+            resource_monitors:
+            - name: "envoy.resource_monitors.global_downstream_max_connections"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+                max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
         command:

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -20,35 +20,41 @@ import (
 
 func TestGetRenderedBootstrapConfig(t *testing.T) {
 	cases := []struct {
-		name         string
-		proxyMetrics *egv1a1.ProxyMetrics
+		name string
+		opts *RenderBootsrapConfigOptions
 	}{
 		{
 			name: "disable-prometheus",
-			proxyMetrics: &egv1a1.ProxyMetrics{
-				Prometheus: &egv1a1.ProxyPrometheusProvider{
-					Disable: true,
+			opts: &RenderBootsrapConfigOptions{
+				ProxyMetrics: &egv1a1.ProxyMetrics{
+					Prometheus: &egv1a1.ProxyPrometheusProvider{
+						Disable: true,
+					},
 				},
 			},
 		},
 		{
 			name: "enable-prometheus",
-			proxyMetrics: &egv1a1.ProxyMetrics{
-				Prometheus: &egv1a1.ProxyPrometheusProvider{},
+			opts: &RenderBootsrapConfigOptions{
+				ProxyMetrics: &egv1a1.ProxyMetrics{
+					Prometheus: &egv1a1.ProxyPrometheusProvider{},
+				},
 			},
 		},
 		{
 			name: "otel-metrics",
-			proxyMetrics: &egv1a1.ProxyMetrics{
-				Prometheus: &egv1a1.ProxyPrometheusProvider{
-					Disable: true,
-				},
-				Sinks: []egv1a1.ProxyMetricSink{
-					{
-						Type: egv1a1.MetricSinkTypeOpenTelemetry,
-						OpenTelemetry: &egv1a1.ProxyOpenTelemetrySink{
-							Host: "otel-collector.monitoring.svc",
-							Port: 4317,
+			opts: &RenderBootsrapConfigOptions{
+				ProxyMetrics: &egv1a1.ProxyMetrics{
+					Prometheus: &egv1a1.ProxyPrometheusProvider{
+						Disable: true,
+					},
+					Sinks: []egv1a1.ProxyMetricSink{
+						{
+							Type: egv1a1.MetricSinkTypeOpenTelemetry,
+							OpenTelemetry: &egv1a1.ProxyOpenTelemetrySink{
+								Host: "otel-collector.monitoring.svc",
+								Port: 4317,
+							},
 						},
 					},
 				},
@@ -56,36 +62,44 @@ func TestGetRenderedBootstrapConfig(t *testing.T) {
 		},
 		{
 			name: "custom-stats-matcher",
-			proxyMetrics: &egv1a1.ProxyMetrics{
-				Matches: []egv1a1.StringMatch{
-					{
-						Type:  ptr.To(egv1a1.StringMatchExact),
-						Value: "http.foo.bar.cluster.upstream_rq",
-					},
-					{
-						Type:  ptr.To(egv1a1.StringMatchPrefix),
-						Value: "http",
-					},
-					{
-						Type:  ptr.To(egv1a1.StringMatchSuffix),
-						Value: "upstream_rq",
-					},
-					{
-						Type:  ptr.To(egv1a1.StringMatchRegularExpression),
-						Value: "virtual.*",
-					},
-					{
-						Type:  ptr.To(egv1a1.StringMatchPrefix),
-						Value: "cluster",
+			opts: &RenderBootsrapConfigOptions{
+				ProxyMetrics: &egv1a1.ProxyMetrics{
+					Matches: []egv1a1.StringMatch{
+						{
+							Type:  ptr.To(egv1a1.StringMatchExact),
+							Value: "http.foo.bar.cluster.upstream_rq",
+						},
+						{
+							Type:  ptr.To(egv1a1.StringMatchPrefix),
+							Value: "http",
+						},
+						{
+							Type:  ptr.To(egv1a1.StringMatchSuffix),
+							Value: "upstream_rq",
+						},
+						{
+							Type:  ptr.To(egv1a1.StringMatchRegularExpression),
+							Value: "virtual.*",
+						},
+						{
+							Type:  ptr.To(egv1a1.StringMatchPrefix),
+							Value: "cluster",
+						},
 					},
 				},
+			},
+		},
+		{
+			name: "with-max-heap-size-bytes",
+			opts: &RenderBootsrapConfigOptions{
+				MaxHeapSizeBytes: 1073741824,
 			},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := GetRenderedBootstrapConfig(tc.proxyMetrics)
+			got, err := GetRenderedBootstrapConfig(tc.opts)
 			require.NoError(t, err)
 
 			if *overrideTestData {

--- a/internal/xds/bootstrap/testdata/merge/default.out.yaml
+++ b/internal/xds/bootstrap/testdata/merge/default.out.yaml
@@ -35,6 +35,13 @@ layeredRuntime:
       rtdsConfig:
         ads: {}
         resourceApiVersion: V3
+overloadManager:
+  refreshInterval: 0.250s
+  resourceMonitors:
+  - name: envoy.resource_monitors.global_downstream_max_connections
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+      maxActiveDownstreamConnections: "50000"
 staticResources:
   clusters:
   - connectTimeout: 0.250s

--- a/internal/xds/bootstrap/testdata/merge/stats_sinks.out.yaml
+++ b/internal/xds/bootstrap/testdata/merge/stats_sinks.out.yaml
@@ -29,6 +29,13 @@ layeredRuntime:
       envoy.restart_features.use_eds_cache_for_ads: true
       re2.max_program_size.error_level: 4294967295
       re2.max_program_size.warn_level: 1000
+overloadManager:
+  refreshInterval: 0.250s
+  resourceMonitors:
+  - name: envoy.resource_monitors.global_downstream_max_connections
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+      maxActiveDownstreamConnections: "50000"
 staticResources:
   clusters:
   - connectTimeout: 0.250s

--- a/internal/xds/bootstrap/testdata/render/custom-stats-matcher.yaml
+++ b/internal/xds/bootstrap/testdata/render/custom-stats-matcher.yaml
@@ -132,3 +132,10 @@ static_resources:
               path_config_source:
                 path: "/sds/xds-trusted-ca.json"
               resource_api_version: V3
+overload_manager:
+  refresh_interval: 0.25s
+  resource_monitors:
+  - name: "envoy.resource_monitors.global_downstream_max_connections"
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+      max_active_downstream_connections: 50000

--- a/internal/xds/bootstrap/testdata/render/disable-prometheus.yaml
+++ b/internal/xds/bootstrap/testdata/render/disable-prometheus.yaml
@@ -99,3 +99,10 @@ static_resources:
               path_config_source:
                 path: "/sds/xds-trusted-ca.json"
               resource_api_version: V3
+overload_manager:
+  refresh_interval: 0.25s
+  resource_monitors:
+  - name: "envoy.resource_monitors.global_downstream_max_connections"
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+      max_active_downstream_connections: 50000

--- a/internal/xds/bootstrap/testdata/render/enable-prometheus.yaml
+++ b/internal/xds/bootstrap/testdata/render/enable-prometheus.yaml
@@ -121,3 +121,10 @@ static_resources:
               path_config_source:
                 path: "/sds/xds-trusted-ca.json"
               resource_api_version: V3
+overload_manager:
+  refresh_interval: 0.25s
+  resource_monitors:
+  - name: "envoy.resource_monitors.global_downstream_max_connections"
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+      max_active_downstream_connections: 50000

--- a/internal/xds/bootstrap/testdata/render/otel-metrics.yaml
+++ b/internal/xds/bootstrap/testdata/render/otel-metrics.yaml
@@ -124,3 +124,10 @@ static_resources:
               path_config_source:
                 path: "/sds/xds-trusted-ca.json"
               resource_api_version: V3
+overload_manager:
+  refresh_interval: 0.25s
+  resource_monitors:
+  - name: "envoy.resource_monitors.global_downstream_max_connections"
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+      max_active_downstream_connections: 50000

--- a/internal/xds/bootstrap/testdata/render/with-max-heap-size-bytes.yaml
+++ b/internal/xds/bootstrap/testdata/render/with-max-heap-size-bytes.yaml
@@ -3,31 +3,11 @@ admin:
   - name: envoy.access_loggers.file
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-      path: {{ .AdminServer.AccessLogPath }}
+      path: /dev/null
   address:
     socket_address:
-      address: {{ .AdminServer.Address }}
-      port_value: {{ .AdminServer.Port }}
-{{- if .StatsMatcher  }}
-stats_config:
-  stats_matcher:
-    inclusion_list:
-      patterns:
-      {{- range $_, $item := .StatsMatcher.Exacts }}
-      - exact: {{$item}}
-      {{- end}}
-      {{- range $_, $item := .StatsMatcher.Prefixs }}
-      - prefix: {{$item}}
-      {{- end}}
-      {{- range $_, $item := .StatsMatcher.Suffixs }}
-      - suffix: {{$item}}
-      {{- end}}
-      {{- range $_, $item := .StatsMatcher.RegularExpressions }}
-      - safe_regex:
-          google_re2: {}
-          regex: {{js $item}}
-      {{- end}}
-{{- end }}
+      address: 127.0.0.1
+      port_value: 19000
 layered_runtime:
   layers:
   - name: global_config
@@ -49,24 +29,13 @@ dynamic_resources:
   cds_config:
     ads: {}
     resource_api_version: V3
-{{- if .OtelMetricSinks }}
-stats_sinks:
-{{- range $idx, $sink := .OtelMetricSinks }}
-- name: "envoy.stat_sinks.open_telemetry"
-  typed_config:
-    "@type": type.googleapis.com/envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig
-    grpc_service:
-      envoy_grpc:
-        cluster_name: otel_metric_sink_{{ $idx }}
-{{- end }}
-{{- end }}
 static_resources:
   listeners:
-  - name: envoy-gateway-proxy-ready-{{ .ReadyServer.Address }}-{{ .ReadyServer.Port }}
+  - name: envoy-gateway-proxy-ready-0.0.0.0-19001
     address:
       socket_address:
-        address: {{ .ReadyServer.Address }}
-        port_value: {{ .ReadyServer.Port }}
+        address: 0.0.0.0
+        port_value: 19001
         protocol: TCP
     filter_chains:
     - filters:
@@ -76,7 +45,6 @@ static_resources:
           stat_prefix: eg-ready-http
           route_config:
             name: local_route
-            {{- if .EnablePrometheus }}
             virtual_hosts:
             - name: prometheus_stats
               domains:
@@ -86,7 +54,6 @@ static_resources:
                   prefix: /stats/prometheus
                 route:
                   cluster: prometheus_stats
-            {{- end }}
           http_filters:
           - name: envoy.filters.http.health_check
             typed_config:
@@ -95,12 +62,11 @@ static_resources:
               headers:
               - name: ":path"
                 string_match:
-                  exact: {{ .ReadyServer.ReadinessPath }}
+                  exact: /ready
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   clusters:
-  {{- if .EnablePrometheus }}
   - name: prometheus_stats
     connect_timeout: 0.250s
     type: STATIC
@@ -112,29 +78,8 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: {{ .AdminServer.Address }}
-                port_value: {{ .AdminServer.Port }}
-  {{- end }}
-  {{- range $idx, $sink := .OtelMetricSinks }}
-  - name: otel_metric_sink_{{ $idx }}
-    connect_timeout: 0.250s
-    type: STRICT_DNS
-    typed_extension_protocol_options:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
-        explicit_http_config:
-          http2_protocol_options: {}
-    lb_policy: ROUND_ROBIN
-    load_assignment:
-      cluster_name: otel_metric_sink_{{ $idx }}
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: {{ $sink.Address }}
-                port_value: {{ $sink.Port }}
-  {{- end }}
+                address: 127.0.0.1
+                port_value: 19000
   - connect_timeout: 10s
     load_assignment:
       cluster_name: xds_cluster
@@ -145,8 +90,8 @@ static_resources:
           endpoint:
             address:
               socket_address:
-                address: {{ .XdsServer.Address }}
-                port_value: {{ .XdsServer.Port }}
+                address: envoy-gateway
+                port_value: 18000
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
@@ -183,11 +128,10 @@ overload_manager:
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
       max_active_downstream_connections: 50000
-  {{- with .OverloadManager.MaxHeapSizeBytes }}
   - name: "envoy.resource_monitors.fixed_heap"
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
-      max_heap_size_bytes: {{ . }}
+      max_heap_size_bytes: 1073741824
   actions:
   - name: "envoy.overload_actions.shrink_heap"
     triggers:
@@ -199,4 +143,3 @@ overload_manager:
     - name: "envoy.resource_monitors.fixed_heap"
       threshold:
         value: 0.98
-  {{- end }}


### PR DESCRIPTION
**What type of PR is this?**
feature

**What this PR does / why we need it**:
Configure overload manager as recommended in [Configuring Envoy as an edge proxy](https://www.envoyproxy.io/docs/envoy/latest/configuration/best_practices/edge#configuring-envoy-as-an-edge-proxy) guide with the following:
* Set global downstream connection limits to `50000`.
* Dynamically set `max_heap_size_bytes` to `80%` of `Envoy` container memory limits. in case there are no limits `max_heap_size_bytes` is not being set. This approach has been agreed [here](https://github.com/envoyproxy/gateway/pull/2062#discussion_r1491049011).


**Which issue(s) this PR fixes**:
Fixes #1966 
Related #1048 

**Note regarding global downstream connection limits**:
latest stable Envoy(v1.29.2) [docs](https://www.envoyproxy.io/docs/envoy/v1.29.2/configuration/operations/overload_manager/overload_manager#limiting-active-connections) suggests to use new overload manager API and also states: "One could also set this limit via specifying an integer through the runtime key overload.global_downstream_max_connections, though this key is deprecated and will be removed in future".
However, when navigating to Downstream connections API [page](https://www.envoyproxy.io/docs/envoy/v1.29.2/api-v3/extensions/resource_monitors/downstream_connections/v3/downstream_connections.proto#downstream-connections-proto) it is stated that it's currently work-in-progress.