### PR TITLE
api: add Mixin accesslog format type

### DIFF
--- a/api/v1alpha1/accesslogging_types.go
+++ b/api/v1alpha1/accesslogging_types.go
@@ -39,11 +39,13 @@ const (
 	ProxyAccessLogFormatTypeText ProxyAccessLogFormatType = "Text"
 	// ProxyAccessLogFormatTypeJSON defines the JSON accesslog format.
 	ProxyAccessLogFormatTypeJSON ProxyAccessLogFormatType = "JSON"
-	// TODO: support format type "mix" in the future.
+	// ProxyAccessLogFormatTypeJSONAndText defines the mixed mode of text and JSON accesslog format.
+	// This is used when the accesslog format is a mix of text and JSON format(e.g. OpenTelemetry).
+	ProxyAccessLogFormatTypeJSONAndText ProxyAccessLogFormatType = "Mixin"
 )
 
 // ProxyAccessLogFormat defines the format of accesslog.
-// By default accesslogs are written to standard output.
+// By default, accesslogs are written to standard output.
 // +union
 //
 // +kubebuilder:validation:XValidation:rule="self.type == 'Text' ? has(self.text) : !has(self.text)",message="If AccessLogFormat type is Text, text field needs to be set."

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -2777,7 +2777,7 @@ _Appears in:_
 
 
 ProxyAccessLogFormat defines the format of accesslog.
-By default accesslogs are written to standard output.
+By default, accesslogs are written to standard output.
 
 _Appears in:_
 - [ProxyAccessLogSetting](#proxyaccesslogsetting)
@@ -2802,6 +2802,7 @@ _Appears in:_
 | ----- | ----------- |
 | `Text` | ProxyAccessLogFormatTypeText defines the text accesslog format.<br /> | 
 | `JSON` | ProxyAccessLogFormatTypeJSON defines the JSON accesslog format.<br /> | 
+| `Mixin` | ProxyAccessLogFormatTypeJSONAndText defines the mixed mode of text and JSON accesslog format.<br />This is used when the accesslog format is a mix of text and JSON format(e.g. OpenTelemetry).<br /> | 
 
 
 #### ProxyAccessLogSetting

--- a/site/content/zh/latest/api/extension_types.md
+++ b/site/content/zh/latest/api/extension_types.md
@@ -2777,7 +2777,7 @@ _Appears in:_
 
 
 ProxyAccessLogFormat defines the format of accesslog.
-By default accesslogs are written to standard output.
+By default, accesslogs are written to standard output.
 
 _Appears in:_
 - [ProxyAccessLogSetting](#proxyaccesslogsetting)
@@ -2802,6 +2802,7 @@ _Appears in:_
 | ----- | ----------- |
 | `Text` | ProxyAccessLogFormatTypeText defines the text accesslog format.<br /> | 
 | `JSON` | ProxyAccessLogFormatTypeJSON defines the JSON accesslog format.<br /> | 
+| `Mixin` | ProxyAccessLogFormatTypeJSONAndText defines the mixed mode of text and JSON accesslog format.<br />This is used when the accesslog format is a mix of text and JSON format(e.g. OpenTelemetry).<br /> | 
 
 
 #### ProxyAccessLogSetting


### PR DESCRIPTION
xref: https://github.com/envoyproxy/gateway/issues/3994

there's a TODO from beginning, how can we support `body` and `attributes` at the same time with OpenTelemetry log sink.
With this proposal, we can setup Text and JSON when Type is `Mixin`, but what should EG do when Type is `Mixin`, but there's a file sink? text take first? take both?
```yaml
format:
  type: Mixin
  text: xxxxx
  json:
    key1: val1
sinks:
- type: OpenTelemetry
- type: File
```

cc @envoyproxy/gateway-maintainers 