### PR TITLE
feat: add knob for disable service

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -245,6 +245,11 @@ const (
 // +kubebuilder:validation:XValidation:message="loadBalancerSourceRanges can only be set for LoadBalancer type",rule="!has(self.loadBalancerSourceRanges) || self.type == 'LoadBalancer'"
 // +kubebuilder:validation:XValidation:message="loadBalancerIP can only be set for LoadBalancer type",rule="!has(self.loadBalancerIP) || self.type == 'LoadBalancer'"
 type KubernetesServiceSpec struct {
+	// Disable disables service if set to true.
+	// By default, the service is enabled.
+	// +optional
+	Disable bool `json:"disable,omitempty"`
+
 	// Annotations that should be appended to the service.
 	// By default, no annotations are appended.
 	//

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
@@ -9901,6 +9901,11 @@ spec:
                               Annotations that should be appended to the service.
                               By default, no annotations are appended.
                             type: object
+                          disable:
+                            description: |-
+                              Disable disables service if set to true.
+                              By default, the service is enabled.
+                            type: boolean
                           externalTrafficPolicy:
                             default: Local
                             description: |-

--- a/internal/infrastructure/kubernetes/infra_resource.go
+++ b/internal/infrastructure/kubernetes/infra_resource.go
@@ -102,6 +102,12 @@ func (i *Infra) createOrUpdateService(ctx context.Context, r ResourceRender) err
 		return err
 	}
 
+	// when Service is disabled,
+	// then delete the object in the kube api server if any.
+	if svc == nil {
+		return i.deleteService(ctx, r)
+	}
+
 	return i.Client.ServerSideApply(ctx, svc)
 }
 

--- a/internal/infrastructure/kubernetes/proxy/resource_provider.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider.go
@@ -69,6 +69,14 @@ func (r *ResourceRender) ServiceAccount() (*corev1.ServiceAccount, error) {
 
 // Service returns the expected Service based on the provided infra.
 func (r *ResourceRender) Service() (*corev1.Service, error) {
+	provider := r.infra.GetProxyConfig().GetEnvoyProxyProvider()
+	envoyServiceConfig := provider.GetEnvoyProxyKubeProvider().EnvoyService
+
+	// If the service is disabled, return nil
+	if envoyServiceConfig.Disable {
+		return nil, nil
+	}
+
 	var ports []corev1.ServicePort
 	for _, listener := range r.infra.Listeners {
 		for _, port := range listener.Ports {
@@ -110,8 +118,6 @@ func (r *ResourceRender) Service() (*corev1.Service, error) {
 	annotations := map[string]string{}
 	maps.Copy(annotations, r.infra.GetProxyMetadata().Annotations)
 
-	provider := r.infra.GetProxyConfig().GetEnvoyProxyProvider()
-	envoyServiceConfig := provider.GetEnvoyProxyKubeProvider().EnvoyService
 	if envoyServiceConfig.Annotations != nil {
 		maps.Copy(annotations, envoyServiceConfig.Annotations)
 	}

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -2096,6 +2096,7 @@ _Appears in:_
 
 | Field | Type | Required | Description |
 | ---   | ---  | ---      | ---         |
+| `disable` | _boolean_ |  false  | Disable disables service if set to true.<br />By default, the service is enabled. |
 | `annotations` | _object (keys:string, values:string)_ |  false  | Annotations that should be appended to the service.<br />By default, no annotations are appended. |
 | `type` | _[ServiceType](#servicetype)_ |  false  | Type determines how the Service is exposed. Defaults to LoadBalancer.<br />Valid options are ClusterIP, LoadBalancer and NodePort.<br />"LoadBalancer" means a service will be exposed via an external load balancer (if the cloud provider supports it).<br />"ClusterIP" means a service will only be accessible inside the cluster, via the cluster IP.<br />"NodePort" means a service will be exposed on a static Port on all Nodes of the cluster. |
 | `loadBalancerClass` | _string_ |  false  | LoadBalancerClass, when specified, allows for choosing the LoadBalancer provider<br />implementation if more than one are available or is otherwise expected to be specified |


### PR DESCRIPTION
Continue work with run Envoy Gateway on baremetal K8s installations without LoadBalancer.
Previos PRs: 
- [Run Envoy Gateway like DaemonSet](https://github.com/envoyproxy/gateway/pull/3092)
- [feat: add knob for switching container port](https://github.com/envoyproxy/gateway/pull/3333)


### In this PR:

I add new field for `KubernetesServiceSpec` for 'don't deploy service'-logic.

### Real case:

If I deploy Envoy Gateway with `EnvoyProxy`:
```yaml
apiVersion: gateway.envoyproxy.io/v1alpha1
kind: EnvoyProxy
metadata:
  name: default
  namespace: envoy-gateway
spec:
  provider:
    kubernetes:
      UseListenerPortAsContainerPort: true
      envoyDaemonSet:
        pod:
          nodeSelector:
            node-role.kubernetes.io/gateway: "true"
        container:
          image: envoyproxy/envoy:v1.29.2
          securityContext:
            allowPrivilegeEscalation: true
            capabilities:
              add:
              - NET_BIND_SERVICE
              drop:
              - ALL
            seccompProfile:
              type: RuntimeDefault
        patch:
          type: StrategicMerge
          value:
            spec:
              template:
                spec:
                  hostNetwork: true
                  dnsPolicy: ClusterFirstWithHostNet
    type: Kubernetes
```

I don't need service for starting Envoy, bc I will connect to envoy with host-port (`hostNetwork: true`)