### PR TITLE
fix debug level logging for IR

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -173,9 +173,7 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 				// Publish the IRs.
 				// Also validate the ir before sending it.
 				for key, val := range result.InfraIR {
-					if vlog := r.Logger.V(4); vlog.Enabled() {
-						vlog.WithValues("infra-ir", key).Info(val.JSONString())
-					}
+					r.Logger.V(1).WithValues("infra-ir", key).Info(val.JSONString())
 					if err := val.Validate(); err != nil {
 						r.Logger.Error(err, "unable to validate infra ir, skipped sending it")
 						errChan <- err
@@ -186,9 +184,7 @@ func (r *Runner) subscribeAndTranslate(ctx context.Context) {
 				}
 
 				for key, val := range result.XdsIR {
-					if vlog := r.Logger.V(4); vlog.Enabled() {
-						vlog.WithValues("xds-ir", key).Info(val.JSONString())
-					}
+					r.Logger.V(1).WithValues("xds-ir", key).Info(val.JSONString())
 					if err := val.Validate(); err != nil {
 						r.Logger.Error(err, "unable to validate xds ir, skipped sending it")
 						errChan <- err


### PR DESCRIPTION
https://pkg.go.dev/github.com/go-logr/zapr#hdr-Implementation_Details
```
V(1) is equivalent to Zap's DebugLevel
```

Now after setting the log level to `default: debug`

I see

```
2024-10-31T01:59:31.138Z	DEBUG	gateway-api	runner/runner.go:176	{"proxy":{"metadata":{"labels":{"gateway.envoyproxy.io/owning-gateway-name":"eg","gateway.envoyproxy.io/owning-gateway-namespace":"default"}},"name":"default/eg","listeners":[{"name":"default/eg/http","address":null,"ports":[{"name":"http-80","protocol":"HTTP","servicePort":80,"containerPort":10080}]}]}}	{"runner": "gateway-api", "infra-ir": "default/eg"}
2024-10-31T01:59:31.138Z	DEBUG	gateway-api	runner/runner.go:187	{"accessLog":{"text":[{"path":"/dev/stdout"}]},"http":[{"name":"default/eg/http","address":"0.0.0.0","port":10080,"metadata":{"kind":"Gateway","name":"eg","namespace":"default","sectionName":"http"},"hostnames":["*"],"routes":[{"name":"httproute/default/backend/rule/0/match/0/www_example_com","hostname":"www.example.com","isHTTP2":false,"pathMatch":{"name":"","prefix":"/","distinct":false},"destination":{"name":"httproute/default/backend/rule/0","settings":[{"weight":1,"protocol":"HTTP","endpoints":[{"host":"10.1.19.7","port":3000}],"addressType":"IP"}]},"metadata":{"kind":"HTTPRoute","name":"backend","namespace":"default"}}],"isHTTP2":false,"path":{"mergeSlashes":true,"escapedSlashesAction":"UnescapeAndRedirect"}}]}	{"runner": "gateway-api", "xds-ir": "default/eg"}
```

Relates to https://github.com/envoyproxy/gateway/pull/4505