### PR TITLE
workaroud for the flaky oidc e2e test

### DIFF
--- a/test/e2e/tests/oidc-backendcluster.go
+++ b/test/e2e/tests/oidc-backendcluster.go
@@ -26,7 +26,7 @@ var OIDCBackendClusterTest = suite.ConformanceTest{
 	Manifests:   []string{"testdata/oidc-keycloak.yaml", "testdata/oidc-securitypolicy-backendcluster.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		t.Run("oidc provider represented by a BackendCluster", func(t *testing.T) {
-			testOIDC(t, suite)
+			testOIDC(t, suite, "testdata/oidc-securitypolicy-backendcluster.yaml")
 		})
 	},
 }

--- a/test/e2e/tests/oidc.go
+++ b/test/e2e/tests/oidc.go
@@ -149,7 +149,7 @@ func testOIDC(t *testing.T, suite *suite.ConformanceTestSuite) {
 			// Parse the response body to get the URL where the login page would post the user-entered credentials
 			if err := oidcClient.ParseLoginForm(res.Body, keyCloakLoginFormID); err != nil {
 				tlog.Logf(t, "failed to parse login form: %v", err)
-				// restart the envoy proxy to recover from the error, this is a workaround for the flaky test
+				// restart the envoy proxy to recover from the error, this is a workaround for the flaky test: https://github.com/envoyproxy/gateway/issues/3898
 				// TODO: we should investigate the root cause of the flakiness and remove this workaround
 				proxyLabel := map[string]string{"gateway.envoyproxy.io/owning-gateway-name": "same-namespace"}
 				err := suite.Client.DeleteAllOf(context.TODO(), &corev1.Pod{}, client.MatchingLabels(proxyLabel), client.InNamespace("envoy-gateway-system"))

--- a/test/e2e/tests/oidc.go
+++ b/test/e2e/tests/oidc.go
@@ -160,7 +160,7 @@ func testOIDC(t *testing.T, suite *suite.ConformanceTestSuite, securityPolicyMan
 					},
 				}
 				require.NoError(t, suite.Client.Delete(context.TODO(), existingSP))
-				suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, securityPolicyManifest, true)
+				suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, securityPolicyManifest, false)
 				SecurityPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: sp, Namespace: ns}, suite.ControllerName, ancestorRef)
 				return false, nil
 			}


### PR DESCRIPTION
Delete and recreate SecurityPolicy to force repushing xDS to Envoy to recover from the OIDC test failure. This is just a workaround to reduce the time of e2e test due to  the failed OIDC test. We still need to investage the root cause and fix it.

Related issue: https://github.com/envoyproxy/gateway/issues/3898
Release Notes: No
