### PR TITLE
Docs: fix incorrect namespace mention

### DIFF
--- a/site/content/en/contributions/design/metadata.md
+++ b/site/content/en/contributions/design/metadata.md
@@ -34,7 +34,15 @@ apiVersion: gateway.networking.k8s.io/v1
 metadata:
   annotations:
     gateway.envoyproxy.io/foo: bar
-/... rest of the resource .../
+  name: myroute
+  namespace: gateway-conformance-infra
+spec:
+  rules:
+    matches:
+    - path:
+        type: PathPrefix
+        value: /mypath
+  
 ```yaml
 name: httproute/gateway-conformance-infra/myroute/rule/0/match/0/*
 match:

--- a/site/content/en/contributions/design/metadata.md
+++ b/site/content/en/contributions/design/metadata.md
@@ -26,9 +26,10 @@ Future enhancements may include:
 ## Translation 
 
 Envoy Gateway uses the following namespace for envoy resource metadata: `gateway.envoyproxy.io/`. For example, an envoy [route][] resource may have the following metadata structure:
-```yaml
 
-````
+Kubernetes resource:
+
+```yaml
 kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
@@ -42,7 +43,10 @@ spec:
     - path:
         type: PathPrefix
         value: /mypath
-  
+```
+
+Metadata structure:
+
 ```yaml
 name: httproute/gateway-conformance-infra/myroute/rule/0/match/0/*
 match:

--- a/site/content/en/contributions/design/metadata.md
+++ b/site/content/en/contributions/design/metadata.md
@@ -25,8 +25,16 @@ Future enhancements may include:
 
 ## Translation 
 
-Envoy Gateway uses the following namespace for envoy resource metadata: `io.envoyproxy.gateway.metadata`. For example, an envoy [route][] resource may have the following metadata structure:
+Envoy Gateway uses the following namespace for envoy resource metadata: `gateway.envoyproxy.io/`. For example, an envoy [route][] resource may have the following metadata structure:
+```yaml
 
+````
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  annotations:
+    gateway.envoyproxy.io/foo: bar
+/... rest of the resource .../
 ```yaml
 name: httproute/gateway-conformance-infra/myroute/rule/0/match/0/*
 match:


### PR DESCRIPTION
The docs mention the wrong namespace for annotations. The namespace is set here I think: https://github.com/guydc/gateway/blob/e54b00f4e227e0e7d65bc6dbecf5b6d1f991dd7e/internal/gatewayapi/route.go#L35

It might be that i misunderstood the documentation and i'm mixing things up. If so, ill be happy to write a separate section with this example.

**What type of PR is this?**
Small correction to the docs.

**What this PR does / why we need it**:
It adds the correct namespace, and a small example of how to use it.

**Which issue(s) this PR fixes**:
-

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
