### PR TITLE
ci: move write permissions to job level in cherrypick workflow

### DIFF
--- a/.github/workflows/cherrypick.yaml
+++ b/.github/workflows/cherrypick.yaml
@@ -6,11 +6,13 @@ on:
     types: ["closed"]
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   cherry_pick_release_v1_0:
+    permissions:
+      pull-requests: write
+      contents: write
     runs-on: ubuntu-22.04
     name: Cherry pick into release-v1.0
     if: ${{ contains(github.event.pull_request.labels.*.name, 'cherrypick/release-v1.0') && github.event.pull_request.merged == true }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Move write permissions to job level in cherrypick workflow. With this fix `Token-Permissions` ossf score becomes 10.

**Which issue(s) this PR fixes**:

Fixes #
