### PR TITLE
fix: multiple reference grants in same namespace

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -769,13 +769,35 @@ func (r *gatewayAPIReconciler) findReferenceGrant(ctx context.Context, from, to 
 	}
 
 	for _, refGrant := range refGrants {
-		if refGrant.Namespace == to.namespace {
-			for _, src := range refGrant.Spec.From {
-				if src.Kind == gwapiv1a2.Kind(from.kind) && string(src.Namespace) == from.namespace {
-					return &refGrant, nil
-				}
+		if refGrant.Namespace != to.namespace {
+			continue
+		}
+
+		var fromAllowed bool
+		for _, refGrantFrom := range refGrant.Spec.From {
+			if string(refGrantFrom.Kind) == from.kind && string(refGrantFrom.Namespace) == from.namespace {
+				fromAllowed = true
+				break
 			}
 		}
+
+		if !fromAllowed {
+			continue
+		}
+
+		var toAllowed bool
+		for _, refGrantTo := range refGrant.Spec.To {
+			if string(refGrantTo.Kind) == to.kind && (refGrantTo.Name == nil || *refGrantTo.Name == "" || string(*refGrantTo.Name) == to.name) {
+				toAllowed = true
+				break
+			}
+		}
+
+		if !toAllowed {
+			continue
+		}
+
+		return &refGrant, nil
 	}
 
 	// No ReferenceGrant found.

--- a/test/e2e/testdata/multi-referencegrants-same-namespace-services.yaml
+++ b/test/e2e/testdata/multi-referencegrants-same-namespace-services.yaml
@@ -1,0 +1,148 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: multireferencegrants-ns
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-backend-v1
+  namespace: multireferencegrants-ns
+spec:
+  selector:
+    app: app-backend-v1
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-backend-v1
+  namespace: multireferencegrants-ns
+  labels:
+    app: app-backend-v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-backend-v1
+  template:
+    metadata:
+      labels:
+        app: app-backend-v1
+    spec:
+      containers:
+      - name: app-backend-v1
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SERVICE_NAME
+          value: app-backend-v1
+        resources:
+          requests:
+            cpu: 10m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-backend-v2
+  namespace: multireferencegrants-ns
+spec:
+  selector:
+    app: app-backend-v2
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-backend-v2
+  namespace: multireferencegrants-ns
+  labels:
+    app: app-backend-v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-backend-v2
+  template:
+    metadata:
+      labels:
+        app: app-backend-v2
+    spec:
+      containers:
+      - name: app-backend-v2
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SERVICE_NAME
+          value: app-backend-v2
+        resources:
+          requests:
+            cpu: 10m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-backend-v3
+  namespace: multireferencegrants-ns
+spec:
+  selector:
+    app: app-backend-v3
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-backend-v3
+  namespace: multireferencegrants-ns
+  labels:
+    app: app-backend-v3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-backend-v3
+  template:
+    metadata:
+      labels:
+        app: app-backend-v3
+    spec:
+      containers:
+      - name: app-backend-v3
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SERVICE_NAME
+          value: app-backend-v3
+        resources:
+          requests:
+            cpu: 10m

--- a/test/e2e/testdata/multi-referencegrants-same-namespace.yaml
+++ b/test/e2e/testdata/multi-referencegrants-same-namespace.yaml
@@ -1,0 +1,92 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: multi-referencegrant-same-namespace
+  namespace: gateway-conformance-infra
+spec:
+  hostnames:
+  - multireferencegrant.local
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: same-namespace
+    namespace: gateway-conformance-infra
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: app-backend-v3
+      namespace: multireferencegrants-ns
+      port: 80
+      weight: 1
+    matches:
+    - path:
+        type: PathPrefix
+        value: /v3/echo
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: app-backend-v2
+      namespace: multireferencegrants-ns
+      port: 80
+      weight: 1
+    matches:
+    - path:
+        type: PathPrefix
+        value: /v2/echo
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: app-backend-v1
+      namespace: multireferencegrants-ns
+      port: 80
+      weight: 1
+    matches:
+    - path:
+        type: PathPrefix
+        value: /v1/echo
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: app-backend-v1-rg
+  namespace: multireferencegrants-ns
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: gateway-conformance-infra
+  to:
+  - group: ""
+    kind: Service
+    name: app-backend-v1
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: app-backend-v2-rg
+  namespace: multireferencegrants-ns
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: gateway-conformance-infra
+  to:
+  - group: ""
+    kind: Service
+    name: app-backend-v2
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: app-backend-v3-rg
+  namespace: multireferencegrants-ns
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: gateway-conformance-infra
+  to:
+  - group: ""
+    kind: Service
+    name: app-backend-v3

--- a/test/e2e/testdata/multi-referencegrants-same-namespace.yaml
+++ b/test/e2e/testdata/multi-referencegrants-same-namespace.yaml
@@ -17,7 +17,7 @@ spec:
       kind: Service
       name: app-backend-v3
       namespace: multireferencegrants-ns
-      port: 80
+      port: 8080
       weight: 1
     matches:
     - path:
@@ -28,7 +28,7 @@ spec:
       kind: Service
       name: app-backend-v2
       namespace: multireferencegrants-ns
-      port: 80
+      port: 8080
       weight: 1
     matches:
     - path:
@@ -39,7 +39,7 @@ spec:
       kind: Service
       name: app-backend-v1
       namespace: multireferencegrants-ns
-      port: 80
+      port: 8080
       weight: 1
     matches:
     - path:

--- a/test/e2e/tests/referencegrants.go
+++ b/test/e2e/tests/referencegrants.go
@@ -1,0 +1,59 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+//go:build e2e
+// +build e2e
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, MultiReferenceGrantsSameNamespaceTest)
+}
+
+var MultiReferenceGrantsSameNamespaceTest = suite.ConformanceTest{
+	ShortName:   "MultiReferenceGrantsSameNamespace",
+	Description: "Test for multiple reference grants in the same namespace",
+	Manifests:   []string{"testdata/multi-referencegrants-same-namespace-services.yaml", "testdata/multi-referencegrants-same-namespace.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "multi-referencegrant-same-namespace", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+		paths := []string{"/v1/echo", "/v2/echo", "/v3/echo"}
+
+		// Expectation all paths should return 200
+		for _, path := range paths {
+			expectedResponse := http.ExpectedResponse{
+				Request: http.Request{
+					Path: path,
+					Host: "multireferencegrant.local",
+				},
+				Response: http.Response{
+					StatusCode: 200,
+				},
+				Namespace: ns,
+			}
+
+			req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
+			cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
+			if err != nil {
+				t.Errorf("failed to get expected response: %v", err)
+			}
+			if err := http.CompareRequest(t, &req, cReq, cResp, expectedResponse); err != nil {
+				t.Errorf("failed to compare request and response: %v", err)
+			}
+		}
+	},
+}


### PR DESCRIPTION
**What type of PR is this?**

The current behavior of Envoy Gateway when working with multiple `ReferenceGrants` in the same namespace is problematic. When searching for a ReferenceGrant for corresponding resources, such as the `HTTPRoute`, it only checks the `ReferenceGrant.spec.from` semantics. However, during translation, the translator validates both the `ReferenceGrant.spec.from` and `ReferenceGrant.spec.to` semantics thoroughly.
As a result, the `findReferenceGrant` method only captures the first `ReferenceGrant` with the correct `From`, meaning other `ReferenceGrants` are not honored. This leads to the corresponding resource that uses two different resource references encountering an error message such as `Backend ref to service <namespace>/<service_name> not permitted by any ReferenceGrant` during translation.

Code for `findReferenceGrant`:
https://github.com/envoyproxy/gateway/blob/349760029d5ea70c003e291e8d1c9d0ddedc3e96/internal/provider/kubernetes/controller.go#L771-L782

Code for translation:
https://github.com/envoyproxy/gateway/blob/349760029d5ea70c003e291e8d1c9d0ddedc3e96/internal/gatewayapi/validate.go#L832-L857

**Proposed Solution**

This PR modifies the `findReferenceGrant` method to also check the To semantics.

Fixes #2149 
