### PR TITLE
fix: remove the limitation for only one backendRef from ext-auth and ext-proc

### DIFF
--- a/api/v1alpha1/ext_auth_types.go
+++ b/api/v1alpha1/ext_auth_types.go
@@ -49,7 +49,6 @@ type ExtAuth struct {
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
 // +kubebuilder:validation:XValidation:message="backendRef or backendRefs needs to be set",rule="has(self.backendRef) || self.backendRefs.size() > 0"
 // +kubebuilder:validation:XValidation:message="BackendRefs must be used, backendRef is not supported.",rule="!has(self.backendRef)"
-// +kubebuilder:validation:XValidation:message="Exactly one backendRef can be specified in backendRefs.",rule="has(self.backendRefs) && self.backendRefs.size()==1"
 // +kubebuilder:validation:XValidation:message="BackendRefs only supports Service and Backend kind.",rule="has(self.backendRefs) ? self.backendRefs.all(f, f.kind == 'Service' || f.kind == 'Backend') : true"
 // +kubebuilder:validation:XValidation:message="BackendRefs only supports Core and gateway.envoyproxy.io group.",rule="has(self.backendRefs) ? (self.backendRefs.all(f, f.group == \"\" || f.group == 'gateway.envoyproxy.io')) : true"
 type GRPCExtAuthService struct {
@@ -61,7 +60,6 @@ type GRPCExtAuthService struct {
 //
 // +kubebuilder:validation:XValidation:message="backendRef or backendRefs needs to be set",rule="has(self.backendRef) || self.backendRefs.size() > 0"
 // +kubebuilder:validation:XValidation:message="BackendRefs must be used, backendRef is not supported.",rule="!has(self.backendRef)"
-// +kubebuilder:validation:XValidation:message="Exactly one backendRef can be specified in backendRefs.",rule="has(self.backendRefs) && self.backendRefs.size()==1"
 // +kubebuilder:validation:XValidation:message="BackendRefs only supports Service and Backend kind.",rule="has(self.backendRefs) ? self.backendRefs.all(f, f.kind == 'Service' || f.kind == 'Backend') : true"
 // +kubebuilder:validation:XValidation:message="BackendRefs only supports Core and gateway.envoyproxy.io group.",rule="has(self.backendRefs) ? (self.backendRefs.all(f, f.group == \"\" || f.group == 'gateway.envoyproxy.io')) : true"
 type HTTPExtAuthService struct {

--- a/api/v1alpha1/ext_proc_types.go
+++ b/api/v1alpha1/ext_proc_types.go
@@ -47,7 +47,6 @@ type ExtProcProcessingMode struct {
 
 // ExtProc defines the configuration for External Processing filter.
 // +kubebuilder:validation:XValidation:message="BackendRefs must be used, backendRef is not supported.",rule="!has(self.backendRef)"
-// +kubebuilder:validation:XValidation:message="Exactly one backendRef can be specified in backendRefs.",rule="has(self.backendRefs) && self.backendRefs.size()==1"
 // +kubebuilder:validation:XValidation:message="BackendRefs only supports Service and Backend kind.",rule="has(self.backendRefs) ? self.backendRefs.all(f, f.kind == 'Service' || f.kind == 'Backend') : true"
 // +kubebuilder:validation:XValidation:message="BackendRefs only supports Core and gateway.envoyproxy.io group.",rule="has(self.backendRefs) ? (self.backendRefs.all(f, f.group == \"\" || f.group == 'gateway.envoyproxy.io')) : true"
 type ExtProc struct {

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
@@ -872,8 +872,6 @@ spec:
                   x-kubernetes-validations:
                   - message: BackendRefs must be used, backendRef is not supported.
                     rule: '!has(self.backendRef)'
-                  - message: Exactly one backendRef can be specified in backendRefs.
-                    rule: has(self.backendRefs) && self.backendRefs.size()==1
                   - message: BackendRefs only supports Service and Backend kind.
                     rule: 'has(self.backendRefs) ? self.backendRefs.all(f, f.kind
                       == ''Service'' || f.kind == ''Backend'') : true'

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -1038,8 +1038,6 @@ spec:
                       rule: has(self.backendRef) || self.backendRefs.size() > 0
                     - message: BackendRefs must be used, backendRef is not supported.
                       rule: '!has(self.backendRef)'
-                    - message: Exactly one backendRef can be specified in backendRefs.
-                      rule: has(self.backendRefs) && self.backendRefs.size()==1
                     - message: BackendRefs only supports Service and Backend kind.
                       rule: 'has(self.backendRefs) ? self.backendRefs.all(f, f.kind
                         == ''Service'' || f.kind == ''Backend'') : true'
@@ -1866,8 +1864,6 @@ spec:
                       rule: has(self.backendRef) || self.backendRefs.size() > 0
                     - message: BackendRefs must be used, backendRef is not supported.
                       rule: '!has(self.backendRef)'
-                    - message: Exactly one backendRef can be specified in backendRefs.
-                      rule: has(self.backendRefs) && self.backendRefs.size()==1
                     - message: BackendRefs only supports Service and Backend kind.
                       rule: 'has(self.backendRefs) ? self.backendRefs.all(f, f.kind
                         == ''Service'' || f.kind == ''Backend'') : true'

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-backend.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-backend.in.yaml
@@ -101,6 +101,9 @@ securityPolicies:
           - header2
         grpc:
           backendRefs:
+            - name: service-2
+              kind: Service
+              port: 8080
             - name: backend-fqdn
               kind: Backend
               group: gateway.envoyproxy.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-backend.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-backend.out.yaml
@@ -169,6 +169,9 @@ securityPolicies:
       failOpen: true
       grpc:
         backendRefs:
+        - kind: Service
+          name: service-2
+          port: 8080
         - group: gateway.envoyproxy.io
           kind: Backend
           name: backend-fqdn
@@ -240,10 +243,16 @@ xdsIR:
           extAuth:
             failOpen: true
             grpc:
-              authority: primary.foo.com:3000
+              authority: service-2.default:8080
               destination:
-                name: securitypolicy/default/policy-for-http-route-1/default/backend-fqdn
+                name: securitypolicy/default/policy-for-http-route-1/0
                 settings:
+                - addressType: IP
+                  endpoints:
+                  - host: 7.7.7.7
+                    port: 8080
+                  protocol: GRPC
+                  weight: 1
                 - addressType: FQDN
                   endpoints:
                   - host: primary.foo.com
@@ -278,10 +287,16 @@ xdsIR:
           extAuth:
             failOpen: true
             grpc:
-              authority: primary.foo.com:3000
+              authority: service-2.default:8080
               destination:
-                name: securitypolicy/default/policy-for-http-route-1/default/backend-fqdn
+                name: securitypolicy/default/policy-for-http-route-1/0
                 settings:
+                - addressType: IP
+                  endpoints:
+                  - host: 7.7.7.7
+                    port: 8080
+                  protocol: GRPC
+                  weight: 1
                 - addressType: FQDN
                   endpoints:
                   - host: primary.foo.com

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-backendref.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-backendref.in.yaml
@@ -145,9 +145,9 @@ securityPolicies:
           - header1
           - header2
         grpc:
-          backendRef:
-            name: grpc-backend
-            port: 9000
+          backendRefs:
+            - name: grpc-backend
+              port: 9000
   - apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: SecurityPolicy
     metadata:
@@ -161,10 +161,10 @@ securityPolicies:
       extAuth:
         failOpen: false
         http:
-          backendRef:
-            Name: http-backend
-            Namespace: envoy-gateway
-            Port: 80
+          backendRefs:
+            - Name: http-backend
+              Namespace: envoy-gateway
+              Port: 80
           Path: /auth
           headersToBackend:
             - header1

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-backendref.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-backendref.out.yaml
@@ -149,8 +149,8 @@ securityPolicies:
     extAuth:
       failOpen: true
       grpc:
-        backendRef:
-          name: grpc-backend
+        backendRefs:
+        - name: grpc-backend
           port: 9000
       headersToExtAuth:
       - header1
@@ -184,8 +184,8 @@ securityPolicies:
     extAuth:
       failOpen: false
       http:
-        backendRef:
-          name: http-backend
+        backendRefs:
+        - name: http-backend
           namespace: envoy-gateway
           port: 80
         headersToBackend:
@@ -263,7 +263,7 @@ xdsIR:
             grpc:
               authority: grpc-backend.default:9000
               destination:
-                name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
+                name: securitypolicy/default/policy-for-http-route-1/0
                 settings:
                 - addressType: IP
                   endpoints:
@@ -301,7 +301,7 @@ xdsIR:
             grpc:
               authority: grpc-backend.default:9000
               destination:
-                name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
+                name: securitypolicy/default/policy-for-http-route-1/0
                 settings:
                 - addressType: IP
                   endpoints:
@@ -339,7 +339,7 @@ xdsIR:
             http:
               authority: http-backend.envoy-gateway:80
               destination:
-                name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
+                name: securitypolicy/default/policy-for-gateway-1/0
                 settings:
                 - addressType: IP
                   endpoints:

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-with-backendtlspolicy.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-with-backendtlspolicy.out.yaml
@@ -322,7 +322,7 @@ xdsIR:
             grpc:
               authority: grpc-backend.default:9000
               destination:
-                name: securitypolicy/default/policy-for-http-route/default/grpc-backend
+                name: securitypolicy/default/policy-for-http-route/0
                 settings:
                 - addressType: IP
                   endpoints:
@@ -365,7 +365,7 @@ xdsIR:
             http:
               authority: http-backend.envoy-gateway:80
               destination:
-                name: securitypolicy/default/policy-for-gateway/envoy-gateway/http-backend
+                name: securitypolicy/default/policy-for-gateway/0
                 settings:
                 - addressType: IP
                   endpoints:

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth.out.yaml
@@ -263,7 +263,7 @@ xdsIR:
             grpc:
               authority: grpc-backend.default:9000
               destination:
-                name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
+                name: securitypolicy/default/policy-for-http-route-1/0
                 settings:
                 - addressType: IP
                   endpoints:
@@ -301,7 +301,7 @@ xdsIR:
             grpc:
               authority: grpc-backend.default:9000
               destination:
-                name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
+                name: securitypolicy/default/policy-for-http-route-1/0
                 settings:
                 - addressType: IP
                   endpoints:
@@ -339,7 +339,7 @@ xdsIR:
             http:
               authority: http-backend.envoy-gateway:80
               destination:
-                name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
+                name: securitypolicy/default/policy-for-gateway-1/0
                 settings:
                 - addressType: IP
                   endpoints:

--- a/internal/xds/translator/testdata/in/xds-ir/ext-auth.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/ext-auth.yaml
@@ -39,6 +39,12 @@ http:
                 settings:
                   - addressType: IP
                     endpoints:
+                      - host: 8.8.4.4
+                        port: 9001
+                    protocol: GRPC
+                    weight: 1
+                  - addressType: IP
+                    endpoints:
                       - host: 8.8.8.8
                         port: 9000
                     protocol: GRPC

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.endpoints.yaml
@@ -40,12 +40,22 @@
     - endpoint:
         address:
           socketAddress:
+            address: 8.8.4.4
+            portValue: 9001
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: securitypolicy/default/policy-for-http-route-1/default/grpc-backend/backend/0
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
             address: 8.8.8.8
             portValue: 9000
       loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
-      region: securitypolicy/default/policy-for-http-route-1/default/grpc-backend/backend/0
+      region: securitypolicy/default/policy-for-http-route-1/default/grpc-backend/backend/1
 - clusterName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
   endpoints:
   - lbEndpoints:

--- a/test/cel-validation/securitypolicy_test.go
+++ b/test/cel-validation/securitypolicy_test.go
@@ -685,7 +685,6 @@ func TestSecurityPolicyTarget(t *testing.T) {
 			},
 			wantErrors: []string{
 				"BackendRefs must be used, backendRef is not supported.",
-				"Exactly one backendRef can be specified in backendRefs.",
 			},
 		},
 		{
@@ -782,7 +781,6 @@ func TestSecurityPolicyTarget(t *testing.T) {
 			},
 			wantErrors: []string{
 				"BackendRefs must be used, backendRef is not supported.",
-				"Exactly one backendRef can be specified in backendRefs.",
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Support multiple Backends elements in ext-auth and remove the CEL limitation in ext-proc.

**Which issue(s) this PR fixes**:
Fixes #4006 
