### PR TITLE
Use Wasm instead of WASM

### DIFF
--- a/internal/gatewayapi/envoyextensionpolicy.go
+++ b/internal/gatewayapi/envoyextensionpolicy.go
@@ -321,7 +321,7 @@ func (t *Translator) translateEnvoyExtensionPolicyForRoute(
 	)
 
 	if wasms, err = t.buildWasms(policy, resources); err != nil {
-		err = perr.WithMessage(err, "WASM")
+		err = perr.WithMessage(err, "Wasm")
 		errs = errors.Join(errs, err)
 	}
 
@@ -380,7 +380,7 @@ func (t *Translator) translateEnvoyExtensionPolicyForGateway(
 		errs = errors.Join(errs, err)
 	}
 	if wasms, err = t.buildWasms(policy, resources); err != nil {
-		err = perr.WithMessage(err, "WASM")
+		err = perr.WithMessage(err, "Wasm")
 		errs = errors.Join(errs, err)
 	}
 

--- a/internal/gatewayapi/ext_service.go
+++ b/internal/gatewayapi/ext_service.go
@@ -82,7 +82,7 @@ func (t *Translator) processExtServiceDestination(
 	return ds, nil
 }
 
-// TODO: also refer to extension type, as WASM may also introduce destinations
+// TODO: also refer to extension type, as Wasm may also introduce destinations
 func irIndexedExtServiceDestinationName(policyNamespacedName types.NamespacedName, policyKind string, idx int) string {
 	return strings.ToLower(fmt.Sprintf(
 		"%s/%s/%s/%d",

--- a/release-notes/v1.1.0-rc.1.yaml
+++ b/release-notes/v1.1.0-rc.1.yaml
@@ -123,7 +123,7 @@ changes:
       Added Support for Loadbalancing Header Hash Policy in BackendTrafficPolicy CRD
       Added Support for Cluster Connection Buffer Size Limit in BackendTrafficPolicy
       Added Support for more Rate Limit Rules in BackendTrafficPolicy CRD
-      Added Support for WASM extension in EnvoyExtensionPolicy CRD
+      Added Support for Wasm extension in EnvoyExtensionPolicy CRD
       Added Support for External Processing extension in EnvoyExtensionPolicy CRD
       Removed Status Print Column from xPolicy CRDs
 
@@ -145,7 +145,7 @@ changes:
       Added e2e test for CEL Access Log Filter
       Added e2e test for GRPC Access Log Service Sink
       Added e2e test for XDS Metadata
-      Added e2e test for WASM from OCI Images and HTTP Source
+      Added e2e test for Wasm from OCI Images and HTTP Source
       Added e2e test for Service IP Routing
       Added e2e test for Multiple GatewayClasses
       Added e2e test for HTTP Full Path rewrite

--- a/site/content/en/contributions/design/envoy-extension-policy.md
+++ b/site/content/en/contributions/design/envoy-extension-policy.md
@@ -113,22 +113,22 @@ spec:
 ## Features / API Fields
 Here is a list of features that can be included in this API
 * Network Filters:
-    * WASM
+    * Wasm
     * Golang
 * HTTP Filters:
     * External Processing
     * Lua
-    * WASM
+    * Wasm
     * Golang
 
 ## Design Decisions
 * This API will only support a single `targetRef` and can bind to a `Gateway` resource or a `HTTPRoute` or `GRPCRoute` or `TCPRoute`.
-* Extensions that support both Network and HTTP filter variants (e.g. WASM, Golang) will be translated to the appropriate filter type according to the sort of route that they attach to.
+* Extensions that support both Network and HTTP filter variants (e.g. Wasm, Golang) will be translated to the appropriate filter type according to the sort of route that they attach to.
 * Extensions that only support HTTP extensibility (Ext-Proc, LUA) can only be attached to HTTP/GRPC Routes.  
 * A user-defined extension that is added to the request processing flow can have a significant impact on security,
   resilience and performance of the proxy. Gateway Operators can restrict access to the extensibility policy using K8s RBAC. 
 * Users may need to customize the order of extension and built-in filters. This will be addressed in a separate issue.  
-* Gateway operators may need to include multiple extensions (e.g. WASM modules developed by different teams and distributed separately). 
+* Gateway operators may need to include multiple extensions (e.g. Wasm modules developed by different teams and distributed separately). 
   This API will support attachment of multiple policies. Extension will execute in an order defined by the priority field.
 * This API resource MUST be part of same namespace as the targetRef resource
 * If the policy targets a resource but cannot attach to it, this information should be reflected

--- a/site/content/en/news/blogs/1.0-release/1.0-release.md
+++ b/site/content/en/news/blogs/1.0-release/1.0-release.md
@@ -57,7 +57,7 @@ Following the 1.0 release, we’ll be focusing on:
   * Exposing more knobs to fine tune more traffic shaping parameters
 * **Features**: More API Gateway features such as authorization (IP Addresses, JWT Claims, API Key, etc.) and compression
 * **Scale**: Building out a performance benchmarking tool into our CI
-* **Extensibility**: We plan on providing a first-class API for data plane extensions such as Lua, WASM, and Ext Proc to enable users to implement their custom use cases
+* **Extensibility**: We plan on providing a first-class API for data plane extensions such as Lua, Wasm, and Ext Proc to enable users to implement their custom use cases
 * **Outside of Kubernetes**: Running Envoy Gateway in non-k8s environments - this has been an [explicit goal](/contributions/design/goals#all-environments) and we’d like to focus on this in the coming months. Envoy Proxy already supports running on bare metal environments, with Envoy Gateway users getting the added advantage of a simpler API
 * **Debug**: And a lot of capabilities with the [egctl CLI](/v1.0.2/tasks/operations/egctl/)
 


### PR DESCRIPTION
This is a really common mistake but WebAssembly is officially Wasm,
not WASM. This fixes that in various places in code base.