### PR TITLE
bug: ClientTrafficPolicy resources are prevented from targeting a SectionName by an incorrect CEL validation

### DIFF
--- a/api/v1alpha1/clienttrafficpolicy_types.go
+++ b/api/v1alpha1/clienttrafficpolicy_types.go
@@ -38,7 +38,6 @@ type ClientTrafficPolicy struct {
 type ClientTrafficPolicySpec struct {
 	// +kubebuilder:validation:XValidation:rule="self.group == 'gateway.networking.k8s.io'", message="this policy can only have a targetRef.group of gateway.networking.k8s.io"
 	// +kubebuilder:validation:XValidation:rule="self.kind == 'Gateway'", message="this policy can only have a targetRef.kind of Gateway"
-	// +kubebuilder:validation:XValidation:rule="!has(self.sectionName)",message="this policy does not yet support the sectionName field"
 	//
 	// TargetRef is the name of the Gateway resource this policy
 	// is being attached to.

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
@@ -366,8 +366,6 @@ spec:
                   rule: self.group == 'gateway.networking.k8s.io'
                 - message: this policy can only have a targetRef.kind of Gateway
                   rule: self.kind == 'Gateway'
-                - message: this policy does not yet support the sectionName field
-                  rule: '!has(self.sectionName)'
               tcpKeepalive:
                 description: |-
                   TcpKeepalive settings associated with the downstream client connection.

--- a/test/cel-validation/clienttrafficpolicy_test.go
+++ b/test/cel-validation/clienttrafficpolicy_test.go
@@ -34,8 +34,6 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 		Spec: egv1a1.ClientTrafficPolicySpec{},
 	}
 
-	sectionName := gwapiv1a2.SectionName("foo")
-
 	cases := []struct {
 		desc         string
 		mutate       func(ctp *egv1a1.ClientTrafficPolicy)

--- a/test/cel-validation/clienttrafficpolicy_test.go
+++ b/test/cel-validation/clienttrafficpolicy_test.go
@@ -122,23 +122,6 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			},
 		},
 		{
-			desc: "sectionName disabled until supported",
-			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
-				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
-					TargetRef: gwapiv1a2.LocalPolicyTargetReferenceWithSectionName{
-						LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{
-							Group: gwapiv1a2.Group("gateway.networking.k8s.io"),
-							Kind:  gwapiv1a2.Kind("Gateway"),
-						},
-						SectionName: &sectionName,
-					},
-				}
-			},
-			wantErrors: []string{
-				"spec.targetRef: Invalid value: \"object\": this policy does not yet support the sectionName field",
-			},
-		},
-		{
 			desc: "tls minimal version greater than tls maximal version",
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{


### PR DESCRIPTION
Removed CEL validation that prevents specifying a `SectionName` for `ClientTrafficPolicy` resources.

The `ClientTrafficPolicy` translation does in-fact support targeting a specific `SectionName`, the CEL validation is wrong.