### PR TITLE
fix(chart): add update permission to infra manager role to fix a permission issue when mergeGateways is true

### DIFF
--- a/charts/gateway-helm/templates/infra-manager-rbac.yaml
+++ b/charts/gateway-helm/templates/infra-manager-rbac.yaml
@@ -16,6 +16,7 @@ rules:
   - get
   - delete
   - patch
+  - update
 - apiGroups:
   - apps
   resources:
@@ -26,6 +27,7 @@ rules:
   - get
   - delete
   - patch
+  - update
 - apiGroups:
   - autoscaling
   resources:
@@ -35,6 +37,7 @@ rules:
   - get
   - delete
   - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:
When `mergeGateways` is set to `true` in `EnvoyProxy`, we use a single deployment to manage a fleet of Envoy Proxies and update it depending on changes in the configuration. In our setup we started to get errors like below once the config was enabled:
```
2024-05-13T13:53:07.620Z ERROR infrastructure runner/runner.go:75 failed to create new infra {"runner": "infrastructure", "error": "failed to create or update deployment gateway-system/envoy-merged-eg-123ac7ae: for Update: deployments.apps \"envoy-merged-eg-123ac7ae\" is forbidden: User \"system:serviceaccount:gateway-system:envoy-gateway\" cannot update resource \"deployments\" in API group \"apps\" in the namespace \"gateway-system\""}
2024-05-13T13:53:07.620Z ERROR watchable message/watchutil.go:56 observed an error {"runner": "infrastructure", "error": "failed to create or update deployment gateway-system/envoy-merged-eg-123ac7ae: for Update: deployments.apps \"envoy-merged-eg-668ac7ae\" is forbidden: User \"system:serviceaccount:gateway-system:envoy-gateway\" cannot update resource \"deployments\" in API group \"apps\" in the namespace \"gateway-system\""} 
```
The service account lacks the `update` permission to update deployments and this PR adds that.

At the moment we are running a forked Helm chart with the changes here and no longer have this permission error.
