### PR TITLE
feat: support egctl install output manifests and fix bugs

### DIFF
--- a/site/content/en/latest/tasks/operations/egctl.md
+++ b/site/content/en/latest/tasks/operations/egctl.md
@@ -884,11 +884,11 @@ We can specify to install only CRDs resources via `--only-crds`
 egctl x install --only-crds
 ```
 
-We can specify `--release-name` and `--namespace` to install envoy-gateway in different places to support multi-tenant mode.
+We can specify `--name` and `--namespace` to install envoy-gateway in different places to support multi-tenant mode.
 > Note: If CRDs are already installed, then we need to specify `--skip-crds` to avoid repeated installation of CRDs resources.
 
 ```bash
-egctl x install --release-name shop-backend --namespace shop
+egctl x install --name shop-backend --namespace shop
 ```
 
 


### PR DESCRIPTION
**What type of PR is this?**

feat: support egctl install output manifests and fix bugs

This PR did the following three things:
+ **Add `-o` flags**:    If the user installs EnvoyGateway via `egctl install`, it will be difficult for the user to know what is installed by default. Even though it is possible to print manifests to STDOUT via `--dry-run`, this makes it uncomfortable for users to see. We support outputting manifests to specified files through `-o`.
+ **Bug fix**:    Fixed the problem of detecting the existence of CRDs when `--dry-run` is specified.
+ **Change `--release-name` to `--name`**:    Please refer to [comment](https://github.com/envoyproxy/gateway/pull/2859#discussion_r1546064226) for details




