### PR TITLE
docs: fix make command from benchmark-test to benchmark

### DIFF
--- a/site/content/en/contributions/DEVELOP.md
+++ b/site/content/en/contributions/DEVELOP.md
@@ -156,7 +156,7 @@ The performance and scalability concerns come from several aspects for control-p
 - The rate of configuration changes.
 
 The benchmark test is running on a [Kind][Kind] cluster, you can start a Kind cluster and 
-run benchmark test on it by executing `make benchmark-test`.
+run benchmark test on it by executing `make benchmark`.
 
 The benchmark report will be included in the release artifacts, you can learn more by downloading
 the detailed benchmark report, namely `benchmark_report.zip`.


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->
docs: Correct benchmark command from `make benchmark-test` to `make benchmark`

**What this PR does / why we need it**:
The developer guide documentation contains an incorrect benchmark command. The current command is written as `make benchmark-test`, but the correct command is `make benchmark`. This PR fixes the issue to prevent confusion for developers following the guide.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4236 
