### PR TITLE
ci: pin linkinator version in docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -36,7 +36,7 @@ jobs:
         config_file: ".github/markdown_lint_config.json"
 
     - name: Install linkinator
-      run: npm install -g linkinator
+      run: npm install -g linkinator@6.0.4
 
     - name: Check links
       run: make docs docs-check-links


### PR DESCRIPTION
**What this PR does / why we need it**:
Pin version of linkinator npm package in docs workflow in order to increase OpenSSF `Pinned-Dependencies` score:
<img width="850" alt="image" src="https://github.com/envoyproxy/gateway/assets/16555289/136e97b1-420a-4819-ae58-f894aacd4ea1">

