### PR TITLE
Fix IsNotFound check for secret and configmap

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -600,7 +600,7 @@ func (r *gatewayAPIReconciler) processSecretRef(
 		types.NamespacedName{Namespace: secretNS, Name: string(secretRef.Name)},
 		secret,
 	)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil && kerrors.IsNotFound(err) {
 		return fmt.Errorf("unable to find the Secret: %s/%s", secretNS, string(secretRef.Name))
 	}
 
@@ -702,7 +702,7 @@ func (r *gatewayAPIReconciler) processConfigMapRef(
 		types.NamespacedName{Namespace: configMapNS, Name: string(configMapRef.Name)},
 		configMap,
 	)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil && kerrors.IsNotFound(err) {
 		return fmt.Errorf("unable to find the ConfigMap: %s/%s", configMapNS, string(configMapRef.Name))
 	}
 


### PR DESCRIPTION
small fix : 
`unable to find the Secret/Configmap` should be returned when IsNotFound error is true.