### PR TITLE
fix: Switch to an immediate drain strategy

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -923,7 +923,6 @@ xds:
                   statPrefix: http-10080
                   useRemoteAddress: true
               name: default/eg/http
-            drainType: MODIFY_ONLY
             name: default/eg/http
             perConnectionBufferLimitBytes: 32768
       - activeState:
@@ -991,7 +990,6 @@ xds:
                   statPrefix: http-8080
                   useRemoteAddress: true
               name: default/eg/grpc
-            drainType: MODIFY_ONLY
             name: default/eg/grpc
             perConnectionBufferLimitBytes: 32768
       - activeState:
@@ -1014,7 +1012,6 @@ xds:
               socketAddress:
                 address: 0.0.0.0
                 portValue: 1234
-            drainType: MODIFY_ONLY
             filterChains:
             - filters:
               - name: envoy.filters.network.tcp_proxy
@@ -1054,7 +1051,6 @@ xds:
               socketAddress:
                 address: 0.0.0.0
                 portValue: 8443
-            drainType: MODIFY_ONLY
             filterChains:
             - filterChainMatch:
                 serverNames:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -691,7 +691,6 @@
                     ],
                     "name": "default/eg/http"
                   },
-                  "drainType": "MODIFY_ONLY",
                   "name": "default/eg/http",
                   "perConnectionBufferLimitBytes": 32768
                 }
@@ -797,7 +796,6 @@
                     ],
                     "name": "default/eg/grpc"
                   },
-                  "drainType": "MODIFY_ONLY",
                   "name": "default/eg/grpc",
                   "perConnectionBufferLimitBytes": 32768
                 }
@@ -834,7 +832,6 @@
                       "portValue": 1234
                     }
                   },
-                  "drainType": "MODIFY_ONLY",
                   "filterChains": [
                     {
                       "filters": [
@@ -900,7 +897,6 @@
                       "portValue": 8443
                     }
                   },
-                  "drainType": "MODIFY_ONLY",
                   "filterChains": [
                     {
                       "filterChainMatch": {

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -404,7 +404,6 @@ xds:
                   statPrefix: http-10080
                   useRemoteAddress: true
               name: default/eg/http
-            drainType: MODIFY_ONLY
             name: default/eg/http
             perConnectionBufferLimitBytes: 32768
       - activeState:
@@ -472,7 +471,6 @@ xds:
                   statPrefix: http-8080
                   useRemoteAddress: true
               name: default/eg/grpc
-            drainType: MODIFY_ONLY
             name: default/eg/grpc
             perConnectionBufferLimitBytes: 32768
       - activeState:
@@ -495,7 +493,6 @@ xds:
               socketAddress:
                 address: 0.0.0.0
                 portValue: 1234
-            drainType: MODIFY_ONLY
             filterChains:
             - filters:
               - name: envoy.filters.network.tcp_proxy
@@ -535,7 +532,6 @@ xds:
               socketAddress:
                 address: 0.0.0.0
                 portValue: 8443
-            drainType: MODIFY_ONLY
             filterChains:
             - filterChainMatch:
                 serverNames:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
@@ -59,7 +59,6 @@ xds:
                 statPrefix: http-10080
                 useRemoteAddress: true
             name: default/eg/http
-          drainType: MODIFY_ONLY
           name: default/eg/http
           perConnectionBufferLimitBytes: 32768
     - activeState:
@@ -127,7 +126,6 @@ xds:
                 statPrefix: http-8080
                 useRemoteAddress: true
             name: default/eg/grpc
-          drainType: MODIFY_ONLY
           name: default/eg/grpc
           perConnectionBufferLimitBytes: 32768
     - activeState:
@@ -150,7 +148,6 @@ xds:
             socketAddress:
               address: 0.0.0.0
               portValue: 1234
-          drainType: MODIFY_ONLY
           filterChains:
           - filters:
             - name: envoy.filters.network.tcp_proxy
@@ -190,7 +187,6 @@ xds:
             socketAddress:
               address: 0.0.0.0
               portValue: 8443
-          drainType: MODIFY_ONLY
           filterChains:
           - filterChainMatch:
               serverNames:

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -544,7 +544,6 @@
                     ],
                     "name": "envoy-gateway-system/eg/http"
                   },
-                  "drainType": "MODIFY_ONLY",
                   "name": "envoy-gateway-system/eg/http",
                   "perConnectionBufferLimitBytes": 32768
                 }

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -320,7 +320,6 @@ xds:
                   statPrefix: http-10080
                   useRemoteAddress: true
               name: envoy-gateway-system/eg/http
-            drainType: MODIFY_ONLY
             name: envoy-gateway-system/eg/http
             perConnectionBufferLimitBytes: 32768
     - '@type': type.googleapis.com/envoy.admin.v3.RoutesConfigDump

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
@@ -76,6 +76,5 @@ xds:
                 statPrefix: http-10080
                 useRemoteAddress: true
             name: envoy-gateway-system/eg/http
-          drainType: MODIFY_ONLY
           name: envoy-gateway-system/eg/http
           perConnectionBufferLimitBytes: 32768

--- a/internal/cmd/egctl/testdata/translate/out/no-service-cluster-ip.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/no-service-cluster-ip.all.yaml
@@ -265,7 +265,6 @@ xds:
                   statPrefix: http-10080
                   useRemoteAddress: true
               name: envoy-gateway-system/eg/http
-            drainType: MODIFY_ONLY
             name: envoy-gateway-system/eg/http
             perConnectionBufferLimitBytes: 32768
     - '@type': type.googleapis.com/envoy.admin.v3.RoutesConfigDump

--- a/internal/cmd/envoy/shutdown_manager.go
+++ b/internal/cmd/envoy/shutdown_manager.go
@@ -114,7 +114,7 @@ func shutdownReadyHandler(w http.ResponseWriter, readyTimeout time.Duration, rea
 }
 
 // Shutdown is called from a preStop hook on the shutdown-manager container where
-// it will initiate a graceful drain sequence on the Envoy proxy and block until
+// it will initiate a drain sequence on the Envoy proxy and block until
 // connections are drained or a timeout is exceeded.
 func Shutdown(drainTimeout time.Duration, minDrainDuration time.Duration, exitAtConnections int) error {
 	startTime := time.Now()
@@ -125,17 +125,12 @@ func Shutdown(drainTimeout time.Duration, minDrainDuration time.Duration, exitAt
 		logger = logging.FileLogger("/proc/1/fd/1", "shutdown-manager", egv1a1.LogLevelInfo)
 	}
 
-	logger.Info(fmt.Sprintf("initiating graceful drain with %.0f second minimum drain period and %.0f second timeout",
+	logger.Info(fmt.Sprintf("initiating drain with %.0f second minimum drain period and %.0f second timeout",
 		minDrainDuration.Seconds(), drainTimeout.Seconds()))
 
 	// Start failing active health checks
 	if err := postEnvoyAdminAPI("healthcheck/fail"); err != nil {
 		logger.Error(err, "error failing active health checks")
-	}
-
-	// Initiate graceful drain sequence
-	if err := postEnvoyAdminAPI("drain_listeners?graceful&skip_exit"); err != nil {
-		logger.Error(err, "error initiating graceful drain")
 	}
 
 	// Poll total connections from Envoy admin API until minimum drain period has
@@ -154,10 +149,10 @@ func Shutdown(drainTimeout time.Duration, minDrainDuration time.Duration, exitAt
 		}
 
 		if elapsedTime > drainTimeout {
-			logger.Info("graceful drain sequence timeout exceeded")
+			logger.Info("drain sequence timeout exceeded")
 			break
 		} else if allowedToExit && conn != nil && *conn <= exitAtConnections {
-			logger.Info("graceful drain sequence completed")
+			logger.Info("drain sequence completed")
 			break
 		}
 

--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -171,6 +171,7 @@ func expectedProxyContainers(infra *ir.ProxyInfra,
 		fmt.Sprintf("--config-yaml %s", bootstrapConfigurations),
 		fmt.Sprintf("--log-level %s", logging.DefaultEnvoyProxyLoggingLevel()),
 		"--cpuset-threads",
+		"--drain-strategy immediate",
 	}
 
 	if infra.Config != nil &&

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
@@ -40,6 +40,7 @@ spec:
         - --config-yaml test bootstrap config
         - --log-level error
         - --cpuset-threads
+        - --drain-strategy immediate
         - --component-log-level filter:info
         command:
         - envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
@@ -224,6 +224,7 @@ spec:
                   value: 0.98
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
@@ -223,6 +223,7 @@ spec:
                   value: 0.98
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
@@ -208,6 +208,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
@@ -182,6 +182,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
@@ -223,6 +223,7 @@ spec:
                   value: 0.98
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
@@ -217,6 +217,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
@@ -208,6 +208,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
@@ -208,6 +208,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         - --drain-time-s 30
         command:
         - envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
@@ -223,6 +223,7 @@ spec:
                   value: 0.98
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
@@ -213,6 +213,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
@@ -40,6 +40,7 @@ spec:
         - --config-yaml test bootstrap config
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         - --concurrency 4
         command:
         - envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
@@ -208,6 +208,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         - --key1 val1
         - --key2 val2
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
@@ -208,6 +208,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
@@ -208,6 +208,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
@@ -208,6 +208,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
@@ -208,6 +208,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -44,6 +44,7 @@ spec:
         - --config-yaml test bootstrap config
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -44,6 +44,7 @@ spec:
         - --config-yaml test bootstrap config
         - --log-level error
         - --cpuset-threads
+        - --drain-strategy immediate
         - --component-log-level filter:info
         command:
         - envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -229,6 +229,7 @@ spec:
                   value: 0.98
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -229,6 +229,7 @@ spec:
                   value: 0.98
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -228,6 +228,7 @@ spec:
                   value: 0.98
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -212,6 +212,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -186,6 +186,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -228,6 +228,7 @@ spec:
                   value: 0.98
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -221,6 +221,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -212,6 +212,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -212,6 +212,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         - --drain-time-s 30
         command:
         - envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -228,6 +228,7 @@ spec:
                   value: 0.98
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -217,6 +217,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -44,6 +44,7 @@ spec:
         - --config-yaml test bootstrap config
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         - --concurrency 4
         command:
         - envoy

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -212,6 +212,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -212,6 +212,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         - --key1 val1
         - --key2 val2
         command:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -212,6 +212,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
@@ -212,6 +212,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -212,6 +212,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -212,6 +212,7 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level warn
         - --cpuset-threads
+        - --drain-strategy immediate
         command:
         - envoy
         env:

--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -169,9 +169,6 @@ func buildXdsTCPListener(name, address string, port uint32, keepalive *ir.TCPKee
 				},
 			},
 		},
-		// Remove /healthcheck/fail from endpoints that trigger a drain of listeners for better control
-		// over the drain process while still allowing the healthcheck to be failed during pod shutdown.
-		DrainType: listenerv3.Listener_MODIFY_ONLY,
 	}
 }
 

--- a/internal/xds/translator/testdata/out/extension-xds-ir/extensionpolicy-tcp-udp-http.listeners.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/extensionpolicy-tcp-udp-http.listeners.yaml
@@ -30,7 +30,6 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http1
-  drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-1/http1
   perConnectionBufferLimitBytes: 32768
   statPrefix: envoy-gateway/gateway-1/http1

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.listeners.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.listeners.yaml
@@ -30,7 +30,6 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: extension-listener
-  drainType: MODIFY_ONLY
   name: extension-listener
   perConnectionBufferLimitBytes: 32768
   statPrefix: mock-extension-inserted-prefix

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/extension-xds-ir/listener-policy.listeners.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/listener-policy.listeners.yaml
@@ -30,7 +30,6 @@
         statPrefix: http-10081
         useRemoteAddress: true
     name: policyextension-listener
-  drainType: MODIFY_ONLY
   name: policyextension-listener
   perConnectionBufferLimitBytes: 32768
   statPrefix: from-the-policy

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-cel.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-cel.listeners.yaml
@@ -179,6 +179,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.listeners.yaml
@@ -140,6 +140,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.listeners.yaml
@@ -224,6 +224,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-multi-cel.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-multi-cel.listeners.yaml
@@ -215,6 +215,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-without-format.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-without-format.listeners.yaml
@@ -172,6 +172,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.listeners.yaml
@@ -172,6 +172,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/authorization.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization.listeners.yaml
@@ -33,6 +33,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
-  drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.listeners.yaml
@@ -30,14 +30,12 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
 - address:
     socketAddress:
       address: 0.0.0.0
       portValue: 10081
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.tcp_proxy

--- a/internal/xds/translator/testdata/out/xds-ir/backend-priority.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-priority.listeners.yaml
@@ -44,6 +44,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: default/gateway-1/http
-  drainType: MODIFY_ONLY
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth.listeners.yaml
@@ -36,6 +36,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: default/gateway-1/http
-  drainType: MODIFY_ONLY
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.listeners.yaml
@@ -30,14 +30,12 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 1500
 - address:
     socketAddress:
       address: 0.0.0.0
       portValue: 10081
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.tcp_proxy

--- a/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.listeners.yaml
@@ -29,7 +29,6 @@
         useRemoteAddress: true
         xffNumTrustedHops: 2
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -68,7 +67,6 @@
         statPrefix: http-8082
         useRemoteAddress: false
     name: second-listener
-  drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -109,6 +107,5 @@
         statPrefix: http-8083
         useRemoteAddress: false
     name: third-listener
-  drainType: MODIFY_ONLY
   name: third-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/client-timeout.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-timeout.listeners.yaml
@@ -32,14 +32,12 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
 - address:
     socketAddress:
       address: 0.0.0.0
       portValue: 10081
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.tcp_proxy

--- a/internal/xds/translator/testdata/out/xds-ir/cors.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/cors.listeners.yaml
@@ -33,6 +33,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
@@ -121,6 +121,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
-  drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.listeners.yaml
@@ -65,6 +65,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: default/gateway-1/http
-  drainType: MODIFY_ONLY
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.listeners.yaml
@@ -66,6 +66,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: default/gateway-1/http
-  drainType: MODIFY_ONLY
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.listeners.yaml
@@ -65,6 +65,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: default/gateway-1/http
-  drainType: MODIFY_ONLY
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.listeners.yaml
@@ -44,6 +44,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: default/gateway-1/http
-  drainType: MODIFY_ONLY
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc.listeners.yaml
@@ -94,6 +94,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
-  drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/fault-injection.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/fault-injection.listeners.yaml
@@ -33,6 +33,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-x-request-id.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-x-request-id.listeners.yaml
@@ -29,7 +29,6 @@
         statPrefix: http-8081
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -62,6 +61,5 @@
         statPrefix: http-8082
         useRemoteAddress: true
     name: second-listener
-  drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-underscores-action.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-underscores-action.listeners.yaml
@@ -28,7 +28,6 @@
         statPrefix: http-8081
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -60,7 +59,6 @@
         statPrefix: http-8082
         useRemoteAddress: true
     name: second-listener
-  drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -93,7 +91,6 @@
         statPrefix: http-8083
         useRemoteAddress: true
     name: third-listener
-  drainType: MODIFY_ONLY
   name: third-listener
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -126,6 +123,5 @@
         statPrefix: http-8084
         useRemoteAddress: true
     name: fourth-listener
-  drainType: MODIFY_ONLY
   name: fourth-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/health-check.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-early-header-mutation.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-early-header-mutation.listeners.yaml
@@ -36,7 +36,6 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -103,6 +102,5 @@
         statPrefix: http-10081
         useRemoteAddress: true
     name: second-listener
-  drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-endpoint-stats.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-endpoint-stats.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: listener-enable-endpoint-stats
-  drainType: MODIFY_ONLY
   name: listener-enable-endpoint-stats
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-health-check.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-health-check.listeners.yaml
@@ -38,6 +38,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-preserve-client-protocol.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-preserve-client-protocol.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
-  drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-regex.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-regex.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-sufixx-with-slash-url-prefix.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-sufixx-with-slash-url-prefix.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.listeners.yaml
@@ -75,6 +75,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-uds-ip.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-uds-ip.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-filters.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-filters.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-clientcert.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-clientcert.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: envoy-gateway/gateway-btls/http
-  drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-btls/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-metadata.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-metadata.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: envoy-gateway/gateway-btls/http
-  drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-btls/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle-multiple-certs.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle-multiple-certs.listeners.yaml
@@ -30,7 +30,6 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: envoy-gateway/gateway-btls/http
-  drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-btls/http
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -65,6 +64,5 @@
         statPrefix: http-10081
         useRemoteAddress: true
     name: envoy-gateway/gateway-btls-2/http
-  drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-btls-2/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: envoy-gateway/gateway-btls/http
-  drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-btls/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.listeners.yaml
@@ -36,7 +36,6 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -78,6 +77,5 @@
         statPrefix: http-10081
         useRemoteAddress: true
     name: second-listener
-  drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http1-trailers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-trailers.listeners.yaml
@@ -32,6 +32,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http10.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http10.listeners.yaml
@@ -33,6 +33,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.listeners.yaml
@@ -38,6 +38,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http2.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http3.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http3.listeners.yaml
@@ -55,7 +55,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10443
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
@@ -58,6 +58,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
@@ -115,6 +115,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
@@ -92,6 +92,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
@@ -61,6 +61,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
@@ -61,6 +61,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
@@ -51,6 +51,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/listener-connection-limit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-connection-limit.listeners.yaml
@@ -30,7 +30,6 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -70,20 +69,17 @@
         statPrefix: http-10081
         useRemoteAddress: true
     name: second-listener
-  drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768
 - address:
     socketAddress:
       address: 0.0.0.0
       portValue: 10082
-  drainType: MODIFY_ONLY
   name: third-listener
   perConnectionBufferLimitBytes: 32768
 - address:
     socketAddress:
       address: 0.0.0.0
       portValue: 10083
-  drainType: MODIFY_ONLY
   name: fourth-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filterChainMatch:
       serverNames:
@@ -64,7 +63,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10081
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.tcp_proxy

--- a/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.listeners.yaml
@@ -30,7 +30,6 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768
   socketOptions:
@@ -70,7 +69,6 @@
         statPrefix: http-10081
         useRemoteAddress: true
     name: second-listener
-  drainType: MODIFY_ONLY
   name: second-listener
   perConnectionBufferLimitBytes: 32768
   socketOptions:
@@ -94,7 +92,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10082
-  drainType: MODIFY_ONLY
   name: third-listener
   perConnectionBufferLimitBytes: 32768
   socketOptions:
@@ -106,7 +103,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10083
-  drainType: MODIFY_ONLY
   name: fourth-listener
   perConnectionBufferLimitBytes: 32768
   socketOptions:

--- a/internal/xds/translator/testdata/out/xds-ir/load-balancer.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/load-balancer.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.listeners.yaml
@@ -34,6 +34,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.listeners.yaml
@@ -162,6 +162,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: default/gateway-1/http
-  drainType: MODIFY_ONLY
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.listeners.yaml
@@ -30,7 +30,6 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: third-listener
-  drainType: MODIFY_ONLY
   filterChains:
   - filterChainMatch:
       serverNames:

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.tcp_proxy

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10001
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager
@@ -60,7 +59,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10002
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager
@@ -119,7 +117,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10003
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager
@@ -180,7 +177,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10004
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager
@@ -243,7 +239,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10005
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10001
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager
@@ -60,7 +59,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10002
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager
@@ -119,7 +117,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10003
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager
@@ -178,7 +175,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10004
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager
@@ -237,7 +233,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10005
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager
@@ -60,7 +59,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10081
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.tcp_proxy

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager
@@ -60,7 +59,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10081
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.tcp_proxy

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.listeners.yaml
@@ -121,6 +121,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/path-settings.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/path-settings.listeners.yaml
@@ -29,6 +29,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.listeners.yaml
@@ -40,6 +40,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.listeners.yaml
@@ -39,6 +39,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.listeners.yaml
@@ -40,6 +40,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.listeners.yaml
@@ -40,6 +40,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.listeners.yaml
@@ -40,6 +40,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager

--- a/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filterChainMatch:
       serverNames:

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-endpoint-stats.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-endpoint-stats.listeners.yaml
@@ -2,6 +2,5 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   name: tcp-route-enable-endpoint-stats
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filterChainMatch:
       serverNames:

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.tcp_proxy

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.tcp_proxy

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filterChainMatch:
       serverNames:

--- a/internal/xds/translator/testdata/out/xds-ir/timeout.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/timeout.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filterChainMatch:
       serverNames:
@@ -24,7 +23,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10081
-  drainType: MODIFY_ONLY
   filterChains:
   - filterChainMatch:
       serverNames:

--- a/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.listeners.yaml
@@ -2,7 +2,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10080
-  drainType: MODIFY_ONLY
   filterChains:
   - filterChainMatch:
       serverNames:
@@ -81,7 +80,6 @@
     socketAddress:
       address: 0.0.0.0
       portValue: 10081
-  drainType: MODIFY_ONLY
   filterChains:
   - filters:
     - name: envoy.filters.network.tcp_proxy

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.listeners.yaml
@@ -58,6 +58,5 @@
           spawnUpstreamSpan: true
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-zipkin.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-zipkin.listeners.yaml
@@ -59,6 +59,5 @@
           spawnUpstreamSpan: true
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/tracing.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing.listeners.yaml
@@ -59,6 +59,5 @@
           spawnUpstreamSpan: true
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.listeners.yaml
@@ -30,6 +30,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: first-listener
-  drainType: MODIFY_ONLY
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/wasm.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/wasm.listeners.yaml
@@ -108,6 +108,5 @@
         statPrefix: http-10080
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
-  drainType: MODIFY_ONLY
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768


### PR DESCRIPTION
* Ensures clients immediately receive a `connection: close` / `GOAWAY` instead of a probabilistic approach of receiving one b/w drain start and drain end (defaults to 600s). This should speed up shutdown with clients reconnecting to newer upgraded proxies.

Fixes: https://github.com/envoyproxy/gateway/issues/4205