### PR TITLE
docs: Fix commands for testing jwt based routing

### DIFF
--- a/site/content/en/latest/tasks/traffic/http-routing.md
+++ b/site/content/en/latest/tasks/traffic/http-routing.md
@@ -204,7 +204,7 @@ TOKEN=$(curl https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/
 Test routing to the `foo-svc` backend by specifying a JWT Token with a claim `name: John Doe`.
 
 ```shell
-curl -sS -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/" | jq .pod
+curl -sS -H "Host: foo.example.com" -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/login" | jq .pod
 "foo-backend-6df8cc6b9f-fmwcg"
 ```
 
@@ -217,7 +217,7 @@ TOKEN=$(curl https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/
 Test HTTP routing to the `bar-svc` backend by specifying a JWT Token with a claim `name: Tom`.
 
 ```shell
-curl -sS -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/" | jq .pod
+curl -sS -H "Host: bar.example.com" -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/" | jq .pod
 "bar-backend-6688b8944c-s8htr"
 ```
 

--- a/site/content/en/v1.0.1/tasks/traffic/http-routing.md
+++ b/site/content/en/v1.0.1/tasks/traffic/http-routing.md
@@ -204,7 +204,7 @@ TOKEN=$(curl https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/
 Test routing to the `foo-svc` backend by specifying a JWT Token with a claim `name: John Doe`.
 
 ```shell
-curl -sS -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/" | jq .pod
+curl -sS -H "Host: foo.example.com" -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/login" | jq .pod
 "foo-backend-6df8cc6b9f-fmwcg"
 ```
 
@@ -217,7 +217,7 @@ TOKEN=$(curl https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/
 Test HTTP routing to the `bar-svc` backend by specifying a JWT Token with a claim `name: Tom`.
 
 ```shell
-curl -sS -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/" | jq .pod
+curl -sS -H "Host: bar.example.com" -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/" | jq .pod
 "bar-backend-6688b8944c-s8htr"
 ```
 


### PR DESCRIPTION
Fix commands for testing jwt based routing.

**What type of PR is this?**
docs: Fix commands for testing jwt based routing

**What this PR does / why we need it**:
The commands used for testing jwt based routing miss host headers which cause 404.

**Which issue(s) this PR fixes**:
https://github.com/envoyproxy/gateway/issues/3242

Fixes #3242 commands for testing jwt based routing
