### PR TITLE
fix: change the wasm download URL to point to the envoy examples repository

### DIFF
--- a/test/e2e/testdata/wasm-http.yaml
+++ b/test/e2e/testdata/wasm-http.yaml
@@ -51,5 +51,5 @@ spec:
     code:
       type: HTTP
       http:
-        url: https://raw.githubusercontent.com/envoyproxy/envoy/main/examples/wasm-cc/lib/envoy_filter_http_wasm_example.wasm
+        url: https://raw.githubusercontent.com/envoyproxy/examples/main/wasm-cc/lib/envoy_filter_http_wasm_example.wasm
         sha256: 79c9f85128bb0177b6511afa85d587224efded376ac0ef76df56595f1e6315c0


### PR DESCRIPTION
**What this PR does / why we need it**:
Envoy moved all their examples from the `envoy` repository to a new `examples` repository. The URL to the wasm example must be updated in the E2E tests.

https://github.com/envoyproxy/envoy/commit/56be4f40fc5c90b6dd15a5242470c1fcf7ee4222

