### PR TITLE
bug: cel tests are always run on a single version of Kubernetes

### DIFF
--- a/tools/make/golang.mk
+++ b/tools/make/golang.mk
@@ -66,7 +66,7 @@ go.test.cel: manifests $(tools/setup-envtest) # Run the CEL validation tests
 	@for ver in $(ENVTEST_K8S_VERSIONS); do \
   		echo "Run CEL Validation on k8s $$ver"; \
         go clean -testcache; \
-        KUBEBUILDER_ASSETS="$(shell $(tools/setup-envtest) use $$ver -p path)" \
+        KUBEBUILDER_ASSETS="$$($(tools/setup-envtest) use $$ver -p path)" \
          go test ./test/cel-validation --tags celvalidation -race; \
     done
 


### PR DESCRIPTION
The cel test invocation was using the wrong verison of Kubernetes every time it was being run.

Here's what the Makefile did before the fix:

```bash
echo -e "\033[0;32m===========> Running go.test.cel ... \033[0m"
for ver in 1.27.1 1.28.0 1.29.0; do \
  		echo "Run CEL Validation on k8s $ver"; \
        go clean -testcache; \
        KUBEBUILDER_ASSETS="/home/user/.local/share/kubebuilder-envtest/k8s/1.30.0-linux-amd64" \
         go test ./test/cel-validation --tags celvalidation -race; \
    done
```

Notice that the `KUBEBUILDER_ASSETS` is already hardcoded to version 1.30. This is because the `$(shell)` expansion used is evaluated only once before make runs the for loop.

Here's what it looks like after the fix:

```bash
echo -e "\033[0;32m===========> Running go.test.cel ... \033[0m"
for ver in 1.27.1 1.28.0 1.29.0; do \
  		echo "Run CEL Validation on k8s $ver"; \
        go clean -testcache; \
        KUBEBUILDER_ASSETS="$(tools/bin/setup-envtest use $ver -p path)" \
         go test ./test/cel-validation --tags celvalidation -race; \
    done
```

Notice that this time `setup-envtest` is called with the correct version every time.