### PR TITLE
disable writing into GatewayClass.Status.SupportedFeatures

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -196,30 +196,6 @@ gatewayClass:
       reason: Accepted
       status: "True"
       type: Accepted
-    supportedFeatures:
-    - GRPCRoute
-    - Gateway
-    - GatewayPort8080
-    - HTTPRoute
-    - HTTPRouteBackendProtocolH2C
-    - HTTPRouteBackendProtocolWebSocket
-    - HTTPRouteBackendRequestHeaderModification
-    - HTTPRouteBackendTimeout
-    - HTTPRouteDestinationPortMatching
-    - HTTPRouteHostRewrite
-    - HTTPRouteMethodMatching
-    - HTTPRouteParentRefPort
-    - HTTPRoutePathRedirect
-    - HTTPRoutePathRewrite
-    - HTTPRoutePortRedirect
-    - HTTPRouteQueryParamMatching
-    - HTTPRouteRequestMirror
-    - HTTPRouteRequestMultipleMirrors
-    - HTTPRouteRequestTimeout
-    - HTTPRouteResponseHeaderModification
-    - HTTPRouteSchemeRedirect
-    - ReferenceGrant
-    - TLSRoute
 gateways:
 - metadata:
     creationTimestamp: null

--- a/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
@@ -12,30 +12,6 @@ gatewayClass:
       reason: Accepted
       status: "True"
       type: Accepted
-    supportedFeatures:
-    - GRPCRoute
-    - Gateway
-    - GatewayPort8080
-    - HTTPRoute
-    - HTTPRouteBackendProtocolH2C
-    - HTTPRouteBackendProtocolWebSocket
-    - HTTPRouteBackendRequestHeaderModification
-    - HTTPRouteBackendTimeout
-    - HTTPRouteDestinationPortMatching
-    - HTTPRouteHostRewrite
-    - HTTPRouteMethodMatching
-    - HTTPRouteParentRefPort
-    - HTTPRoutePathRedirect
-    - HTTPRoutePathRewrite
-    - HTTPRoutePortRedirect
-    - HTTPRouteQueryParamMatching
-    - HTTPRouteRequestMirror
-    - HTTPRouteRequestMultipleMirrors
-    - HTTPRouteRequestTimeout
-    - HTTPRouteResponseHeaderModification
-    - HTTPRouteSchemeRedirect
-    - ReferenceGrant
-    - TLSRoute
 gateways:
 - metadata:
     creationTimestamp: null

--- a/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.route.json
+++ b/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.route.json
@@ -17,31 +17,6 @@
           "reason": "Accepted",
           "message": "Valid GatewayClass"
         }
-      ],
-      "supportedFeatures": [
-        "GRPCRoute",
-        "Gateway",
-        "GatewayPort8080",
-        "HTTPRoute",
-        "HTTPRouteBackendProtocolH2C",
-        "HTTPRouteBackendProtocolWebSocket",
-        "HTTPRouteBackendRequestHeaderModification",
-        "HTTPRouteBackendTimeout",
-        "HTTPRouteDestinationPortMatching",
-        "HTTPRouteHostRewrite",
-        "HTTPRouteMethodMatching",
-        "HTTPRouteParentRefPort",
-        "HTTPRoutePathRedirect",
-        "HTTPRoutePathRewrite",
-        "HTTPRoutePortRedirect",
-        "HTTPRouteQueryParamMatching",
-        "HTTPRouteRequestMirror",
-        "HTTPRouteRequestMultipleMirrors",
-        "HTTPRouteRequestTimeout",
-        "HTTPRouteResponseHeaderModification",
-        "HTTPRouteSchemeRedirect",
-        "ReferenceGrant",
-        "TLSRoute"
       ]
     }
   },

--- a/internal/cmd/egctl/testdata/translate/out/invalid-envoyproxy.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/invalid-envoyproxy.all.yaml
@@ -38,30 +38,6 @@ gatewayClass:
       reason: InvalidParameters
       status: "False"
       type: Accepted
-    supportedFeatures:
-    - GRPCRoute
-    - Gateway
-    - GatewayPort8080
-    - HTTPRoute
-    - HTTPRouteBackendProtocolH2C
-    - HTTPRouteBackendProtocolWebSocket
-    - HTTPRouteBackendRequestHeaderModification
-    - HTTPRouteBackendTimeout
-    - HTTPRouteDestinationPortMatching
-    - HTTPRouteHostRewrite
-    - HTTPRouteMethodMatching
-    - HTTPRouteParentRefPort
-    - HTTPRoutePathRedirect
-    - HTTPRoutePathRewrite
-    - HTTPRoutePortRedirect
-    - HTTPRouteQueryParamMatching
-    - HTTPRouteRequestMirror
-    - HTTPRouteRequestMultipleMirrors
-    - HTTPRouteRequestTimeout
-    - HTTPRouteResponseHeaderModification
-    - HTTPRouteSchemeRedirect
-    - ReferenceGrant
-    - TLSRoute
 gateways:
 - metadata:
     creationTimestamp: null

--- a/internal/cmd/egctl/testdata/translate/out/rejected-http-route.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/rejected-http-route.route.yaml
@@ -12,30 +12,6 @@ gatewayClass:
       reason: Accepted
       status: "True"
       type: Accepted
-    supportedFeatures:
-    - GRPCRoute
-    - Gateway
-    - GatewayPort8080
-    - HTTPRoute
-    - HTTPRouteBackendProtocolH2C
-    - HTTPRouteBackendProtocolWebSocket
-    - HTTPRouteBackendRequestHeaderModification
-    - HTTPRouteBackendTimeout
-    - HTTPRouteDestinationPortMatching
-    - HTTPRouteHostRewrite
-    - HTTPRouteMethodMatching
-    - HTTPRouteParentRefPort
-    - HTTPRoutePathRedirect
-    - HTTPRoutePathRewrite
-    - HTTPRoutePortRedirect
-    - HTTPRouteQueryParamMatching
-    - HTTPRouteRequestMirror
-    - HTTPRouteRequestMultipleMirrors
-    - HTTPRouteRequestTimeout
-    - HTTPRouteResponseHeaderModification
-    - HTTPRouteSchemeRedirect
-    - ReferenceGrant
-    - TLSRoute
 gateways:
 - metadata:
     creationTimestamp: null

--- a/internal/cmd/egctl/testdata/translate/out/valid-envoyproxy.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/valid-envoyproxy.all.yaml
@@ -31,30 +31,6 @@ gatewayClass:
       reason: Accepted
       status: "True"
       type: Accepted
-    supportedFeatures:
-    - GRPCRoute
-    - Gateway
-    - GatewayPort8080
-    - HTTPRoute
-    - HTTPRouteBackendProtocolH2C
-    - HTTPRouteBackendProtocolWebSocket
-    - HTTPRouteBackendRequestHeaderModification
-    - HTTPRouteBackendTimeout
-    - HTTPRouteDestinationPortMatching
-    - HTTPRouteHostRewrite
-    - HTTPRouteMethodMatching
-    - HTTPRouteParentRefPort
-    - HTTPRoutePathRedirect
-    - HTTPRoutePathRewrite
-    - HTTPRoutePortRedirect
-    - HTTPRouteQueryParamMatching
-    - HTTPRouteRequestMirror
-    - HTTPRouteRequestMultipleMirrors
-    - HTTPRouteRequestTimeout
-    - HTTPRouteResponseHeaderModification
-    - HTTPRouteSchemeRedirect
-    - ReferenceGrant
-    - TLSRoute
 gateways:
 - metadata:
     creationTimestamp: null

--- a/internal/cmd/egctl/translate_test.go
+++ b/internal/cmd/egctl/translate_test.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/envoyproxy/gateway/internal/gatewayapi/status"
 	"github.com/envoyproxy/gateway/internal/utils/field"
 	"github.com/envoyproxy/gateway/internal/utils/file"
 )
@@ -360,9 +359,10 @@ func TestTranslate(t *testing.T) {
 
 			// Supported features are dynamic, instead of hard-coding them in the output files
 			// we define them here.
-			if want.GatewayClass != nil {
-				want.GatewayClass.Status.SupportedFeatures = status.GatewaySupportedFeatures
-			}
+			// Disabled until GatewayClass.Status.SupportedFeatures is stable
+			// if want.GatewayClass != nil {
+			//	want.GatewayClass.Status.SupportedFeatures = status.GatewaySupportedFeatures
+			// }
 
 			opts := cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")
 			require.Empty(t, cmp.Diff(want, got, opts))

--- a/internal/gatewayapi/status/gatewayclass.go
+++ b/internal/gatewayapi/status/gatewayclass.go
@@ -37,7 +37,10 @@ const (
 // for the provided GatewayClass.
 func SetGatewayClassAccepted(gc *gwapiv1.GatewayClass, accepted bool, reason, msg string) *gwapiv1.GatewayClass {
 	gc.Status.Conditions = MergeConditions(gc.Status.Conditions, computeGatewayClassAcceptedCondition(gc, accepted, reason, msg))
-	gc.Status.SupportedFeatures = GatewaySupportedFeatures
+	// Disable SupportedFeatures until the field moves from experimental to stable to avoid
+	// status failures due to changes in the datatype. This can occur because we cannot control
+	// how a CRD is installed in the cluster
+	// gc.Status.SupportedFeatures = GatewaySupportedFeatures
 	return gc
 }
 


### PR DESCRIPTION
disable until the field moves from experiemental to stable so status writes for a GatewayClass dont fail when the datatypes differ

Relates to a breaking change soon to be introduced in https://github.com/kubernetes-sigs/gateway-api/pull/3200.