### PR TITLE
chore: move tcp test resources out of the base

### DIFF
--- a/test/e2e/base/manifests.yaml
+++ b/test/e2e/base/manifests.yaml
@@ -77,27 +77,6 @@ spec:
           matchLabels:
             gateway-conformance: backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: Gateway
-metadata:
-  name: my-tcp-gateway
-  namespace: gateway-conformance-infra
-spec:
-  gatewayClassName: "{GATEWAY_CLASS_NAME}"
-  listeners:
-  - name: foo
-    protocol: TCP
-    port: 8080
-    allowedRoutes:
-      kinds:
-      - kind: TCPRoute
-  - name: bar
-    protocol: TCP
-    port: 8090
-    allowedRoutes:
-      kinds:
-      - kind: TCPRoute
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/test/e2e/testdata/tcp-route.yaml
+++ b/test/e2e/testdata/tcp-route.yaml
@@ -1,3 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: my-tcp-gateway
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: foo
+    protocol: TCP
+    port: 8080
+    allowedRoutes:
+      kinds:
+      - kind: TCPRoute
+  - name: bar
+    protocol: TCP
+    port: 8090
+    allowedRoutes:
+      kinds:
+      - kind: TCPRoute
+---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:


### PR DESCRIPTION
move tcp test resources out of the base to reduce resource consumption of e2e tests.