### PR TITLE
ci: cleanup osv-scanner config

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,7 +1,3 @@
-[[IgnoredVulns]]
-id = "GO-2022-0646"
-reason = "No a real issue, just a warning about third party package."
-
 [[PackageOverrides]]
 name = "github.com/AdaLogics/go-fuzz-headers"
 version = "0.0.0-20230811130428-ced1acdcaa24"
@@ -15,13 +11,6 @@ version = "0.0.0-20230301143203-a9d515a09cc2"
 ecosystem = "Go"
 license.override = ["MIT"]
 reason = "Unidentified license, remove once https://github.com/google/deps.dev/issues/87 is resolved"
-
-[[PackageOverrides]]
-name = "github.com/containers/storage"
-version = "1.55.0"
-ecosystem = "Go"
-license.override = ["Apache-2.0"]
-reason = "Unidentified license, remove once https://github.com/google/deps.dev/issues/104 is resolved"
 
 [[PackageOverrides]]
 name = "github.com/distribution/distribution/v3"
@@ -41,32 +30,28 @@ reason = "This package has dual license - the code is licensed under the Apache 
 name = "github.com/go-sql-driver/mysql"
 version = "1.8.1"
 ecosystem = "Go"
-# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from license scanning instead
-license.override = ["Apache-2.0"]
+license.ignore = true
 reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
 
 [[PackageOverrides]]
 name = "github.com/hashicorp/errwrap"
 version = "1.1.0"
 ecosystem = "Go"
-# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from license scanning instead
-license.override = ["Apache-2.0"]
+license.ignore = true
 reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
 
 [[PackageOverrides]]
 name = "github.com/hashicorp/go-multierror"
 version = "1.1.1"
 ecosystem = "Go"
-# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from license scanning instead
-license.override = ["Apache-2.0"]
+license.ignore = true
 reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
 
 [[PackageOverrides]]
 name = "github.com/hashicorp/hcl"
 version = "1.0.0"
 ecosystem = "Go"
-# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from license scanning instead
-license.override = ["Apache-2.0"]
+license.ignore = true
 reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
 
 [[PackageOverrides]]
@@ -80,8 +65,7 @@ reason = "This package has dual license - the code is licensed under the Apache 
 name = "github.com/shoenig/go-m1cpu"
 version = "0.1.6"
 ecosystem = "Go"
-# Override the license to an allowed one until https://github.com/google/osv-scanner/issues/1124 is resolved and we can skip it from license scanning instead
-license.override = ["Apache-2.0"]
+license.ignore = true
 reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/cncf-exceptions-2023-08-31.spdx"
 
 [[PackageOverrides]]
@@ -89,10 +73,3 @@ name = "stdlib"
 ecosystem = "Go"
 license.override = ["BSD-3-Clause"]
 reason = "Unidentified license, remove once https://github.com/google/deps.dev/issues/86 is resolved"
-
-[[PackageOverrides]]
-name = "sigs.k8s.io/json"
-version = "0.0.0-20221116044647-bc3834ca7abd"
-ecosystem = "Go"
-license.override = ["Apache-2.0"]
-reason = "https://github.com/kubernetes-sigs/json/blob/main/LICENSE"


### PR DESCRIPTION
**What this PR does / why we need it**:
* Remove unneeded sections in `osv-scanner.toml`:
  * `IgnoredVulns` for `GO-2022-0646` - no longer relevant since it's related to `github.com/aws/aws-sdk-go` package which was removed in #4161.
  * `PackageOverrides` for `github.com/containers/storage` - since https://github.com/google/deps.dev/issues/104 is resolved.
  * `PackageOverrides` for `sigs.k8s.io/json` - package license is now identified. 
* Use `license.ignore` instead of `license.override` for all MPL-2.0 packages which are approved by CNCF.  