### PR TITLE
ci: fix openssf-scorecard permission issue

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -13,6 +13,9 @@ on:
   schedule:
   - cron: '44 15 * * 5'
 
+permissions:
+  contents: read
+
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes openssf-scorecard issue: `Warn: no topLevel permission defined: .github/workflows/osv-scanner.yml:1`