### PR TITLE
ci: add license scan workflow

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -18,10 +18,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b  # v4.1.5
     - name: Run scanner
-      uses: google/osv-scanner-action/osv-scanner-action@75532bf0bf75464b047d80414dbce04449498365 # v1.7.3
+      uses: google/osv-scanner-action/osv-scanner-action@75532bf0bf75464b047d80414dbce04449498365  # v1.7.3
       with:
         scan-args: |-
           --skip-git
           --experimental-licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib
           ./
-      continue-on-error: true # TODO remove once all issues are resolved
+      continue-on-error: true  # TODO remove once all issues are resolved

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -1,0 +1,27 @@
+name: License Scan
+
+on:
+  pull_request:
+    branches:
+    - "main"
+  push:
+    branches:
+    - "main"
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b  # v4.1.5
+    - name: Run scanner
+      uses: google/osv-scanner-action/osv-scanner-action@75532bf0bf75464b047d80414dbce04449498365 # v1.7.3
+      with:
+        scan-args: |-
+          --skip-git
+          --experimental-licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib
+          ./
+      continue-on-error: true # TODO remove once all issues are resolved


### PR DESCRIPTION
**What this PR does / why we need it**:
* Added license scan workflow for project dependencies which is aligned with [CNCF guidelines](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
* osv-scanner [experimental license scanning](https://google.github.io/osv-scanner/experimental/license-scanning/) is used as agreed [here](https://github.com/envoyproxy/gateway/issues/2917#issuecomment-2091176893).
* The license scan is running in non-blocking mode since it is currently failing. Once all issues are resolved we can configure it to fail the build. See more details [here](https://github.com/envoyproxy/gateway/issues/2917#issuecomment-2089656466).
* The license scan is running together with vulnerability scan. I opened an issue to add support for running only license scan. See more details [here](https://github.com/envoyproxy/gateway/issues/2917#issuecomment-2096662949).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2917 
