### PR TITLE
feat: set full URI for the envoy-gateway service using name and namespace

### DIFF
--- a/internal/infrastructure/kubernetes/infra.go
+++ b/internal/infrastructure/kubernetes/infra.go
@@ -50,6 +50,9 @@ type Infra struct {
 	// Namespace is the Namespace used for managed infra.
 	Namespace string
 
+	// DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+	DNSDomain string
+
 	// EnvoyGateway is the configuration used to startup Envoy Gateway.
 	EnvoyGateway *egv1a1.EnvoyGateway
 
@@ -61,6 +64,7 @@ type Infra struct {
 func NewInfra(cli client.Client, cfg *config.Server) *Infra {
 	return &Infra{
 		Namespace:    cfg.Namespace,
+		DNSDomain:    cfg.DNSDomain,
 		EnvoyGateway: cfg.EnvoyGateway,
 		Client:       New(cli),
 	}

--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -83,6 +83,8 @@ func expectedProxyContainers(infra *ir.ProxyInfra,
 	containerSpec *egv1a1.KubernetesContainerSpec,
 	shutdownConfig *egv1a1.ShutdownConfig,
 	shutdownManager *egv1a1.ShutdownManager,
+	namespace string,
+	dnsDomain string,
 ) ([]corev1.Container, error) {
 	// Define slice to hold container ports
 	var ports []corev1.ContainerPort
@@ -132,7 +134,7 @@ func expectedProxyContainers(infra *ir.ProxyInfra,
 			TrustedCA:   filepath.Join("/sds", common.SdsCAFilename),
 		},
 		MaxHeapSizeBytes: maxHeapSizeBytes,
-		XdsServerHost:    ptr.To(fmt.Sprintf("%s.%s.svc.cluster.local", infra.Config.Name, infra.Config.Namespace)),
+		XdsServerHost:    ptr.To(fmt.Sprintf("envoy-gateway.%s.svc.%s", namespace, dnsDomain)),
 	}
 
 	args, err := common.BuildProxyArgs(infra, shutdownConfig, bootstrapConfigOptions, fmt.Sprintf("$(%s)", envoyPodEnvVar))

--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -132,6 +132,7 @@ func expectedProxyContainers(infra *ir.ProxyInfra,
 			TrustedCA:   filepath.Join("/sds", common.SdsCAFilename),
 		},
 		MaxHeapSizeBytes: maxHeapSizeBytes,
+		XdsServerHost:    ptr.To(fmt.Sprintf("%s.%s.svc.cluster.local", infra.Config.Name, infra.Config.Namespace)),
 	}
 
 	args, err := common.BuildProxyArgs(infra, shutdownConfig, bootstrapConfigOptions, fmt.Sprintf("$(%s)", envoyPodEnvVar))

--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -134,7 +134,7 @@ func expectedProxyContainers(infra *ir.ProxyInfra,
 			TrustedCA:   filepath.Join("/sds", common.SdsCAFilename),
 		},
 		MaxHeapSizeBytes: maxHeapSizeBytes,
-		XdsServerHost:    ptr.To(fmt.Sprintf("envoy-gateway.%s.svc.%s", namespace, dnsDomain)),
+		XdsServerHost:    ptr.To(fmt.Sprintf("%s.%s.svc.%s", config.EnvoyGatewayServiceName, namespace, dnsDomain)),
 	}
 
 	args, err := common.BuildProxyArgs(infra, shutdownConfig, bootstrapConfigOptions, fmt.Sprintf("$(%s)", envoyPodEnvVar))

--- a/internal/infrastructure/kubernetes/proxy/resource_provider.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider.go
@@ -45,12 +45,16 @@ type ResourceRender struct {
 	// Namespace is the Namespace used for managed infra.
 	Namespace string
 
+	// DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+	DNSDomain string
+
 	ShutdownManager *egv1a1.ShutdownManager
 }
 
-func NewResourceRender(ns string, infra *ir.ProxyInfra, gateway *egv1a1.EnvoyGateway) *ResourceRender {
+func NewResourceRender(ns string, dnsDomain string, infra *ir.ProxyInfra, gateway *egv1a1.EnvoyGateway) *ResourceRender {
 	return &ResourceRender{
 		Namespace:       ns,
+		DNSDomain:       dnsDomain,
 		infra:           infra,
 		ShutdownManager: gateway.GetEnvoyGatewayProvider().GetEnvoyGatewayKubeProvider().ShutdownManager,
 	}
@@ -258,7 +262,7 @@ func (r *ResourceRender) Deployment() (*appsv1.Deployment, error) {
 
 	proxyConfig := r.infra.GetProxyConfig()
 	// Get expected bootstrap configurations rendered ProxyContainers
-	containers, err := expectedProxyContainers(r.infra, deploymentConfig.Container, proxyConfig.Spec.Shutdown, r.ShutdownManager)
+	containers, err := expectedProxyContainers(r.infra, deploymentConfig.Container, proxyConfig.Spec.Shutdown, r.ShutdownManager, r.Namespace, r.DNSDomain)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +364,7 @@ func (r *ResourceRender) DaemonSet() (*appsv1.DaemonSet, error) {
 	proxyConfig := r.infra.GetProxyConfig()
 
 	// Get expected bootstrap configurations rendered ProxyContainers
-	containers, err := expectedProxyContainers(r.infra, daemonSetConfig.Container, proxyConfig.Spec.Shutdown, r.ShutdownManager)
+	containers, err := expectedProxyContainers(r.infra, daemonSetConfig.Container, proxyConfig.Spec.Shutdown, r.ShutdownManager, r.Namespace, r.DNSDomain)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
@@ -58,6 +58,13 @@ func newTestInfraWithAddresses(addresses []string) *ir.Infra {
 func newTestInfraWithAnnotationsAndLabels(annotations, labels map[string]string) *ir.Infra {
 	i := ir.NewInfra()
 
+	i.Proxy.Config = &egv1a1.EnvoyProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "envoy-gateway",
+			Namespace: "envoy-gateway-system",
+		},
+	}
+
 	i.Proxy.GetProxyMetadata().Annotations = annotations
 	if len(labels) > 0 {
 		i.Proxy.GetProxyMetadata().Labels = labels

--- a/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
@@ -58,13 +58,6 @@ func newTestInfraWithAddresses(addresses []string) *ir.Infra {
 func newTestInfraWithAnnotationsAndLabels(annotations, labels map[string]string) *ir.Infra {
 	i := ir.NewInfra()
 
-	i.Proxy.Config = &egv1a1.EnvoyProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "envoy-gateway",
-			Namespace: "envoy-gateway-system",
-		},
-	}
-
 	i.Proxy.GetProxyMetadata().Annotations = annotations
 	if len(labels) > 0 {
 		i.Proxy.GetProxyMetadata().Labels = labels
@@ -571,7 +564,7 @@ func TestDeployment(t *testing.T) {
 				tc.infra.Proxy.Config.Spec.ExtraArgs = tc.extraArgs
 			}
 
-			r := NewResourceRender(cfg.Namespace, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
+			r := NewResourceRender(cfg.Namespace, cfg.DNSDomain, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
 			dp, err := r.Deployment()
 			require.NoError(t, err)
 
@@ -1000,7 +993,7 @@ func TestDaemonSet(t *testing.T) {
 				tc.infra.Proxy.Config.Spec.ExtraArgs = tc.extraArgs
 			}
 
-			r := NewResourceRender(cfg.Namespace, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
+			r := NewResourceRender(cfg.Namespace, cfg.DNSDomain, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
 			ds, err := r.DaemonSet()
 			require.NoError(t, err)
 
@@ -1150,7 +1143,7 @@ func TestService(t *testing.T) {
 				provider.EnvoyService = tc.service
 			}
 
-			r := NewResourceRender(cfg.Namespace, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
+			r := NewResourceRender(cfg.Namespace, cfg.DNSDomain, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
 			svc, err := r.Service()
 			require.NoError(t, err)
 
@@ -1193,7 +1186,7 @@ func TestConfigMap(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := NewResourceRender(cfg.Namespace, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
+			r := NewResourceRender(cfg.Namespace, cfg.DNSDomain, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
 			cm, err := r.ConfigMap()
 			require.NoError(t, err)
 
@@ -1236,7 +1229,7 @@ func TestServiceAccount(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := NewResourceRender(cfg.Namespace, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
+			r := NewResourceRender(cfg.Namespace, cfg.DNSDomain, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
 			sa, err := r.ServiceAccount()
 			require.NoError(t, err)
 
@@ -1292,7 +1285,7 @@ func TestPDB(t *testing.T) {
 
 			provider.GetEnvoyProxyKubeProvider()
 
-			r := NewResourceRender(cfg.Namespace, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
+			r := NewResourceRender(cfg.Namespace, cfg.DNSDomain, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
 
 			pdb, err := r.PodDisruptionBudget()
 			require.NoError(t, err)
@@ -1378,7 +1371,7 @@ func TestHorizontalPodAutoscaler(t *testing.T) {
 			}
 			provider.GetEnvoyProxyKubeProvider()
 
-			r := NewResourceRender(cfg.Namespace, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
+			r := NewResourceRender(cfg.Namespace, cfg.DNSDomain, tc.infra.GetProxyInfra(), cfg.EnvoyGateway)
 			hpa, err := r.HorizontalPodAutoscaler()
 			require.NoError(t, err)
 

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
@@ -131,7 +131,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
@@ -130,7 +130,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
@@ -130,7 +130,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
@@ -104,7 +104,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
@@ -130,7 +130,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
@@ -139,7 +139,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
@@ -130,7 +130,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
@@ -130,7 +130,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
@@ -130,7 +130,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
@@ -135,7 +135,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
@@ -130,7 +130,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
@@ -130,7 +130,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
@@ -130,7 +130,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
@@ -130,7 +130,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
@@ -130,7 +130,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -136,7 +136,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -136,7 +136,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -135,7 +135,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -134,7 +134,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -108,7 +108,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -135,7 +135,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -143,7 +143,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -134,7 +134,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -134,7 +134,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -135,7 +135,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -139,7 +139,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -134,7 +134,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -134,7 +134,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -134,7 +134,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
@@ -134,7 +134,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -134,7 +134,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -134,7 +134,7 @@ spec:
                     endpoint:
                       address:
                         socket_address:
-                          address: envoy-gateway
+                          address: envoy-gateway.envoy-gateway-system.svc.cluster.local
                           port_value: 18000
               typed_extension_protocol_options:
                 envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/internal/infrastructure/kubernetes/proxy_configmap_test.go
+++ b/internal/infrastructure/kubernetes/proxy_configmap_test.go
@@ -111,7 +111,7 @@ func TestCreateOrUpdateProxyConfigMap(t *testing.T) {
 					Build()
 			}
 			kube := NewInfra(cli, cfg)
-			r := proxy.NewResourceRender(kube.Namespace, infra.GetProxyInfra(), kube.EnvoyGateway)
+			r := proxy.NewResourceRender(kube.Namespace, kube.DNSDomain, infra.GetProxyInfra(), kube.EnvoyGateway)
 			err := kube.createOrUpdateConfigMap(context.Background(), r)
 			require.NoError(t, err)
 			actual := &corev1.ConfigMap{
@@ -169,7 +169,7 @@ func TestDeleteConfigProxyMap(t *testing.T) {
 			infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
 			infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = infra.Proxy.Name
 
-			r := proxy.NewResourceRender(kube.Namespace, infra.GetProxyInfra(), kube.EnvoyGateway)
+			r := proxy.NewResourceRender(kube.Namespace, kube.DNSDomain, infra.GetProxyInfra(), kube.EnvoyGateway)
 			cm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: kube.Namespace,

--- a/internal/infrastructure/kubernetes/proxy_daemonset_test.go
+++ b/internal/infrastructure/kubernetes/proxy_daemonset_test.go
@@ -66,7 +66,7 @@ func TestCreateOrUpdateProxyDaemonSet(t *testing.T) {
 		},
 	}
 
-	r := proxy.NewResourceRender(cfg.Namespace, infra.GetProxyInfra(), cfg.EnvoyGateway)
+	r := proxy.NewResourceRender(cfg.Namespace, cfg.DNSDomain, infra.GetProxyInfra(), cfg.EnvoyGateway)
 	ds, err := r.DaemonSet()
 	require.NoError(t, err)
 
@@ -245,7 +245,7 @@ func TestCreateOrUpdateProxyDaemonSet(t *testing.T) {
 			}
 
 			kube := NewInfra(cli, cfg)
-			r := proxy.NewResourceRender(kube.Namespace, tc.in.GetProxyInfra(), cfg.EnvoyGateway)
+			r := proxy.NewResourceRender(kube.Namespace, kube.DNSDomain, tc.in.GetProxyInfra(), cfg.EnvoyGateway)
 			err := kube.createOrUpdateDaemonSet(context.Background(), r)
 			if tc.wantErr {
 				require.Error(t, err)

--- a/internal/infrastructure/kubernetes/proxy_deployment_test.go
+++ b/internal/infrastructure/kubernetes/proxy_deployment_test.go
@@ -59,7 +59,7 @@ func TestCreateOrUpdateProxyDeployment(t *testing.T) {
 	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
 	infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = infra.Proxy.Name
 
-	r := proxy.NewResourceRender(cfg.Namespace, infra.GetProxyInfra(), cfg.EnvoyGateway)
+	r := proxy.NewResourceRender(cfg.Namespace, cfg.DNSDomain, infra.GetProxyInfra(), cfg.EnvoyGateway)
 	deploy, err := r.Deployment()
 	require.NoError(t, err)
 
@@ -238,7 +238,7 @@ func TestCreateOrUpdateProxyDeployment(t *testing.T) {
 			}
 
 			kube := NewInfra(cli, cfg)
-			r := proxy.NewResourceRender(kube.Namespace, tc.in.GetProxyInfra(), cfg.EnvoyGateway)
+			r := proxy.NewResourceRender(kube.Namespace, kube.DNSDomain, tc.in.GetProxyInfra(), cfg.EnvoyGateway)
 			err := kube.createOrUpdateDeployment(context.Background(), r)
 			if tc.wantErr {
 				require.Error(t, err)
@@ -284,7 +284,7 @@ func TestDeleteProxyDeployment(t *testing.T) {
 			infra := ir.NewInfra()
 			infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
 			infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = infra.Proxy.Name
-			r := proxy.NewResourceRender(kube.Namespace, infra.GetProxyInfra(), kube.EnvoyGateway)
+			r := proxy.NewResourceRender(kube.Namespace, kube.DNSDomain, infra.GetProxyInfra(), kube.EnvoyGateway)
 
 			err := kube.createOrUpdateDeployment(context.Background(), r)
 			require.NoError(t, err)

--- a/internal/infrastructure/kubernetes/proxy_infra.go
+++ b/internal/infrastructure/kubernetes/proxy_infra.go
@@ -23,7 +23,7 @@ func (i *Infra) CreateOrUpdateProxyInfra(ctx context.Context, infra *ir.Infra) e
 		return errors.New("infra proxy ir is nil")
 	}
 
-	r := proxy.NewResourceRender(i.Namespace, infra.GetProxyInfra(), i.EnvoyGateway)
+	r := proxy.NewResourceRender(i.Namespace, i.DNSDomain, infra.GetProxyInfra(), i.EnvoyGateway)
 	return i.createOrUpdate(ctx, r)
 }
 
@@ -33,6 +33,6 @@ func (i *Infra) DeleteProxyInfra(ctx context.Context, infra *ir.Infra) error {
 		return errors.New("infra ir is nil")
 	}
 
-	r := proxy.NewResourceRender(i.Namespace, infra.GetProxyInfra(), i.EnvoyGateway)
+	r := proxy.NewResourceRender(i.Namespace, i.DNSDomain, infra.GetProxyInfra(), i.EnvoyGateway)
 	return i.delete(ctx, r)
 }

--- a/internal/infrastructure/kubernetes/proxy_service_test.go
+++ b/internal/infrastructure/kubernetes/proxy_service_test.go
@@ -32,7 +32,7 @@ func TestDeleteProxyService(t *testing.T) {
 
 			infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
 			infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = infra.Proxy.Name
-			r := proxy.NewResourceRender(kube.Namespace, infra.GetProxyInfra(), kube.EnvoyGateway)
+			r := proxy.NewResourceRender(kube.Namespace, kube.DNSDomain, infra.GetProxyInfra(), kube.EnvoyGateway)
 			err := kube.createOrUpdateService(context.Background(), r)
 			require.NoError(t, err)
 

--- a/internal/infrastructure/kubernetes/proxy_serviceaccount_test.go
+++ b/internal/infrastructure/kubernetes/proxy_serviceaccount_test.go
@@ -187,7 +187,7 @@ func TestCreateOrUpdateProxyServiceAccount(t *testing.T) {
 
 			kube := NewInfra(cli, cfg)
 
-			r := proxy.NewResourceRender(kube.Namespace, tc.in.GetProxyInfra(), cfg.EnvoyGateway)
+			r := proxy.NewResourceRender(kube.Namespace, kube.DNSDomain, tc.in.GetProxyInfra(), cfg.EnvoyGateway)
 			err = kube.createOrUpdateServiceAccount(context.Background(), r)
 			require.NoError(t, err)
 
@@ -220,7 +220,7 @@ func TestDeleteProxyServiceAccount(t *testing.T) {
 			infra := ir.NewInfra()
 			infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNamespaceLabel] = "default"
 			infra.Proxy.GetProxyMetadata().Labels[gatewayapi.OwningGatewayNameLabel] = infra.Proxy.Name
-			r := proxy.NewResourceRender(kube.Namespace, infra.GetProxyInfra(), kube.EnvoyGateway)
+			r := proxy.NewResourceRender(kube.Namespace, kube.DNSDomain, infra.GetProxyInfra(), kube.EnvoyGateway)
 
 			err := kube.createOrUpdateServiceAccount(context.Background(), r)
 			require.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Rajat Vig <rvig@etsy.com>

**What type of PR is this?**

Sets the `xdsServerHost` in Kubernetes to be fully qualified Service Name using the namespace.

**What this PR does / why we need it**:

Instead of defaulting to `envoy-gateway` sets the `xdsServerHost` to be `envoy-gateway.envoy-gateway-system.svc.cluster.local`.

Release Notes: No
