### PR TITLE
docs: Fix capital D in ratelimit example

### DIFF
--- a/site/content/en/docs/tasks/traffic/global-rate-limit.md
+++ b/site/content/en/docs/tasks/traffic/global-rate-limit.md
@@ -871,7 +871,7 @@ spec:
       - clientSelectors:
         - sourceCIDR: 
             value: 0.0.0.0/0
-            type: distinct
+            type: Distinct
         limit:
           requests: 3
           unit: Hour

--- a/site/content/en/latest/tasks/traffic/global-rate-limit.md
+++ b/site/content/en/latest/tasks/traffic/global-rate-limit.md
@@ -870,7 +870,7 @@ spec:
       - clientSelectors:
         - sourceCIDR: 
             value: 0.0.0.0/0
-            type: distinct
+            type: Distinct
         limit:
           requests: 3
           unit: Hour

--- a/site/content/en/v1.1/tasks/traffic/global-rate-limit.md
+++ b/site/content/en/v1.1/tasks/traffic/global-rate-limit.md
@@ -871,7 +871,7 @@ spec:
       - clientSelectors:
         - sourceCIDR: 
             value: 0.0.0.0/0
-            type: distinct
+            type: Distinct
         limit:
           requests: 3
           unit: Hour


### PR DESCRIPTION
**What type of PR is this?**

docs: Fix capital D in ratelimit example

**What this PR does / why we need it**:

This is a super dummy 1-char fix to docs fixing the capitalization of a rate limit example.

I see the same error in the versioned docs, let me know and I can fix the rest of them (not sure since they seem to be tied to a released tag):

```
site/content/en/docs/tasks/traffic/global-rate-limit.md:            type: distinct
site/content/en/latest/tasks/traffic/global-rate-limit.md:            type: distinct
site/content/en/v0.5/user/rate-limit.md:          type: distinct
site/content/en/v0.6/user/rate-limit.md:            type: distinct
site/content/en/v1.1/tasks/traffic/global-rate-limit.md:            type: distinct

```
