### PR TITLE
oidc: add tcp keep alive to idp

### DIFF
--- a/internal/xds/translator/oidc.go
+++ b/internal/xds/translator/oidc.go
@@ -274,6 +274,8 @@ func createOAuth2TokenEndpointClusters(tCtx *types.ResourceVersionTable,
 			settings:     []*ir.DestinationSetting{ds},
 			tSocket:      tSocket,
 			endpointType: cluster.endpointType,
+			// This is a workaround for the lack of retry policy in the OAuth2 filter.
+			tcpkeepalive: &ir.TCPKeepalive{},
 		}
 		if cluster.tls {
 			tSocket, err = buildXdsUpstreamTLSSocket(cluster.hostname)

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.clusters.yaml
@@ -102,3 +102,5 @@
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: oauth.foo.com
   type: STRICT_DNS
+  upstreamConnectionOptions:
+    tcpKeepalive: {}

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
@@ -68,6 +68,8 @@
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: oauth.foo.com
   type: STRICT_DNS
+  upstreamConnectionOptions:
+    tcpKeepalive: {}
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
@@ -104,3 +106,5 @@
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: oauth.bar.com
   type: STRICT_DNS
+  upstreamConnectionOptions:
+    tcpKeepalive: {}


### PR DESCRIPTION
This PR adds a `tcpkeepalive` to the IDP provider cluster of OIDC.

This is a workaround before retry is supported in Envoy upstream. https://github.com/envoyproxy/envoy/issues/33572

Fix: https://github.com/envoyproxy/gateway/issues/3178