### PR TITLE
fix: Reduce the amount of memory used by the in-memory extension manager gRPC server buffer

### DIFF
--- a/internal/extension/registry/extension_manager.go
+++ b/internal/extension/registry/extension_manager.go
@@ -80,7 +80,7 @@ func NewInMemoryManager(cfg v1alpha1.ExtensionManager, server extension.EnvoyGat
 		return nil, nil, fmt.Errorf("in-memory manager must be passed a server")
 	}
 
-	buffer := 101024 * 1024
+	buffer := 10 * 1024 * 1024
 	lis := bufconn.Listen(buffer)
 
 	baseServer := grpc.NewServer()


### PR DESCRIPTION
Noticed that the amount of memory being used for the in-memory extension server buffer was too large due to a typo.