### PR TITLE
Docs/Tests: documentation and e2e tests for Datadog tracing

### DIFF
--- a/charts/gateway-addons-helm/Chart.lock
+++ b/charts/gateway-addons-helm/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 1.3.1
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.73.1
-digest: sha256:4c16df8d7efc27aff566fa5dfd2eba6527adbf3fc8e94e7e3ccfc0cee7836f1c
-generated: "2024-06-20T11:46:59.148579+08:00"
+  version: 0.108.0
+digest: sha256:ea6663bb1358123b96b69d2c5b0b8c20650a43dc39b24c482f0560201fd2cc3a
+generated: "2024-10-19T12:59:47.251089661+02:00"

--- a/charts/gateway-addons-helm/Chart.yaml
+++ b/charts/gateway-addons-helm/Chart.yaml
@@ -47,5 +47,5 @@ dependencies:
     condition: tempo.enabled
   - name: opentelemetry-collector
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.73.1
+    version: 0.108.0
     condition: opentelemetry-collector.enabled

--- a/charts/gateway-addons-helm/README.md
+++ b/charts/gateway-addons-helm/README.md
@@ -25,7 +25,7 @@ An Add-ons Helm chart for Envoy Gateway
 | https://grafana.github.io/helm-charts | grafana | 8.0.0 |
 | https://grafana.github.io/helm-charts | loki | 4.8.0 |
 | https://grafana.github.io/helm-charts | tempo | 1.3.1 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.73.1 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.108.0 |
 | https://prometheus-community.github.io/helm-charts | prometheus | 25.21.0 |
 
 ## Usage
@@ -103,7 +103,7 @@ To uninstall the chart:
 | loki.singleBinary.replicas | int | `1` |  |
 | loki.test.enabled | bool | `false` |  |
 | loki.write.replicas | int | `0` |  |
-| opentelemetry-collector.config.exporters.logging.verbosity | string | `"detailed"` |  |
+| opentelemetry-collector.config.exporters.debug.verbosity | string | `"detailed"` |  |
 | opentelemetry-collector.config.exporters.loki.endpoint | string | `"http://loki.monitoring.svc:3100/loki/api/v1/push"` |  |
 | opentelemetry-collector.config.exporters.otlp.endpoint | string | `"tempo.monitoring.svc:4317"` |  |
 | opentelemetry-collector.config.exporters.otlp.tls.insecure | bool | `true` |  |
@@ -112,6 +112,7 @@ To uninstall the chart:
 | opentelemetry-collector.config.processors.attributes.actions[0].action | string | `"insert"` |  |
 | opentelemetry-collector.config.processors.attributes.actions[0].key | string | `"loki.attribute.labels"` |  |
 | opentelemetry-collector.config.processors.attributes.actions[0].value | string | `"k8s.pod.name, k8s.namespace.name"` |  |
+| opentelemetry-collector.config.receivers.datadog.endpoint | string | `"${env:MY_POD_IP}:8126"` |  |
 | opentelemetry-collector.config.receivers.otlp.protocols.grpc.endpoint | string | `"${env:MY_POD_IP}:4317"` |  |
 | opentelemetry-collector.config.receivers.otlp.protocols.http.endpoint | string | `"${env:MY_POD_IP}:4318"` |  |
 | opentelemetry-collector.config.receivers.zipkin.endpoint | string | `"${env:MY_POD_IP}:9411"` |  |
@@ -120,12 +121,15 @@ To uninstall the chart:
 | opentelemetry-collector.config.service.pipelines.logs.processors[0] | string | `"attributes"` |  |
 | opentelemetry-collector.config.service.pipelines.logs.receivers[0] | string | `"otlp"` |  |
 | opentelemetry-collector.config.service.pipelines.metrics.exporters[0] | string | `"prometheus"` |  |
-| opentelemetry-collector.config.service.pipelines.metrics.receivers[0] | string | `"otlp"` |  |
+| opentelemetry-collector.config.service.pipelines.metrics.receivers[0] | string | `"datadog"` |  |
+| opentelemetry-collector.config.service.pipelines.metrics.receivers[1] | string | `"otlp"` |  |
 | opentelemetry-collector.config.service.pipelines.traces.exporters[0] | string | `"otlp"` |  |
-| opentelemetry-collector.config.service.pipelines.traces.receivers[0] | string | `"otlp"` |  |
-| opentelemetry-collector.config.service.pipelines.traces.receivers[1] | string | `"zipkin"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.receivers[0] | string | `"datadog"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.receivers[1] | string | `"otlp"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.receivers[2] | string | `"zipkin"` |  |
 | opentelemetry-collector.enabled | bool | `false` |  |
 | opentelemetry-collector.fullnameOverride | string | `"otel-collector"` |  |
+| opentelemetry-collector.image.repository | string | `"otel/opentelemetry-collector-contrib"` |  |
 | opentelemetry-collector.mode | string | `"deployment"` |  |
 | prometheus.alertmanager.enabled | bool | `false` |  |
 | prometheus.enabled | bool | `true` |  |

--- a/charts/gateway-addons-helm/values.yaml
+++ b/charts/gateway-addons-helm/values.yaml
@@ -181,11 +181,13 @@ opentelemetry-collector:
   enabled: false
   fullnameOverride: otel-collector
   mode: deployment
+  image:
+    repository: "otel/opentelemetry-collector-contrib"
   config:
     exporters:
       prometheus:
         endpoint: 0.0.0.0:19001
-      logging:
+      debug:
         verbosity: detailed
       loki:
         endpoint: "http://loki.monitoring.svc:3100/loki/api/v1/push"
@@ -207,6 +209,8 @@ opentelemetry-collector:
             # Loki will convert this to k8s_pod_name label.
             value: k8s.pod.name, k8s.namespace.name
     receivers:
+      datadog:
+        endpoint: ${env:MY_POD_IP}:8126
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
       otlp:
@@ -223,6 +227,7 @@ opentelemetry-collector:
           exporters:
             - prometheus
           receivers:
+            - datadog
             - otlp
         logs:
           exporters:
@@ -235,5 +240,6 @@ opentelemetry-collector:
           exporters:
             - otlp
           receivers:
+            - datadog
             - otlp
             - zipkin

--- a/site/content/en/latest/install/gateway-addons-helm-api.md
+++ b/site/content/en/latest/install/gateway-addons-helm-api.md
@@ -27,7 +27,7 @@ An Add-ons Helm chart for Envoy Gateway
 | https://grafana.github.io/helm-charts | grafana | 8.0.0 |
 | https://grafana.github.io/helm-charts | loki | 4.8.0 |
 | https://grafana.github.io/helm-charts | tempo | 1.3.1 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.73.1 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.108.0 |
 | https://prometheus-community.github.io/helm-charts | prometheus | 25.21.0 |
 
 ## Values
@@ -82,7 +82,7 @@ An Add-ons Helm chart for Envoy Gateway
 | loki.singleBinary.replicas | int | `1` |  |
 | loki.test.enabled | bool | `false` |  |
 | loki.write.replicas | int | `0` |  |
-| opentelemetry-collector.config.exporters.logging.verbosity | string | `"detailed"` |  |
+| opentelemetry-collector.config.exporters.debug.verbosity | string | `"detailed"` |  |
 | opentelemetry-collector.config.exporters.loki.endpoint | string | `"http://loki.monitoring.svc:3100/loki/api/v1/push"` |  |
 | opentelemetry-collector.config.exporters.otlp.endpoint | string | `"tempo.monitoring.svc:4317"` |  |
 | opentelemetry-collector.config.exporters.otlp.tls.insecure | bool | `true` |  |
@@ -91,6 +91,7 @@ An Add-ons Helm chart for Envoy Gateway
 | opentelemetry-collector.config.processors.attributes.actions[0].action | string | `"insert"` |  |
 | opentelemetry-collector.config.processors.attributes.actions[0].key | string | `"loki.attribute.labels"` |  |
 | opentelemetry-collector.config.processors.attributes.actions[0].value | string | `"k8s.pod.name, k8s.namespace.name"` |  |
+| opentelemetry-collector.config.receivers.datadog.endpoint | string | `"${env:MY_POD_IP}:8126"` |  |
 | opentelemetry-collector.config.receivers.otlp.protocols.grpc.endpoint | string | `"${env:MY_POD_IP}:4317"` |  |
 | opentelemetry-collector.config.receivers.otlp.protocols.http.endpoint | string | `"${env:MY_POD_IP}:4318"` |  |
 | opentelemetry-collector.config.receivers.zipkin.endpoint | string | `"${env:MY_POD_IP}:9411"` |  |
@@ -99,12 +100,15 @@ An Add-ons Helm chart for Envoy Gateway
 | opentelemetry-collector.config.service.pipelines.logs.processors[0] | string | `"attributes"` |  |
 | opentelemetry-collector.config.service.pipelines.logs.receivers[0] | string | `"otlp"` |  |
 | opentelemetry-collector.config.service.pipelines.metrics.exporters[0] | string | `"prometheus"` |  |
-| opentelemetry-collector.config.service.pipelines.metrics.receivers[0] | string | `"otlp"` |  |
+| opentelemetry-collector.config.service.pipelines.metrics.receivers[0] | string | `"datadog"` |  |
+| opentelemetry-collector.config.service.pipelines.metrics.receivers[1] | string | `"otlp"` |  |
 | opentelemetry-collector.config.service.pipelines.traces.exporters[0] | string | `"otlp"` |  |
-| opentelemetry-collector.config.service.pipelines.traces.receivers[0] | string | `"otlp"` |  |
-| opentelemetry-collector.config.service.pipelines.traces.receivers[1] | string | `"zipkin"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.receivers[0] | string | `"datadog"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.receivers[1] | string | `"otlp"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.receivers[2] | string | `"zipkin"` |  |
 | opentelemetry-collector.enabled | bool | `false` |  |
 | opentelemetry-collector.fullnameOverride | string | `"otel-collector"` |  |
+| opentelemetry-collector.image.repository | string | `"otel/opentelemetry-collector-contrib"` |  |
 | opentelemetry-collector.mode | string | `"deployment"` |  |
 | prometheus.alertmanager.enabled | bool | `false` |  |
 | prometheus.enabled | bool | `true` |  |

--- a/site/content/zh/latest/install/gateway-addons-helm-api.md
+++ b/site/content/zh/latest/install/gateway-addons-helm-api.md
@@ -27,7 +27,7 @@ An Add-ons Helm chart for Envoy Gateway
 | https://grafana.github.io/helm-charts | grafana | 8.0.0 |
 | https://grafana.github.io/helm-charts | loki | 4.8.0 |
 | https://grafana.github.io/helm-charts | tempo | 1.3.1 |
-| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.73.1 |
+| https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.108.0 |
 | https://prometheus-community.github.io/helm-charts | prometheus | 25.21.0 |
 
 ## Values
@@ -82,7 +82,7 @@ An Add-ons Helm chart for Envoy Gateway
 | loki.singleBinary.replicas | int | `1` |  |
 | loki.test.enabled | bool | `false` |  |
 | loki.write.replicas | int | `0` |  |
-| opentelemetry-collector.config.exporters.logging.verbosity | string | `"detailed"` |  |
+| opentelemetry-collector.config.exporters.debug.verbosity | string | `"detailed"` |  |
 | opentelemetry-collector.config.exporters.loki.endpoint | string | `"http://loki.monitoring.svc:3100/loki/api/v1/push"` |  |
 | opentelemetry-collector.config.exporters.otlp.endpoint | string | `"tempo.monitoring.svc:4317"` |  |
 | opentelemetry-collector.config.exporters.otlp.tls.insecure | bool | `true` |  |
@@ -91,6 +91,7 @@ An Add-ons Helm chart for Envoy Gateway
 | opentelemetry-collector.config.processors.attributes.actions[0].action | string | `"insert"` |  |
 | opentelemetry-collector.config.processors.attributes.actions[0].key | string | `"loki.attribute.labels"` |  |
 | opentelemetry-collector.config.processors.attributes.actions[0].value | string | `"k8s.pod.name, k8s.namespace.name"` |  |
+| opentelemetry-collector.config.receivers.datadog.endpoint | string | `"${env:MY_POD_IP}:8126"` |  |
 | opentelemetry-collector.config.receivers.otlp.protocols.grpc.endpoint | string | `"${env:MY_POD_IP}:4317"` |  |
 | opentelemetry-collector.config.receivers.otlp.protocols.http.endpoint | string | `"${env:MY_POD_IP}:4318"` |  |
 | opentelemetry-collector.config.receivers.zipkin.endpoint | string | `"${env:MY_POD_IP}:9411"` |  |
@@ -99,12 +100,15 @@ An Add-ons Helm chart for Envoy Gateway
 | opentelemetry-collector.config.service.pipelines.logs.processors[0] | string | `"attributes"` |  |
 | opentelemetry-collector.config.service.pipelines.logs.receivers[0] | string | `"otlp"` |  |
 | opentelemetry-collector.config.service.pipelines.metrics.exporters[0] | string | `"prometheus"` |  |
-| opentelemetry-collector.config.service.pipelines.metrics.receivers[0] | string | `"otlp"` |  |
+| opentelemetry-collector.config.service.pipelines.metrics.receivers[0] | string | `"datadog"` |  |
+| opentelemetry-collector.config.service.pipelines.metrics.receivers[1] | string | `"otlp"` |  |
 | opentelemetry-collector.config.service.pipelines.traces.exporters[0] | string | `"otlp"` |  |
-| opentelemetry-collector.config.service.pipelines.traces.receivers[0] | string | `"otlp"` |  |
-| opentelemetry-collector.config.service.pipelines.traces.receivers[1] | string | `"zipkin"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.receivers[0] | string | `"datadog"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.receivers[1] | string | `"otlp"` |  |
+| opentelemetry-collector.config.service.pipelines.traces.receivers[2] | string | `"zipkin"` |  |
 | opentelemetry-collector.enabled | bool | `false` |  |
 | opentelemetry-collector.fullnameOverride | string | `"otel-collector"` |  |
+| opentelemetry-collector.image.repository | string | `"otel/opentelemetry-collector-contrib"` |  |
 | opentelemetry-collector.mode | string | `"deployment"` |  |
 | prometheus.alertmanager.enabled | bool | `false` |  |
 | prometheus.enabled | bool | `true` |  |

--- a/test/e2e/testdata/tracing-datadog.yaml
+++ b/test/e2e/testdata/tracing-datadog.yaml
@@ -1,0 +1,161 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: eg-special-case-datadog
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: datadog-tracing
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-config
+  namespace: monitoring
+data:
+  config.alloy: |
+    logging {
+      level  = "debug"
+      format = "logfmt"
+    }
+
+    otelcol.processor.batch "default" {
+      output {
+        metrics = [otelcol.exporter.otlp.default.input]
+        traces  = [otelcol.exporter.otlp.default.input]
+      }
+    }
+
+    otelcol.processor.deltatocumulative "default" {
+      max_stale = "5m"
+      max_streams = 100
+      output {
+        metrics = [otelcol.processor.batch.default.input]
+      }
+    }
+
+    otelcol.exporter.otlp "default" {
+      client {
+        endpoint = "otel-collector:4317"
+        tls {
+          insecure = true
+        }
+      }
+    }
+
+    otelcol.receiver.datadog "default" {
+      endpoint = "0.0.0.0:8126"
+      output {
+        metrics = [otelcol.processor.deltatocumulative.default.input]
+        traces  = [otelcol.processor.batch.default.input]
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alloy-deployment
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alloy
+  template:
+    metadata:
+      labels:
+        app: alloy
+    spec:
+      containers:
+      - name: alloy
+        image: grafana/alloy:v1.4.2
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/alloy/config.alloy
+          subPath: config.alloy
+        command: ["alloy", "run", "--stability.level=experimental", "--server.http.listen-addr=0.0.0.0:12345", "--storage.path=/var/lib/alloy/data", "/etc/alloy/config.alloy"]
+      volumes:
+      - name: config-volume
+        configMap:
+          name: alloy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alloy-collector
+  namespace: monitoring
+spec:
+  selector:
+    app: alloy
+  ports:
+  - protocol: TCP
+    port: 8126
+    targetPort: 8126
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: datadog-tracing
+  namespace: gateway-conformance-infra
+spec:
+  logging:
+    level:
+      default: debug
+  telemetry:
+    tracing:
+      provider:
+        type: Datadog
+        backendRefs:
+          - name: alloy-collector
+            namespace: monitoring
+            port: 8126
+      customTags:
+        "provider":
+          type: Literal
+          literal:
+            value: "datadog"
+        "k8s.cluster.name":
+          type: Literal
+          literal:
+            value: "envoy-gateway"
+        "k8s.pod.name":
+          type: Environment
+          environment:
+            name: ENVOY_POD_NAME
+            defaultValue: "-"
+        "k8s.namespace.name":
+          type: Environment
+          environment:
+            name: ENVOY_GATEWAY_NAMESPACE
+            defaultValue: "envoy-gateway-system"
+  shutdown:
+    drainTimeout: 5s
+    minDrainDuration: 1s
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tracing-datadog
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: eg-special-case-datadog
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /datadog
+      backendRefs:
+        - name: infra-backend-v2
+          port: 8080

--- a/test/e2e/testdata/tracing-datadog.yaml
+++ b/test/e2e/testdata/tracing-datadog.yaml
@@ -78,17 +78,17 @@ spec:
         app: alloy
     spec:
       containers:
-      - name: alloy
-        image: grafana/alloy:v1.4.2
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/alloy/config.alloy
-          subPath: config.alloy
-        command: ["alloy", "run", "--stability.level=experimental", "--server.http.listen-addr=0.0.0.0:12345", "--storage.path=/var/lib/alloy/data", "/etc/alloy/config.alloy"]
+        - name: alloy
+          image: grafana/alloy:v1.4.2
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/alloy/config.alloy
+              subPath: config.alloy
+          command: ["alloy", "run", "--stability.level=experimental", "--server.http.listen-addr=0.0.0.0:12345", "--storage.path=/var/lib/alloy/data", "/etc/alloy/config.alloy"]
       volumes:
-      - name: config-volume
-        configMap:
-          name: alloy-config
+        - name: config-volume
+          configMap:
+            name: alloy-config
 ---
 apiVersion: v1
 kind: Service
@@ -99,9 +99,9 @@ spec:
   selector:
     app: alloy
   ports:
-  - protocol: TCP
-    port: 8126
-    targetPort: 8126
+    - protocol: TCP
+      port: 8126
+      targetPort: 8126
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy

--- a/test/e2e/testdata/tracing-datadog.yaml
+++ b/test/e2e/testdata/tracing-datadog.yaml
@@ -19,85 +19,15 @@ spec:
       name: datadog-tracing
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: alloy-config
-  namespace: monitoring
-data:
-  config.alloy: |
-    logging {
-      level  = "debug"
-      format = "logfmt"
-    }
-
-    otelcol.processor.batch "default" {
-      output {
-        metrics = [otelcol.exporter.otlp.default.input]
-        traces  = [otelcol.exporter.otlp.default.input]
-      }
-    }
-
-    otelcol.processor.deltatocumulative "default" {
-      max_stale = "5m"
-      max_streams = 100
-      output {
-        metrics = [otelcol.processor.batch.default.input]
-      }
-    }
-
-    otelcol.exporter.otlp "default" {
-      client {
-        endpoint = "otel-collector:4317"
-        tls {
-          insecure = true
-        }
-      }
-    }
-
-    otelcol.receiver.datadog "default" {
-      endpoint = "0.0.0.0:8126"
-      output {
-        metrics = [otelcol.processor.deltatocumulative.default.input]
-        traces  = [otelcol.processor.batch.default.input]
-      }
-    }
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: alloy-deployment
-  namespace: monitoring
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: alloy
-  template:
-    metadata:
-      labels:
-        app: alloy
-    spec:
-      containers:
-        - name: alloy
-          image: grafana/alloy:v1.4.2
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/alloy/config.alloy
-              subPath: config.alloy
-          command: ["alloy", "run", "--stability.level=experimental", "--server.http.listen-addr=0.0.0.0:12345", "--storage.path=/var/lib/alloy/data", "/etc/alloy/config.alloy"]
-      volumes:
-        - name: config-volume
-          configMap:
-            name: alloy-config
----
-apiVersion: v1
 kind: Service
 metadata:
-  name: alloy-collector
+  name: datadog-agent
   namespace: monitoring
 spec:
   selector:
-    app: alloy
+    app.kubernetes.io/instance: eg-addons
+    app.kubernetes.io/name: opentelemetry-collector
+    component: standalone-collector
   ports:
     - protocol: TCP
       port: 8126
@@ -117,7 +47,7 @@ spec:
       provider:
         type: Datadog
         backendRefs:
-          - name: alloy-collector
+          - name: datadog-agent
             namespace: monitoring
             port: 8126
       customTags:

--- a/test/helm/gateway-addons-helm/e2e.out.yaml
+++ b/test/helm/gateway-addons-helm/e2e.out.yaml
@@ -32,10 +32,10 @@ metadata:
   name: otel-collector
   namespace: monitoring
   labels:
-    helm.sh/chart: opentelemetry-collector-0.73.1
+    helm.sh/chart: opentelemetry-collector-0.108.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: gateway-addons-helm
-    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: gateway-addons-helm/charts/prometheus/templates/serviceaccount.yaml
@@ -219,16 +219,16 @@ metadata:
   name: otel-collector
   namespace: monitoring
   labels:
-    helm.sh/chart: opentelemetry-collector-0.73.1
+    helm.sh/chart: opentelemetry-collector-0.108.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: gateway-addons-helm
-    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   relay: |
     exporters:
-      debug: {}
-      logging:
+      debug:
         verbosity: detailed
       loki:
         endpoint: http://loki.monitoring.svc:3100/loki/api/v1/push
@@ -239,9 +239,8 @@ data:
       prometheus:
         endpoint: 0.0.0.0:19001
     extensions:
-      health_check: {}
-      memory_ballast:
-        size_in_percentage: 40
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     processors:
       attributes:
         actions:
@@ -254,6 +253,8 @@ data:
         limit_percentage: 80
         spike_limit_percentage: 25
     receivers:
+      datadog:
+        endpoint: ${env:MY_POD_IP}:8126
       jaeger:
         protocols:
           grpc:
@@ -296,6 +297,7 @@ data:
           - memory_limiter
           - batch
           receivers:
+          - datadog
           - otlp
         traces:
           exporters:
@@ -304,6 +306,7 @@ data:
           - memory_limiter
           - batch
           receivers:
+          - datadog
           - otlp
           - zipkin
       telemetry:
@@ -9517,11 +9520,12 @@ metadata:
   name: otel-collector
   namespace: monitoring
   labels:
-    helm.sh/chart: opentelemetry-collector-0.73.1
+    helm.sh/chart: opentelemetry-collector-0.108.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: gateway-addons-helm
-    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
+    
     component: standalone-collector
 spec:
   type: ClusterIP
@@ -9733,11 +9737,12 @@ metadata:
   name: otel-collector
   namespace: monitoring
   labels:
-    helm.sh/chart: opentelemetry-collector-0.73.1
+    helm.sh/chart: opentelemetry-collector-0.108.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: gateway-addons-helm
-    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
+    
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -9751,7 +9756,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4eb06aca6ff4da4de927cb9ba7d8ceb883d2484011fbd670683037b8ea4d996c
+        checksum/config: 270a8503091b51a264317115cf6df46b4501b03fc135eca95b93dca57a522a70
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -9765,12 +9770,11 @@ spec:
         {}
       containers:
         - name: opentelemetry-collector
-          command:
-            - /otelcol-contrib
+          args:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.88.0"
+          image: "otel/opentelemetry-collector-contrib:0.111.0"
           imagePullPolicy: IfNotPresent
           ports:
             


### PR DESCRIPTION
Hi

This PR introduce documentation and end-to-end tests for Datadog tracing which added in https://github.com/envoyproxy/gateway/pull/4298


End-to-end test implemented via [Grafana Alloy](https://grafana.com/docs/alloy/latest/), where Alloy acts as adapter from [Datadog agent interface](https://github.com/DataDog/datadog-agent) into `OpenTelemetry` format.

Thanks
