### PR TITLE
feat: support target selectors on Envoy Gateway Extension Server policies

### DIFF
--- a/internal/gatewayapi/extensionserverpolicy.go
+++ b/internal/gatewayapi/extensionserverpolicy.go
@@ -18,6 +18,7 @@ import (
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/gatewayapi/status"
 	"github.com/envoyproxy/gateway/internal/ir"
 	"github.com/envoyproxy/gateway/internal/utils"
@@ -50,7 +51,7 @@ func (t *Translator) ProcessExtensionServerPolicies(policies []unstructured.Unst
 		policy := policy.DeepCopy()
 		var policyStatus gwapiv1a2.PolicyStatus
 		accepted := false
-		targetRefs, err := extractTargetRefs(policy)
+		targetRefs, err := extractTargetRefs(policy, gateways)
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("error finding targetRefs for policy %s: %w", policy.GetName(), err))
 			continue
@@ -96,34 +97,20 @@ func (t *Translator) ProcessExtensionServerPolicies(policies []unstructured.Unst
 	return res, errs
 }
 
-func extractTargetRefs(policy *unstructured.Unstructured) ([]gwapiv1a2.LocalPolicyTargetReferenceWithSectionName, error) {
-	ret := []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName{}
+func extractTargetRefs(policy *unstructured.Unstructured, gateways []*GatewayContext) ([]gwapiv1a2.LocalPolicyTargetReferenceWithSectionName, error) {
 	spec, found := policy.Object["spec"].(map[string]any)
 	if !found {
 		return nil, fmt.Errorf("no targets found for the policy")
 	}
-	targetRefs, found := spec["targetRefs"]
-	if found {
-		if refArr, ok := targetRefs.([]any); ok {
-			for i := range refArr {
-				ref, err := extractSingleTargetRef(refArr[i])
-				if err != nil {
-					return nil, err
-				}
-				ret = append(ret, ref)
-			}
-		} else {
-			return nil, fmt.Errorf("targetRefs is not an array")
-		}
+	specAsJson, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("no targets found for the policy")
 	}
-	targetRef, found := spec["targetRef"]
-	if found {
-		ref, err := extractSingleTargetRef(targetRef)
-		if err != nil {
-			return nil, err
-		}
-		ret = append(ret, ref)
+	var targetRefs egv1a1.PolicyTargetReferences
+	if err := json.Unmarshal(specAsJson, &targetRefs); err != nil {
+		return nil, fmt.Errorf("no targets found for the policy")
 	}
+	ret := getPolicyTargetRefs(targetRefs, gateways)
 	if len(ret) == 0 {
 		return nil, fmt.Errorf("no targets found for the policy")
 	}

--- a/internal/gatewayapi/extensionserverpolicy.go
+++ b/internal/gatewayapi/extensionserverpolicy.go
@@ -102,12 +102,12 @@ func extractTargetRefs(policy *unstructured.Unstructured, gateways []*GatewayCon
 	if !found {
 		return nil, fmt.Errorf("no targets found for the policy")
 	}
-	specAsJson, err := json.Marshal(spec)
+	specAsJSON, err := json.Marshal(spec)
 	if err != nil {
 		return nil, fmt.Errorf("no targets found for the policy")
 	}
 	var targetRefs egv1a1.PolicyTargetReferences
-	if err := json.Unmarshal(specAsJson, &targetRefs); err != nil {
+	if err := json.Unmarshal(specAsJSON, &targetRefs); err != nil {
 		return nil, fmt.Errorf("no targets found for the policy")
 	}
 	ret := getPolicyTargetRefs(targetRefs, gateways)
@@ -115,21 +115,6 @@ func extractTargetRefs(policy *unstructured.Unstructured, gateways []*GatewayCon
 		return nil, fmt.Errorf("no targets found for the policy")
 	}
 	return ret, nil
-}
-
-func extractSingleTargetRef(data any) (gwapiv1a2.LocalPolicyTargetReferenceWithSectionName, error) {
-	var currRef gwapiv1a2.LocalPolicyTargetReferenceWithSectionName
-	d, err := json.Marshal(data)
-	if err != nil {
-		return currRef, err
-	}
-	if err := json.Unmarshal(d, &currRef); err != nil {
-		return currRef, err
-	}
-	if currRef.Group == "" || currRef.Name == "" || currRef.Kind == "" {
-		return currRef, fmt.Errorf("invalid targetRef found: %s", string(d))
-	}
-	return currRef, nil
 }
 
 func policyStatusToUnstructured(policyStatus gwapiv1a2.PolicyStatus) map[string]any {

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -542,7 +542,12 @@ func getPolicyTargetRefs[T client.Object](policy egv1a1.PolicyTargetReferences, 
 	// to targets that were already found via the selectors. Only add them to the returned list if
 	// they are not yet there. Always add them at the end.
 	fastLookup := sets.New(ret...)
+	var emptyTargetRef gwapiv1a2.LocalPolicyTargetReferenceWithSectionName
 	for _, v := range policy.GetTargetRefs() {
+		if v == emptyTargetRef {
+			// This can happen when the targetRef structure is read from extension server policies
+			continue
+		}
 		if !fastLookup.Has(v) {
 			ret = append(ret, v)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for target selectors on extension server policies

**Which issue(s) this PR fixes**:
Fixes #3798 
