### PR TITLE
run cel validation on different k8s versions

### DIFF
--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -1,5 +1,7 @@
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION ?= 1.27.1
+ENVTEST_K8S_VERSION ?= 1.28.0
+# Need run cel validation across multiple versions of k8s
+ENVTEST_K8S_VERSIONS ?= 1.27.1 1.28.0 1.29.0
 # GATEWAY_API_VERSION refers to the version of Gateway API CRDs.
 # For more details, see https://gateway-api.sigs.k8s.io/guides/getting-started/#installing-gateway-api 
 GATEWAY_API_VERSION ?= $(shell go list -m -f '{{.Version}}' sigs.k8s.io/gateway-api)


### PR DESCRIPTION
Separated from https://github.com/envoyproxy/gateway/pull/3080, xref: https://github.com/envoyproxy/gateway/pull/3080/files?diff=split&w=0#r1547213400

CEL must be validated on supported k8s versions.