### PR TITLE
Fix:  secrets/config map updates do not trigger reconciles

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -1228,16 +1228,12 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 	}
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &corev1.Secret{},
-			handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, s *corev1.Secret) []reconcile.Request {
-				return r.enqueueClass(ctx, s)
-			}),
 			secretPredicates...)); err != nil {
 		return err
 	}
 
 	// Watch ConfigMap CRUDs and process affected ClienTraffiPolicies and BackendTLSPolicies.
 	configMapPredicates := []predicate.TypedPredicate[*corev1.ConfigMap]{
-		predicate.TypedGenerationChangedPredicate[*corev1.ConfigMap]{},
 		predicate.NewTypedPredicateFuncs[*corev1.ConfigMap](func(cm *corev1.ConfigMap) bool {
 			return r.validateConfigMapForReconcile(cm)
 		}),


### PR DESCRIPTION
ensure secret/config map changes trigger a reconcile

**What type of PR is this?**
<!--
Remove TypedGenerationChangedPredicate from configmaps / secrets as those don't have spec nor generation, they will not trigger a reconcile even if they change.

**What this PR does / why we need it**:
Ensure that update to secret and configmas will tigger a reconcile, currently updates are ignored.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/envoyproxy/gateway/issues/3496

