### PR TITLE
API: Follow up on XFCC header

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -4590,12 +4590,12 @@ func (in *XForwardedClientCert) DeepCopyInto(out *XForwardedClientCert) {
 	*out = *in
 	if in.Mode != nil {
 		in, out := &in.Mode, &out.Mode
-		*out = new(ForwardMode)
+		*out = new(XFCCForwardMode)
 		**out = **in
 	}
 	if in.CertDetailsToAdd != nil {
 		in, out := &in.CertDetailsToAdd, &out.CertDetailsToAdd
-		*out = make([]ClientCertData, len(*in))
+		*out = make([]XFCCCertData, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
@@ -164,29 +164,46 @@ spec:
                     type: string
                   xForwardedClientCert:
                     description: |-
-                      Configure Envoy proxy how to handle the x-forwarded-client-cert (XFCC) HTTP header.
-                      When enabled, Hash and By is always set
+                      XForwardedClientCert configures how Envoy Proxy handle the x-forwarded-client-cert (XFCC) HTTP header.
+
+
+                      x-forwarded-client-cert (XFCC) is an HTTP header used to forward the certificate
+                      information of part or all of the clients or proxies that a request has flowed through,
+                      on its way from the client to the server.
+
+
+                      Envoy proxy may choose to sanitize/append/forward the XFCC header before proxying the request.
+
+
+                      If not set, the default behavior is sanitizing the XFCC header.
                     properties:
                       certDetailsToAdd:
-                        description: Specifies the fields in the client certificate
-                          to be forwarded on the x-forwarded-client-cert (XFCC) HTTP
-                          header
+                        description: |-
+                          CertDetailsToAdd specifies the fields in the client certificate to be forwarded in the XFCC header.
+
+
+                          Hash(the SHA 256 digest of the current client certificate) and By(the Subject Alternative Name)
+                          are always included if the client certificate is forwarded.
+
+
+                          This field is only applicable when the mode is set to `AppendForward` or
+                          `SanitizeSet` and the client connection is mTLS.
                         items:
-                          description: |-
-                            Specifies the fields in the client certificate to be forwarded on the x-forwarded-client-cert (XFCC) HTTP header
-                            By default, x-forwarded-client-cert (XFCC) will always include By and Hash data
+                          description: XFCCCertData specifies the fields in the client
+                            certificate to be forwarded in the XFCC header.
                           enum:
                           - Subject
                           - Cert
                           - Chain
-                          - Dns
-                          - Uri
+                          - DNS
+                          - URI
                           type: string
                         maxItems: 5
                         type: array
                       mode:
-                        description: Envoy Proxy mode how to handle the x-forwarded-client-cert
-                          (XFCC) HTTP header.
+                        description: |-
+                          Mode defines how XFCC header is handled by Envoy Proxy.
+                          If not set, the default mode is `Sanitize`.
                         enum:
                         - Sanitize
                         - ForwardOnly
@@ -195,6 +212,12 @@ spec:
                         - AlwaysForwardOnly
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: certDetailsToAdd can only be set when mode is AppendForward
+                        or SanitizeSet
+                      rule: '(has(self.certDetailsToAdd) && self.certDetailsToAdd.size()
+                        > 0) ? (self.mode == ''AppendForward'' || self.mode == ''SanitizeSet'')
+                        : true'
                 type: object
               http1:
                 description: HTTP1 provides HTTP/1 configuration on the listener.

--- a/internal/gatewayapi/clienttrafficpolicy.go
+++ b/internal/gatewayapi/clienttrafficpolicy.go
@@ -552,16 +552,12 @@ func translateListenerHeaderSettings(headerSettings *egv1a1.HeaderSettings, http
 
 	if headerSettings.XForwardedClientCert != nil {
 		httpIR.Headers.XForwardedClientCert = &ir.XForwardedClientCert{
-			Mode: ir.ForwardMode(ptr.Deref(headerSettings.XForwardedClientCert.Mode, egv1a1.ForwardModeSanitize)),
+			Mode: ptr.Deref(headerSettings.XForwardedClientCert.Mode, egv1a1.XFCCForwardModeSanitize),
 		}
 
-		var certDetailsToAdd []ir.ClientCertData
-		if httpIR.Headers.XForwardedClientCert.Mode == ir.ForwardModeAppendForward || httpIR.Headers.XForwardedClientCert.Mode == ir.ForwardModeSanitizeSet {
-			for _, data := range headerSettings.XForwardedClientCert.CertDetailsToAdd {
-				certDetailsToAdd = append(certDetailsToAdd, ir.ClientCertData(data))
-			}
-
-			httpIR.Headers.XForwardedClientCert.CertDetailsToAdd = certDetailsToAdd
+		if httpIR.Headers.XForwardedClientCert.Mode == egv1a1.XFCCForwardModeAppendForward ||
+			httpIR.Headers.XForwardedClientCert.Mode == egv1a1.XFCCForwardModeSanitizeSet {
+			httpIR.Headers.XForwardedClientCert.CertDetailsToAdd = headerSettings.XForwardedClientCert.CertDetailsToAdd
 		}
 	}
 }

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert-custom-data.in.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert-custom-data.in.yaml
@@ -76,7 +76,7 @@ clientTrafficPolicies:
         mode: SanitizeSet
         certDetailsToAdd:
         - Cert
-        - Uri
+        - URI
         - Chain
     tls:
       clientValidation:
@@ -99,10 +99,10 @@ clientTrafficPolicies:
         mode: SanitizeSet
         certDetailsToAdd:
         - Cert
-        - Uri
+        - URI
         - Chain
         - Subject
-        - Dns
+        - DNS
     tls:
       clientValidation:
         caCertificateRefs:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert-custom-data.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert-custom-data.out.yaml
@@ -121,7 +121,7 @@ clientTrafficPolicies:
       xForwardedClientCert:
         certDetailsToAdd:
         - Cert
-        - Uri
+        - URI
         - Chain
         mode: SanitizeSet
     targetRef:
@@ -160,10 +160,10 @@ clientTrafficPolicies:
       xForwardedClientCert:
         certDetailsToAdd:
         - Cert
-        - Uri
+        - URI
         - Chain
         - Subject
-        - Dns
+        - DNS
         mode: SanitizeSet
     targetRef:
       group: gateway.networking.k8s.io
@@ -652,7 +652,7 @@ xdsIR:
         xForwardedClientCert:
           certDetailsToAdd:
           - Cert
-          - Uri
+          - URI
           - Chain
           mode: SanitizeSet
       hostnames:
@@ -685,10 +685,10 @@ xdsIR:
         xForwardedClientCert:
           certDetailsToAdd:
           - Cert
-          - Uri
+          - URI
           - Chain
           - Subject
-          - Dns
+          - DNS
           mode: SanitizeSet
       hostnames:
       - '*'

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert.in.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert.in.yaml
@@ -30,6 +30,9 @@ clientTrafficPolicies:
     headers:
       xForwardedClientCert:
         mode: ForwardOnly
+        certDetailsToAdd:
+        - URI
+        - DNS
     tls:
       clientValidation:
         caCertificateRefs:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert.out.yaml
@@ -43,6 +43,9 @@ clientTrafficPolicies:
   spec:
     headers:
       xForwardedClientCert:
+        certDetailsToAdd:
+        - URI
+        - DNS
         mode: ForwardOnly
     targetRef:
       group: gateway.networking.k8s.io

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -377,34 +377,10 @@ const (
 // +k8s:deepcopy-gen=true
 type XForwardedClientCert struct {
 	// Envoy Proxy mode how to handle the x-forwarded-client-cert (XFCC) HTTP header.
-	Mode ForwardMode `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Mode egv1a1.XFCCForwardMode `json:"mode,omitempty" yaml:"mode,omitempty"`
 	// Specifies the fields in the client certificate to be forwarded on the x-forwarded-client-cert (XFCC) HTTP header
-	CertDetailsToAdd []ClientCertData `json:"certDetailsToAdd,omitempty" yaml:"certDetailsToAdd,omitempty"`
+	CertDetailsToAdd []egv1a1.XFCCCertData `json:"certDetailsToAdd,omitempty" yaml:"certDetailsToAdd,omitempty"`
 }
-
-// Envoy Proxy mode how to handle the x-forwarded-client-cert (XFCC) HTTP header.
-// +k8s:deepcopy-gen=true
-type ForwardMode egv1a1.ForwardMode
-
-const (
-	ForwardModeSanitize          = ForwardMode(egv1a1.ForwardModeSanitize)
-	ForwardModeForwardOnly       = ForwardMode(egv1a1.ForwardModeForwardOnly)
-	ForwardModeAppendForward     = ForwardMode(egv1a1.ForwardModeAppendForward)
-	ForwardModeSanitizeSet       = ForwardMode(egv1a1.ForwardModeSanitizeSet)
-	ForwardModeAlwaysForwardOnly = ForwardMode(egv1a1.ForwardModeAlwaysForwardOnly)
-)
-
-// Specifies the fields in the client certificate to be forwarded on the x-forwarded-client-cert (XFCC) HTTP header
-// +k8s:deepcopy-gen=true
-type ClientCertData egv1a1.ClientCertData
-
-const (
-	ClientCertDataSubject = ClientCertData(egv1a1.ClientCertDataSubject)
-	ClientCertDataCert    = ClientCertData(egv1a1.ClientCertDataCert)
-	ClientCertDataChain   = ClientCertData(egv1a1.ClientCertDataChain)
-	ClientCertDataDNS     = ClientCertData(egv1a1.ClientCertDataDNS)
-	ClientCertDataURI     = ClientCertData(egv1a1.ClientCertDataURI)
-)
 
 // ClientIPDetectionSettings provides configuration for determining the original client IP address for requests.
 // +k8s:deepcopy-gen=true

--- a/internal/ir/zz_generated.deepcopy.go
+++ b/internal/ir/zz_generated.deepcopy.go
@@ -2617,7 +2617,7 @@ func (in *XForwardedClientCert) DeepCopyInto(out *XForwardedClientCert) {
 	*out = *in
 	if in.CertDetailsToAdd != nil {
 		in, out := &in.CertDetailsToAdd, &out.CertDetailsToAdd
-		*out = make([]ClientCertData, len(*in))
+		*out = make([]v1alpha1.XFCCCertData, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/utils/ptr"
 
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/ir"
 	"github.com/envoyproxy/gateway/internal/utils/protocov"
 	xdsfilters "github.com/envoyproxy/gateway/internal/xds/filters"
@@ -796,15 +797,15 @@ func buildForwardClientCertDetailsAction(in *ir.HeaderSettings) hcmv3.HttpConnec
 	if in != nil {
 		if in.XForwardedClientCert != nil {
 			switch in.XForwardedClientCert.Mode {
-			case ir.ForwardModeSanitize:
+			case egv1a1.XFCCForwardModeSanitize:
 				return hcmv3.HttpConnectionManager_SANITIZE
-			case ir.ForwardModeForwardOnly:
+			case egv1a1.XFCCForwardModeForwardOnly:
 				return hcmv3.HttpConnectionManager_FORWARD_ONLY
-			case ir.ForwardModeAppendForward:
+			case egv1a1.XFCCForwardModeAppendForward:
 				return hcmv3.HttpConnectionManager_APPEND_FORWARD
-			case ir.ForwardModeSanitizeSet:
+			case egv1a1.XFCCForwardModeSanitizeSet:
 				return hcmv3.HttpConnectionManager_SANITIZE_SET
-			case ir.ForwardModeAlwaysForwardOnly:
+			case egv1a1.XFCCForwardModeAlwaysForwardOnly:
 				return hcmv3.HttpConnectionManager_ALWAYS_FORWARD_ONLY
 			}
 		}
@@ -828,15 +829,15 @@ func buildSetCurrentClientCertDetails(in *ir.HeaderSettings) *hcmv3.HttpConnecti
 	clientCertDetails := &hcmv3.HttpConnectionManager_SetCurrentClientCertDetails{}
 	for _, data := range in.XForwardedClientCert.CertDetailsToAdd {
 		switch data {
-		case ir.ClientCertDataCert:
+		case egv1a1.XFCCCertDataCert:
 			clientCertDetails.Cert = true
-		case ir.ClientCertDataChain:
+		case egv1a1.XFCCCertDataChain:
 			clientCertDetails.Chain = true
-		case ir.ClientCertDataDNS:
+		case egv1a1.XFCCCertDataDNS:
 			clientCertDetails.Dns = true
-		case ir.ClientCertDataSubject:
+		case egv1a1.XFCCCertDataSubject:
 			clientCertDetails.Subject = &wrapperspb.BoolValue{Value: true}
-		case ir.ClientCertDataURI:
+		case egv1a1.XFCCCertDataURI:
 			clientCertDetails.Uri = true
 		}
 	}

--- a/internal/xds/translator/testdata/in/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.yaml
@@ -10,8 +10,6 @@ http:
   headers:
     xForwardedClientCert:
       mode: Sanitize
-      certDetailsToAdd:
-      - Subject
   tls:
     alpnProtocols:
     - h2
@@ -125,8 +123,8 @@ http:
       mode: SanitizeSet
       certDetailsToAdd:
       - Subject
-      - Dns
-      - Uri
+      - DNS
+      - URI
   tls:
     alpnProtocols:
     - h2
@@ -165,10 +163,10 @@ http:
       mode: SanitizeSet
       certDetailsToAdd:
       - Subject
-      - Dns
+      - DNS
       - Chain
       - Cert
-      - Uri
+      - URI
   tls:
     alpnProtocols:
     - h2

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -472,25 +472,6 @@ _Appears in:_
 | `claim` | _string_ |  true  | Claim is the JWT Claim that should be saved into the header : it can be a nested claim of type<br />(eg. "claim.nested.key", "sub"). The nested claim name must use dot "."<br />to separate the JSON name path. |
 
 
-#### ClientCertData
-
-_Underlying type:_ _string_
-
-Specifies the fields in the client certificate to be forwarded on the x-forwarded-client-cert (XFCC) HTTP header
-By default, x-forwarded-client-cert (XFCC) will always include By and Hash data
-
-_Appears in:_
-- [XForwardedClientCert](#xforwardedclientcert)
-
-| Value | Description |
-| ----- | ----------- |
-| `Subject` | Whether to forward the subject of the client cert.<br /> | 
-| `Cert` | Whether to forward the entire client cert in URL encoded PEM format.<br />This will appear in the XFCC header comma separated from other values with the value Cert=”PEM”.<br /> | 
-| `Chain` | Whether to forward the entire client cert chain (including the leaf cert) in URL encoded PEM format.<br />This will appear in the XFCC header comma separated from other values with the value Chain=”PEM”.<br /> | 
-| `Dns` | Whether to forward the DNS type Subject Alternative Names of the client cert.<br /> | 
-| `Uri` | Whether to forward the URI type Subject Alternative Name of the client cert.<br /> | 
-
-
 #### ClientIPDetectionSettings
 
 
@@ -1549,24 +1530,6 @@ _Appears in:_
 | `after` | _[EnvoyFilter](#envoyfilter)_ |  true  | After defines the filter that should come after the filter.<br />Only one of Before or After must be set. |
 
 
-#### ForwardMode
-
-_Underlying type:_ _string_
-
-Envoy Proxy mode how to handle the x-forwarded-client-cert (XFCC) HTTP header.
-
-_Appears in:_
-- [XForwardedClientCert](#xforwardedclientcert)
-
-| Value | Description |
-| ----- | ----------- |
-| `Sanitize` | Do not send the XFCC header to the next hop. This is the default value.<br /> | 
-| `ForwardOnly` | When the client connection is mTLS (Mutual TLS), forward the XFCC header<br />in the request.<br /> | 
-| `AppendForward` | When the client connection is mTLS, append the client certificate<br />information to the request’s XFCC header and forward it.<br /> | 
-| `SanitizeSet` | When the client connection is mTLS, reset the XFCC header with the client<br />certificate information and send it to the next hop.<br /> | 
-| `AlwaysForwardOnly` | Always forward the XFCC header in the request, regardless of whether the<br />client connection is mTLS.<br /> | 
-
-
 #### GRPCExtAuthService
 
 
@@ -1834,7 +1797,7 @@ _Appears in:_
 | Field | Type | Required | Description |
 | ---   | ---  | ---      | ---         |
 | `enableEnvoyHeaders` | _boolean_ |  false  | EnableEnvoyHeaders configures Envoy Proxy to add the "X-Envoy-" headers to requests<br />and responses. |
-| `xForwardedClientCert` | _[XForwardedClientCert](#xforwardedclientcert)_ |  false  | Configure Envoy proxy how to handle the x-forwarded-client-cert (XFCC) HTTP header.<br />When enabled, Hash and By is always set |
+| `xForwardedClientCert` | _[XForwardedClientCert](#xforwardedclientcert)_ |  false  | XForwardedClientCert configures how Envoy Proxy handle the x-forwarded-client-cert (XFCC) HTTP header.<br /><br />x-forwarded-client-cert (XFCC) is an HTTP header used to forward the certificate<br />information of part or all of the clients or proxies that a request has flowed through,<br />on its way from the client to the server.<br /><br />Envoy proxy may choose to sanitize/append/forward the XFCC header before proxying the request.<br /><br />If not set, the default behavior is sanitizing the XFCC header. |
 | `withUnderscoresAction` | _[WithUnderscoresAction](#withunderscoresaction)_ |  false  | WithUnderscoresAction configures the action to take when an HTTP header with underscores<br />is encountered. The default action is to reject the request. |
 | `preserveXRequestID` | _boolean_ |  false  | PreserveXRequestID configures Envoy to keep the X-Request-ID header if passed for a request that is edge<br />(Edge request is the request from external clients to front Envoy) and not reset it, which is the current Envoy behaviour.<br />It defaults to false. |
 
@@ -3580,19 +3543,55 @@ _Appears in:_
 | `post` | _[XDSTranslatorHook](#xdstranslatorhook) array_ |  true  |  |
 
 
+#### XFCCCertData
+
+_Underlying type:_ _string_
+
+XFCCCertData specifies the fields in the client certificate to be forwarded in the XFCC header.
+
+_Appears in:_
+- [XForwardedClientCert](#xforwardedclientcert)
+
+| Value | Description |
+| ----- | ----------- |
+| `Subject` | XFCCCertDataSubject is the Subject field of the current client certificate.<br /> | 
+| `Cert` | XFCCCertDataCert is the entire client certificate in URL encoded PEM format.<br /> | 
+| `Chain` | XFCCCertDataChain is the entire client certificate chain (including the leaf certificate) in URL encoded PEM format.<br /> | 
+| `DNS` | XFCCCertDataDNS is the DNS type Subject Alternative Name field of the current client certificate.<br /> | 
+| `URI` | XFCCCertDataURI is the URI type Subject Alternative Name field of the current client certificate.<br /> | 
+
+
+#### XFCCForwardMode
+
+_Underlying type:_ _string_
+
+XFCCForwardMode defines how XFCC header is handled by Envoy Proxy.
+
+_Appears in:_
+- [XForwardedClientCert](#xforwardedclientcert)
+
+| Value | Description |
+| ----- | ----------- |
+| `Sanitize` | XFCCForwardModeSanitize removes the XFCC header from the request. This is the default mode.<br /> | 
+| `ForwardOnly` | XFCCForwardModeForwardOnly forwards the XFCC header in the request if the client connection is mTLS.<br /> | 
+| `AppendForward` | XFCCForwardModeAppendForward appends the client certificate information to the request’s XFCC header and forward it if the client connection is mTLS.<br /> | 
+| `SanitizeSet` | XFCCForwardModeSanitizeSet resets the XFCC header with the client certificate information and forward it if the client connection is mTLS.<br />The existing certificate information in the XFCC header is removed.<br /> | 
+| `AlwaysForwardOnly` | XFCCForwardModeAlwaysForwardOnly always forwards the XFCC header in the request, regardless of whether the client connection is mTLS.<br /> | 
+
+
 #### XForwardedClientCert
 
 
 
-Configure Envoy proxy how to handle the x-forwarded-client-cert (XFCC) HTTP header.
+XForwardedClientCert configures how Envoy Proxy handle the x-forwarded-client-cert (XFCC) HTTP header.
 
 _Appears in:_
 - [HeaderSettings](#headersettings)
 
 | Field | Type | Required | Description |
 | ---   | ---  | ---      | ---         |
-| `mode` | _[ForwardMode](#forwardmode)_ |  false  | Envoy Proxy mode how to handle the x-forwarded-client-cert (XFCC) HTTP header. |
-| `certDetailsToAdd` | _[ClientCertData](#clientcertdata) array_ |  false  | Specifies the fields in the client certificate to be forwarded on the x-forwarded-client-cert (XFCC) HTTP header |
+| `mode` | _[XFCCForwardMode](#xfccforwardmode)_ |  false  | Mode defines how XFCC header is handled by Envoy Proxy.<br />If not set, the default mode is `Sanitize`. |
+| `certDetailsToAdd` | _[XFCCCertData](#xfcccertdata) array_ |  false  | CertDetailsToAdd specifies the fields in the client certificate to be forwarded in the XFCC header.<br /><br />Hash(the SHA 256 digest of the current client certificate) and By(the Subject Alternative Name)<br />are always included if the client certificate is forwarded.<br /><br />This field is only applicable when the mode is set to `AppendForward` or<br />`SanitizeSet` and the client connection is mTLS. |
 
 
 #### XForwardedForSettings

--- a/test/cel-validation/clienttrafficpolicy_test.go
+++ b/test/cel-validation/clienttrafficpolicy_test.go
@@ -333,6 +333,31 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 				"spec.http2.InitialConnectionWindowSize: Invalid value: \"\": initialConnectionWindowSize must be of the format \"^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$\"",
 			},
 		},
+		{
+			desc: "invalid xffc setting",
+			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
+				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
+					TargetRef: gwapiv1a2.LocalPolicyTargetReferenceWithSectionName{
+						LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{
+							Group: gwapiv1a2.Group("gateway.networking.k8s.io"),
+							Kind:  gwapiv1a2.Kind("Gateway"),
+							Name:  gwapiv1a2.ObjectName("eg"),
+						},
+					},
+					Headers: &egv1a1.HeaderSettings{
+						XForwardedClientCert: &egv1a1.XForwardedClientCert{
+							Mode: ptr.To(egv1a1.XFCCForwardModeSanitize),
+							CertDetailsToAdd: []egv1a1.XFCCCertData{
+								egv1a1.XFCCCertDataChain,
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{
+				" spec.headers.xForwardedClientCert: Invalid value: \"object\": certDetailsToAdd can only be set when mode is AppendForward or SanitizeSet",
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This a follow-up PR to address comments on https://github.com/envoyproxy/gateway/pull/3202.
* XFCC header setting naming
* Add validation for xfcc setting
* Add some comments

Close https://github.com/envoyproxy/gateway/issues/2599