### PR TITLE
set invalid Listener.SupportedKinds to empty list

### DIFF
--- a/internal/gatewayapi/contexts.go
+++ b/internal/gatewayapi/contexts.go
@@ -77,8 +77,7 @@ type ListenerContext struct {
 
 func (l *ListenerContext) SetSupportedKinds(kinds ...gwapiv1.RouteGroupKind) {
 	l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds = make([]gwapiv1.RouteGroupKind, 0, len(kinds))
-	l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds =
-		append(l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds, kinds...)
+	l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds = append(l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds, kinds...)
 }
 
 func (l *ListenerContext) IncrementAttachedRoutes() {

--- a/internal/gatewayapi/contexts.go
+++ b/internal/gatewayapi/contexts.go
@@ -76,7 +76,9 @@ type ListenerContext struct {
 }
 
 func (l *ListenerContext) SetSupportedKinds(kinds ...gwapiv1.RouteGroupKind) {
-	l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds = kinds
+	l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds = make([]gwapiv1.RouteGroupKind, 0, len(kinds))
+	l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds =
+		append(l.gateway.Status.Listeners[l.listenerStatusIdx].SupportedKinds, kinds...)
 }
 
 func (l *ListenerContext) IncrementAttachedRoutes() {

--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -74,7 +74,7 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR resource
 			case gwapiv1.UDPProtocolType:
 				t.validateAllowedRoutes(listener, resource.KindUDPRoute)
 			default:
-				listener.SetSupportedKinds(gwapiv1.RouteGroupKind{Kind: "InvalidKind"})
+				listener.SetSupportedKinds()
 				status.SetGatewayListenerStatusCondition(listener.gateway.Gateway,
 					listener.listenerStatusIdx,
 					gwapiv1.ListenerConditionAccepted,

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
@@ -34,8 +34,7 @@ gateways:
         status: "True"
         type: ResolvedRefs
       name: unsupported
-      supportedKinds:
-      - kind: InvalidKind
+      supportedKinds: []
 httpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: HTTPRoute


### PR DESCRIPTION
Fixes: https://github.com/envoyproxy/gateway/issues/4216

Relates to https://kubernetes.slack.com/archives/CR0H13KGA/p1727457195236889