### PR TITLE
api: fix WasmCodeSourceType enum validation

### DIFF
--- a/api/v1alpha1/wasm_types.go
+++ b/api/v1alpha1/wasm_types.go
@@ -83,7 +83,7 @@ type WasmCodeSource struct {
 }
 
 // WasmCodeSourceType specifies the types of sources for the wasm code.
-// +kubebuilder:validation:Enum=Global;Local
+// +kubebuilder:validation:Enum=HTTP;Image
 type WasmCodeSourceType string
 
 const (

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
@@ -304,8 +304,8 @@ spec:
                         type:
                           allOf:
                           - enum:
-                            - Global
-                            - Local
+                            - HTTP
+                            - Image
                           - enum:
                             - HTTP
                             - Image


### PR DESCRIPTION
### What

This PR fixes the validation enum values of the `WasmCodeSourceType` type. 

When the following `EnvoyExtensionPolicy` resource was deployed, the CRD validation failed
```yaml
---
apiVersion: gateway.envoyproxy.io/v1alpha1
kind: EnvoyExtensionPolicy
metadata:
  name: my-wasm-1
  namespace: envoy-gateway-system
spec:
  targetRef:
    kind: Gateway
    name: eg
    group: gateway.networking.k8s.io
  wasm:
    - name: my_wasm_1
      code:
        type: Image
        image:
          url: oci://example.com/project/my-wasm:latest
          pullSecret:
            name: "some-secret-name"
      failOpen: true
      config:
        foo: value1
```

The validation message:
```
The EnvoyExtensionPolicy "my-wasm-1" is invalid: 
* spec.wasm[0].code.type: Unsupported value: "Image": supported values: "Global", "Local"
* <nil>: Invalid value: "": "spec.wasm[0].code.type" must validate all the schemas (allOf)
```

### Verification steps

* Checkout the current branch
* Create local Kind cluster
```
make create-cluster
```
* Build custom image
```
make kube-install-image
```
* Run custom image
```
IMAGE_PULL_POLICY=IfNotPresent make kube-deploy
```
* Create `EnvoyExtensionPolicy` resource
```yaml
kubectl apply -f - << EOF
---
apiVersion: gateway.envoyproxy.io/v1alpha1
kind: EnvoyExtensionPolicy
metadata:
  name: my-wasm-1
  namespace: envoy-gateway-system
spec:
  targetRef:
    kind: Gateway
    name: eg
    group: gateway.networking.k8s.io
  wasm:
    - name: my_wasm_1
      code:
        type: Image
        image:
          url: oci://example.com/project/my-wasm:latest
          pullSecret:
            name: "some-secret-name"
      failOpen: true
      config:
        foo: value1
EOF
```

The resource should be created without issues

```
envoyextensionpolicy.gateway.envoyproxy.io/my-wasm-1 created
```