### PR TITLE
feat(translator): Add names to filterchains based on the listener name

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -974,6 +974,7 @@ xds:
                       path: /dev/stdout
                   cluster: tcproute/default/backend/rule/-1
                   statPrefix: tcp
+              name: tcproute/default/backend
             name: default/eg/tcp
             perConnectionBufferLimitBytes: 32768
       - activeState:
@@ -1016,6 +1017,7 @@ xds:
                       path: /dev/stdout
                   cluster: tlsroute/default/backend/rule/-1
                   statPrefix: passthrough
+              name: tlsroute/default/backend
             listenerFilters:
             - name: envoy.filters.listener.tls_inspector
               typedConfig:

--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -865,6 +865,7 @@ xds:
                   serverHeaderTransformation: PASS_THROUGH
                   statPrefix: http
                   useRemoteAddress: true
+              name: default/eg/http
             drainType: MODIFY_ONLY
             name: default/eg/http
             perConnectionBufferLimitBytes: 32768
@@ -932,6 +933,7 @@ xds:
                   serverHeaderTransformation: PASS_THROUGH
                   statPrefix: http
                   useRemoteAddress: true
+              name: default/eg/grpc
             drainType: MODIFY_ONLY
             name: default/eg/grpc
             perConnectionBufferLimitBytes: 32768

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -792,7 +792,8 @@
                             "statPrefix": "tcp"
                           }
                         }
-                      ]
+                      ],
+                      "name": "tcproute/default/backend"
                     }
                   ],
                   "name": "default/eg/tcp",
@@ -862,7 +863,8 @@
                             "statPrefix": "passthrough"
                           }
                         }
-                      ]
+                      ],
+                      "name": "tlsroute/default/backend"
                     }
                   ],
                   "listenerFilters": [

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -620,7 +620,8 @@
                           "useRemoteAddress": true
                         }
                       }
-                    ]
+                    ],
+                    "name": "default/eg/http"
                   },
                   "drainType": "MODIFY_ONLY",
                   "name": "default/eg/http",
@@ -725,7 +726,8 @@
                           "useRemoteAddress": true
                         }
                       }
-                    ]
+                    ],
+                    "name": "default/eg/grpc"
                   },
                   "drainType": "MODIFY_ONLY",
                   "name": "default/eg/grpc",

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -363,6 +363,7 @@ xds:
                   serverHeaderTransformation: PASS_THROUGH
                   statPrefix: http
                   useRemoteAddress: true
+              name: default/eg/http
             drainType: MODIFY_ONLY
             name: default/eg/http
             perConnectionBufferLimitBytes: 32768
@@ -430,6 +431,7 @@ xds:
                   serverHeaderTransformation: PASS_THROUGH
                   statPrefix: http
                   useRemoteAddress: true
+              name: default/eg/grpc
             drainType: MODIFY_ONLY
             name: default/eg/grpc
             perConnectionBufferLimitBytes: 32768

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -472,6 +472,7 @@ xds:
                       path: /dev/stdout
                   cluster: tcproute/default/backend/rule/-1
                   statPrefix: tcp
+              name: tcproute/default/backend
             name: default/eg/tcp
             perConnectionBufferLimitBytes: 32768
       - activeState:
@@ -514,6 +515,7 @@ xds:
                       path: /dev/stdout
                   cluster: tlsroute/default/backend/rule/-1
                   statPrefix: passthrough
+              name: tlsroute/default/backend
             listenerFilters:
             - name: envoy.filters.listener.tls_inspector
               typedConfig:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
@@ -58,6 +58,7 @@ xds:
                 serverHeaderTransformation: PASS_THROUGH
                 statPrefix: http
                 useRemoteAddress: true
+            name: default/eg/http
           drainType: MODIFY_ONLY
           name: default/eg/http
           perConnectionBufferLimitBytes: 32768
@@ -125,6 +126,7 @@ xds:
                 serverHeaderTransformation: PASS_THROUGH
                 statPrefix: http
                 useRemoteAddress: true
+            name: default/eg/grpc
           drainType: MODIFY_ONLY
           name: default/eg/grpc
           perConnectionBufferLimitBytes: 32768

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
@@ -167,6 +167,7 @@ xds:
                     path: /dev/stdout
                 cluster: tcproute/default/backend/rule/-1
                 statPrefix: tcp
+            name: tcproute/default/backend
           name: default/eg/tcp
           perConnectionBufferLimitBytes: 32768
     - activeState:
@@ -209,6 +210,7 @@ xds:
                     path: /dev/stdout
                 cluster: tlsroute/default/backend/rule/-1
                 statPrefix: passthrough
+            name: tlsroute/default/backend
           listenerFilters:
           - name: envoy.filters.listener.tls_inspector
             typedConfig:

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -476,7 +476,8 @@
                           "useRemoteAddress": true
                         }
                       }
-                    ]
+                    ],
+                    "name": "envoy-gateway-system/eg/http"
                   },
                   "drainType": "MODIFY_ONLY",
                   "name": "envoy-gateway-system/eg/http",

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -281,6 +281,7 @@ xds:
                   serverHeaderTransformation: PASS_THROUGH
                   statPrefix: http
                   useRemoteAddress: true
+              name: envoy-gateway-system/eg/http
             drainType: MODIFY_ONLY
             name: envoy-gateway-system/eg/http
             perConnectionBufferLimitBytes: 32768

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
@@ -75,6 +75,7 @@ xds:
                 serverHeaderTransformation: PASS_THROUGH
                 statPrefix: http
                 useRemoteAddress: true
+            name: envoy-gateway-system/eg/http
           drainType: MODIFY_ONLY
           name: envoy-gateway-system/eg/http
           perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -441,6 +441,7 @@ func addXdsTCPFilterChain(xdsListener *listenerv3.Listener, irRoute *ir.TCPRoute
 
 	filterChain := &listenerv3.FilterChain{
 		Filters: filters,
+		Name:    irRoute.Name,
 	}
 
 	if isTLSPassthrough {

--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -318,6 +318,7 @@ func (t *Translator) addHCMToXDSListener(xdsListener *listenerv3.Listener, irLis
 
 	filterChain := &listenerv3.FilterChain{
 		Filters: filters,
+		Name:    irListener.Name,
 	}
 
 	if irListener.TLS != nil {

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.listeners.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: extension-listener
   drainType: MODIFY_ONLY
   name: extension-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/extension-xds-ir/listener-policy.listeners.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/listener-policy.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: policyextension-listener
   drainType: MODIFY_ONLY
   name: policyextension-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.listeners.yaml
@@ -139,6 +139,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.listeners.yaml
@@ -191,6 +191,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.listeners.yaml
@@ -139,6 +139,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/authorization.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization.listeners.yaml
@@ -32,6 +32,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: envoy-gateway/gateway-1/http
   drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.listeners.yaml
@@ -45,6 +45,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tcp-route-dest
         statPrefix: tcp
+    name: tcp-route-dest
   name: second-listener
   perConnectionBufferLimitBytes: 1500
 - address:

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth.listeners.yaml
@@ -35,6 +35,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: default/gateway-1/http
   drainType: MODIFY_ONLY
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.listeners.yaml
@@ -45,5 +45,6 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tcp-route-dest
         statPrefix: tcp
+    name: tcp-route-dest
   name: second-listener
   perConnectionBufferLimitBytes: 1500

--- a/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 1500

--- a/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.listeners.yaml
@@ -28,6 +28,7 @@
         statPrefix: http
         useRemoteAddress: true
         xffNumTrustedHops: 2
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
@@ -66,6 +67,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: false
+    name: second-listener
   drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768
@@ -106,6 +108,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: false
+    name: third-listener
   drainType: MODIFY_ONLY
   name: third-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/client-timeout.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-timeout.listeners.yaml
@@ -31,6 +31,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/client-timeout.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-timeout.listeners.yaml
@@ -48,5 +48,6 @@
         cluster: second-route-dest
         idleTimeout: 1200s
         statPrefix: tcp
+    name: second-route
   name: second-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/cors.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/cors.listeners.yaml
@@ -32,6 +32,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
@@ -120,6 +120,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: envoy-gateway/gateway-1/http
   drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.listeners.yaml
@@ -64,6 +64,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: default/gateway-1/http
   drainType: MODIFY_ONLY
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc.listeners.yaml
@@ -93,6 +93,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: envoy-gateway/gateway-1/http
   drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/fault-injection.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/fault-injection.listeners.yaml
@@ -32,6 +32,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-x-request-id.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-x-request-id.listeners.yaml
@@ -28,6 +28,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
@@ -60,6 +61,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: second-listener
   drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-underscores-action.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-underscores-action.listeners.yaml
@@ -27,6 +27,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
@@ -58,6 +59,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: second-listener
   drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768
@@ -90,6 +92,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: third-listener
   drainType: MODIFY_ONLY
   name: third-listener
   perConnectionBufferLimitBytes: 32768
@@ -122,6 +125,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: fourth-listener
   drainType: MODIFY_ONLY
   name: fourth-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/health-check.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-endpoint-stats.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-endpoint-stats.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: listener-enable-endpoint-stats
   drainType: MODIFY_ONLY
   name: listener-enable-endpoint-stats
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-preserve-client-protocol.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-preserve-client-protocol.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: envoy-gateway/gateway-1/http
   drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-regex.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-regex.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-filters.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-filters.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: envoy-gateway/gateway-btls/http
   drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-btls/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle-multiple-certs.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle-multiple-certs.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: envoy-gateway/gateway-btls/http
   drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-btls/http
   perConnectionBufferLimitBytes: 32768
@@ -63,6 +64,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: envoy-gateway/gateway-btls-2/http
   drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-btls-2/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: envoy-gateway/gateway-btls/http
   drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-btls/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.listeners.yaml
@@ -35,6 +35,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
@@ -76,6 +77,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: second-listener
   drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http1-trailers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-trailers.listeners.yaml
@@ -31,6 +31,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http10.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http10.listeners.yaml
@@ -32,6 +32,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.listeners.yaml
@@ -37,6 +37,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http2.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http3.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http3.listeners.yaml
@@ -33,6 +33,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: envoy-gateway/gateway-1/tls
     transportSocket:
       name: envoy.transport_sockets.quic
       typedConfig:
@@ -82,6 +83,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: envoy-gateway/gateway-1/tls
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch.listeners.yaml
@@ -42,6 +42,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: first-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
@@ -57,6 +57,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
@@ -114,6 +114,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
@@ -91,6 +91,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
@@ -60,6 +60,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
@@ -60,6 +60,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
@@ -50,6 +50,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/listener-connection-limit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-connection-limit.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
@@ -68,6 +69,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: second-listener
   drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.listeners.yaml
@@ -72,6 +72,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tls-route-dest
         statPrefix: tcp
+    name: tcp-route-dest
   listenerFilters:
   - name: envoy.filters.listener.proxy_protocol
     typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.listeners.yaml
@@ -33,6 +33,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: first-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
@@ -68,6 +69,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: second-listener
   drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/load-balancer.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/load-balancer.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.listeners.yaml
@@ -33,6 +33,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.listeners.yaml
@@ -30,6 +30,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: first-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.listeners.yaml
@@ -57,6 +57,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: default/gateway-1/http
   drainType: MODIFY_ONLY
   name: default/gateway-1/http-quic
   udpListenerConfig:
@@ -159,6 +160,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: default/gateway-1/http
   drainType: MODIFY_ONLY
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: third-listener
   drainType: MODIFY_ONLY
   filterChains:
   - filterChainMatch:
@@ -60,6 +61,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: first-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -102,6 +104,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: second-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
@@ -127,6 +127,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tcp-route-dest
         statPrefix: passthrough
+    name: fifth-route
   - filterChainMatch:
       serverNames:
       - bar.net
@@ -136,6 +137,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tls-route-dest
         statPrefix: passthrough
+    name: sixth-route
   listenerFilters:
   - name: envoy.filters.listener.tls_inspector
     typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.listeners.yaml
@@ -10,29 +10,34 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tcp-route-simple-dest
         statPrefix: tcp
+    name: tcp-route-simple
   - filters:
     - name: envoy.filters.network.tcp_proxy
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tcp-route-simple-1-dest
         statPrefix: tcp
+    name: tcp-route-simple-1
   - filters:
     - name: envoy.filters.network.tcp_proxy
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tcp-route-simple-2-dest
         statPrefix: tcp
+    name: tcp-route-simple-2
   - filters:
     - name: envoy.filters.network.tcp_proxy
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tcp-route-simple-3-dest
         statPrefix: tcp
+    name: tcp-route-simple-3
   - filters:
     - name: envoy.filters.network.tcp_proxy
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tcp-route-simple-4-dest
         statPrefix: tcp
+    name: tcp-route-simple-4
   name: tcp-listener-simple
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.listeners.yaml
@@ -30,6 +30,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: first-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -88,6 +89,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: second-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -148,6 +150,7 @@
           subject: true
         statPrefix: https
         useRemoteAddress: true
+    name: third-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -210,6 +213,7 @@
           uri: true
         statPrefix: https
         useRemoteAddress: true
+    name: fourth-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -274,6 +278,7 @@
           uri: true
         statPrefix: https
         useRemoteAddress: true
+    name: fifth-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate.listeners.yaml
@@ -30,6 +30,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: first-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -88,6 +89,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: second-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -146,6 +148,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: third-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -204,6 +207,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: fourth-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -262,6 +266,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: fifth-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.listeners.yaml
@@ -30,6 +30,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: first-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.listeners.yaml
@@ -68,6 +68,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tls-terminate-dest
         statPrefix: terminate
+    name: tls-route-terminate
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls.listeners.yaml
@@ -30,6 +30,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: first-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls.listeners.yaml
@@ -68,6 +68,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tls-terminate-dest
         statPrefix: terminate
+    name: tls-route-terminate
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.listeners.yaml
@@ -115,6 +115,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/path-settings.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/path-settings.listeners.yaml
@@ -28,6 +28,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.listeners.yaml
@@ -39,6 +39,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.listeners.yaml
@@ -38,6 +38,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.listeners.yaml
@@ -39,6 +39,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.listeners.yaml
@@ -39,6 +39,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.listeners.yaml
@@ -39,6 +39,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
@@ -30,6 +30,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: first-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.listeners.yaml
@@ -32,6 +32,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: first-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.listeners.yaml
@@ -15,6 +15,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tcp-route-complex-dest
         statPrefix: passthrough
+    name: tcp-route-complex
   listenerFilters:
   - name: envoy.filters.listener.tls_inspector
     typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.listeners.yaml
@@ -10,5 +10,6 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tcp-route-simple-dest
         statPrefix: tcp
+    name: tcp-route-simple
   name: tcp-listener-simple
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.listeners.yaml
@@ -10,6 +10,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tls-terminate-dest
         statPrefix: terminate
+    name: tls-route-terminate
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -33,6 +34,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tls-terminate-hostname-dest
         statPrefix: terminate
+    name: tls-terminate-hostname
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.listeners.yaml
@@ -15,6 +15,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tcp-route-weighted-backend-dest
         statPrefix: passthrough
+    name: tcp-route-weighted-backend
   listenerFilters:
   - name: envoy.filters.listener.tls_inspector
     typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/timeout.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/timeout.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.listeners.yaml
@@ -13,6 +13,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tls-passthrough-foo-dest
         statPrefix: passthrough
+    name: tls-route-passthrough-foo
   listenerFilters:
   - name: envoy.filters.listener.tls_inspector
     typedConfig:
@@ -34,6 +35,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tls-passthrough-bar-dest
         statPrefix: passthrough
+    name: tls-route-passthrough-bar
   listenerFilters:
   - name: envoy.filters.listener.tls_inspector
     typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.listeners.yaml
@@ -33,6 +33,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: https
         useRemoteAddress: true
+    name: first-listener
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.listeners.yaml
@@ -89,6 +89,7 @@
         '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
         cluster: tls-terminate-dest
         statPrefix: terminate
+    name: tls-route-terminate
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.listeners.yaml
@@ -57,6 +57,7 @@
             value: 90
           spawnUpstreamSpan: true
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/tracing.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing.listeners.yaml
@@ -58,6 +58,7 @@
             value: 90
           spawnUpstreamSpan: true
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.listeners.yaml
@@ -29,6 +29,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: first-listener
   drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/wasm.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/wasm.listeners.yaml
@@ -88,6 +88,7 @@
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http
         useRemoteAddress: true
+    name: envoy-gateway/gateway-1/http
   drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR populates the filterChain name in xDS listeners based on the listener from which a filter chain originated.

**Which issue(s) this PR fixes**:
Fixes #3461 
