### PR TITLE
Fix: HTTPRoute status only shows one parent when targeting multiple Gateways from different Gatewayclasses

### DIFF
--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -16,6 +16,7 @@ new features: |
 bug fixes: |
   Only log endpoint configuration in verbose logging mode (`-v 4` or higher)
   The xDS translation failed when wasm http code source configured without a sha
+  HTTPRoute status only shows one parent when targeting multiple Gateways from different GatewayClasses
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
Fixes: https://github.com/envoyproxy/gateway/issues/4264
Release Note: yes