### PR TITLE
fix(chart): set ttlSecondsAfterFinished on certgen job to 30 by default

### DIFF
--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -48,7 +48,7 @@ certgen:
   job:
     annotations: {}
     resources: {}
-    ttlSecondsAfterFinished: 0
+    ttlSecondsAfterFinished: 30
   rbac:
     annotations: {}
     labels: {}

--- a/site/content/en/latest/install/api.md
+++ b/site/content/en/latest/install/api.md
@@ -26,7 +26,7 @@ The Helm chart for Envoy Gateway
 |-----|------|---------|-------------|
 | certgen.job.annotations | object | `{}` |  |
 | certgen.job.resources | object | `{}` |  |
-| certgen.job.ttlSecondsAfterFinished | int | `0` |  |
+| certgen.job.ttlSecondsAfterFinished | int | `30` |  |
 | certgen.rbac.annotations | object | `{}` |  |
 | certgen.rbac.labels | object | `{}` |  |
 | config.envoyGateway.gateway.controllerName | string | `"gateway.envoyproxy.io/gatewayclass-controller"` |  |

--- a/test/helm/default.yaml
+++ b/test/helm/default.yaml
@@ -524,4 +524,4 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       serviceAccountName: eg-gateway-helm-certgen
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30


### PR DESCRIPTION
This is painless workaround for ArgoCD bug: argoproj/argo-cd#6880