### PR TITLE
correct kubectl command to show deployment in envoy-gateway-system na…

### DIFF
--- a/site/content/en/latest/user/operations/customize-envoyproxy.md
+++ b/site/content/en/latest/user/operations/customize-envoyproxy.md
@@ -55,7 +55,7 @@ After you apply the config, you should see the replicas of envoyproxy changes to
 And also you can dynamically change the value.
 
 ``` shell
-kubectl get deployment -l gateway.envoyproxy.io/owning-gateway-name=eg
+kubectl get deployment -l gateway.envoyproxy.io/owning-gateway-name=eg -n envoy-gateway-system
 ```
 
 ## Customize EnvoyProxy Image

--- a/site/content/en/v1.0.0/user/operations/customize-envoyproxy.md
+++ b/site/content/en/v1.0.0/user/operations/customize-envoyproxy.md
@@ -55,7 +55,7 @@ After you apply the config, you should see the replicas of envoyproxy changes to
 And also you can dynamically change the value.
 
 ``` shell
-kubectl get deployment -l gateway.envoyproxy.io/owning-gateway-name=eg
+kubectl get deployment -l gateway.envoyproxy.io/owning-gateway-name=eg -n envoy-gateway-system
 ```
 
 ## Customize EnvoyProxy Image


### PR DESCRIPTION

**What type of PR is this?**
* "docs: updates/fixes kubectl command in user guide 'customize envoyproxy' to reference envoy-gateway-system namespace (was missing)"

**What this PR does / why we need it**:

i believe it was an omission - the deployment in question resides in envoy-gateway-system
