### PR TITLE
docs: fix missing heading self-links

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -134,9 +134,6 @@ github_branch= "main"
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 # gcs_engine_id = "d72aa9b2712488cc3"
 
-# Enable Algolia DocSearch
-algolia_docsearch = false
-
 # Enable Lunr.js offline search
 offlineSearch = true
 
@@ -148,7 +145,7 @@ prism_syntax_highlighting = false
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 # Set to true to disable the About link in the site footer
-footer_about_disable = false
+footer_about_enable = true
 # Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top navbar
 navbar_logo = true
 # Set to true if you don't want the top navbar to be translucent when over a `block/cover`, like on the homepage.

--- a/site/layouts/_default/_markup/render-heading.html
+++ b/site/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,1 @@
+{{ template "_default/_markup/td-render-heading.html" . }}


### PR DESCRIPTION
introduced by https://github.com/envoyproxy/gateway/pull/3652

related to: https://github.com/google/docsy/pull/1831


cc @arkodg 