### PR TITLE
docs: fix broken BackendTLSPolicy samples

### DIFF
--- a/site/content/en/latest/tasks/security/backend-tls.md
+++ b/site/content/en/latest/tasks/security/backend-tls.md
@@ -139,19 +139,19 @@ Create a [BackendTLSPolicy][] instructing Envoy Gateway to establish a TLS conne
 
 ```shell
 cat <<EOF | kubectl apply -f -
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1alpha3
 kind: BackendTLSPolicy
 metadata:
   name: enable-backend-tls
   namespace: default
 spec:
-  targetRef:
-    group: ''
+  targetRefs:
+  - group: ''
     kind: Service
     name: tls-backend
     sectionName: "443"
-  tls:
-    caCertRefs:
+  validation:
+    caCertificateRefs:
     - name: example-ca
       group: ''
       kind: ConfigMap
@@ -165,19 +165,19 @@ Save and apply the following resource to your cluster:
 
 ```yaml
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1alpha3
 kind: BackendTLSPolicy
 metadata:
   name: enable-backend-tls
   namespace: default
 spec:
-  targetRef:
-    group: ''
+  targetRefs:
+  - group: ''
     kind: Service
     name: tls-backend
     sectionName: "443"
-  tls:
-    caCertRefs:
+  validation:
+    caCertificateRefs:
     - name: example-ca
       group: ''
       kind: ConfigMap

--- a/site/content/en/latest/tasks/security/ext-auth.md
+++ b/site/content/en/latest/tasks/security/ext-auth.md
@@ -347,18 +347,18 @@ the communication between the Envoy proxy and the gRPC auth service.
 
 ```shell
 cat <<EOF | kubectl apply -f -
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1alpha3
 kind: BackendTLSPolicy
 metadata:
   name: grpc-ext-auth-btls
 spec:
-  targetRef:
-    group: ''
+  targetRefs:
+  - group: ''
     kind: Service
     name: grpc-ext-auth
     sectionName: "9002"
-  tls:
-    caCertRefs:
+  validation:
+    caCertificateRefs:
     - name: grpc-ext-auth-ca
       group: ''
       kind: ConfigMap
@@ -372,18 +372,18 @@ Save and apply the following resource to your cluster:
 
 ```yaml
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1alpha3
 kind: BackendTLSPolicy
 metadata:
   name: grpc-ext-auth-btls
 spec:
-  targetRef:
-    group: ''
+  targetRefs:
+  - group: ''
     kind: Service
     name: grpc-ext-auth
     sectionName: "9002"
-  tls:
-    caCertRefs:
+  validation:
+    caCertificateRefs:
     - name: grpc-ext-auth-ca
       group: ''
       kind: ConfigMap


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix `BackendTLSPolicy` samples in docs so they will be aligned with Gateway API v1.1.0.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
