### PR TITLE
docs: Clarification for type which calls itself "JSON" but actually cannot be.

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -456,7 +456,9 @@ const (
 	JSONMerge MergeType = "JSONMerge"
 )
 
-// KubernetesPatchSpec defines how to perform the patch operation
+// KubernetesPatchSpec defines how to perform the patch operation.
+// Note that `value` can be an in-line YAML document, as can be seen in e.g. (the example of patching the Envoy proxy Deployment)[https://gateway.envoyproxy.io/docs/tasks/operations/customize-envoyproxy/#patching-deployment-for-envoyproxy].
+// Note also that, currently, strings containing literal JSON are _rejected_.
 type KubernetesPatchSpec struct {
 	// Type is the type of merge operation to perform
 	//

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -2265,7 +2265,9 @@ _Appears in:_
 
 
 
-KubernetesPatchSpec defines how to perform the patch operation
+KubernetesPatchSpec defines how to perform the patch operation.
+Note that `value` can be an in-line YAML document, as can be seen in e.g. (the example of patching the Envoy proxy Deployment)[https://gateway.envoyproxy.io/docs/tasks/operations/customize-envoyproxy/#patching-deployment-for-envoyproxy].
+Note also that, currently, strings containing literal JSON are _rejected_.
 
 _Appears in:_
 - [KubernetesDaemonSetSpec](#kubernetesdaemonsetspec)

--- a/site/content/zh/latest/api/extension_types.md
+++ b/site/content/zh/latest/api/extension_types.md
@@ -2265,7 +2265,9 @@ _Appears in:_
 
 
 
-KubernetesPatchSpec defines how to perform the patch operation
+KubernetesPatchSpec defines how to perform the patch operation.
+Note that `value` can be an in-line YAML document, as can be seen in e.g. (the example of patching the Envoy proxy Deployment)[https://gateway.envoyproxy.io/docs/tasks/operations/customize-envoyproxy/#patching-deployment-for-envoyproxy].
+Note also that, currently, strings containing literal JSON are _rejected_.
 
 _Appears in:_
 - [KubernetesDaemonSetSpec](#kubernetesdaemonsetspec)


### PR DESCRIPTION
**What this PR does / why we need it**:
Clicking through the docs from `EnvoyProxy`, looking to customize a gateway Deployment or Service, you land on these docs. The type of `value` is given as k8s type `JSON`, but for what I assume are complicated api-machinery deserialization quirks, cannot acutally be a JSON string, which is how I read it. Adding clarification to that.

Ie
This is fine, and is not "JSON" in the simple meaning
```
value:
  foo: bar
```

Note that the above is first-class, ie NOT
```
value: |
  foo: bar
```

And this is actually _rejected_ 
```
value: '{ "foo": "bar" }'
```