### PR TITLE
fix: security policy reference grant from field type

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -441,7 +441,7 @@ func (r *gatewayAPIReconciler) processSecurityPolicyObjectRefs(
 
 			if backendNamespace != policy.Namespace {
 				from := ObjectKindNamespacedName{
-					kind:      gatewayapi.KindHTTPRoute,
+					kind:      gatewayapi.KindSecurityPolicy,
 					namespace: policy.Namespace,
 					name:      policy.Name,
 				}


### PR DESCRIPTION
**What type of PR is this?**
fix: security policy reference grant from field type

**What this PR does / why we need it**:
When creating a SecurityPolicy  in a different namespace than the targeted service, the controller expects a ReferenceGrant resource with an entry in the *from* field of the type `HTTPRoute`. 
```yaml
spec:
  from:
  - group: gateway.networking.k8s.io
    kind: HTTPRoute
    namespace: envoy-gateway-system
```
That resource does not even exist in our tests because the HTTPRoute lives in other namespace. But the securitypolicy only works if we add that entry.

This PR fixes that and requires the existence of a referencegrant with a securitypolicy type in the *from* field.

**Which issue(s) this PR fixes**:
Not created any issue. Just submitting the fix.
