### PR TITLE
fix: make Write create files without the executable bit set

### DIFF
--- a/internal/utils/file/file.go
+++ b/internal/utils/file/file.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Write(data string, filepath string) error {
-	file, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	file, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The `file.Write` function is used exclusively by unit tests to override testdata output. It is also a convenience to create the initial testdata output YAML files.

There's no reason to create YAML files with the executable bit set. This PR modifies the default mode used for file creation to not turn on the executable flag.