### PR TITLE
docs: removes unimplemented attributes in the extproc example

### DIFF
--- a/site/content/en/contributions/design/envoy-extension-policy.md
+++ b/site/content/en/contributions/design/envoy-extension-policy.md
@@ -96,12 +96,6 @@ spec:
       response:
         headers: SKIP
         body: STREAMED
-    attributes:
-      request:
-      - xds.route_metadata
-      - connection.requested_server_name
-      response:
-      - request.path
     messageTimeout: 5s
   targetRef:
     group: gateway.networking.k8s.io


### PR DESCRIPTION
**What type of PR is this?**
the title says.

**What this PR does / why we need it**:
This document is misleading by using unimplemented field named "attributes" 
which presumably will be implemented in https://github.com/envoyproxy/gateway/issues/3170

**Which issue(s) this PR fixes**:
N/A
