### PR TITLE
chore: bump go to 1.22.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway
 
-go 1.22.3
+go 1.22.4
 
 require (
 	fortio.org/fortio v1.63.9

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/docsy-example
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2 // indirect

--- a/tools/src/buf/go.mod
+++ b/tools/src/buf/go.mod
@@ -1,6 +1,6 @@
 module local
 
-go 1.22.3
+go 1.22.4
 
 require github.com/bufbuild/buf v1.32.2
 

--- a/tools/src/controller-gen/go.mod
+++ b/tools/src/controller-gen/go.mod
@@ -1,6 +1,6 @@
 module local
 
-go 1.22.3
+go 1.22.4
 
 require sigs.k8s.io/controller-tools v0.15.0
 

--- a/tools/src/crd-ref-docs/go.mod
+++ b/tools/src/crd-ref-docs/go.mod
@@ -1,6 +1,6 @@
 module local
 
-go 1.22.3
+go 1.22.4
 
 require github.com/elastic/crd-ref-docs v0.0.13-0.20240413123740-ea9fcaa0230f
 

--- a/tools/src/golangci-lint/go.mod
+++ b/tools/src/golangci-lint/go.mod
@@ -1,6 +1,6 @@
 module local
 
-go 1.22.3
+go 1.22.4
 
 require github.com/golangci/golangci-lint v1.59.0
 

--- a/tools/src/helm-docs/go.mod
+++ b/tools/src/helm-docs/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway/tools/src/helm-docs
 
-go 1.22.3
+go 1.22.4
 
 require github.com/norwoodj/helm-docs v1.13.0
 

--- a/tools/src/kind/go.mod
+++ b/tools/src/kind/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway/tools/src/kind
 
-go 1.22.3
+go 1.22.4
 
 require sigs.k8s.io/kind v0.23.0
 

--- a/tools/src/protoc-gen-go-grpc/go.mod
+++ b/tools/src/protoc-gen-go-grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway/tools/src/protoc-gen-go-grpc
 
-go 1.22.3
+go 1.22.4
 
 require google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
 

--- a/tools/src/protoc-gen-go/go.mod
+++ b/tools/src/protoc-gen-go/go.mod
@@ -1,5 +1,5 @@
 module github.com/envoyproxy/gateway/tools/src/protoc-gen-go
 
-go 1.22.3
+go 1.22.4
 
 require google.golang.org/protobuf v1.33.0

--- a/tools/src/setup-envtest/go.mod
+++ b/tools/src/setup-envtest/go.mod
@@ -1,6 +1,6 @@
 module local
 
-go 1.22.3
+go 1.22.4
 
 require sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20240423173400-ed81fa696dea
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix CVEs breaking OSV and Trivy scans: 
- https://github.com/envoyproxy/gateway/actions/runs/9392620534/job/25867184358
- https://github.com/envoyproxy/gateway/actions/runs/9392620643/job/25867185043

