### PR TITLE
fix: enable client timeout test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -55,7 +55,6 @@ func TestE2E(t *testing.T) {
 		// All e2e tests should leave Features empty.
 		SupportedFeatures: sets.New[features.SupportedFeature](features.SupportGateway),
 		SkipTests: []string{
-			tests.ClientTimeoutTest.ShortName,        // https://github.com/envoyproxy/gateway/issues/2720
 			tests.GatewayInfraResourceTest.ShortName, // https://github.com/envoyproxy/gateway/issues/3191
 			tests.UseClientProtocolTest.ShortName,    // https://github.com/envoyproxy/gateway/issues/3473
 		},

--- a/test/e2e/testdata/client-timeout.yaml
+++ b/test/e2e/testdata/client-timeout.yaml
@@ -7,7 +7,7 @@ spec:
   targetRef:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
-    name: client-timeout
+    name: http-client-timeout
   faultInjection:
     delay:
       fixedDelay: 100ms

--- a/test/e2e/testdata/client-timeout.yaml
+++ b/test/e2e/testdata/client-timeout.yaml
@@ -1,4 +1,18 @@
 apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: client-timeout
+  namespace: gateway-conformance-infra
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: client-timeout
+  faultInjection:
+    delay:
+      fixedDelay: 100ms
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:
   name: client-timeout
@@ -8,10 +22,9 @@ spec:
     group: gateway.networking.k8s.io
     kind: Gateway
     name: same-namespace
-    namespace: gateway-conformance-infra
   timeout:
     http:
-      requestReceivedTimeout: 1ms
+      requestReceivedTimeout: 50ms
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
Uses fault filter to create a more predictable timeout for request, by delaying it before being sent upstream and triggering the timeout: 

https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-request-timeout

> The amount of time that Envoy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent upstream


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2720 
