### PR TITLE
fix: envoy shutdown flaky test

### DIFF
--- a/test/config/gatewayclass.yaml
+++ b/test/config/gatewayclass.yaml
@@ -106,6 +106,16 @@ spec:
     kubernetes:
       envoyDeployment:
         replicas: 2
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: envoy
+                      readinessProbe:
+                        initialDelaySeconds: 5
 ---
 kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1

--- a/test/e2e/upgrade/eg_upgrade_test.go
+++ b/test/e2e/upgrade/eg_upgrade_test.go
@@ -56,8 +56,7 @@ func TestEGUpgrade(t *testing.T) {
 		// All e2e tests should leave Features empty.
 		SupportedFeatures: sets.New[features.SupportedFeature](features.SupportGateway),
 		SkipTests: []string{
-			tests.EnvoyShutdownTest.ShortName, // https://github.com/envoyproxy/gateway/issues/3262
-			tests.EGUpgradeTest.ShortName,     // https://github.com/envoyproxy/gateway/issues/3311
+			tests.EGUpgradeTest.ShortName, // https://github.com/envoyproxy/gateway/issues/3311
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR delays readiness of envoy to allow XDS sync as discussed in #2810. This is done specifically for the upgrade test suite gateway class. 

Test flakiness seems to be related to 404 responses in early stages of the load test, which likely indicates that new proxy instances are ready before being programmed. 

```sh
--- FAIL: TestEGUpgrade (230.50s)
    --- PASS: TestEGUpgrade/EGUpgrade (152.90s)
        --- PASS: TestEGUpgrade/EGUpgrade/Upgrade_from_an_older_eg_release_should_succeed (152.89s)
    --- FAIL: TestEGUpgrade/EnvoyShutdown (68.06s)
        --- FAIL: TestEGUpgrade/EnvoyShutdown/All_requests_must_succeed (68.04s)
        utils.go:176: failed to create load: error 404 for http://172.18.255.208/envoy-shutdown (82 bytes)
        utils.go:185: Load completed after 0s with 2 requests, 0 success, 2 failures and 2 errors
```

**Which issue(s) this PR fixes**:
Fixes #3262 
