### PR TITLE
fix egctl release artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,6 +80,14 @@ jobs:
           name: benchmark_report
           path: release-artifacts
 
+      - name: Build egctl multiarch binaries
+        run: |
+          make build-multiarch BINS="egctl"
+          tar -zcvf egctl_${{ env.release_tag }}_linux_amd64.tar.gz bin/linux/amd64/
+          tar -zcvf egctl_${{ env.release_tag }}_linux_arm64.tar.gz bin/linux/arm64/
+          tar -zcvf egctl_${{ env.release_tag }}_darwin_amd64.tar.gz bin/darwin/amd64/
+          tar -zcvf egctl_${{ env.release_tag }}_darwin_arm64.tar.gz bin/darwin/arm64/
+
       - name: Upload Release Manifests
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v0.1.15
         with:
@@ -88,7 +96,7 @@ jobs:
             release-artifacts/quickstart.yaml
             release-artifacts/release-notes.yaml
             release-artifacts/benchmark_report.zip
-            release-artifacts/egctl_${{ env.release_tag }}_linux_amd64.tar.gz
-            release-artifacts/egctl_${{ env.release_tag }}_linux_arm64.tar.gz
-            release-artifacts/egctl_${{ env.release_tag }}_darwin_amd64.tar.gz
-            release-artifacts/egctl_${{ env.release_tag }}_darwin_arm64.tar.gz
+            egctl_${{ env.release_tag }}_linux_amd64.tar.gz
+            egctl_${{ env.release_tag }}_linux_arm64.tar.gz
+            egctl_${{ env.release_tag }}_darwin_amd64.tar.gz
+            egctl_${{ env.release_tag }}_darwin_arm64.tar.gz

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -249,16 +249,7 @@ generate-manifests: helm-generate.gateway-helm ## Generate Kubernetes release ma
 	@$(call log, "Added: $(OUTPUT_DIR)/quickstart.yaml")
 
 .PHONY: generate-artifacts
-generate-artifacts: generate-manifests generate-egctl-releases ## Generate release artifacts.
+generate-artifacts: generate-manifests ## Generate release artifacts.
 	@$(LOG_TARGET)
 	cp -r $(ROOT_DIR)/release-notes/$(TAG).yaml $(OUTPUT_DIR)/release-notes.yaml
 	@$(call log, "Added: $(OUTPUT_DIR)/release-notes.yaml")
-
-.PHONY: generate-egctl-releases
-generate-egctl-releases: ## Generate egctl releases
-	@$(LOG_TARGET)
-	mkdir -p $(OUTPUT_DIR)/
-	curl -sSL https://github.com/envoyproxy/gateway/releases/download/latest/egctl_latest_darwin_amd64.tar.gz -o $(OUTPUT_DIR)/egctl_$(TAG)_darwin_amd64.tar.gz
-	curl -sSL https://github.com/envoyproxy/gateway/releases/download/latest/egctl_latest_darwin_arm64.tar.gz -o $(OUTPUT_DIR)/egctl_$(TAG)_darwin_arm64.tar.gz
-	curl -sSL https://github.com/envoyproxy/gateway/releases/download/latest/egctl_latest_linux_amd64.tar.gz -o $(OUTPUT_DIR)/egctl_$(TAG)_linux_amd64.tar.gz
-	curl -sSL https://github.com/envoyproxy/gateway/releases/download/latest/egctl_latest_linux_arm64.tar.gz -o $(OUTPUT_DIR)/egctl_$(TAG)_linux_arm64.tar.gz


### PR DESCRIPTION
* the release artifact for `egctl` was being pulled from the `latest` release instead of a binary associated with the release tag
