### PR TITLE
fix(translator): set ignoreCase for header matchers in extAuth

### DIFF
--- a/internal/xds/translator/extauth.go
+++ b/internal/xds/translator/extauth.go
@@ -113,6 +113,7 @@ func extAuthConfig(extAuth *ir.ExtAuth) *extauthv3.ExtAuthz {
 			MatchPattern: &matcherv3.StringMatcher_Exact{
 				Exact: header,
 			},
+			IgnoreCase: true,
 		})
 	}
 
@@ -178,6 +179,7 @@ func httpService(http *ir.HTTPExtAuthService) *extauthv3.HttpService {
 			MatchPattern: &matcherv3.StringMatcher_Exact{
 				Exact: header,
 			},
+			IgnoreCase: true,
 		})
 	}
 

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.listeners.yaml
@@ -21,7 +21,9 @@
             allowedHeaders:
               patterns:
               - exact: header1
+                ignoreCase: true
               - exact: header2
+                ignoreCase: true
             grpcService:
               envoyGrpc:
                 authority: grpc-backend.default:9000
@@ -38,7 +40,9 @@
                 allowedUpstreamHeaders:
                   patterns:
                   - exact: header1
+                    ignoreCase: true
                   - exact: header2
+                    ignoreCase: true
               pathPrefix: /auth
               serverUri:
                 cluster: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.listeners.yaml
@@ -27,7 +27,9 @@
                 allowedUpstreamHeaders:
                   patterns:
                   - exact: header1
+                    ignoreCase: true
                   - exact: header2
+                    ignoreCase: true
               pathPrefix: /auth
               serverUri:
                 cluster: securitypolicy/default/policy-for-http-route-2/envoy-gateway/http-backend
@@ -86,7 +88,9 @@
                 allowedUpstreamHeaders:
                   patterns:
                   - exact: header1
+                    ignoreCase: true
                   - exact: header2
+                    ignoreCase: true
               pathPrefix: /auth
               serverUri:
                 cluster: securitypolicy/default/policy-for-http-route-2/envoy-gateway/http-backend


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
-->
This PR set ignoreCase to true for header matchers in extAuth.

**What this PR does / why we need it**:

HTTP Header names are case-insensitive according to [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt) and [envoy will normalize the header keys to be all lowercase by default](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/header_casing).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3372
