### PR TITLE
docs: updates task testing instructions to use tabs for with|without external load balancer 

### DIFF
--- a/site/content/en/latest/tasks/quickstart.md
+++ b/site/content/en/latest/tasks/quickstart.md
@@ -48,6 +48,25 @@ consideration when debugging.
 ## Testing the Configuration
 
 {{< tabpane text=true >}}
+{{% tab header="With External LoadBalancer Support" %}}
+
+You can also test the same functionality by sending traffic to the External IP. To get the external IP of the
+Envoy service, run:
+
+```shell
+export GATEWAY_HOST=$(kubectl get svc/${ENVOY_SERVICE} -n envoy-gateway-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+```
+
+In certain environments, the load balancer may be exposed using a hostname, instead of an IP address. If so, replace
+`ip` in the above command with `hostname`.
+
+Curl the example app through Envoy proxy:
+
+```shell
+curl --verbose --header "Host: www.example.com" http://$GATEWAY_HOST/get
+```
+
+{{% /tab %}}
 {{% tab header="Without LoadBalancer Support" %}}
 
 Get the name of the Envoy service created the by the example Gateway:
@@ -66,26 +85,6 @@ Curl the example app through Envoy proxy:
 
 ```shell
 curl --verbose --header "Host: www.example.com" http://localhost:8888/get
-```
-
-{{% /tab %}}
-
-{{% tab header="External LoadBalancer Support" %}}
-
-You can also test the same functionality by sending traffic to the External IP. To get the external IP of the
-Envoy service, run:
-
-```shell
-export GATEWAY_HOST=$(kubectl get svc/${ENVOY_SERVICE} -n envoy-gateway-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-```
-
-In certain environments, the load balancer may be exposed using a hostname, instead of an IP address. If so, replace
-`ip` in the above command with `hostname`.
-
-Curl the example app through Envoy proxy:
-
-```shell
-curl --verbose --header "Host: www.example.com" http://$GATEWAY_HOST/get
 ```
 
 {{% /tab %}}

--- a/site/content/en/latest/tasks/security/backend-tls.md
+++ b/site/content/en/latest/tasks/security/backend-tls.md
@@ -208,7 +208,37 @@ kubectl get HTTPRoute backend -o yaml
 
 ## Testing
 
-### Clusters without External LoadBalancer Support
+{{< tabpane text=true >}}
+{{% tab header="With External LoadBalancer Support" %}}
+
+Get the External IP of the Gateway:
+
+```shell
+export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
+```
+
+Query the example app through the Gateway:
+
+```shell
+curl -v -HHost:www.example.com --resolve "www.example.com:80:${GATEWAY_HOST}" \
+http://www.example.com:80/get
+```
+
+Inspect the output and see that the response contains the details of the TLS handshake between Envoy and the backend:
+
+```shell
+< HTTP/1.1 200 OK
+[...]
+ "tls": {
+  "version": "TLSv1.2",
+  "serverName": "www.example.com",
+  "negotiatedProtocol": "http/1.1",
+  "cipherSuite": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+ }
+```
+
+{{% /tab %}}
+{{% tab header="Without LoadBalancer Support" %}}
 
 Get the name of the Envoy service created the by the example Gateway:
 
@@ -242,32 +272,7 @@ Inspect the output and see that the response contains the details of the TLS han
  }
 ```
 
-### Clusters with External LoadBalancer Support
-
-Get the External IP of the Gateway:
-
-```shell
-export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
-```
-
-Query the example app through the Gateway:
-
-```shell
-curl -v -HHost:www.example.com --resolve "www.example.com:80:${GATEWAY_HOST}" \
-http://www.example.com:80/get
-```
-
-Inspect the output and see that the response contains the details of the TLS handshake between Envoy and the backend:
-
-```shell
-< HTTP/1.1 200 OK
-[...]
- "tls": {
-  "version": "TLSv1.2",
-  "serverName": "www.example.com",
-  "negotiatedProtocol": "http/1.1",
-  "cipherSuite": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
- }
-```
+{{% /tab %}}
+{{< /tabpane >}}
 
 [BackendTLSPolicy]: https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/

--- a/site/content/en/latest/tasks/security/mutual-tls.md
+++ b/site/content/en/latest/tasks/security/mutual-tls.md
@@ -133,7 +133,32 @@ spec:
 
 ## Testing
 
-### Clusters without External LoadBalancer Support
+{{< tabpane text=true >}}
+{{% tab header="With External LoadBalancer Support" %}}
+
+Get the External IP of the Gateway:
+
+```shell
+export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
+```
+
+Query the example app through the Gateway:
+
+```shell
+curl -v -HHost:www.example.com --resolve "www.example.com:443:${GATEWAY_HOST}" \
+--cert client.example.com.crt --key client.example.com.key \
+--cacert example.com.crt https://www.example.com/get
+```
+
+Don't specify the client key and certificate in the above command, and ensure that the connection fails:
+
+```shell
+curl -v -HHost:www.example.com --resolve "www.example.com:443:${GATEWAY_HOST}" \
+--cacert example.com.crt https://www.example.com/get
+```
+
+{{% /tab %}}
+{{% tab header="Without LoadBalancer Support" %}}
 
 Get the name of the Envoy service created the by the example Gateway:
 
@@ -155,27 +180,7 @@ curl -v -HHost:www.example.com --resolve "www.example.com:8443:127.0.0.1" \
 --cacert example.com.crt https://www.example.com:8443/get
 ```
 
-### Clusters with External LoadBalancer Support
-
-Get the External IP of the Gateway:
-
-```shell
-export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
-```
-
-Query the example app through the Gateway:
-
-```shell
-curl -v -HHost:www.example.com --resolve "www.example.com:443:${GATEWAY_HOST}" \
---cert client.example.com.crt --key client.example.com.key \
---cacert example.com.crt https://www.example.com/get
-```
-
-Dont specify the client key and certificate in the above command, and ensure that the connection fails
-
-```shell
-curl -v -HHost:www.example.com --resolve "www.example.com:443:${GATEWAY_HOST}" \
---cacert example.com.crt https://www.example.com/get
-```
+{{% /tab %}}
+{{< /tabpane >}}
 
 [ClientTrafficPolicy]: ../../../api/extension_types#clienttrafficpolicy

--- a/site/content/en/latest/tasks/security/secure-gateways.md
+++ b/site/content/en/latest/tasks/security/secure-gateways.md
@@ -65,7 +65,24 @@ kubectl get gateway/eg -o yaml
 
 ## Testing
 
-### Clusters without External LoadBalancer Support
+{{< tabpane text=true >}}
+{{% tab header="With External LoadBalancer Support" %}}
+
+Get the External IP of the Gateway:
+
+```shell
+export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
+```
+
+Query the example app through the Gateway:
+
+```shell
+curl -v -HHost:www.example.com --resolve "www.example.com:443:${GATEWAY_HOST}" \
+--cacert example.com.crt https://www.example.com/get
+```
+
+{{% /tab %}}
+{{% tab header="Without LoadBalancer Support" %}}
 
 Get the name of the Envoy service created the by the example Gateway:
 
@@ -86,20 +103,9 @@ curl -v -HHost:www.example.com --resolve "www.example.com:8443:127.0.0.1" \
 --cacert example.com.crt https://www.example.com:8443/get
 ```
 
-### Clusters with External LoadBalancer Support
+{{% /tab %}}
+{{< /tabpane >}}
 
-Get the External IP of the Gateway:
-
-```shell
-export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
-```
-
-Query the example app through the Gateway:
-
-```shell
-curl -v -HHost:www.example.com --resolve "www.example.com:443:${GATEWAY_HOST}" \
---cacert example.com.crt https://www.example.com/get
-```
 
 ## Multiple HTTPS Listeners
 
@@ -467,7 +473,14 @@ kubectl patch httproute backend --type=json --patch '
 
 ## Testing
 
-### Clusters without External LoadBalancer Support
+{{< tabpane text=true >}}
+{{% tab header="With External LoadBalancer Support" %}}
+
+Refer to the steps mentioned earlier under [Testing in clusters with External LoadBalancer Support](#testing)
+
+
+{{% /tab %}}
+{{% tab header="Without LoadBalancer Support" %}}
 
 Get the name of the Envoy service created the by the example Gateway:
 
@@ -497,9 +510,8 @@ curl -v -HHost:www.sample.com --resolve "www.sample.com:8443:127.0.0.1" \
 
 Since the multiple certificates are configured on the same Gateway listener, Envoy was able to provide the client with appropriate certificate based on the SNI in the client request.
 
-### Clusters with External LoadBalancer Support
-
-Refer to the steps mentioned earlier under [Testing in clusters with External LoadBalancer Support](#clusters-with-external-loadbalancer-support)
+{{% /tab %}}
+{{< /tabpane >}}
 
 ## Next Steps
 

--- a/site/content/en/latest/tasks/security/tls-passthrough.md
+++ b/site/content/en/latest/tasks/security/tls-passthrough.md
@@ -68,7 +68,24 @@ kubectl patch gateway eg --type=json --patch '
 
 ## Testing
 
-### Clusters without External LoadBalancer Support
+{{< tabpane text=true >}}
+{{% tab header="With External LoadBalancer Support" %}}
+
+You can also test the same functionality by sending traffic to the External IP of the Gateway:
+
+```shell
+export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
+```
+
+Curl the example app through the Gateway, e.g. Envoy proxy:
+
+```shell
+curl -v -HHost:passthrough.example.com --resolve "passthrough.example.com:6443:${GATEWAY_HOST}" \
+--cacert example.com.crt https://passthrough.example.com:6443/get
+```
+
+{{% /tab %}}
+{{% tab header="Without LoadBalancer Support" %}}
 
 Get the name of the Envoy service created the by the example Gateway:
 
@@ -89,20 +106,8 @@ curl -v --resolve "passthrough.example.com:6043:127.0.0.1" https://passthrough.e
 --cacert passthrough.example.com.crt
 ```
 
-### Clusters with External LoadBalancer Support
-
-You can also test the same functionality by sending traffic to the External IP of the Gateway:
-
-```shell
-export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
-```
-
-Curl the example app through the Gateway, e.g. Envoy proxy:
-
-```shell
-curl -v -HHost:passthrough.example.com --resolve "passthrough.example.com:6443:${GATEWAY_HOST}" \
---cacert example.com.crt https://passthrough.example.com:6443/get
-```
+{{% /tab %}}
+{{< /tabpane >}}
 
 ## Clean-Up
 

--- a/site/content/en/latest/tasks/security/tls-termination.md
+++ b/site/content/en/latest/tasks/security/tls-termination.md
@@ -49,7 +49,24 @@ kubectl get gateway/eg -o yaml
 
 ## Testing
 
-### Clusters without External LoadBalancer Support
+{{< tabpane text=true >}}
+{{% tab header="With External LoadBalancer Support" %}}
+
+Get the External IP of the Gateway:
+
+```shell
+export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
+```
+
+Query the example app through the Gateway:
+
+```shell
+curl -v -HHost:www.example.com --resolve "www.example.com:443:${GATEWAY_HOST}" \
+--cacert example.com.crt https://www.example.com/get
+```
+
+{{% /tab %}}
+{{% tab header="Without LoadBalancer Support" %}}
 
 Get the name of the Envoy service created the by the example Gateway:
 
@@ -70,17 +87,5 @@ curl -v -HHost:www.example.com --resolve "www.example.com:8443:127.0.0.1" \
 --cacert example.com.crt https://www.example.com:8443/get
 ```
 
-### Clusters with External LoadBalancer Support
-
-Get the External IP of the Gateway:
-
-```shell
-export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
-```
-
-Query the example app through the Gateway:
-
-```shell
-curl -v -HHost:www.example.com --resolve "www.example.com:443:${GATEWAY_HOST}" \
---cacert example.com.crt https://www.example.com/get
-```
+{{% /tab %}}
+{{< /tabpane >}}

--- a/site/content/en/latest/tasks/traffic/http3.md
+++ b/site/content/en/latest/tasks/traffic/http3.md
@@ -108,13 +108,8 @@ kubectl get gateway/eg -o yaml
 
 ## Testing
 
-### Clusters without External LoadBalancer Support
-
-It is not possible at the moment to port-forward UDP protocol in kubernetes service 
-check out https://github.com/kubernetes/kubernetes/issues/47862. 
-Hence we need external loadbalancer to test this feature out.
-
-### Clusters with External LoadBalancer Support
+{{< tabpane text=true >}}
+{{% tab header="With External LoadBalancer Support" %}}
 
 Get the External IP of the Gateway:
 
@@ -124,8 +119,18 @@ export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].
 
 Query the example app through the Gateway:
 
-Below example uses a custom docker image with custom curl binary with built-in http3.
+The below example uses a custom docker image with custom `curl` binary with built-in http3.
 
 ```shell
 docker run --net=host --rm ghcr.io/macbre/curl-http3 curl -kv --http3 -HHost:www.example.com --resolve "www.example.com:443:${GATEWAY_HOST}" https://www.example.com/get
 ```
+
+{{% /tab %}}
+{{% tab header="Without LoadBalancer Support" %}}
+
+It is not possible at the moment to port-forward UDP protocol in kubernetes service 
+check out https://github.com/kubernetes/kubernetes/issues/47862. 
+Hence we need external loadbalancer to test this feature out.
+
+{{% /tab %}}
+{{< /tabpane >}}


### PR DESCRIPTION
**What type of PR is this?**

Updates tasks in docs to use tabs for testing with & without load balancer support:

- tasks/traffic/http3.md
- tasks/security/tls-passthrough.md
- tasks/security/secure-gateways.md
- tasks/security/backend-tls.md
- tasks/security/mutual-tls.md
- tasks/security/tls-termination.md

Also reverses the order: with lb support first, without second.

Fixes #3259 
