### PR TITLE
fix: handle invalid sectionName in BackendTLSPolicy for Backend

### DIFF
--- a/internal/gatewayapi/backendtlspolicy.go
+++ b/internal/gatewayapi/backendtlspolicy.go
@@ -145,7 +145,10 @@ func backendTLSTargetMatched(policy gwapiv1a3.BackendTLSPolicy, target gwapiv1a2
 			target.Kind == currTarget.Kind &&
 			backendNamespace == policy.Namespace &&
 			target.Name == currTarget.Name {
-			if currTarget.SectionName != nil && *currTarget.SectionName != *target.SectionName {
+			if currTarget.SectionName != nil {
+				if target.SectionName != nil && *currTarget.SectionName == *target.SectionName {
+					return true
+				}
 				return false
 			}
 			return true

--- a/internal/gatewayapi/testdata/backendtlspolicy-default-ns.in.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-default-ns.in.yaml
@@ -33,7 +33,11 @@ httpRoutes:
             - name: http-backend
               namespace: default
               port: 8080
-            - name: backend-ip-tls
+            - name: backend-ip-tls-1
+              namespace: default
+              kind: Backend
+              group: gateway.envoyproxy.io
+            - name: backend-ip-tls-2
               namespace: default
               kind: Backend
               group: gateway.envoyproxy.io
@@ -140,13 +144,30 @@ backendTLSPolicies:
   - apiVersion: gateway.networking.k8s.io/v1alpha2
     kind: BackendTLSPolicy
     metadata:
-      name: policy-btls-backend-ip
+      name: policy-btls-backend-ip-1
       namespace: default
     spec:
       targetRefs:
         - group: gateway.envoyproxy.io
           kind: Backend
-          name: backend-ip-tls
+          name: backend-ip-tls-1
+      validation:
+        caCertificateRefs:
+          - name: ca-cmap
+            group: ''
+            kind: ConfigMap
+        hostname: ip-backend
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: BackendTLSPolicy
+    metadata:
+      name: policy-btls-backend-ip-2
+      namespace: default
+    spec:
+      targetRefs:
+        - group: gateway.envoyproxy.io
+          kind: Backend
+          name: backend-ip-tls-2
+          sectionName: 3443
       validation:
         caCertificateRefs:
           - name: ca-cmap
@@ -157,10 +178,20 @@ backends:
   - apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: Backend
     metadata:
-      name: backend-ip-tls
+      name: backend-ip-tls-1
       namespace: default
     spec:
       endpoints:
         - ip:
             address: 2.2.2.2
+            port: 3443
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: Backend
+    metadata:
+      name: backend-ip-tls-2
+      namespace: default
+    spec:
+      endpoints:
+        - ip:
+            address: 3.3.3.3
             port: 3443

--- a/internal/gatewayapi/testdata/backendtlspolicy-default-ns.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-default-ns.out.yaml
@@ -34,13 +34,13 @@ backendTLSPolicies:
   kind: BackendTLSPolicy
   metadata:
     creationTimestamp: null
-    name: policy-btls-backend-ip
+    name: policy-btls-backend-ip-1
     namespace: default
   spec:
     targetRefs:
     - group: gateway.envoyproxy.io
       kind: Backend
-      name: backend-ip-tls
+      name: backend-ip-tls-1
     validation:
       caCertificateRefs:
       - group: ""
@@ -60,17 +60,55 @@ backendTLSPolicies:
         status: "True"
         type: Accepted
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: BackendTLSPolicy
+  metadata:
+    creationTimestamp: null
+    name: policy-btls-backend-ip-2
+    namespace: default
+  spec:
+    targetRefs:
+    - group: gateway.envoyproxy.io
+      kind: Backend
+      name: backend-ip-tls-2
+      sectionName: "3443"
+    validation:
+      caCertificateRefs:
+      - group: ""
+        kind: ConfigMap
+        name: ca-cmap
+      hostname: ip-backend
+  status:
+    ancestors: null
 backends:
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: Backend
   metadata:
     creationTimestamp: null
-    name: backend-ip-tls
+    name: backend-ip-tls-1
     namespace: default
   spec:
     endpoints:
     - ip:
         address: 2.2.2.2
+        port: 3443
+  status:
+    conditions:
+    - lastTransitionTime: null
+      message: The Backend was accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: Backend
+  metadata:
+    creationTimestamp: null
+    name: backend-ip-tls-2
+    namespace: default
+  spec:
+    endpoints:
+    - ip:
+        address: 3.3.3.3
         port: 3443
   status:
     conditions:
@@ -139,7 +177,11 @@ httpRoutes:
         port: 8080
       - group: gateway.envoyproxy.io
         kind: Backend
-        name: backend-ip-tls
+        name: backend-ip-tls-1
+        namespace: default
+      - group: gateway.envoyproxy.io
+        kind: Backend
+        name: backend-ip-tls-2
         namespace: default
       matches:
       - path:
@@ -221,8 +263,13 @@ xdsIR:
             tls:
               caCertificate:
                 certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKekNDQWcrZ0F3SUJBZ0lVQWw2VUtJdUttenRlODFjbGx6NVBmZE4ySWxJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0l6RVFNQTRHQTFVRUF3d0hiWGxqYVdWdWRERVBNQTBHQTFVRUNnd0dhM1ZpWldSaU1CNFhEVEl6TVRBdwpNakExTkRFMU4xb1hEVEkwTVRBd01UQTFOREUxTjFvd0l6RVFNQTRHQTFVRUF3d0hiWGxqYVdWdWRERVBNQTBHCkExVUVDZ3dHYTNWaVpXUmlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXdTVGMKMXlqOEhXNjJueW5rRmJYbzRWWEt2MmpDMFBNN2RQVmt5ODdGd2VaY1RLTG9XUVZQUUUycDJrTERLNk9Fc3ptTQp5eXIreHhXdHlpdmVyZW1yV3FuS2tOVFloTGZZUGhnUWtjemliN2VVYWxtRmpVYmhXZEx2SGFrYkVnQ29kbjNiCmt6NTdtSW5YMlZwaURPS2c0a3lIZml1WFdwaUJxckN4MEtOTHB4bzNERVFjRmNzUVRlVEh6aDQ3NTJHVjA0UlUKVGkvR0VXeXpJc2w0Umc3dEd0QXdtY0lQZ1VOVWZZMlEzOTBGR3FkSDRhaG4rbXcvNmFGYlczMVc2M2Q5WUpWcQppb3lPVmNhTUlwTTVCL2M3UWM4U3VoQ0kxWUdoVXlnNGNSSExFdzVWdGlraW95RTNYMDRrbmEzalFBajU0WWJSCmJwRWhjMzVhcEtMQjIxSE9VUUlEQVFBQm8xTXdVVEFkQmdOVkhRNEVGZ1FVeXZsMFZJNXZKVlN1WUZYdTdCNDgKNlBiTUVBb3dId1lEVlIwakJCZ3dGb0FVeXZsMFZJNXZKVlN1WUZYdTdCNDg2UGJNRUFvd0R3WURWUjBUQVFILwpCQVV3QXdFQi96QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFNTHhyZ0ZWTXVOUnEyd0F3Y0J0N1NuTlI1Q2Z6CjJNdlhxNUVVbXVhd0lVaTlrYVlqd2RWaURSRUdTams3SlcxN3ZsNTc2SGpEa2RmUndpNEUyOFN5ZFJJblpmNkoKaThIWmNaN2NhSDZEeFIzMzVmZ0hWekxpNU5pVGNlL09qTkJRelEyTUpYVkRkOERCbUc1ZnlhdEppT0pRNGJXRQpBN0ZsUDBSZFAzQ08zR1dFME01aVhPQjJtMXFXa0UyZXlPNFVIdndUcU5RTGRyZEFYZ0RRbGJhbTllNEJHM0dnCmQvNnRoQWtXRGJ0L1FOVCtFSkhEQ3ZoRFJLaDFSdUdIeWcrWSsvbmViVFdXckZXc2t0UnJiT29IQ1ppQ3BYSTEKM2VYRTZudDBZa2d0RHhHMjJLcW5ocEFnOWdVU3MyaGxob3h5dmt6eUYwbXU2TmhQbHdBZ25xNysvUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
-                name: policy-btls-backend-ip/default-ca
+                name: policy-btls-backend-ip-1/default-ca
               sni: ip-backend
+            weight: 1
+          - addressType: IP
+            endpoints:
+            - host: 3.3.3.3
+              port: 3443
             weight: 1
         hostname: '*'
         isHTTP2: false


### PR DESCRIPTION
Targeting a `sectionName` for `kind:backend` is invalid in BackendTLSPolicy because there is no notion of sections in Backend

Fixes: https://github.com/envoyproxy/gateway/issues/4291