### PR TITLE
Move v1.1 docs tag to v1.1.2

### DIFF
--- a/site/layouts/shortcodes/helm-version.html
+++ b/site/layouts/shortcodes/helm-version.html
@@ -3,8 +3,8 @@
 {{- "v0.0.0-latest" -}}
 {{- end -}}
 {{- with (strings.HasPrefix $pagePrefix "v1.1") -}}
-{{- "v1.1.3" -}}
+{{- "v1.1.2" -}}
 {{- end -}}
 {{- with (strings.HasPrefix $pagePrefix "doc") -}}
-{{- "v1.1.3" -}}
+{{- "v1.1.2" -}}
 {{- end -}}

--- a/site/layouts/shortcodes/yaml-version.html
+++ b/site/layouts/shortcodes/yaml-version.html
@@ -3,8 +3,8 @@
 {{- "latest" -}}
 {{- end -}}
 {{- with (strings.HasPrefix $pagePrefix "v1.1") -}}
-{{- "v1.1.3" -}}
+{{- "v1.1.2" -}}
 {{- end -}}
 {{- with (strings.HasPrefix $pagePrefix "doc") -}}
-{{- "v1.1.3" -}}
+{{- "v1.1.2" -}}
 {{- end -}}


### PR DESCRIPTION
Wait until the v1.1.3 binary exists

Fixes: https://github.com/envoyproxy/gateway/issues/4614
