### PR TITLE
ci: fix osv vulnerability and license scans and add license overrides

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -20,8 +20,12 @@ jobs:
     - name: Run scanner
       uses: google/osv-scanner-action/osv-scanner-action@678a866dcba398c8ed0124a09928d250f187b52a  # v1.8.4
       with:
+        # TODO enable call analysis once https://github.com/google/osv-scanner/issues/1220 is resolved
         scan-args: |-
           --skip-git
           --experimental-licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib
+          --no-call-analysis=go
           ./
-      continue-on-error: true  # TODO remove once all issues are resolved
+      # TODO remove once github.com/hashicorp/go-getter gets license exception in CNCF or removed from the project
+      # See https://github.com/cncf/foundation/issues/624
+      continue-on-error: true

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -26,9 +26,9 @@ jobs:
       scan-args: |-
         --skip-git
         --recursive
-        ./
         --config
         tools/osv-scanner/config.toml
+        ./
 
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
@@ -38,9 +38,9 @@ jobs:
       contents: read
       security-events: write
     with:
+      # TODO enable call analysis once https://github.com/google/osv-scanner/issues/1220 is resolved
       scan-args: |-
         --skip-git
         --recursive
+        --no-call-analysis=go
         ./
-        --config
-        tools/osv-scanner/config.toml

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,122 @@
+[[IgnoredVulns]]
+id = "GO-2022-0646"
+reason = "No a real issue, just a warning about third party package."
+
+[[PackageOverrides]]
+name = "github.com/AdaLogics/go-fuzz-headers"
+version = "0.0.0-20230811130428-ced1acdcaa24"
+ecosystem = "Go"
+license.override = ["Apache-2.0"]
+reason = "Unknown license since package version is missing in pkg.go.dev"
+
+[[PackageOverrides]]
+name = "github.com/asaskevich/govalidator"
+version = "0.0.0-20230301143203-a9d515a09cc2"
+ecosystem = "Go"
+license.override = ["MIT"]
+reason = "Unknown license, remove once https://github.com/google/deps.dev/issues/87 is resolved"
+
+[[PackageOverrides]]
+name = "github.com/containers/storage"
+version = "1.55.0"
+ecosystem = "Go"
+license.override = ["Apache-2.0"]
+reason = "Unknown license, remove once https://github.com/google/deps.dev/issues/104 is resolved"
+
+[[PackageOverrides]]
+name = "github.com/distribution/distribution/v3"
+version = "3.0.0-beta.1"
+ecosystem = "Go"
+license.override = ["Apache-2.0"]
+reason = "Unknown license, remove once https://github.com/google/deps.dev/issues/105 is resolved"
+
+[[PackageOverrides]]
+name = "github.com/docker/go-metrics"
+version = "0.0.1"
+ecosystem = "Go"
+license.override = ["Apache-2.0"]
+reason = "This package has dual license - the code is licensed under the Apache 2.0 license and the docs under CC-BY-SA-4.0 license"
+
+[[PackageOverrides]]
+name = "github.com/go-sql-driver/mysql"
+version = "1.8.1"
+ecosystem = "Go"
+# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from licnese scanning instead
+license.override = ["Apache-2.0"]
+reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
+
+[[PackageOverrides]]
+name = "github.com/hashicorp/errwrap"
+version = "1.1.0"
+ecosystem = "Go"
+# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from licnese scanning instead
+license.override = ["Apache-2.0"]
+reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
+
+[[PackageOverrides]]
+name = "github.com/hashicorp/go-cleanhttp"
+version = "0.5.2"
+ecosystem = "Go"
+# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from licnese scanning instead
+license.override = ["Apache-2.0"]
+reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
+
+[[PackageOverrides]]
+name = "github.com/hashicorp/go-multierror"
+version = "1.1.1"
+ecosystem = "Go"
+# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from licnese scanning instead
+license.override = ["Apache-2.0"]
+reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
+
+[[PackageOverrides]]
+name = "github.com/hashicorp/go-version"
+version = "1.7.0"
+ecosystem = "Go"
+# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from licnese scanning instead
+license.override = ["Apache-2.0"]
+reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
+
+[[PackageOverrides]]
+name = "github.com/hashicorp/hcl"
+version = "1.0.0"
+ecosystem = "Go"
+# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from licnese scanning instead
+license.override = ["Apache-2.0"]
+reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
+
+[[PackageOverrides]]
+name = "github.com/moby/patternmatcher"
+version = "0.6.0"
+ecosystem = "Go"
+license.override = ["Apache-2.0"]
+reason = "Unknown license, remove once https://github.com/google/deps.dev/issues/106 is resolved"
+
+[[PackageOverrides]]
+name = "github.com/opencontainers/go-digest"
+version = "1.0.0"
+ecosystem = "Go"
+license.override = ["Apache-2.0"]
+reason = "This package has dual license - the code is licensed under the Apache 2.0 license and the docs under CC-BY-SA-4.0 license"
+
+[[PackageOverrides]]
+name = "github.com/shoenig/go-m1cpu"
+version = "0.1.6"
+ecosystem = "Go"
+# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from licnese scanning instead
+license.override = ["Apache-2.0"]
+reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/cncf-exceptions-2023-08-31.spdx"
+
+[[PackageOverrides]]
+name = "stdlib"
+ecosystem = "Go"
+license.override = ["BSD-3-Clause"]
+reason = "Unknown license, remove once https://github.com/google/deps.dev/issues/86 is resolved"
+
+[[PackageOverrides]]
+name = "github.com/grafana/tempo"
+version = "1.5.0"
+ecosystem = "Go"
+# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from licnese scanning instead
+license.override = ["Apache-2.0"]
+reason = "This package is only used in e2e tests so we can ignore its license"

--- a/tools/osv-scanner/config.toml
+++ b/tools/osv-scanner/config.toml
@@ -1,3 +1,0 @@
-[[IgnoredVulns]]
-id = "GO-2022-0646 "
-reason = "No a real issue, just a warning about third party package."


### PR DESCRIPTION
**What this PR does / why we need it**:
* Disable call analysis in both osv vulnerability and license scans until https://github.com/google/osv-scanner/issues/1220 is resolved.
* Add license overrides for packages with unknown licenses and for packages which got [license exception](https://github.com/cncf/foundation/blob/main/license-exceptions/README.md) from CNCF.
* Move osv-scanner config file to default location (`osv-scanner.toml`) in order to make it reusable also by openssf-scorecard.
* There are 2 remaining packages with an unapproved license (both have `MPL-2.0` license):
  * `github.com/hashicorp/go-getter`
  * `github.com/hashicorp/go-safetemp` - imported by  `github.com/hashicorp/go-getter`
  
  See related CNCF issue regarding license exception request for these packages: https://github.com/cncf/foundation/issues/624.
  We can either wait for this issue to be resolved (it's quite old) or consider to remove `github.com/hashicorp/go-getter` usage.
  import path:
  github.com/envoyproxy/gateway/internal/cmd/egctl
  github.com/replicatedhq/troubleshoot/pkg/convert
  github.com/replicatedhq/troubleshoot/pkg/analyze
  github.com/hashicorp/go-getter
  