### PR TITLE
chore: move backend tls test resources out of the base

### DIFF
--- a/test/e2e/base/manifests.yaml
+++ b/test/e2e/base/manifests.yaml
@@ -50,33 +50,6 @@ spec:
       name: zipkin-tracing
       namespace: envoy-gateway-system
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: backend-namespaces
-  namespace: gateway-conformance-infra
-spec:
-  gatewayClassName: "{GATEWAY_CLASS_NAME}"
-  listeners:
-  - name: https
-    port: 443
-    protocol: HTTPS
-    tls:
-      certificateRefs:
-      - group: ""
-        kind: Secret
-        name: backend-tls-certificate
-      mode: Terminate
-  - name: http
-    port: 80
-    protocol: HTTP
-    allowedRoutes:
-      namespaces:
-        from: Selector
-        selector:
-          matchLabels:
-            gateway-conformance: backend
----
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:

--- a/test/e2e/base/manifests.yaml
+++ b/test/e2e/base/manifests.yaml
@@ -971,3 +971,6 @@ spec:
   shutdown:
     drainTimeout: 5s
     minDrainDuration: 1s
+
+# Important: please do not add resources to this manifest unless they are shared resources used by multiple tests.
+# If you need to add resources specific to a single test, please add them to the test's manifest file in the testdata directory.

--- a/test/e2e/testdata/backend-tls-settings.yaml
+++ b/test/e2e/testdata/backend-tls-settings.yaml
@@ -11,9 +11,9 @@ spec:
       protocol: HTTPS
       tls:
         certificateRefs:
-        - group: ""
-          kind: Secret
-          name: backend-tls-certificate
+          - group: ""
+            kind: Secret
+            name: backend-tls-certificate
         mode: Terminate
     - name: http
       port: 80

--- a/test/e2e/testdata/backend-tls-settings.yaml
+++ b/test/e2e/testdata/backend-tls-settings.yaml
@@ -6,24 +6,24 @@ metadata:
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
   listeners:
-  - name: https
-    port: 443
-    protocol: HTTPS
-    tls:
-      certificateRefs:
-      - group: ""
-        kind: Secret
-        name: backend-tls-certificate
-      mode: Terminate
-  - name: http
-    port: 80
-    protocol: HTTP
-    allowedRoutes:
-      namespaces:
-        from: Selector
-        selector:
-          matchLabels:
-            gateway-conformance: backend
+    - name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+        - group: ""
+          kind: Secret
+          name: backend-tls-certificate
+        mode: Terminate
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              gateway-conformance: backend
 ---
 apiVersion: v1
 data:

--- a/test/e2e/testdata/backend-tls-settings.yaml
+++ b/test/e2e/testdata/backend-tls-settings.yaml
@@ -1,3 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: backend-namespaces
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: https
+    port: 443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: backend-tls-certificate
+      mode: Terminate
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Selector
+        selector:
+          matchLabels:
+            gateway-conformance: backend
+---
 apiVersion: v1
 data:
   ca.crt: |

--- a/test/e2e/tests/oidc.go
+++ b/test/e2e/tests/oidc.go
@@ -78,7 +78,7 @@ var OIDCTest = suite.ConformanceTest{
 			)
 			require.NoError(t, err)
 
-			if err := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
+			if err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 5*time.Minute, true,
 				func(_ context.Context) (done bool, err error) {
 					t.Logf("sending request to %s", testURL)
 

--- a/test/e2e/tests/oidc.go
+++ b/test/e2e/tests/oidc.go
@@ -85,6 +85,7 @@ var OIDCTest = suite.ConformanceTest{
 					// Send a request to the http route with OIDC configured.
 					// It will be redirected to the keycloak login page
 					res, err := client.Get(testURL, true)
+					require.NoError(t, err, "Failed to get the login page")
 					require.Equal(t, 200, res.StatusCode, "Expected 200 OK")
 
 					// Parse the response body to get the URL where the login page would post the user-entered credentials

--- a/test/e2e/tests/oidc_testclient.go
+++ b/test/e2e/tests/oidc_testclient.go
@@ -212,7 +212,7 @@ func extractFromData(responseBody string, match formMatch, includeFromInputs boo
 	// Find the form with the specified ID or match criteria
 	form := findForm(doc, match)
 	if form == nil {
-		return "", "", nil, fmt.Errorf("%s not found", match)
+		return "", "", nil, fmt.Errorf("%s not found in %s", match, responseBody)
 	}
 
 	var (

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -93,6 +93,7 @@ func SecurityPolicyMustBeAccepted(t *testing.T, client client.Client, policyName
 		}
 
 		if policyAcceptedByAncestor(policy.Status.Ancestors, controllerName, ancestorRef) {
+			t.Logf("SecurityPolicy has been accepted: %v", policy)
 			return true, nil
 		}
 


### PR DESCRIPTION
* move backend tls test resources out of the base to reduce resource consumption of e2e tests.
* fix flaky OIDC test.