### PR TITLE
chore: set klog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -286,7 +286,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/component-base v0.31.1 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/klog/v2 v2.130.1
 	k8s.io/kube-openapi v0.0.0-20240521193020-835d969ad83a // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.17.2 // indirect

--- a/internal/provider/kubernetes/kubernetes.go
+++ b/internal/provider/kubernetes/kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -47,6 +48,7 @@ func New(cfg *rest.Config, svr *ec.Server, resources *message.ProviderResources)
 	}
 
 	log.SetLogger(mgrOpts.Logger)
+	klog.SetLogger(mgrOpts.Logger)
 
 	if !ptr.Deref(svr.EnvoyGateway.Provider.Kubernetes.LeaderElection.Disable, false) {
 		mgrOpts.LeaderElection = true


### PR DESCRIPTION
before:
```console
2024-10-16T11:42:37.646Z	INFO	provider	kubernetes/controller.go:190	no accepted gatewayclass	{"runner": "provider"}
I1016 11:42:53.639624       1 leaderelection.go:268] successfully acquired lease envoy-gateway-system/5b9825d2.gateway.envoyproxy.io
```

after:
```console
2024-10-16T12:35:52.033Z	INFO	provider	leaderelection/leaderelection.go:254	attempting to acquire leader lease envoy-gateway-system/5b9825d2.gateway.envoyproxy.io...	{"runner": "provider"}
2024-10-16T12:36:18.142Z	INFO	provider	leaderelection/leaderelection.go:268	successfully acquired lease envoy-gateway-system/5b9825d2.gateway.envoyproxy.io	{"runner": "provider"}
```