### PR TITLE
fix: add proxy protocol always as first listenerFilter

### DIFF
--- a/internal/xds/translator/proxy_protocol.go
+++ b/internal/xds/translator/proxy_protocol.go
@@ -32,7 +32,8 @@ func patchProxyProtocolFilter(xdsListener *listenerv3.Listener, irListener *ir.H
 	proxyProtocolFilter := buildProxyProtocolFilter()
 
 	if proxyProtocolFilter != nil {
-		xdsListener.ListenerFilters = append(xdsListener.ListenerFilters, proxyProtocolFilter)
+		// Add the Proxy Protocol filter as first to listeners.
+		xdsListener.ListenerFilters = append([]*listenerv3.ListenerFilter{proxyProtocolFilter}, xdsListener.ListenerFilters...)
 	}
 }
 

--- a/internal/xds/translator/proxy_protocol_test.go
+++ b/internal/xds/translator/proxy_protocol_test.go
@@ -1,0 +1,58 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"testing"
+
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/gateway/internal/ir"
+)
+
+func TestPatchProxyProtocolFilter(t *testing.T) {
+	type testCase struct {
+		name     string
+		listener *listenerv3.Listener
+	}
+
+	irListener := &ir.HTTPListener{
+		EnableProxyProtocol: true,
+	}
+
+	testCases := []testCase{
+		{
+			name: "listener with proxy proto available already",
+			listener: &listenerv3.Listener{
+				ListenerFilters: []*listenerv3.ListenerFilter{
+					{
+						Name: wellknown.ProxyProtocol,
+					},
+				},
+			},
+		},
+		{
+			name: "listener with tls, append proxy proto",
+			listener: &listenerv3.Listener{
+				ListenerFilters: []*listenerv3.ListenerFilter{
+					{
+						Name: wellknown.TLSInspector,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			patchProxyProtocolFilter(tc.listener, irListener)
+			// proxy proto filter should be added always as first
+			require.Equal(t, wellknown.ProxyProtocol, tc.listener.ListenerFilters[0].Name)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

fix: add proxy protocol always as first listenerFilter

**What this PR does / why we need it**:

As you can see I did issue about 3 months ago and since that I have had random issues that envoy will not reply anything back. Now I decided that I will go through the egctl dumps and I found out that the order in tls and proxy protocol listenerFilters are incorrect somehow.

not working
```
                  "listenerFilters": [
                    {
                      "name": "envoy.filters.listener.tls_inspector",
                      "typedConfig": {
                        "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
                      }
                    },
                    {
                      "name": "envoy.filters.listener.proxy_protocol",
                      "typedConfig": {
                        "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol"
                      }
                    }
                  ],
```

working
```
                  "listenerFilters": [
                    {
                      "name": "envoy.filters.listener.proxy_protocol",
                      "typedConfig": {
                        "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol"
                      }
                    },
                    {
                      "name": "envoy.filters.listener.tls_inspector",
                      "typedConfig": {
                        "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
                      }
                    }
                  ],
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2968
