### PR TITLE
ci: enable osv-scanner call analysis

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -24,5 +24,4 @@ jobs:
         scan-args: |-
           --skip-git
           --experimental-licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib
-          --no-call-analysis=go
           ./

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -29,7 +29,6 @@ jobs:
       scan-args: |-
         --skip-git
         --recursive
-        --no-call-analysis=go
         ./
 
   scan-pr:
@@ -44,5 +43,4 @@ jobs:
       scan-args: |-
         --skip-git
         --recursive
-        --no-call-analysis=go
         ./


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable `osv-scanner` call analysis since https://github.com/google/osv-scanner/issues/1220 was fixed in latest release(v1.8.5).
