### PR TITLE
performance: changing Infra and Xds IR log values to JSONString

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -172,7 +172,7 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 				// Publish the IRs.
 				// Also validate the ir before sending it.
 				for key, val := range result.InfraIR {
-					r.Logger.WithValues("infra-ir", key).Info(val.YAMLString())
+					r.Logger.WithValues("infra-ir", key).Info(val.JSONString())
 					if err := val.Validate(); err != nil {
 						r.Logger.Error(err, "unable to validate infra ir, skipped sending it")
 						errChan <- err
@@ -183,7 +183,7 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 				}
 
 				for key, val := range result.XdsIR {
-					r.Logger.WithValues("xds-ir", key).Info(val.YAMLString())
+					r.Logger.WithValues("xds-ir", key).Info(val.JSONString())
 					if err := val.Validate(); err != nil {
 						r.Logger.Error(err, "unable to validate xds ir, skipped sending it")
 						errChan <- err

--- a/internal/ir/infra.go
+++ b/internal/ir/infra.go
@@ -7,6 +7,7 @@ package ir
 
 import (
 	"cmp"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -32,6 +33,11 @@ type Infra struct {
 func (i Infra) YAMLString() string {
 	y, _ := yaml.Marshal(&i)
 	return string(y)
+}
+
+func (i Infra) JSONString() string {
+	j, _ := json.MarshalIndent(&i, "", "\t")
+	return string(j)
 }
 
 // ProxyInfra defines managed proxy infrastructure.

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -7,6 +7,7 @@ package ir
 
 import (
 	"cmp"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -174,6 +175,11 @@ func (x Xds) GetUDPListener(name string) *UDPListener {
 func (x Xds) YAMLString() string {
 	y, _ := yaml.Marshal(x.Printable())
 	return string(y)
+}
+
+func (x Xds) JSONString() string {
+	j, _ := json.MarshalIndent(x.Printable(), "", "\t")
+	return string(j)
 }
 
 // Printable returns a deep copy of the resource that can be safely logged.


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

changing infra and xds IR log value from yaml to json

before:

<img width="713" alt="image" src="https://github.com/user-attachments/assets/c5abd00c-3f11-4c12-83f4-7b15521e81b8">

after:

<img width="692" alt="image" src="https://github.com/user-attachments/assets/34d0533c-b684-45db-ab01-b30ca84988a4">

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

fix #3698

before:

<img width="894" alt="image" src="https://github.com/user-attachments/assets/2982ff27-b719-4a8c-bc6f-1eb8cda47175">

after:

<img width="883" alt="image" src="https://github.com/user-attachments/assets/55805a55-7a2f-4f49-b098-abb851037daa">

AYCS, the highest mem cost has been decreased from 1370MB to 590MB.
