### PR TITLE
chore: replace profiles section in benchmark report to static content

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -146,9 +146,6 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
     - uses: ./tools/github-actions/setup-deps
 
-    - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c  # v2.0.2
-
     # Benchmark
     - name: Run Benchmark tests
       env:

--- a/.github/workflows/latest_release.yaml
+++ b/.github/workflows/latest_release.yaml
@@ -25,9 +25,6 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
     - uses: ./tools/github-actions/setup-deps
 
-    - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c  # v2.0.2
-
     # Benchmark
     - name: Run Benchmark tests
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - uses: ./tools/github-actions/setup-deps
 
-      - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c  # v2.0.2
-
       # Benchmark
       - name: Run Benchmark tests
         env:

--- a/test/benchmark/suite/render.go
+++ b/test/benchmark/suite/render.go
@@ -77,8 +77,7 @@ func RenderReport(writer io.Writer, name, description string, titleLevel int, re
 	writeSection(writer, "Metrics", titleLevel+1, "")
 	renderMetricsTable(writer, reports)
 
-	writeSection(writer, "Profiles", titleLevel+1, "")
-	renderProfilesTable(writer, "Memory", "heap", titleLevel+2, reports)
+	writeSection(writer, "Profiles", titleLevel+1, renderProfilesContent())
 
 	return nil
 }
@@ -149,15 +148,17 @@ func renderMetricsTable(writer io.Writer, reports []*BenchmarkReport) {
 	_ = table.Flush()
 }
 
-func renderProfilesTable(writer io.Writer, target, key string, titleLevel int, reports []*BenchmarkReport) {
-	writeSection(writer, target, titleLevel, "")
+func renderProfilesContent() string {
+	return fmt.Sprintf(`The profiles at different scales are stored under %s directory in report, with name %s.
 
-	for _, report := range reports {
-		// The image is not be rendered yet, so it is a placeholder for the path.
-		// The image will be rendered after the test has finished.
-		writeSection(writer, report.Name, titleLevel+1,
-			fmt.Sprintf("![%s-%s](%s.png)", key, report.Name, report.ProfilesPath[key]))
-	}
+You can visualize them by running:
+
+%s
+
+Currently, the supported profile types are:
+- heap
+
+`, "`/profiles`", "`{ProfileType}.{TestCase}.pprof`", "```shell\ngo tool pprof -http=: path/to/your.pprof\n```")
 }
 
 // writeSection writes one section in Markdown style, content is optional.

--- a/test/benchmark/suite/report.go
+++ b/test/benchmark/suite/report.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +30,6 @@ type BenchmarkReport struct {
 	Name              string
 	Result            []byte
 	Metrics           map[string]float64 // metricTableHeaderName:metricValue
-	ProfilesPath      map[string]string  // profileKey:profileFilepath
 	ProfilesOutputDir string
 
 	kubeClient kube.CLIClient
@@ -46,7 +44,6 @@ func NewBenchmarkReport(name, profilesOutputDir string, kubeClient kube.CLIClien
 	return &BenchmarkReport{
 		Name:              name,
 		Metrics:           make(map[string]float64),
-		ProfilesPath:      make(map[string]string),
 		ProfilesOutputDir: profilesOutputDir,
 		kubeClient:        kubeClient,
 		promClient:        promClient,
@@ -143,11 +140,6 @@ func (r *BenchmarkReport) GetProfiles(ctx context.Context) error {
 	if err = os.WriteFile(heapProfPath, heapProf, 0o600); err != nil {
 		return fmt.Errorf("failed to write profiles %s: %w", heapProfPath, err)
 	}
-
-	// Remove parent output report dir.
-	splits := strings.SplitN(heapProfPath, "/", 2)[0]
-	heapProfPath = strings.TrimPrefix(heapProfPath, splits+"/")
-	r.ProfilesPath["heap"] = heapProfPath
 
 	return nil
 }

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -172,12 +172,6 @@ run-benchmark: install-benchmark-server ## Run benchmark tests
 	kubectl wait --timeout=$(WAIT_TIMEOUT) -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
 	kubectl apply -f test/benchmark/config/gatewayclass.yaml
 	go test -v -tags benchmark -timeout $(BENCHMARK_TIMEOUT) ./test/benchmark --rps=$(BENCHMARK_RPS) --connections=$(BENCHMARK_CONNECTIONS) --duration=$(BENCHMARK_DURATION) --report-save-dir=$(BENCHMARK_REPORT_DIR)
-	# render benchmark profiles into image
-	dot -V
-	@for profile in $(wildcard test/benchmark/$(BENCHMARK_REPORT_DIR)/profiles/*.pprof); do \
-		$(call log, "Rendering profile image for: $${profile}"); \
-		go tool pprof -png $${profile} > $${profile}.png; \
-	done
 
 .PHONY: install-benchmark-server
 install-benchmark-server: ## Install nighthawk server for benchmark test


### PR DESCRIPTION

**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

Profile section was brought in #3951, but something wrong with its generated images, so replacing them into a static content, like instructions on how to visualize these profile data.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
