### PR TITLE
docs: Fix global rate limit doc for sourceCIDR type

### DIFF
--- a/site/content/en/latest/tasks/traffic/global-rate-limit.md
+++ b/site/content/en/latest/tasks/traffic/global-rate-limit.md
@@ -511,9 +511,9 @@ transfer-encoding: chunked
 Here is an example of a rate limit implemented by the application developer to limit distinct users who can be differentiated based on their
  IP address (also reflected in the  `X-Forwarded-For` header).
 
-Note: EG supports two kinds of rate limit for the IP address: exact and distinct.
-* exact means that all IP addresses within the specified Source IP CIDR share the same rate limit bucket.
-* distinct means that each IP address within the specified Source IP CIDR has its own rate limit bucket.
+Note: EG supports two kinds of rate limit for the IP address: Exact and Distinct.
+* Exact means that all IP addresses within the specified Source IP CIDR share the same rate limit bucket.
+* Distinct means that each IP address within the specified Source IP CIDR has its own rate limit bucket.
 
 ```shell
 cat <<EOF | kubectl apply -f -
@@ -534,7 +534,7 @@ spec:
       - clientSelectors:
         - sourceCIDR: 
             value: 0.0.0.0/0
-            type: distinct
+            type: Distinct
         limit:
           requests: 3
           unit: Hour

--- a/site/content/en/v1.0.1/tasks/traffic/global-rate-limit.md
+++ b/site/content/en/v1.0.1/tasks/traffic/global-rate-limit.md
@@ -511,9 +511,9 @@ transfer-encoding: chunked
 Here is an example of a rate limit implemented by the application developer to limit distinct users who can be differentiated based on their
  IP address (also reflected in the  `X-Forwarded-For` header).
 
-Note: EG supports two kinds of rate limit for the IP address: exact and distinct.
-* exact means that all IP addresses within the specified Source IP CIDR share the same rate limit bucket.
-* distinct means that each IP address within the specified Source IP CIDR has its own rate limit bucket.
+Note: EG supports two kinds of rate limit for the IP address: Exact and Distinct.
+* Exact means that all IP addresses within the specified Source IP CIDR share the same rate limit bucket.
+* Distinct means that each IP address within the specified Source IP CIDR has its own rate limit bucket.
 
 ```shell
 cat <<EOF | kubectl apply -f -
@@ -534,7 +534,7 @@ spec:
       - clientSelectors:
         - sourceCIDR: 
             value: 0.0.0.0/0
-            type: distinct
+            type: Distinct
         limit:
           requests: 3
           unit: Hour


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix's the doc to use the correct enum names for the sourceCIDR type for global rate limiting.  This could be a bug in the translator but this fixes the doc in case it not.


