### PR TITLE
fix keycloak ipv6 issue

### DIFF
--- a/test/e2e/testdata/oidc-keycloak.yaml
+++ b/test/e2e/testdata/oidc-keycloak.yaml
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: keycloak
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:23.0.6
+          image: quay.io/keycloak/keycloak:26.0.4
           imagePullPolicy: IfNotPresent
           args:
             - "start-dev"


### PR DESCRIPTION
Fixes: https://github.com/envoyproxy/gateway/issues/4598
Release Notes: no

Old version:

```bash
 k -n gateway-conformance-infra logs setup-keycloak-cw75d 
Defaulted container "setup-keycloak" out of: setup-keycloak, wait-for-keycloak (init)
+ /opt/keycloak/bin/kcadm.sh create users -s username=oidcuser -s enabled=true --server http://keycloak --realm master --user admin --password admin
Logging into http://keycloak as user admin of realm master
HTTPS required [invalid_request]
```

New version:

```bash
k -n gateway-conformance-infra exec -it keycloak-cbcd7848f-9nk7b -- bash 
bash-5.1$ /opt/keycloak/bin/kcadm.sh create users -s username=oidcuser -s enabled=true --server http://keycloak --realm master --user admin --password admin
Logging into http://keycloak as user admin of realm master
Created new user with id '73c7d50e-890c-4311-a744-150e6a29ba1
```