### PR TITLE
fix: Add SourceMatchType validation for acceptable values

### DIFF
--- a/api/v1alpha1/ratelimit_types.go
+++ b/api/v1alpha1/ratelimit_types.go
@@ -114,6 +114,7 @@ type RateLimitSelectCondition struct {
 	SourceCIDR *SourceMatch `json:"sourceCIDR,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=Exact;Distinct
 type SourceMatchType string
 
 const (
@@ -129,7 +130,6 @@ const (
 type SourceMatch struct {
 	// +optional
 	// +kubebuilder:default=Exact
-	// +kubebuilder:validation:Enum=Exact;Distinct
 	Type *SourceMatchType `json:"type,omitempty"`
 
 	// Value is the IP CIDR that represents the range of Source IP Addresses of the client.

--- a/api/v1alpha1/ratelimit_types.go
+++ b/api/v1alpha1/ratelimit_types.go
@@ -129,6 +129,7 @@ const (
 type SourceMatch struct {
 	// +optional
 	// +kubebuilder:default=Exact
+	// +kubebuilder:validation:Enum=Exact;Distinct
 	Type *SourceMatchType `json:"type,omitempty"`
 
 	// Value is the IP CIDR that represents the range of Source IP Addresses of the client.

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -571,6 +571,9 @@ spec:
                                     properties:
                                       type:
                                         default: Exact
+                                        enum:
+                                        - Exact
+                                        - Distinct
                                         type: string
                                       value:
                                         description: |-
@@ -701,6 +704,9 @@ spec:
                                     properties:
                                       type:
                                         default: Exact
+                                        enum:
+                                        - Exact
+                                        - Distinct
                                         type: string
                                       value:
                                         description: |-

--- a/test/e2e/testdata/ratelimit-cidr-match.yaml
+++ b/test/e2e/testdata/ratelimit-cidr-match.yaml
@@ -16,7 +16,7 @@ spec:
         - clientSelectors:
             - sourceCIDR:
                 value: 0.0.0.0/0
-                type: distinct
+                type: Distinct
           limit:
             requests: 3
             unit: Hour

--- a/test/e2e/testdata/ratelimit-multiple-listeners.yaml
+++ b/test/e2e/testdata/ratelimit-multiple-listeners.yaml
@@ -48,7 +48,7 @@ spec:
         - clientSelectors:
             - sourceCIDR:
                 value: 0.0.0.0/0
-                type: distinct
+                type: Distinct
           limit:
             requests: 3
             unit: Hour


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds validation to SourceMatch to only allow the accepted values. This is to prevent people using a lowercase  version of "Distinct" which will then default to using "Exact" for the ratelimiting. 

I lost a few hours to this 😄  

