### PR TITLE
feat(translator): add regex origins for CORS

### DIFF
--- a/api/v1alpha1/cors_types.go
+++ b/api/v1alpha1/cors_types.go
@@ -26,11 +26,22 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:validation:Pattern=`^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$`
 type Origin string
 
+// RegexOrigin is
+//
+// For example, the following are valid origins:
+// - https://foo.example.com
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+type RegexOrigin string
+
 // CORS defines the configuration for Cross-Origin Resource Sharing (CORS).
 type CORS struct {
 	// AllowOrigins defines the origins that are allowed to make requests.
 	// +kubebuilder:validation:MinItems=1
 	AllowOrigins []Origin `json:"allowOrigins,omitempty" yaml:"allowOrigins"`
+	// AllowRegexOrigins defines the origin regexes that are allowed to make requests.
+	AllowRegexOrigins []RegexOrigin `json:"allowRegexOrigins,omitempty" yaml:"allowRegexOrigins"`
 	// AllowMethods defines the methods that are allowed to make requests.
 	// +kubebuilder:validation:MinItems=1
 	AllowMethods []string `json:"allowMethods,omitempty" yaml:"allowMethods"`

--- a/api/v1alpha1/cors_types.go
+++ b/api/v1alpha1/cors_types.go
@@ -26,10 +26,16 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:validation:Pattern=`^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$`
 type Origin string
 
-// RegexOrigin is
+// RegexOrigin is defined by full-fledged regex, so it is possible to use any
+// scheme, domain, port or any other value. The value should be valid regex
+// string.
+// Syntax should be according to https://github.com/google/re2/wiki/Syntax.
+// Also, backslashes must be escaped.
 //
 // For example, the following are valid origins:
 // - https://foo.example.com
+// - https?://(.*\\.)?example\\.com
+// - .*://localhost(?:\\:\\d+)?
 //
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -605,6 +605,11 @@ func (in *CORS) DeepCopyInto(out *CORS) {
 		*out = make([]Origin, len(*in))
 		copy(*out, *in)
 	}
+	if in.AllowRegexOrigins != nil {
+		in, out := &in.AllowRegexOrigins, &out.AllowRegexOrigins
+		*out = make([]RegexOrigin, len(*in))
+		copy(*out, *in)
+	}
 	if in.AllowMethods != nil {
 		in, out := &in.AllowMethods, &out.AllowMethods
 		*out = make([]string, len(*in))

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -232,16 +232,17 @@ spec:
                       are allowed to make requests.
                     items:
                       description: |-
-                        RegexOrigin is defined by the scheme (protocol), hostname (domain), and port of
-                        the URL used to access it. The hostname can be "precise" which is just the
-                        domain name or "wildcard" which is a domain name prefixed with a single
-                        wildcard label such as "*.example.com".
-                        In addition to that a single wildcard (with or without scheme) can be
-                        configured to match any origin.
+                        RegexOrigin is defined by full-fledged regex, so it is possible to use any
+                        scheme, domain, port or any other value. The value should be valid regex
+                        string.
+                        Syntax should be according to https://github.com/google/re2/wiki/Syntax.
+                        Also, backslashes must be escaped.
 
 
                         For example, the following are valid origins:
                         - https://foo.example.com
+                        - https?://(.*\\.)?example\\.com
+                        - .*://localhost(?:\\:\\d+)?
                       maxLength: 253
                       minLength: 1
                       type: string

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -227,6 +227,25 @@ spec:
                       type: string
                     minItems: 1
                     type: array
+                  allowRegexOrigins:
+                    description: AllowRegexOrigins defines the origin regexes that
+                      are allowed to make requests.
+                    items:
+                      description: |-
+                        RegexOrigin is defined by the scheme (protocol), hostname (domain), and port of
+                        the URL used to access it. The hostname can be "precise" which is just the
+                        domain name or "wildcard" which is a domain name prefixed with a single
+                        wildcard label such as "*.example.com".
+                        In addition to that a single wildcard (with or without scheme) can be
+                        configured to match any origin.
+
+
+                        For example, the following are valid origins:
+                        - https://foo.example.com
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    type: array
                   exposeHeaders:
                     description: ExposeHeaders defines the headers that can be exposed
                       in the responses.

--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -564,6 +564,12 @@ func (t *Translator) buildCORS(cors *egv1a1.CORS) *ir.CORS {
 		}
 	}
 
+	for _, origin := range cors.AllowRegexOrigins {
+		allowOrigins = append(allowOrigins, &ir.StringMatch{
+			SafeRegex: (*string)(&origin),
+		})
+	}
+
 	return &ir.CORS{
 		AllowOrigins:     allowOrigins,
 		AllowMethods:     cors.AllowMethods,

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors.in.yaml
@@ -95,6 +95,25 @@ httpRoutes:
       backendRefs:
       - name: service-2
         port: 8080
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-3
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-3
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-2
+        port: 8080
 securityPolicies:
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: SecurityPolicy
@@ -167,4 +186,21 @@ securityPolicies:
       exposeHeaders:
       - "x-header-7"
       - "x-header-8"
+      maxAge: 2000s
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: SecurityPolicy
+  metadata:
+    namespace: default
+    name: policy-for-route-3
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httproute-3
+    cors:
+      allowRegexOrigins:
+      - "https://foobar.com:3[0-9]{3}"
+      allowMethods:
+      - GET
+      - POST
       maxAge: 2000s

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
@@ -402,11 +402,11 @@ securityPolicies:
     namespace: default
   spec:
     cors:
-      allowRegexOrigins:
-      - "https://foobar.com:3[0-9]{3}"
       allowMethods:
       - GET
       - POST
+      allowRegexOrigins:
+      - https://foobar.com:3[0-9]{3}
       maxAge: 33m20s
     targetRef:
       group: gateway.networking.k8s.io
@@ -669,5 +669,5 @@ xdsIR:
             allowOrigins:
             - distinct: false
               name: ""
-              safeRegex: "https://foobar.com:3[0-9]{3}"
+              safeRegex: https://foobar.com:3[0-9]{3}
             maxAge: 33m20s

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
@@ -96,7 +96,7 @@ gateways:
       protocol: HTTP
   status:
     listeners:
-    - attachedRoutes: 1
+    - attachedRoutes: 2
       conditions:
       - lastTransitionTime: null
         message: Sending translated listener configuration to the data plane
@@ -197,6 +197,44 @@ httpRoutes:
   metadata:
     creationTimestamp: null
     name: httproute-2
+    namespace: default
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - name: gateway-3
+      namespace: envoy-gateway
+      sectionName: http
+    rules:
+    - backendRefs:
+      - name: service-2
+        port: 8080
+      matches:
+      - path:
+          value: /
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-3
+        namespace: envoy-gateway
+        sectionName: http
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    creationTimestamp: null
+    name: httproute-3
     namespace: default
   spec:
     hostnames:
@@ -341,6 +379,39 @@ securityPolicies:
       group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: httproute-2
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-3
+        namespace: envoy-gateway
+        sectionName: http
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: SecurityPolicy
+  metadata:
+    creationTimestamp: null
+    name: policy-for-route-3
+    namespace: default
+  spec:
+    cors:
+      allowRegexOrigins:
+      - "https://foobar.com:3[0-9]{3}"
+      allowMethods:
+      - GET
+      - POST
+      maxAge: 33m20s
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httproute-3
   status:
     ancestors:
     - ancestorRef:
@@ -569,4 +640,34 @@ xdsIR:
             exposeHeaders:
             - x-header-7
             - x-header-8
+            maxAge: 33m20s
+      - destination:
+          name: httproute/default/httproute-3/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            protocol: HTTP
+            weight: 1
+        hostname: gateway.envoyproxy.io
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-3
+          namespace: default
+        name: httproute/default/httproute-3/rule/0/match/0/gateway_envoyproxy_io
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /
+        security:
+          cors:
+            allowMethods:
+            - GET
+            - POST
+            allowOrigins:
+            - distinct: false
+              name: ""
+              safeRegex: "https://foobar.com:3[0-9]{3}"
             maxAge: 33m20s

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -515,6 +515,7 @@ _Appears in:_
 | Field | Type | Required | Description |
 | ---   | ---  | ---      | ---         |
 | `allowOrigins` | _[Origin](#origin) array_ |  true  | AllowOrigins defines the origins that are allowed to make requests. |
+| `allowRegexOrigins` | _[RegexOrigin](#regexorigin) array_ |  true  | AllowRegexOrigins defines the origin regexes that are allowed to make requests. |
 | `allowMethods` | _string array_ |  true  | AllowMethods defines the methods that are allowed to make requests. |
 | `allowHeaders` | _string array_ |  true  | AllowHeaders defines the headers that are allowed to be sent with requests. |
 | `exposeHeaders` | _string array_ |  true  | ExposeHeaders defines the headers that can be exposed in the responses. |
@@ -3190,6 +3191,27 @@ _Appears in:_
 | Field | Type | Required | Description |
 | ---   | ---  | ---      | ---         |
 | `certificateRef` | _[SecretObjectReference](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.SecretObjectReference)_ |  false  | CertificateRef defines the client certificate reference for TLS connections.<br />Currently only a Kubernetes Secret of type TLS is supported. |
+
+
+#### RegexOrigin
+
+_Underlying type:_ _string_
+
+RegexOrigin is defined by full-fledged regex, so it is possible to use any
+scheme, domain, port or any other value. The value should be valid regex
+string.
+Syntax should be according to https://github.com/google/re2/wiki/Syntax.
+Also, backslashes must be escaped.
+
+
+For example, the following are valid origins:
+- https://foo.example.com
+- https?://(.*\\.)?example\\.com
+- .*://localhost(?:\\:\\d+)?
+
+_Appears in:_
+- [CORS](#cors)
+
 
 
 #### RemoteJWKS

--- a/site/content/zh/latest/api/extension_types.md
+++ b/site/content/zh/latest/api/extension_types.md
@@ -515,6 +515,7 @@ _Appears in:_
 | Field | Type | Required | Description |
 | ---   | ---  | ---      | ---         |
 | `allowOrigins` | _[Origin](#origin) array_ |  true  | AllowOrigins defines the origins that are allowed to make requests. |
+| `allowRegexOrigins` | _[RegexOrigin](#regexorigin) array_ |  true  | AllowRegexOrigins defines the origin regexes that are allowed to make requests. |
 | `allowMethods` | _string array_ |  true  | AllowMethods defines the methods that are allowed to make requests. |
 | `allowHeaders` | _string array_ |  true  | AllowHeaders defines the headers that are allowed to be sent with requests. |
 | `exposeHeaders` | _string array_ |  true  | ExposeHeaders defines the headers that can be exposed in the responses. |
@@ -3190,6 +3191,27 @@ _Appears in:_
 | Field | Type | Required | Description |
 | ---   | ---  | ---      | ---         |
 | `certificateRef` | _[SecretObjectReference](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.SecretObjectReference)_ |  false  | CertificateRef defines the client certificate reference for TLS connections.<br />Currently only a Kubernetes Secret of type TLS is supported. |
+
+
+#### RegexOrigin
+
+_Underlying type:_ _string_
+
+RegexOrigin is defined by full-fledged regex, so it is possible to use any
+scheme, domain, port or any other value. The value should be valid regex
+string.
+Syntax should be according to https://github.com/google/re2/wiki/Syntax.
+Also, backslashes must be escaped.
+
+
+For example, the following are valid origins:
+- https://foo.example.com
+- https?://(.*\\.)?example\\.com
+- .*://localhost(?:\\:\\d+)?
+
+_Appears in:_
+- [CORS](#cors)
+
 
 
 #### RemoteJWKS

--- a/test/e2e/testdata/cors.yaml
+++ b/test/e2e/testdata/cors.yaml
@@ -13,6 +13,8 @@ spec:
     - "https://www.foo.com"
     - "https://www.bar.com"
     - "https://*.foobar.com"
+    allowRegexOrigins:
+    - "https://foo.com:3[0-9]{3}"
     allowMethods:
     - GET
     - POST

--- a/test/e2e/tests/cors.go
+++ b/test/e2e/tests/cors.go
@@ -124,5 +124,68 @@ var CorsTest = suite.ConformanceTest{
 				t.Errorf("failed to compare request and response: %v", err)
 			}
 		})
+
+		t.Run("should enable cors with Allow Origin full-fledged Regex", func(t *testing.T) {
+			ns := "gateway-conformance-infra"
+			routeNN := types.NamespacedName{Name: "http-with-cors", Namespace: ns}
+			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+			expectedResponse := http.ExpectedResponse{
+				Request: http.Request{
+					Path: "/cors",
+					Headers: map[string]string{
+						"Origin": "https://foo.com:3123",
+					},
+				},
+				Response: http.Response{
+					Headers: map[string]string{
+						"access-control-allow-origin":   "https://foo.com:3123",
+						"access-control-expose-headers": "x-header-3, x-header-4",
+					},
+				},
+				Namespace: ns,
+			}
+
+			req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
+			cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
+			if err != nil {
+				t.Errorf("failed to get expected response: %v", err)
+			}
+
+			if err := http.CompareRequest(t, &req, cReq, cResp, expectedResponse); err != nil {
+				t.Errorf("failed to compare request and response: %v", err)
+			}
+		})
+
+		t.Run("should not contain cors header with full-fledged Regex", func(t *testing.T) {
+			ns := "gateway-conformance-infra"
+			routeNN := types.NamespacedName{Name: "http-with-cors", Namespace: ns}
+			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+			expectedResponse := http.ExpectedResponse{
+				Request: http.Request{
+					Path: "/cors",
+					Headers: map[string]string{
+						"Origin": "https://foo.com:4123",
+					},
+				},
+				Response: http.Response{
+					AbsentHeaders: []string{"access-control-allow-origin"},
+				},
+				Namespace: ns,
+			}
+
+			req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
+			cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
+			if err != nil {
+				t.Errorf("failed to get expected response: %v", err)
+			}
+
+			if err := http.CompareRequest(t, &req, cReq, cResp, expectedResponse); err != nil {
+				t.Errorf("failed to compare request and response: %v", err)
+			}
+		})
 	},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

I've added new field to `CORS` struct to get ability set flexible regexes to CORSes, because current situation allow only prefix wildcard. So in case of:
```
      - "tld\\.domain(?:\\..*)?"
      - ".*:\\/\\/localhost(?:\\:\\d+)?"
      - "http:\\/\\/((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}:30\\d\\d"
      - null
```
like mobile app origins or when there is no origing (`null`) it is impossible to set CORS.
Second point why I did new field is to have back compatibility with existent configuration.