### PR TITLE
lint: ignore gosec G115

### DIFF
--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -773,7 +773,7 @@ func ratelimitUnitToDuration(unit egv1a1.RateLimitUnit) int64 {
 
 func int64ToUint32(in int64) (uint32, bool) {
 	if in >= 0 && in <= math.MaxUint32 {
-		return uint32(in), true // nolint: gosec
+		return uint32(in), true
 	}
 	return 0, false
 }

--- a/internal/gatewayapi/clienttrafficpolicy.go
+++ b/internal/gatewayapi/clienttrafficpolicy.go
@@ -703,7 +703,7 @@ func translateHTTP2Settings(http2Settings *egv1a1.HTTP2Settings, httpIR *ir.HTTP
 				MinHTTP2InitialStreamWindowSize,
 				MaxHTTP2InitialStreamWindowSize))
 		default:
-			http2.InitialStreamWindowSize = ptr.To(uint32(initialStreamWindowSize)) // nolint: gosec
+			http2.InitialStreamWindowSize = ptr.To(uint32(initialStreamWindowSize))
 		}
 	}
 
@@ -718,7 +718,7 @@ func translateHTTP2Settings(http2Settings *egv1a1.HTTP2Settings, httpIR *ir.HTTP
 				MinHTTP2InitialConnectionWindowSize,
 				MaxHTTP2InitialConnectionWindowSize))
 		default:
-			http2.InitialConnectionWindowSize = ptr.To(uint32(initialConnectionWindowSize)) // nolint: gosec
+			http2.InitialConnectionWindowSize = ptr.To(uint32(initialConnectionWindowSize))
 		}
 	}
 
@@ -878,7 +878,7 @@ func buildConnection(connection *egv1a1.ClientConnection) (*ir.ClientConnection,
 			return nil, fmt.Errorf("BufferLimit value %s is out of range, must be between 0 and %d",
 				connection.BufferLimit.String(), math.MaxUint32)
 		}
-		irConnection.BufferLimitBytes = ptr.To(uint32(bufferLimit)) // nolint: gosec
+		irConnection.BufferLimitBytes = ptr.To(uint32(bufferLimit))
 	}
 
 	return irConnection, nil

--- a/internal/gatewayapi/clustersettings.go
+++ b/internal/gatewayapi/clustersettings.go
@@ -190,7 +190,7 @@ func buildBackendConnection(policy egv1a1.ClusterSettings) (*ir.BackendConnectio
 				return nil, fmt.Errorf("BufferLimit value %s is out of range", bc.BufferLimit.String())
 			}
 
-			bcIR.BufferLimitBytes = ptr.To(uint32(bf)) // nolint: gosec
+			bcIR.BufferLimitBytes = ptr.To(uint32(bf))
 		}
 	}
 
@@ -339,7 +339,7 @@ func buildConsistentHashLoadBalancer(policy egv1a1.LoadBalancer) (*ir.Consistent
 	if policy.ConsistentHash.TableSize != nil {
 		tableSize := policy.ConsistentHash.TableSize
 
-		if *tableSize > MaxConsistentHashTableSize || !big.NewInt(int64(*tableSize)).ProbablyPrime(0) { // nolint: gosec
+		if *tableSize > MaxConsistentHashTableSize || !big.NewInt(int64(*tableSize)).ProbablyPrime(0) {
 			return nil, fmt.Errorf("invalid TableSize value %d", *tableSize)
 		}
 

--- a/internal/gatewayapi/filters.go
+++ b/internal/gatewayapi/filters.go
@@ -358,7 +358,7 @@ func (t *Translator) processRedirectFilter(
 	}
 
 	if redirect.StatusCode != nil {
-		redirectCode := int32(*redirect.StatusCode) // nolint: gosec
+		redirectCode := int32(*redirect.StatusCode)
 		// Envoy supports 302, 303, 307, and 308, but gateway API only includes 301 and 302
 		if redirectCode == 301 || redirectCode == 302 {
 			redir.StatusCode = &redirectCode

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -513,7 +513,7 @@ func parseCIDR(cidr string) (*ir.CIDRMatch, error) {
 	return &ir.CIDRMatch{
 		CIDR:    ipn.String(),
 		IP:      ip.String(),
-		MaskLen: uint32(mask), // nolint: gosec
+		MaskLen: uint32(mask),
 		IsIPv6:  ip.To4() == nil,
 	}, nil
 }

--- a/internal/gatewayapi/http.go
+++ b/internal/gatewayapi/http.go
@@ -42,7 +42,7 @@ func buildIRHTTP2Settings(http2Settings *egv1a1.HTTP2Settings) (*ir.HTTP2Setting
 				MinHTTP2InitialStreamWindowSize,
 				MaxHTTP2InitialStreamWindowSize))
 		default:
-			http2.InitialStreamWindowSize = ptr.To(uint32(initialStreamWindowSize)) // nolint: gosec
+			http2.InitialStreamWindowSize = ptr.To(uint32(initialStreamWindowSize))
 		}
 	}
 
@@ -57,7 +57,7 @@ func buildIRHTTP2Settings(http2Settings *egv1a1.HTTP2Settings) (*ir.HTTP2Setting
 				MinHTTP2InitialConnectionWindowSize,
 				MaxHTTP2InitialConnectionWindowSize))
 		default:
-			http2.InitialConnectionWindowSize = ptr.To(uint32(initialConnectionWindowSize)) // nolint: gosec
+			http2.InitialConnectionWindowSize = ptr.To(uint32(initialConnectionWindowSize))
 		}
 	}
 

--- a/internal/xds/translator/local_ratelimit.go
+++ b/internal/xds/translator/local_ratelimit.go
@@ -147,9 +147,9 @@ func (*localRateLimit) patchRoute(route *routev3.Route, irRoute *ir.HTTPRoute) e
 	localRl := &localrlv3.LocalRateLimit{
 		StatPrefix: localRateLimitFilterStatPrefix,
 		TokenBucket: &typev3.TokenBucket{
-			MaxTokens: uint32(local.Default.Requests), // nolint: gosec
+			MaxTokens: uint32(local.Default.Requests),
 			TokensPerFill: &wrapperspb.UInt32Value{
-				Value: uint32(local.Default.Requests), // nolint: gosec
+				Value: uint32(local.Default.Requests),
 			},
 			FillInterval: ratelimitUnitToDuration(local.Default.Unit),
 		},
@@ -273,9 +273,9 @@ func buildRouteLocalRateLimits(local *ir.LocalRateLimit) (
 		descriptor := &rlv3.LocalRateLimitDescriptor{
 			Entries: descriptorEntries,
 			TokenBucket: &typev3.TokenBucket{
-				MaxTokens: uint32(rule.Limit.Requests), // nolint: gosec
+				MaxTokens: uint32(rule.Limit.Requests),
 				TokensPerFill: &wrapperspb.UInt32Value{
-					Value: uint32(rule.Limit.Requests), // nolint: gosec
+					Value: uint32(rule.Limit.Requests),
 				},
 				FillInterval: ratelimitUnitToDuration(rule.Limit.Unit),
 			},

--- a/internal/xds/translator/ratelimit.go
+++ b/internal/xds/translator/ratelimit.go
@@ -337,7 +337,7 @@ func buildRateLimitServiceDescriptors(global *ir.GlobalRateLimit) []*rlsconfv3.R
 			pbDesc.Key = getRouteRuleDescriptor(rIdx, -1)
 			pbDesc.Value = getRouteRuleDescriptor(rIdx, -1)
 			rateLimit := rlsconfv3.RateLimitPolicy{
-				RequestsPerUnit: uint32(rule.Limit.Requests), // nolint: gosec
+				RequestsPerUnit: uint32(rule.Limit.Requests),
 				Unit:            rlsconfv3.RateLimitUnit(rlsconfv3.RateLimitUnit_value[strings.ToUpper(string(rule.Limit.Unit))]),
 			}
 			pbDesc.RateLimit = &rateLimit
@@ -360,7 +360,7 @@ func buildRateLimitServiceDescriptors(global *ir.GlobalRateLimit) []*rlsconfv3.R
 			// Add the ratelimit values to the last descriptor
 			if mIdx == len(rule.HeaderMatches)-1 {
 				rateLimit := rlsconfv3.RateLimitPolicy{
-					RequestsPerUnit: uint32(rule.Limit.Requests), // nolint: gosec
+					RequestsPerUnit: uint32(rule.Limit.Requests),
 					Unit:            rlsconfv3.RateLimitUnit(rlsconfv3.RateLimitUnit_value[strings.ToUpper(string(rule.Limit.Unit))]),
 				}
 				pbDesc.RateLimit = &rateLimit
@@ -402,7 +402,7 @@ func buildRateLimitServiceDescriptors(global *ir.GlobalRateLimit) []*rlsconfv3.R
 			pbDesc.Key = "masked_remote_address"
 			pbDesc.Value = rule.CIDRMatch.CIDR
 			rateLimit := rlsconfv3.RateLimitPolicy{
-				RequestsPerUnit: uint32(rule.Limit.Requests), // nolint: gosec
+				RequestsPerUnit: uint32(rule.Limit.Requests),
 				Unit:            rlsconfv3.RateLimitUnit(rlsconfv3.RateLimitUnit_value[strings.ToUpper(string(rule.Limit.Unit))]),
 			}
 
@@ -522,5 +522,5 @@ func (t *Translator) getRateLimitServiceGrpcHostPort() (string, uint32) {
 	if err != nil {
 		panic(err)
 	}
-	return u.Hostname(), uint32(p) // nolint: gosec
+	return u.Hostname(), uint32(p)
 }

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -598,7 +598,7 @@ func buildRetryPolicy(route *ir.HTTPRoute) (*routev3.RetryPolicy, error) {
 func buildRetryStatusCodes(codes []ir.HTTPStatus) []uint32 {
 	ret := make([]uint32, len(codes))
 	for i, c := range codes {
-		ret[i] = uint32(c) // nolint: gosec
+		ret[i] = uint32(c)
 	}
 	return ret
 }

--- a/internal/xds/translator/utils.go
+++ b/internal/xds/translator/utils.go
@@ -63,7 +63,7 @@ func url2Cluster(strURL string) (*urlCluster, error) {
 		}
 	}
 
-	name := clusterName(u.Hostname(), uint32(port)) // nolint: gosec
+	name := clusterName(u.Hostname(), uint32(port))
 
 	if ip, err := netip.ParseAddr(u.Hostname()); err == nil {
 		if ip.Unmap().Is4() {
@@ -74,7 +74,7 @@ func url2Cluster(strURL string) (*urlCluster, error) {
 	return &urlCluster{
 		name:         name,
 		hostname:     u.Hostname(),
-		port:         uint32(port), // nolint: gosec
+		port:         uint32(port),
 		endpointType: epType,
 		tls:          u.Scheme == "https",
 	}, nil

--- a/test/e2e/tests/backend_tls_settings.go
+++ b/test/e2e/tests/backend_tls_settings.go
@@ -301,7 +301,7 @@ func restartDeploymentAndWaitForRollout(t *testing.T, timeoutConfig config.Timeo
 		}
 
 		// all pods are rolled
-		if rolled == int32(len(podList.Items)) && rolled >= *dp.Spec.Replicas { // nolint: gosec
+		if rolled == int32(len(podList.Items)) && rolled >= *dp.Spec.Replicas {
 			return true, nil
 		}
 

--- a/test/e2e/tests/envoy_shutdown.go
+++ b/test/e2e/tests/envoy_shutdown.go
@@ -163,7 +163,7 @@ func restartProxyAndWaitForRollout(t *testing.T, timeoutConfig config.TimeoutCon
 		}
 
 		// all pods are rolled
-		if rolled == int32(len(podList.Items)) && rolled >= *dp.Spec.Replicas { // nolint: gosec
+		if rolled == int32(len(podList.Items)) && rolled >= *dp.Spec.Replicas {
 			return true, nil
 		}
 

--- a/tools/linter/golangci-lint/.golangci.yml
+++ b/tools/linter/golangci-lint/.golangci.yml
@@ -25,6 +25,9 @@ linters:
     - unparam
 
 linters-settings:
+  gosec:
+    excludes:
+      - G115
   depguard:
     rules:
       Main:


### PR DESCRIPTION
exclude `gosec` rule G115: Potential integer overflow when converting between integer types