### PR TITLE
[release/v1.0] dont fail CI if codecov upload fails (#3123)

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -54,7 +54,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@4fe8c5f003fae66aa5ebb77cfd3e7bfbbda0b6b0  # v3.1.5
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         files: ./coverage.xml
         name: codecov-envoy-gateway
         verbose: true


### PR DESCRIPTION
* dont fail CI is Codecov upload fails

Codecov uploads recently started failing
relates to https://github.com/codecov/codecov-action/issues/1359



* fix lint



---------


(cherry picked from commit e12fdeb138506a8f52419aaf8d18898982ba8e44)

