### PR TITLE
translator: set SpawnUpstreamSpan to true

### DIFF
--- a/internal/xds/translator/testdata/out/xds-ir/tracing.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing.listeners.yaml
@@ -56,6 +56,7 @@
               serviceName: fake-name.fake-ns
           randomSampling:
             value: 90
+          spawnUpstreamSpan: true
         useRemoteAddress: true
   drainType: MODIFY_ONLY
   name: first-listener

--- a/internal/xds/translator/tracing.go
+++ b/internal/xds/translator/tracing.go
@@ -15,6 +15,7 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tracingtype "github.com/envoyproxy/go-control-plane/envoy/type/tracing/v3"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/utils/ptr"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -114,6 +115,9 @@ func buildHCMTracing(tracing *ir.Tracing) (*hcm.HttpConnectionManager_Tracing, e
 			},
 		},
 		CustomTags: tags,
+		SpawnUpstreamSpan: &wrapperspb.BoolValue{
+			Value: true,
+		},
 	}, nil
 }
 

--- a/internal/xds/translator/tracing.go
+++ b/internal/xds/translator/tracing.go
@@ -114,10 +114,8 @@ func buildHCMTracing(tracing *ir.Tracing) (*hcm.HttpConnectionManager_Tracing, e
 				TypedConfig: ocAny,
 			},
 		},
-		CustomTags: tags,
-		SpawnUpstreamSpan: &wrapperspb.BoolValue{
-			Value: true,
-		},
+		CustomTags:        tags,
+		SpawnUpstreamSpan: wrapperspb.Bool(true),
 	}, nil
 }
 


### PR DESCRIPTION
According the [doc](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/observability/tracing#different-modes-of-envoy), EG should set `SpawnUpstreamSpan` to `true`.

```
	//   - If Envoy is used as gateway or independent proxy, or users want to make the sidecar and its
	//     application as different hops in the trace chain, this flag should be set to true.
```

