### PR TITLE
[release/v1.1] fix: change the wasm download URL to point to the envoy examples repo…

### DIFF
--- a/test/e2e/testdata/wasm-http.yaml
+++ b/test/e2e/testdata/wasm-http.yaml
@@ -51,5 +51,5 @@ spec:
     code:
       type: HTTP
       http:
-        url: https://raw.githubusercontent.com/envoyproxy/envoy/main/examples/wasm-cc/lib/envoy_filter_http_wasm_example.wasm
+        url: https://raw.githubusercontent.com/envoyproxy/examples/main/wasm-cc/lib/envoy_filter_http_wasm_example.wasm
         sha256: 79c9f85128bb0177b6511afa85d587224efded376ac0ef76df56595f1e6315c0


### PR DESCRIPTION
…sitory (#4014)

Fix the wasm download URL to point to the envoy examples repository.


(cherry picked from commit 975b1e82a4c0fd64298096a5109ebb4ed345f5cb)
