### PR TITLE
ci: add trivy image vulnerabilities scan workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,19 +13,19 @@ permissions:
 jobs:
   image-scan:
     permissions:
-      contents: read # for actions/checkout to fetch code
+      contents: read  # for actions/checkout to fetch code
     name: Image Scan
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f  # v4.1.3
+    - name: Checkout code
+      uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f  # v4.1.3
 
-      - name: Build an image from Dockerfile
-        run: |
-          IMAGE=envoy-proxy/gateway-dev TAG=${{ github.sha }} make image
+    - name: Build an image from Dockerfile
+      run: |
+        IMAGE=envoy-proxy/gateway-dev TAG=${{ github.sha }} make image
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55  # v0.19.0
-        with:
-          image-ref: envoy-proxy/gateway-dev:${{ github.sha }}
-          exit-code: '1'
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55  # v0.19.0
+      with:
+        image-ref: envoy-proxy/gateway-dev:${{ github.sha }}
+        exit-code: '1'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,31 @@
+name: trivy
+
+on:
+  push:
+    branches:
+    - "main"
+  schedule:
+  - cron: '55 17 * * 5'
+
+permissions:
+  contents: read
+
+jobs:
+  image-scan:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+    name: Image Scan
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f  # v4.1.3
+
+      - name: Build an image from Dockerfile
+        run: |
+          IMAGE=envoy-proxy/gateway-dev TAG=${{ github.sha }} make image
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55  # v0.19.0
+        with:
+          image-ref: envoy-proxy/gateway-dev:${{ github.sha }}
+          exit-code: '1'


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduced Trivy image vulnerabilities scan workflow:
* This workflow will be triggered on merge to main and also once a week. I thought about triggering it also on PRs but I decided to avoid it in order to not block all PRs when a new vulnerability is detected.
* I didn't upload scan results to GitHub code scanning since when choosing `sarif` output format results don't appear in stdin. Since code scanning results are not public I kept the default `table` format so anyone can see it. See related [issue](https://github.com/aquasecurity/trivy-action/issues/116).
* Currently only `eg` image is scanned. Regarding `envoy-proxy` and `rate-limit` images, I think that they should be scanned as part of their ow repos CI process. We can discuss it later if needed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3168 
