### PR TITLE
Feat: expose ratelimit image to helm chart

### DIFF
--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -39,6 +39,10 @@ config:
       kubernetes:
         shutdownManager:
           image: ${ImageRepository}:${ImageTag}
+        rateLimitDeployment:
+          container:
+            image: "envoyproxy/ratelimit:master"
+
     logging:
       level:
         default: info

--- a/site/content/en/latest/install/api.md
+++ b/site/content/en/latest/install/api.md
@@ -31,6 +31,7 @@ The Helm chart for Envoy Gateway
 | certgen.rbac.labels | object | `{}` |  |
 | config.envoyGateway.gateway.controllerName | string | `"gateway.envoyproxy.io/gatewayclass-controller"` |  |
 | config.envoyGateway.logging.level.default | string | `"info"` |  |
+| config.envoyGateway.provider.kubernetes.rateLimitDeployment.container.image | string | `"envoyproxy/ratelimit:master"` |  |
 | config.envoyGateway.provider.kubernetes.shutdownManager.image | string | `"docker.io/envoyproxy/gateway:latest"` |  |
 | config.envoyGateway.provider.type | string | `"Kubernetes"` |  |
 | createNamespace | bool | `false` |  |

--- a/test/helm/default.yaml
+++ b/test/helm/default.yaml
@@ -35,6 +35,9 @@ data:
         default: info
     provider:
       kubernetes:
+        rateLimitDeployment:
+          container:
+            image: envoyproxy/ratelimit:master
         shutdownManager:
           image: docker.io/envoyproxy/gateway-dev:latest
       type: Kubernetes


### PR DESCRIPTION
This PR exposes the Ratelimt image to the helm chart so it can be replaced in an airgapped environment.

fix https://github.com/envoyproxy/gateway/issues/3049