### PR TITLE
chore: update matrix

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -84,7 +84,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        version: [ v1.27.11, v1.28.7, v1.29.2, v1.30.0 ]
+        version: [ v1.27.13, v1.28.9, v1.29.4, v1.30.0 ]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
     - uses: ./tools/github-actions/setup-deps
@@ -112,7 +112,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        version: [ v1.27.11, v1.28.7, v1.29.2, v1.30.0 ]
+        version: [ v1.27.13, v1.28.9, v1.29.4, v1.30.0 ]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
     - uses: ./tools/github-actions/setup-deps

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -84,7 +84,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        version: [ v1.26.14, v1.27.11, v1.28.7, v1.29.2 ]
+        version: [ v1.27.11, v1.28.7, v1.29.2, 1.30.0 ]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
     - uses: ./tools/github-actions/setup-deps
@@ -112,7 +112,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        version: [ v1.26.14, v1.27.11, v1.28.7, v1.29.2 ]
+        version: [ v1.27.11, v1.28.7, v1.29.2, 1.30.0 ]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
     - uses: ./tools/github-actions/setup-deps

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -84,7 +84,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        version: [ v1.27.11, v1.28.7, v1.29.2, 1.30.0 ]
+        version: [ v1.27.11, v1.28.7, v1.29.2, v1.30.0 ]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
     - uses: ./tools/github-actions/setup-deps
@@ -112,7 +112,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        version: [ v1.27.11, v1.28.7, v1.29.2, 1.30.0 ]
+        version: [ v1.27.11, v1.28.7, v1.29.2, v1.30.0 ]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
     - uses: ./tools/github-actions/setup-deps

--- a/.github/workflows/experimental_conformance.yaml
+++ b/.github/workflows/experimental_conformance.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ v1.27.11, v1.28.7, v1.29.2, v1.30.0 ]
+        version: [ v1.27.13, v1.28.9, v1.29.4, v1.30.0 ]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
     - uses: ./tools/github-actions/setup-deps

--- a/.github/workflows/experimental_conformance.yaml
+++ b/.github/workflows/experimental_conformance.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ v1.26.14, v1.27.11, v1.28.7, v1.29.2 ]
+        version: [ v1.27.11, v1.28.7, v1.29.2, 1.30.0 ]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
     - uses: ./tools/github-actions/setup-deps

--- a/.github/workflows/experimental_conformance.yaml
+++ b/.github/workflows/experimental_conformance.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ v1.27.11, v1.28.7, v1.29.2, 1.30.0 ]
+        version: [ v1.27.11, v1.28.7, v1.29.2, v1.30.0 ]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
     - uses: ./tools/github-actions/setup-deps

--- a/site/content/en/latest/install/matrix.md
+++ b/site/content/en/latest/install/matrix.md
@@ -7,10 +7,10 @@ Envoy Gateway relies on the Envoy Proxy and the Gateway API, and runs within a K
 
 | Envoy Gateway version | Envoy Proxy version         | Rate Limit version | Gateway API version | Kubernetes version         |
 |-----------------------|-----------------------------|--------------------|---------------------|----------------------------|
-| v1.0.0                | **distroless-v1.29.2**      | **19f2079f**       | **v1.0.0**          | v1.26, v1.27, v1.28, v1.29 |
-| v0.6.0                | **distroless-v1.28-latest** | **b9796237**       | **v1.0.0**          | v1.26, v1.27, v1.28        |
-| v0.5.0                | **v1.27-latest**            | **e059638d**       | **v0.7.1**          | v1.25, v1.26, v1.27        |
-| v0.4.0                | **v1.26-latest**            | **542a6047**       | **v0.6.2**          | v1.25, v1.26, v1.27        |
-| v0.3.0                | **v1.25-latest**            | **f28024e3**       | **v0.6.1**          | v1.24, v1.25, v1.26        |
-| v0.2.0                | **v1.23-latest**            |                    | **v0.5.1**          | v1.24                      |
-| latest                | **dev-latest**              | **master**         | **v1.0.0**          | v1.26, v1.27, v1.28, v1.29 |
+| v1.0                  | **distroless-v1.29.2**      | **19f2079f**       | **v1.0.0**          | v1.26, v1.27, v1.28, v1.29 |
+| v0.6                  | **distroless-v1.28-latest** | **b9796237**       | **v1.0.0**          | v1.26, v1.27, v1.28        |
+| v0.5                  | **v1.27-latest**            | **e059638d**       | **v0.7.1**          | v1.25, v1.26, v1.27        |
+| v0.4                  | **v1.26-latest**            | **542a6047**       | **v0.6.2**          | v1.25, v1.26, v1.27        |
+| v0.3                  | **v1.25-latest**            | **f28024e3**       | **v0.6.1**          | v1.24, v1.25, v1.26        |
+| v0.2                  | **v1.23-latest**            |                    | **v0.5.1**          | v1.24                      |
+| latest                | **dev-latest**              | **master**         | **v1.0.0**          | v1.27, v1.28, v1.29, v1.30 |


### PR DESCRIPTION
fixes: #3449

remove 1.26, add 1.30

bump:
1.27.11 -> 1.27.13
1.28.7 -> 1.28.9
1.29.2 -> 1.29.4