### PR TITLE
Use <proto>-<port> for naming service and container ports

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/quickstart.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/quickstart.all.yaml
@@ -80,7 +80,7 @@ infraIR:
         name: envoy-gateway-system/eg/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -359,6 +359,10 @@ func irUDPListenerName(listener *ListenerContext, udpRoute *UDPRouteContext) str
 	return fmt.Sprintf("%s/%s/%s/%s", listener.gateway.Namespace, listener.gateway.Name, listener.Name, udpRoute.Name)
 }
 
+func irListenerPortName(proto ir.ProtocolType, port int32) string {
+	return strings.ToLower(fmt.Sprintf("%s-%d", proto, port))
+}
+
 func irRoutePrefix(route RouteContext) string {
 	// add a "/" at the end of the prefix to prevent mismatching routes with the
 	// same prefix. For example, route prefix "/foo/" should not match a route "/foobar".

--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -7,7 +7,6 @@ package gatewayapi
 
 import (
 	"fmt"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -147,7 +146,7 @@ func (t *Translator) processInfraIRListener(listener *ListenerContext, infraIR I
 	}
 
 	infraPort := ir.ListenerPort{
-		Name:          strings.ToLower(fmt.Sprintf("%s-%d", proto, servicePort.port)),
+		Name:          irListenerPortName(proto, servicePort.port),
 		Protocol:      proto,
 		ServicePort:   servicePort.port,
 		ContainerPort: servicePortToContainerPort(servicePort.port),

--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -7,6 +7,7 @@ package gatewayapi
 
 import (
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -145,12 +146,8 @@ func (t *Translator) processInfraIRListener(listener *ListenerContext, infraIR I
 		proto = ir.UDPProtocolType
 	}
 
-	infraPortName := string(listener.Name)
-	if t.MergeGateways {
-		infraPortName = irHTTPListenerName(listener)
-	}
 	infraPort := ir.ListenerPort{
-		Name:          infraPortName,
+		Name:          strings.ToLower(fmt.Sprintf("%s-%d", proto, servicePort.port)),
 		Protocol:      proto,
 		ServicePort:   servicePort.port,
 		ContainerPort: servicePortToContainerPort(servicePort.port),

--- a/internal/gatewayapi/testdata/backendtlspolicy-ca-only.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-ca-only.out.yaml
@@ -119,7 +119,7 @@ infraIR:
         name: envoy-gateway/gateway-btls/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtlspolicy-default-ns.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-default-ns.out.yaml
@@ -118,7 +118,7 @@ infraIR:
         name: envoy-gateway/gateway-btls/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtlspolicy-invalid-ca.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-invalid-ca.out.yaml
@@ -119,7 +119,7 @@ infraIR:
         name: envoy-gateway/gateway-btls/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtlspolicy-system-truststore.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-system-truststore.out.yaml
@@ -115,7 +115,7 @@ infraIR:
         name: envoy-gateway/gateway-btls/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtlspolicy-without-referencegrant.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-without-referencegrant.out.yaml
@@ -120,7 +120,7 @@ infraIR:
         name: envoy-gateway/gateway-btls/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-override-replace.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-override-replace.out.yaml
@@ -196,7 +196,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions.out.yaml
@@ -505,7 +505,7 @@ infraIR:
         name: another-namespace/not-same-namespace-gateway/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -520,7 +520,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -535,14 +535,14 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-2/tcp
         ports:
         - containerPort: 10053
-          name: tcp
+          name: tcp-53
           protocol: TCP
           servicePort: 53
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-status-fault-injection.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-status-fault-injection.out.yaml
@@ -303,7 +303,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -318,7 +318,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-circuitbreakers-error.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-circuitbreakers-error.out.yaml
@@ -285,7 +285,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -300,7 +300,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-circuitbreakers.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-circuitbreakers.out.yaml
@@ -226,7 +226,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -241,7 +241,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-healthcheck.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-healthcheck.out.yaml
@@ -436,7 +436,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -451,7 +451,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-loadbalancer.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-loadbalancer.out.yaml
@@ -325,7 +325,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -340,7 +340,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-default-route-level-limit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-default-route-level-limit.out.yaml
@@ -137,7 +137,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-invalid-limit-unit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-invalid-limit-unit.out.yaml
@@ -141,7 +141,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-invalid-match-type.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-invalid-match-type.out.yaml
@@ -137,7 +137,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-invalid-multiple-route-level-limits.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-invalid-multiple-route-level-limits.out.yaml
@@ -144,7 +144,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit.out.yaml
@@ -140,7 +140,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-proxyprotocol.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-proxyprotocol.out.yaml
@@ -218,7 +218,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -233,7 +233,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit-invalid-regex.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit-invalid-regex.out.yaml
@@ -123,7 +123,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit.out.yaml
@@ -238,7 +238,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -253,7 +253,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-retries.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-retries.out.yaml
@@ -237,7 +237,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -252,7 +252,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-same-prefix-httproutes.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-same-prefix-httproutes.out.yaml
@@ -156,7 +156,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-gateway.out.yaml
@@ -146,14 +146,14 @@ infraIR:
         name: default/tcp-gateway/foo
         ports:
         - containerPort: 8162
-          name: foo
+          name: udp-8162
           protocol: UDP
           servicePort: 8162
       - address: null
         name: default/tcp-gateway/bar
         ports:
         - containerPort: 8089
-          name: bar
+          name: tcp-8089
           protocol: TCP
           servicePort: 8089
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-route.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-route.out.yaml
@@ -221,14 +221,14 @@ infraIR:
         name: default/tcp-gateway/foo
         ports:
         - containerPort: 8162
-          name: foo
+          name: udp-8162
           protocol: UDP
           servicePort: 8162
       - address: null
         name: default/tcp-gateway/bar
         ports:
         - containerPort: 8089
-          name: bar
+          name: tcp-8089
           protocol: TCP
           servicePort: 8089
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcpkeepalive.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcpkeepalive.out.yaml
@@ -222,7 +222,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -237,7 +237,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-timeout-error.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-timeout-error.out.yaml
@@ -114,7 +114,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-timeout.out.yaml
@@ -226,7 +226,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -241,7 +241,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit-with-format-error.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit-with-format-error.out.yaml
@@ -140,14 +140,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit-with-out-of-range-error.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit-with-out-of-range-error.out.yaml
@@ -140,14 +140,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit.out.yaml
@@ -140,14 +140,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-client-ip-detection.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-client-ip-detection.out.yaml
@@ -230,28 +230,28 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 8081
-          name: http-1
+          name: http-8081
           protocol: HTTP
           servicePort: 8081
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8082
-          name: http-2
+          name: http-8082
           protocol: HTTP
           servicePort: 8082
       - address: null
         name: envoy-gateway/gateway-1/http-3
         ports:
         - containerPort: 8083
-          name: http-3
+          name: http-8083
           protocol: HTTP
           servicePort: 8083
       - address: null
         name: envoy-gateway/gateway-1/http-4
         ports:
         - containerPort: 8084
-          name: http-4
+          name: http-8084
           protocol: HTTP
           servicePort: 8084
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-connection-limit-error.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-connection-limit-error.out.yaml
@@ -142,14 +142,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-connection-limit.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-connection-limit.out.yaml
@@ -142,14 +142,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-headers.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-headers.out.yaml
@@ -106,14 +106,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-http10.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-http10.out.yaml
@@ -199,21 +199,21 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       - address: null
         name: envoy-gateway/gateway-1/http-3
         ports:
         - containerPort: 8081
-          name: http-3
+          name: http-8081
           protocol: HTTP
           servicePort: 8081
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-http3.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-http3.out.yaml
@@ -118,7 +118,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10443
-          name: tls
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-idle-timeout-with-error.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-idle-timeout-with-error.out.yaml
@@ -77,7 +77,7 @@ infraIR:
         name: envoy-gateway/gateway/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-idle-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-idle-timeout.out.yaml
@@ -108,14 +108,14 @@ infraIR:
         name: envoy-gateway/gateway/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls.out.yaml
@@ -197,14 +197,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10443
-          name: http-1
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:
@@ -219,7 +219,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http-1
         ports:
         - containerPort: 10443
-          name: http-1
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-path-settings.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-path-settings.out.yaml
@@ -106,14 +106,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-preserve-case.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-preserve-case.out.yaml
@@ -106,14 +106,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-proxyprotocol.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-proxyprotocol.out.yaml
@@ -106,14 +106,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions.out.yaml
@@ -458,7 +458,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -473,14 +473,14 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-2/tcp
         ports:
         - containerPort: 10053
-          name: tcp
+          name: tcp-53
           protocol: TCP
           servicePort: 53
       metadata:
@@ -495,7 +495,7 @@ infraIR:
         name: envoy-gateway/gateway-3/bar-foo
         ports:
         - containerPort: 10080
-          name: bar-foo
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -510,7 +510,7 @@ infraIR:
         name: not-same-namespace/not-same-namespace-gateway/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-tcp-keepalive.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-tcp-keepalive.out.yaml
@@ -142,14 +142,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-timeout-with-error.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-timeout-with-error.out.yaml
@@ -77,7 +77,7 @@ infraIR:
         name: envoy-gateway/gateway/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-timeout.out.yaml
@@ -108,14 +108,14 @@ infraIR:
         name: envoy-gateway/gateway/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-tls-settings.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-tls-settings.out.yaml
@@ -123,14 +123,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10443
-          name: http-1
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-trailers.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-trailers.out.yaml
@@ -105,14 +105,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8080
-          name: http-2
+          name: http-8080
           protocol: HTTP
           servicePort: 8080
       metadata:

--- a/internal/gatewayapi/testdata/conflicting-policies.out.yaml
+++ b/internal/gatewayapi/testdata/conflicting-policies.out.yaml
@@ -215,7 +215,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: default/gateway-1/http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/disable-accesslog.out.yaml
+++ b/internal/gatewayapi/testdata/disable-accesslog.out.yaml
@@ -108,7 +108,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-invalid-cross-ns-ref.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-invalid-cross-ns-ref.out.yaml
@@ -79,7 +79,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-override-replace.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-override-replace.out.yaml
@@ -192,7 +192,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions.out.yaml
@@ -505,7 +505,7 @@ infraIR:
         name: another-namespace/not-same-namespace-gateway/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -520,7 +520,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -535,14 +535,14 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-2/tcp
         ports:
         - containerPort: 10053
-          name: tcp
+          name: tcp-53
           protocol: TCP
           servicePort: 53
       metadata:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-matching-port.out.yaml
@@ -117,7 +117,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-port.out.yaml
@@ -117,7 +117,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-reference-grant.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-reference-grant.out.yaml
@@ -119,7 +119,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-service.out.yaml
@@ -118,7 +118,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.out.yaml
@@ -259,7 +259,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoypatchpolicy-cross-ns-target.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-cross-ns-target.out.yaml
@@ -47,7 +47,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoypatchpolicy-invalid-feature-disabled.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-invalid-feature-disabled.out.yaml
@@ -58,7 +58,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: envoy-gateway/gateway-1/http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoypatchpolicy-invalid-target-kind-merge-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-invalid-target-kind-merge-gateways.out.yaml
@@ -58,7 +58,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: envoy-gateway/gateway-1/http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoypatchpolicy-invalid-target-kind.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-invalid-target-kind.out.yaml
@@ -47,7 +47,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoypatchpolicy-valid-merge-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-valid-merge-gateways.out.yaml
@@ -58,7 +58,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: envoy-gateway/gateway-1/http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoypatchpolicy-valid.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-valid.out.yaml
@@ -47,7 +47,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-backend.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-backend.out.yaml
@@ -124,7 +124,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json-no-format.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json-no-format.out.yaml
@@ -114,7 +114,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json.out.yaml
@@ -117,7 +117,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-with-bad-sinks.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-with-bad-sinks.out.yaml
@@ -115,7 +115,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog.out.yaml
@@ -122,7 +122,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/envoyproxy-valid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-valid.out.yaml
@@ -105,7 +105,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/extensions/httproute-with-extension-filter-invalid-group.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-extension-filter-invalid-group.out.yaml
@@ -95,7 +95,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/extensions/httproute-with-non-matching-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-non-matching-extension-filter.out.yaml
@@ -93,7 +93,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/extensions/httproute-with-unsupported-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-unsupported-extension-filter.out.yaml
@@ -93,7 +93,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
@@ -93,7 +93,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
@@ -82,7 +82,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
@@ -82,7 +82,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-infrastructure.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-infrastructure.out.yaml
@@ -95,7 +95,7 @@ infraIR:
         name: default/gateway-1/https
         ports:
         - containerPort: 10443
-          name: https
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-addresses-with-ipaddress.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-addresses-with-ipaddress.out.yaml
@@ -52,7 +52,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tcp
         ports:
         - containerPort: 10080
-          name: tcp
+          name: tcp-80
           protocol: TCP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-mismatch-port-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-mismatch-port-protocol.out.yaml
@@ -45,7 +45,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tcp
         ports:
         - containerPort: 10162
-          name: tcp
+          name: tcp-162
           protocol: TCP
           servicePort: 162
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-backends.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-backends.out.yaml
@@ -45,7 +45,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tcp
         ports:
         - containerPort: 10080
-          name: tcp
+          name: tcp-80
           protocol: TCP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-rules.out.yaml
@@ -45,7 +45,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tcp
         ports:
         - containerPort: 10080
-          name: tcp
+          name: tcp-80
           protocol: TCP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -89,7 +89,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10443
-          name: tls
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
@@ -119,14 +119,14 @@ infraIR:
         name: envoy-gateway/gateway-1/tls-passthrough
         ports:
         - containerPort: 10090
-          name: tls-passthrough
+          name: tls-90
           protocol: TLS
           servicePort: 90
       - address: null
         name: envoy-gateway/gateway-1/tls-terminate
         ports:
         - containerPort: 10443
-          name: tls-terminate
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-mismatch-port-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-mismatch-port-protocol.out.yaml
@@ -45,7 +45,7 @@ infraIR:
         name: envoy-gateway/gateway-1/udp
         ports:
         - containerPort: 10162
-          name: udp
+          name: udp-162
           protocol: UDP
           servicePort: 162
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-backends.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-backends.out.yaml
@@ -45,7 +45,7 @@ infraIR:
         name: envoy-gateway/gateway-1/udp
         ports:
         - containerPort: 10080
-          name: udp
+          name: udp-80
           protocol: UDP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-rules.out.yaml
@@ -45,7 +45,7 @@ infraIR:
         name: envoy-gateway/gateway-1/udp
         ports:
         - containerPort: 10080
-          name: udp
+          name: udp-80
           protocol: UDP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-tcproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-tcproute.out.yaml
@@ -45,7 +45,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tcp
         ports:
         - containerPort: 10080
-          name: tcp
+          name: tcp-80
           protocol: TCP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-udproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-udproute.out.yaml
@@ -45,7 +45,7 @@ infraIR:
         name: envoy-gateway/gateway-1/udp
         ports:
         - containerPort: 10080
-          name: udp
+          name: udp-80
           protocol: UDP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration-with-same-algorithm-different-fqdn.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration-with-same-algorithm-different-fqdn.out.yaml
@@ -91,7 +91,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10443
-          name: tls
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration.out.yaml
@@ -91,7 +91,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10443
-          name: tls
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
@@ -88,7 +88,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10443
-          name: tls
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-preexisting-status-condition.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-preexisting-status-condition.out.yaml
@@ -82,7 +82,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
@@ -45,7 +45,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tcp
         ports:
         - containerPort: 10162
-          name: tcp
+          name: tcp-162
           protocol: TCP
           servicePort: 162
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-udproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-udproutes.out.yaml
@@ -45,7 +45,7 @@ infraIR:
         name: envoy-gateway/gateway-1/udp
         ports:
         - containerPort: 10162
-          name: udp
+          name: udp-162
           protocol: UDP
           servicePort: 162
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-stale-status-condition.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-stale-status-condition.out.yaml
@@ -88,7 +88,7 @@ infraIR:
         name: default/gateway-1/https
         ports:
         - containerPort: 10443
-          name: https
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-or-tls-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-or-tls-port.out.yaml
@@ -74,7 +74,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tcp1
         ports:
         - containerPort: 10162
-          name: tcp1
+          name: tcp-162
           protocol: TCP
           servicePort: 162
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-udp-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-udp-port.out.yaml
@@ -72,7 +72,7 @@ infraIR:
         name: envoy-gateway/gateway-1/udp1
         ports:
         - containerPort: 10162
-          name: udp1
+          name: udp-162
           protocol: UDP
           servicePort: 162
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
@@ -147,14 +147,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 10081
-          name: http-2
+          name: http-81
           protocol: HTTP
           servicePort: 81
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
@@ -110,14 +110,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/tcp
         ports:
         - containerPort: 10080
-          name: tcp
+          name: tcp-80
           protocol: TCP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
@@ -110,14 +110,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/udp
         ports:
         - containerPort: 10080
-          name: udp
+          name: udp-80
           protocol: UDP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-with-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-with-sectionname.out.yaml
@@ -72,14 +72,14 @@ infraIR:
         name: envoy-gateway/gateway-1/tcp1
         ports:
         - containerPort: 10162
-          name: tcp1
+          name: tcp-162
           protocol: TCP
           servicePort: 162
       - address: null
         name: envoy-gateway/gateway-1/tcp2
         ports:
         - containerPort: 10163
-          name: tcp2
+          name: tcp-163
           protocol: TCP
           servicePort: 163
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
@@ -72,14 +72,14 @@ infraIR:
         name: envoy-gateway/gateway-1/tcp1
         ports:
         - containerPort: 10161
-          name: tcp1
+          name: tcp-161
           protocol: TCP
           servicePort: 161
       - address: null
         name: envoy-gateway/gateway-1/tcp2
         ports:
         - containerPort: 10162
-          name: tcp2
+          name: tcp-162
           protocol: TCP
           servicePort: 162
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-with-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-with-sectionname.out.yaml
@@ -72,14 +72,14 @@ infraIR:
         name: envoy-gateway/gateway-1/udp1
         ports:
         - containerPort: 10162
-          name: udp1
+          name: udp-162
           protocol: UDP
           servicePort: 162
       - address: null
         name: envoy-gateway/gateway-1/udp2
         ports:
         - containerPort: 10163
-          name: udp2
+          name: udp-163
           protocol: UDP
           servicePort: 163
       metadata:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-without-sectionname.out.yaml
@@ -72,14 +72,14 @@ infraIR:
         name: envoy-gateway/gateway-1/udp1
         ports:
         - containerPort: 10161
-          name: udp1
+          name: udp-161
           protocol: UDP
           servicePort: 161
       - address: null
         name: envoy-gateway/gateway-1/udp2
         ports:
         - containerPort: 10162
-          name: udp2
+          name: udp-162
           protocol: UDP
           servicePort: 162
       metadata:

--- a/internal/gatewayapi/testdata/grpcroute-with-empty-backends.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-empty-backends.out.yaml
@@ -82,7 +82,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/grpcroute-with-header-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-header-match.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/grpcroute-with-method-and-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-method-and-service-match.out.yaml
@@ -90,7 +90,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/grpcroute-with-method-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-method-match.out.yaml
@@ -88,7 +88,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/grpcroute-with-request-header-modifier.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-request-header-modifier.out.yaml
@@ -87,7 +87,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
@@ -88,7 +88,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-and-backendtrafficpolicy-with-timeout-error.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-and-backendtrafficpolicy-with-timeout-error.out.yaml
@@ -121,7 +121,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-and-backendtrafficpolicy-with-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-and-backendtrafficpolicy-with-timeout.out.yaml
@@ -227,7 +227,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -242,7 +242,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
@@ -293,56 +293,56 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10081
-          name: http-1
+          name: http-81
           protocol: HTTP
           servicePort: 81
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 10082
-          name: http-2
+          name: http-82
           protocol: HTTP
           servicePort: 82
       - address: null
         name: envoy-gateway/gateway-1/http-3
         ports:
         - containerPort: 10083
-          name: http-3
+          name: http-83
           protocol: HTTP
           servicePort: 83
       - address: null
         name: envoy-gateway/gateway-1/http-4
         ports:
         - containerPort: 10084
-          name: http-4
+          name: http-84
           protocol: HTTP
           servicePort: 84
       - address: null
         name: envoy-gateway/gateway-1/http-5
         ports:
         - containerPort: 10085
-          name: http-5
+          name: http-85
           protocol: HTTP
           servicePort: 85
       - address: null
         name: envoy-gateway/gateway-1/http-6
         ports:
         - containerPort: 10086
-          name: http-6
+          name: http-86
           protocol: HTTP
           servicePort: 86
       - address: null
         name: envoy-gateway/gateway-1/http-7
         ports:
         - containerPort: 10087
-          name: http-7
+          name: http-87
           protocol: HTTP
           servicePort: 87
       - address: null
         name: envoy-gateway/gateway-1/http-8
         ports:
         - containerPort: 10088
-          name: http-8
+          name: http-88
           protocol: HTTP
           servicePort: 88
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
@@ -293,7 +293,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
@@ -117,14 +117,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10443
-          name: tls
+          name: https-443
           protocol: HTTPS
           servicePort: 443
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -113,7 +113,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
@@ -82,7 +82,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-matching-port.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -115,7 +115,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-serviceimport-backendrefs-diff-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-serviceimport-backendrefs-diff-address-type.out.yaml
@@ -90,7 +90,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-serviceimport-backendrefs-same-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-serviceimport-backendrefs-same-address-type.out.yaml
@@ -90,7 +90,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref-fqdn-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref-fqdn-address-type.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref-mixed-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref-mixed-address-type.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
@@ -84,7 +84,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-backend-request-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-backend-request-timeout.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-not-attaching-to-listener-non-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-not-attaching-to-listener-non-matching-port.out.yaml
@@ -85,7 +85,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http-1
         ports:
         - containerPort: 10080
-          name: http-1
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-request-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-request-timeout.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-rule-with-empty-backends-and-no-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-empty-backends-and-no-filters.out.yaml
@@ -79,7 +79,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -92,7 +92,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -84,7 +84,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-backendref-serviceimport-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-serviceimport-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
@@ -81,7 +81,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -102,7 +102,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -112,7 +112,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -98,7 +98,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -93,7 +93,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
@@ -96,7 +96,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
@@ -98,7 +98,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
@@ -99,7 +99,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -90,7 +90,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
@@ -94,7 +94,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
@@ -94,7 +94,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
@@ -83,7 +83,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
@@ -87,7 +87,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
@@ -84,7 +84,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
@@ -83,7 +83,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.import.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.import.out.yaml
@@ -85,7 +85,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
@@ -83,7 +83,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-unsupported-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-unsupported-filter.out.yaml
@@ -89,7 +89,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -84,7 +84,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-invalid-regex.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-regex.out.yaml
@@ -119,7 +119,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -134,7 +134,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10081
-          name: http
+          name: http-81
           protocol: HTTP
           servicePort: 81
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
@@ -100,7 +100,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
@@ -112,7 +112,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
@@ -94,7 +94,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
@@ -94,7 +94,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
@@ -94,7 +94,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -92,7 +92,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -90,7 +90,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -93,7 +93,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -90,7 +90,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -89,7 +89,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -93,7 +93,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
@@ -108,7 +108,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -102,7 +102,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
@@ -112,7 +112,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -98,7 +98,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
@@ -93,7 +93,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
@@ -96,7 +96,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-headers.out.yaml
@@ -98,7 +98,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-invalid-headers.out.yaml
@@ -99,7 +99,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
@@ -90,7 +90,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-valid-headers.out.yaml
@@ -94,7 +94,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
@@ -94,7 +94,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
@@ -83,7 +83,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
@@ -81,7 +81,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
@@ -109,7 +109,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
@@ -87,7 +87,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
@@ -87,7 +87,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -85,7 +85,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
@@ -93,7 +93,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
@@ -94,7 +94,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
@@ -91,7 +91,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
@@ -91,7 +91,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-hostname.out.yaml
@@ -97,7 +97,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-multiple-filters.out.yaml
@@ -99,7 +99,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path-type.out.yaml
@@ -95,7 +95,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path.out.yaml
@@ -94,7 +94,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-missing-path.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-missing-path.out.yaml
@@ -92,7 +92,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
@@ -93,7 +93,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
@@ -84,7 +84,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
@@ -269,7 +269,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/merge-invalid-multiple-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/merge-invalid-multiple-gateways.out.yaml
@@ -116,14 +116,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: envoy-gateway/gateway-1/http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-2/udp
         ports:
         - containerPort: 10080
-          name: envoy-gateway/gateway-2/udp
+          name: udp-80
           protocol: UDP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/merge-valid-multiple-gateways-multiple-listeners-same-ports.out.yaml
+++ b/internal/gatewayapi/testdata/merge-valid-multiple-gateways-multiple-listeners-same-ports.out.yaml
@@ -152,14 +152,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: envoy-gateway/gateway-1/http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-1/http-2
         ports:
         - containerPort: 8888
-          name: envoy-gateway/gateway-1/http-2
+          name: http-8888
           protocol: HTTP
           servicePort: 8888
       metadata:

--- a/internal/gatewayapi/testdata/merge-valid-multiple-gateways-multiple-routes.out.yaml
+++ b/internal/gatewayapi/testdata/merge-valid-multiple-gateways-multiple-routes.out.yaml
@@ -203,14 +203,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: envoy-gateway/gateway-1/http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-2/http-2
         ports:
         - containerPort: 8888
-          name: envoy-gateway/gateway-2/http-2
+          name: http-8888
           protocol: HTTP
           servicePort: 8888
       metadata:

--- a/internal/gatewayapi/testdata/merge-valid-multiple-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/merge-valid-multiple-gateways.out.yaml
@@ -125,14 +125,14 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: envoy-gateway/gateway-1/http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-2/http-2
         ports:
         - containerPort: 8888
-          name: envoy-gateway/gateway-2/http-2
+          name: http-8888
           protocol: HTTP
           servicePort: 8888
       metadata:

--- a/internal/gatewayapi/testdata/merge-with-isolated-policies-2.out.yaml
+++ b/internal/gatewayapi/testdata/merge-with-isolated-policies-2.out.yaml
@@ -406,14 +406,14 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: default/gateway-1/http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: default/gateway-2/http
         ports:
         - containerPort: 10081
-          name: default/gateway-2/http
+          name: http-81
           protocol: HTTP
           servicePort: 81
       metadata:

--- a/internal/gatewayapi/testdata/merge-with-isolated-policies.out.yaml
+++ b/internal/gatewayapi/testdata/merge-with-isolated-policies.out.yaml
@@ -236,14 +236,14 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: default/gateway-1/http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: default/gateway-2/http-2
         ports:
         - containerPort: 8888
-          name: default/gateway-2/http-2
+          name: http-8888
           protocol: HTTP
           servicePort: 8888
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-invalid-cross-ns-ref.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-invalid-cross-ns-ref.out.yaml
@@ -47,7 +47,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-override-replace.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-override-replace.out.yaml
@@ -124,7 +124,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-status-conditions.out.yaml
@@ -210,7 +210,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -225,14 +225,14 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       - address: null
         name: envoy-gateway/gateway-2/tcp
         ports:
         - containerPort: 10053
-          name: tcp
+          name: tcp-53
           protocol: TCP
           servicePort: 53
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-basic-auth.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-basic-auth.out.yaml
@@ -130,7 +130,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
@@ -238,7 +238,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -253,7 +253,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -268,7 +268,7 @@ infraIR:
         name: envoy-gateway/gateway-3/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-matching-port.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-port.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-reference-grant.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-reference-grant.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-service.out.yaml
@@ -86,7 +86,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-with-backendtlspolicy.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-with-backendtlspolicy.out.yaml
@@ -190,7 +190,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth.out.yaml
@@ -130,7 +130,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-and-invalid-oidc.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-and-invalid-oidc.out.yaml
@@ -124,7 +124,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-with-custom-extractor.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-with-custom-extractor.out.yaml
@@ -160,7 +160,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -175,7 +175,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt.out.yaml
@@ -160,7 +160,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -175,7 +175,7 @@ infraIR:
         name: envoy-gateway/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.out.yaml
@@ -47,7 +47,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-secretref.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-secretref.out.yaml
@@ -127,7 +127,7 @@ infraIR:
         name: default/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -142,7 +142,7 @@ infraIR:
         name: default/gateway-2/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:
@@ -157,7 +157,7 @@ infraIR:
         name: default/gateway-3/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc.out.yaml
@@ -124,7 +124,7 @@ infraIR:
         name: envoy-gateway/gateway-1/http
         ports:
         - containerPort: 10080
-          name: http
+          name: http-80
           protocol: HTTP
           servicePort: 80
       metadata:

--- a/internal/gatewayapi/testdata/tcproute-attaching-to-gateway-with-listener-tls-terminate.out.yaml
+++ b/internal/gatewayapi/testdata/tcproute-attaching-to-gateway-with-listener-tls-terminate.out.yaml
@@ -51,7 +51,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10090
-          name: tls
+          name: tls-90
           protocol: TLS
           servicePort: 90
       metadata:

--- a/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
@@ -48,7 +48,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10090
-          name: tls
+          name: tls-90
           protocol: TLS
           servicePort: 90
       metadata:

--- a/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
@@ -47,7 +47,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10091
-          name: tls
+          name: tls-91
           protocol: TLS
           servicePort: 91
       metadata:

--- a/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -48,7 +48,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10090
-          name: tls
+          name: tls-90
           protocol: TLS
           servicePort: 90
       metadata:

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
@@ -47,7 +47,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10091
-          name: tls
+          name: tls-91
           protocol: TLS
           servicePort: 91
       metadata:

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
@@ -47,7 +47,7 @@ infraIR:
         name: envoy-gateway/gateway-1/tls
         ports:
         - containerPort: 10091
-          name: tls
+          name: tls-91
           protocol: TLS
           servicePort: 91
       metadata:

--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -119,8 +119,7 @@ func expectedProxyContainers(infra *ir.ProxyInfra,
 				return nil, fmt.Errorf("invalid protocol %q", p.Protocol)
 			}
 			port := corev1.ContainerPort{
-				// hashed container port name including up to the 6 characters of the port name and the maximum of 15 characters.
-				Name:          utils.GetHashedName(p.Name, 6),
+				Name:          p.Name,
 				ContainerPort: p.ContainerPort,
 				Protocol:      protocol,
 			}

--- a/internal/infrastructure/kubernetes/proxy/resource_provider.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider.go
@@ -76,7 +76,7 @@ func (r *ResourceRender) Service() (*corev1.Service, error) {
 			}
 
 			p := corev1.ServicePort{
-				Name:       ExpectedResourceHashedName(port.Name),
+				Name:       port.Name,
 				Protocol:   protocol,
 				Port:       port.ServicePort,
 				TargetPort: target,
@@ -86,7 +86,7 @@ func (r *ResourceRender) Service() (*corev1.Service, error) {
 			if port.Protocol == ir.HTTPSProtocolType {
 				if listener.HTTP3 != nil {
 					p := corev1.ServicePort{
-						Name:       ExpectedResourceHashedName(port.Name + "-h3"),
+						Name:       port.Name + "-h3",
 						Protocol:   corev1.ProtocolUDP,
 						Port:       port.ServicePort,
 						TargetPort: target,

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -68,10 +68,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -69,10 +69,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -216,10 +216,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -216,10 +216,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -214,10 +214,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -198,10 +198,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -172,10 +172,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         readinessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -218,10 +218,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -209,10 +209,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -198,10 +198,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -199,10 +199,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -218,10 +218,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -203,10 +203,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -69,10 +69,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -198,10 +198,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -200,10 +200,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -198,10 +198,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -198,10 +198,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -198,10 +198,10 @@ spec:
         name: envoy
         ports:
         - containerPort: 8080
-          name: EnvoyH-d76a15e2
+          name: EnvoyHTTPPort
           protocol: TCP
         - containerPort: 8443
-          name: EnvoyH-6658f727
+          name: EnvoyHTTPSPort
           protocol: TCP
         - containerPort: 19001
           name: metrics

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/clusterIP-custom-addresses.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/clusterIP-custom-addresses.yaml
@@ -14,11 +14,11 @@ spec:
   clusterIPs:
     - 10.102.168.100
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
+    - name: EnvoyHTTPPort
       port: 0
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
+    - name: EnvoyHTTPSPort
       port: 0
       protocol: TCP
       targetPort: 8443

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/custom.yaml
@@ -13,11 +13,11 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
+    - name: EnvoyHTTPPort
       port: 0
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
+    - name: EnvoyHTTPSPort
       port: 0
       protocol: TCP
       targetPort: 8443

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/default.yaml
@@ -12,11 +12,11 @@ metadata:
 spec:
   externalTrafficPolicy: Local
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
+    - name: EnvoyHTTPPort
       port: 0
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
+    - name: EnvoyHTTPSPort
       port: 0
       protocol: TCP
       targetPort: 8443

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/override-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/override-annotations.yaml
@@ -17,11 +17,11 @@ metadata:
 spec:
   externalTrafficPolicy: Local
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
+    - name: EnvoyHTTPPort
       port: 0
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
+    - name: EnvoyHTTPSPort
       port: 0
       protocol: TCP
       targetPort: 8443

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/patch-service.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/patch-service.yaml
@@ -12,11 +12,11 @@ metadata:
 spec:
   externalTrafficPolicy: Local
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
+    - name: EnvoyHTTPPort
       port: 0
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
+    - name: EnvoyHTTPSPort
       port: 0
       protocol: TCP
       targetPort: 8443

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/with-annotations.yaml
@@ -15,11 +15,11 @@ metadata:
 spec:
   externalTrafficPolicy: Local
   ports:
-    - name: envoy-EnvoyHTTPPort-d76a15e2
+    - name: EnvoyHTTPPort
       port: 0
       protocol: TCP
       targetPort: 8080
-    - name: envoy-EnvoyHTTPSPort-6658f727
+    - name: EnvoyHTTPSPort
       port: 0
       protocol: TCP
       targetPort: 8443

--- a/test/e2e/tests/gateway_infra_resource.go
+++ b/test/e2e/tests/gateway_infra_resource.go
@@ -129,10 +129,9 @@ var GatewayInfraResourceTest = suite.ConformanceTest{
 			for _, container := range gatewayDeployment.Spec.Template.Spec.Containers {
 				var isTCPPortNameMatch, isHTTPPortNumberMatch bool
 
-				hashedPortName := utils.GetHashedName(newListenerTCPName, 6)
 				if container.Name == "envoy" {
 					for _, port := range container.Ports {
-						if port.Name == hashedPortName {
+						if port.Name == newListenerTCPName {
 							isTCPPortNameMatch = true
 						}
 
@@ -142,11 +141,11 @@ var GatewayInfraResourceTest = suite.ConformanceTest{
 					}
 
 					if !isTCPPortNameMatch {
-						t.Errorf("container expected TCP port name '%v' is not found", hashedPortName)
+						t.Errorf("container expected TCP port name '%v' is not found", newListenerTCPName)
 					}
 
 					if !isHTTPPortNumberMatch {
-						t.Errorf("container expected HTTP port number '%v' is not found", hashedPortName)
+						t.Errorf("container expected HTTP port number '%v' is not found", newListenerTCPName)
 					}
 				}
 			}

--- a/test/e2e/tests/gateway_infra_resource.go
+++ b/test/e2e/tests/gateway_infra_resource.go
@@ -88,6 +88,7 @@ var GatewayInfraResourceTest = suite.ConformanceTest{
 			awaitOperation.Add(1)
 
 			newListenerTCPName := "custom-tcp"
+			containerPortName := "tcp-5432"
 			newListenerHTTPPort := int32(8001)
 
 			changedGatewayObj := &gwapiv1.Gateway{
@@ -129,7 +130,7 @@ var GatewayInfraResourceTest = suite.ConformanceTest{
 
 				if container.Name == "envoy" {
 					for _, port := range container.Ports {
-						if port.Name == newListenerTCPName {
+						if port.Name == containerPortName {
 							isTCPPortNameMatch = true
 						}
 
@@ -139,11 +140,11 @@ var GatewayInfraResourceTest = suite.ConformanceTest{
 					}
 
 					if !isTCPPortNameMatch {
-						t.Errorf("container expected TCP port name '%v' is not found", newListenerTCPName)
+						t.Errorf("container expected TCP port name '%v' is not found", containerPortName)
 					}
 
 					if !isHTTPPortNumberMatch {
-						t.Errorf("container expected HTTP port number '%v' is not found", newListenerTCPName)
+						t.Errorf("container expected HTTP port number '%d' is not found", newListenerHTTPPort)
 					}
 				}
 			}

--- a/test/e2e/tests/gateway_infra_resource.go
+++ b/test/e2e/tests/gateway_infra_resource.go
@@ -21,8 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
-
-	"github.com/envoyproxy/gateway/internal/utils"
 )
 
 func init() {


### PR DESCRIPTION
Takes inspiration from https://github.com/envoyproxy/gateway/pull/2973 to name port, not off the listener but off the port-proto ensuring that patch (during updates) also works

Fixes https://github.com/envoyproxy/gateway/pull/3130#issuecomment-2045093056 by adding a stable name

