### PR TITLE
Set ignore_health_on_host_removal to true for static clusters

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -778,6 +778,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: httproute/default/backend/rule/0
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: httproute/default/backend/rule/0
           outlierDetection: {}
@@ -797,6 +798,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: grpcroute/default/backend/rule/0
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: grpcroute/default/backend/rule/0
           outlierDetection: {}
@@ -823,6 +825,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: tcproute/default/backend/rule/-1
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: tcproute/default/backend/rule/-1
           outlierDetection: {}
@@ -842,6 +845,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: tlsroute/default/backend/rule/-1
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: tlsroute/default/backend/rule/-1
           outlierDetection: {}
@@ -861,6 +865,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: udproute/default/backend/rule/-1
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: udproute/default/backend/rule/-1
           outlierDetection: {}

--- a/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
@@ -106,6 +106,7 @@ xds:
             ads: {}
             resourceApiVersion: V3
           serviceName: httproute/envoy-gateway-system/backend/rule/0
+        ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: httproute/envoy-gateway-system/backend/rule/0
         outlierDetection: {}

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -466,6 +466,7 @@
                   },
                   "serviceName": "httproute/default/backend/rule/0"
                 },
+                "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "httproute/default/backend/rule/0",
                 "outlierDetection": {},
@@ -495,6 +496,7 @@
                   },
                   "serviceName": "grpcroute/default/backend/rule/0"
                 },
+                "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "grpcroute/default/backend/rule/0",
                 "outlierDetection": {},
@@ -535,6 +537,7 @@
                   },
                   "serviceName": "tcproute/default/backend/rule/-1"
                 },
+                "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "tcproute/default/backend/rule/-1",
                 "outlierDetection": {},
@@ -564,6 +567,7 @@
                   },
                   "serviceName": "tlsroute/default/backend/rule/-1"
                 },
+                "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "tlsroute/default/backend/rule/-1",
                 "outlierDetection": {},
@@ -593,6 +597,7 @@
                   },
                   "serviceName": "udproute/default/backend/rule/-1"
                 },
+                "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "udproute/default/backend/rule/-1",
                 "outlierDetection": {},

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -257,6 +257,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: httproute/default/backend/rule/0
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: httproute/default/backend/rule/0
           outlierDetection: {}
@@ -276,6 +277,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: grpcroute/default/backend/rule/0
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: grpcroute/default/backend/rule/0
           outlierDetection: {}
@@ -302,6 +304,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: tcproute/default/backend/rule/-1
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: tcproute/default/backend/rule/-1
           outlierDetection: {}
@@ -321,6 +324,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: tlsroute/default/backend/rule/-1
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: tlsroute/default/backend/rule/-1
           outlierDetection: {}
@@ -340,6 +344,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: udproute/default/backend/rule/-1
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: udproute/default/backend/rule/-1
           outlierDetection: {}

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
@@ -16,6 +16,7 @@ xds:
             ads: {}
             resourceApiVersion: V3
           serviceName: httproute/default/backend/rule/0
+        ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: httproute/default/backend/rule/0
         outlierDetection: {}
@@ -35,6 +36,7 @@ xds:
             ads: {}
             resourceApiVersion: V3
           serviceName: grpcroute/default/backend/rule/0
+        ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: grpcroute/default/backend/rule/0
         outlierDetection: {}
@@ -61,6 +63,7 @@ xds:
             ads: {}
             resourceApiVersion: V3
           serviceName: tcproute/default/backend/rule/-1
+        ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: tcproute/default/backend/rule/-1
         outlierDetection: {}
@@ -80,6 +83,7 @@ xds:
             ads: {}
             resourceApiVersion: V3
           serviceName: tlsroute/default/backend/rule/-1
+        ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: tlsroute/default/backend/rule/-1
         outlierDetection: {}
@@ -99,6 +103,7 @@ xds:
             ads: {}
             resourceApiVersion: V3
           serviceName: udproute/default/backend/rule/-1
+        ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: udproute/default/backend/rule/-1
         outlierDetection: {}

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -358,6 +358,7 @@
                   },
                   "serviceName": "httproute/envoy-gateway-system/backend/rule/0"
                 },
+                "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "httproute/envoy-gateway-system/backend/rule/0",
                 "outlierDetection": {},

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -201,6 +201,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: httproute/envoy-gateway-system/backend/rule/0
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: httproute/envoy-gateway-system/backend/rule/0
           outlierDetection: {}

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
@@ -16,6 +16,7 @@ xds:
             ads: {}
             resourceApiVersion: V3
           serviceName: httproute/envoy-gateway-system/backend/rule/0
+        ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: httproute/envoy-gateway-system/backend/rule/0
         outlierDetection: {}

--- a/internal/cmd/egctl/testdata/translate/out/no-service-cluster-ip.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/no-service-cluster-ip.all.yaml
@@ -201,6 +201,7 @@ xds:
               ads: {}
               resourceApiVersion: V3
             serviceName: httproute/envoy-gateway-system/routes/rule/0
+          ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: httproute/envoy-gateway-system/routes/rule/0
           outlierDetection: {}

--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -158,6 +158,9 @@ func buildXdsCluster(args *xdsClusterArgs) *clusterv3.Cluster {
 				},
 			},
 		}
+		// Dont wait for a health check to determine health and remove these endpoints
+		// if the endpoint has been removed via EDS by the control plane
+		cluster.IgnoreHealthOnHostRemoval = true
 	} else {
 		cluster.ClusterDiscoveryType = &clusterv3.Cluster_Type{Type: clusterv3.Cluster_STRICT_DNS}
 		cluster.DnsRefreshRate = durationpb.New(30 * time.Second)

--- a/internal/xds/translator/testdata/out/extension-xds-ir/extensionpolicy-tcp-udp-http.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/extensionpolicy-tcp-udp-http.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: udp-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: udp-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-als-tcp.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-als-tcp.clusters.yaml
@@ -11,6 +11,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: accesslog/monitoring/envoy-als/port/9000
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog/monitoring/envoy-als/port/9000
   outlierDetection:

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-cel.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-cel.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-multi-cel.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-multi-cel.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-types.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-types.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: accesslog_als_0_1
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_0_1
   outlierDetection: {}
@@ -51,6 +53,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: accesslog_als_0_2
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_0_2
   outlierDetection: {}
@@ -75,6 +78,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: accesslog_als_1_1
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_1_1
   outlierDetection: {}
@@ -99,6 +103,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: accesslog_als_1_2
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_1_2
   outlierDetection: {}
@@ -123,6 +128,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: accesslog_als_2_1
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_2_1
   outlierDetection: {}
@@ -147,6 +153,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: accesslog_als_2_2
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_2_2
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-without-format.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-without-format.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: accesslog/monitoring/envoy-als/port/9000
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog/monitoring/envoy-als/port/9000
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: accesslog/monitoring/envoy-als/port/9000
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog/monitoring/envoy-als/port/9000
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-client-cidr.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-client-cidr.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-3/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-3/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-multiple-principals.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-multiple-principals.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: udp-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: udp-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/backend-priority.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-priority.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/default/policy-for-http-route/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: envoyextensionpolicy/default/policy-for-http-route/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/1
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.clusters.yaml
@@ -13,6 +13,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/cors.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/cors.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/custom-response.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-response.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/1
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/1
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/1
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
   outlierDetection: {}
@@ -85,6 +89,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}
@@ -45,6 +47,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/default/policy-for-http-route/0
+  ignoreHealthOnHostRemoval: true
   name: envoyextensionpolicy/default/policy-for-http-route/0
   outlierDetection:
     baseEjectionTime: 30s

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/default/policy-for-route-2/0/grpc-backend-4
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: envoyextensionpolicy/default/policy-for-route-2/0/grpc-backend-4
   outlierDetection: {}
@@ -68,6 +71,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/default/policy-for-route-1/0/grpc-backend-2
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: envoyextensionpolicy/default/policy-for-route-1/0/grpc-backend-2
   outlierDetection: {}
@@ -92,6 +96,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/envoy-gateway/policy-for-gateway-2/0/grpc-backend-3
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: envoyextensionpolicy/envoy-gateway/policy-for-gateway-2/0/grpc-backend-3
   outlierDetection: {}
@@ -116,6 +121,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/envoy-gateway/policy-for-gateway-1/0/grpc-backend
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: envoyextensionpolicy/envoy-gateway/policy-for-gateway-1/0/grpc-backend
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/fault-injection.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/fault-injection.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fourth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
   outlierDetection: {}
@@ -78,6 +82,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fifth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fifth-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-x-request-id.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-x-request-id.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-underscores-action.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-underscores-action.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fourth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/health-check.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check.clusters.yaml
@@ -25,6 +25,7 @@
     interval: 3s
     timeout: 0.500s
     unhealthyThreshold: 3
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection:
@@ -61,6 +62,7 @@
     interval: 5s
     timeout: 1s
     unhealthyThreshold: 3
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection:
@@ -94,6 +96,7 @@
         text: "70696e67"
     timeout: 1s
     unhealthyThreshold: 3
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection:
@@ -127,6 +130,7 @@
         binary: cGluZw==
     timeout: 1s
     unhealthyThreshold: 3
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
   outlierDetection:
@@ -158,6 +162,7 @@
     interval: 5s
     timeout: 1s
     unhealthyThreshold: 3
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fifth-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-early-header-mutation.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-early-header-mutation.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -37,6 +38,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-endpoint-stats.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-health-check.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-health-check.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-preserve-client-protocol.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-preserve-client-protocol.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-req-resp-sizes-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-req-resp-sizes-stats.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fourth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
   outlierDetection: {}
@@ -78,6 +82,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fifth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fifth-route-dest
   outlierDetection: {}
@@ -95,6 +100,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: sixth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: sixth-route-dest
   outlierDetection: {}
@@ -112,6 +118,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: seventh-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: seventh-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: mirror-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: mirror-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: mirror-route-dest1
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: mirror-route-dest1
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: valid-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: valid-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: redirect-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: redirect-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: regex-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: regex-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: request-header-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: request-header-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: response-header-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: response-header-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: response-header-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: response-header-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: response-header-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: response-header-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: rewrite-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-sufixx-with-slash-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-sufixx-with-slash-url-prefix.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: rewrite-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: rewrite-route
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: rewrite-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: rewrite-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-regex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-regex.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: rewrite-route
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: regex-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: regex-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-uds-ip.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-uds-ip.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-filters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-filters.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-clientcert.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-clientcert.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/envoy-gateway/httproute-btls/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-metadata.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-metadata.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/envoy-gateway/httproute-btls/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle-multiple-certs.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle-multiple-certs.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/envoy-gateway/httproute-btls/rule/0
   outlierDetection: {}
@@ -68,6 +69,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/envoy-gateway/httproute-btls-2/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/envoy-gateway/httproute-btls/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -37,6 +38,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http1-trailers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-trailers.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http10.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http10.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -36,6 +37,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -60,6 +62,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}
@@ -87,6 +90,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fourth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http2.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/http3.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http3.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-www.test.com-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-www.test.com-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-www.test.com-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-www.test.com-dest
   outlierDetection: {}
@@ -71,6 +73,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: "192_168_1_250_8080"
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: "192_168_1_250_8080"
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: "192_168_1_250_443"
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: "192_168_1_250_443"
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/listener-connection-limit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-connection-limit.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tls-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   name: first-route-dest
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -26,6 +27,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: RANDOM
   name: second-route-dest
   outlierDetection: {}
@@ -43,6 +45,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}
@@ -60,6 +63,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fourth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: MAGLEV
   name: fourth-route-dest
   outlierDetection: {}
@@ -77,6 +81,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fifth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   leastRequestLbConfig:
     slowStartConfig:
@@ -97,6 +102,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: sixth-route-dest
+  ignoreHealthOnHostRemoval: true
   name: sixth-route-dest
   outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
@@ -116,6 +122,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: seventh-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: MAGLEV
   name: seventh-route-dest
   outlierDetection: {}
@@ -133,6 +140,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: eighth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: MAGLEV
   maglevLbConfig:
     tableSize: "524287"
@@ -152,6 +160,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: ninth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: MAGLEV
   name: ninth-route-dest
   outlierDetection: {}
@@ -169,6 +178,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tenth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: MAGLEV
   name: tenth-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-http-route-2/envoy-gateway/http-backend
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: securitypolicy/default/policy-for-http-route-2/envoy-gateway/http-backend
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-3/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-3/rule/0
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fourth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
   outlierDetection: {}
@@ -78,6 +82,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-dest
   outlierDetection: {}
@@ -95,6 +100,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tls-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-simple-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-simple-1-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-1-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-simple-2-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-2-dest
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-simple-3-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-3-dest
   outlierDetection: {}
@@ -78,6 +82,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-simple-4-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-4-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fourth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
   outlierDetection: {}
@@ -78,6 +82,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fifth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fifth-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fourth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
   outlierDetection: {}
@@ -78,6 +82,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fifth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fifth-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tls-terminate-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-terminate-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tls-terminate-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-terminate-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/path-settings.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/path-settings.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -29,6 +30,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -48,6 +50,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fourth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
   outlierDetection: {}
@@ -44,6 +46,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: third-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
   outlierDetection: {}
@@ -61,6 +64,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: fourth-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-listener-ipfamily.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-listener-ipfamily.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-dual-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-dual-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-complex-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-complex-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-simple-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tls-terminate-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-terminate-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tls-terminate-hostname-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-terminate-hostname-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tcp-route-weighted-backend-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-weighted-backend-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/timeout.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tls-passthrough-foo-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-passthrough-foo-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: tls-terminate-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-terminate-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-datadog.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-datadog.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-zipkin.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-zipkin.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: direct-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/udp-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-endpoint-stats.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: udp-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: udp-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/udp-req-resp-sizes-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-req-resp-sizes-stats.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: udp-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: udp-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: udp-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: udp-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
   outlierDetection: {}

--- a/internal/xds/translator/testdata/out/xds-ir/wasm.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/wasm.clusters.yaml
@@ -10,6 +10,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
   outlierDetection: {}
@@ -27,6 +28,7 @@
       ads: {}
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
   outlierDetection: {}


### PR DESCRIPTION
Removes the endpoint from the pool faster instead of waiting for the result of the active health check.
Since the control plane already has definitive endpoint health info from the EndpointSlice API, it's safe to set this.

Fixes: https://github.com/envoyproxy/gateway/issues/4564