### PR TITLE
remove myself from maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,7 +9,6 @@ admins:
 
 maintainers:
 
-- AliceProxy
 - arkodg
 - Xunzhuo
 - zirain
@@ -25,6 +24,7 @@ emeritus-maintainers:
 - skriss
 - youngnick
 - qicz
+- Alice-Lilith
 
 reviewers:
 

--- a/site/content/en/contributions/CODEOWNERS.md
+++ b/site/content/en/contributions/CODEOWNERS.md
@@ -5,7 +5,6 @@ description: "This section includes Maintainers of Envoy Gateway."
 
 ## The following maintainers, listed in alphabetical order, own everything
 
-- @AliceProxy
 - @arkodg
 - @qicz
 - @Xunzhuo
@@ -19,3 +18,4 @@ description: "This section includes Maintainers of Envoy Gateway."
 - @LukeShu
 - @skriss
 - @youngnick
+- @Alice-Lilith

--- a/site/content/en/news/releases/_index.md
+++ b/site/content/en/news/releases/_index.md
@@ -31,7 +31,7 @@ communications with the Envoy Gateway community, and the mechanics of the releas
 |:-------:|:--------------------------------------------------------------:|
 | 2022 Q4 |    Daneyon Hansen ([danehans](https://github.com/danehans))    |
 | 2023 Q1 |    Xunzhuo Liu ([Xunzhuo](https://github.com/Xunzhuo))         |
-| 2023 Q2 |    Alice Wasko ([AliceProxy](https://github.com/AliceProxy))   |
+| 2023 Q2 |    Alice Wasko ([Alice-Lilith](https://github.com/Alice-Lilith))   |
 | 2023 Q3 |    Arko Dasgupta ([arkodg](https://github.com/arkodg))         |
 | 2023 Q4 |    Arko Dasgupta ([arkodg](https://github.com/arkodg))         |
 | 2024 Q1 |    Xunzhuo Liu ([Xunzhuo](https://github.com/Xunzhuo))         |

--- a/site/content/en/v0.2/contributions/CODEOWNERS.md
+++ b/site/content/en/v0.2/contributions/CODEOWNERS.md
@@ -5,7 +5,7 @@ description: "This section includes Maintainers of Envoy Gateway."
 
 ## The following maintainers, listed in alphabetical order, own everything
 
-- @AliceProxy
+- @Alice-Lilith
 - @arkodg
 - @Xunzhuo
 - @zirain

--- a/site/content/en/v0.2/contributions/RELEASING.md
+++ b/site/content/en/v0.2/contributions/RELEASING.md
@@ -97,10 +97,10 @@ Configuration looks like following:
             cherrypick/release-v0.4
           # put release manager here
           reviewers: |
-            AliceProxy
+            Alice-Lilith
 ```
 
-Replace `v0.4` with real branch name, and `AliceProxy` with the real name of RM.
+Replace `v0.4` with real branch name, and `Alice-Lilith` with the real name of RM.
 
 ## Minor Release
 

--- a/site/content/en/v0.3/contributions/CODEOWNERS.md
+++ b/site/content/en/v0.3/contributions/CODEOWNERS.md
@@ -5,7 +5,7 @@ description: "This section includes Maintainers of Envoy Gateway."
 
 ## The following maintainers, listed in alphabetical order, own everything
 
-- @AliceProxy
+- @Alice-Lilith
 - @arkodg
 - @Xunzhuo
 - @zirain

--- a/site/content/en/v0.3/contributions/RELEASING.md
+++ b/site/content/en/v0.3/contributions/RELEASING.md
@@ -97,10 +97,10 @@ Configuration looks like following:
             cherrypick/release-v0.4
           # put release manager here
           reviewers: |
-            AliceProxy
+            Alice-Lilith
 ```
 
-Replace `v0.4` with real branch name, and `AliceProxy` with the real name of RM.
+Replace `v0.4` with real branch name, and `Alice-Lilith` with the real name of RM.
 
 ## Minor Release
 

--- a/site/content/en/v0.4/contributions/CODEOWNERS.md
+++ b/site/content/en/v0.4/contributions/CODEOWNERS.md
@@ -5,7 +5,7 @@ description: "This section includes Maintainers of Envoy Gateway."
 
 ## The following maintainers, listed in alphabetical order, own everything
 
-- @AliceProxy
+- @Alice-Lilith
 - @arkodg
 - @Xunzhuo
 - @zirain

--- a/site/content/en/v0.4/contributions/RELEASING.md
+++ b/site/content/en/v0.4/contributions/RELEASING.md
@@ -97,10 +97,10 @@ Configuration looks like following:
             cherrypick/release-v0.4
           # put release manager here
           reviewers: |
-            AliceProxy
+            Alice-Lilith
 ```
 
-Replace `v0.4` with real branch name, and `AliceProxy` with the real name of RM.
+Replace `v0.4` with real branch name, and `Alice-Lilith` with the real name of RM.
 
 ## Minor Release
 

--- a/site/content/en/v0.5/contributions/CODEOWNERS.md
+++ b/site/content/en/v0.5/contributions/CODEOWNERS.md
@@ -5,7 +5,7 @@ description: "This section includes Maintainers of Envoy Gateway."
 
 ## The following maintainers, listed in alphabetical order, own everything
 
-- @AliceProxy
+- @Alice-Lilith
 - @arkodg
 - @Xunzhuo
 - @zirain

--- a/site/content/en/v0.5/contributions/RELEASING.md
+++ b/site/content/en/v0.5/contributions/RELEASING.md
@@ -97,10 +97,10 @@ Configuration looks like following:
             cherrypick/release-v0.4
           # put release manager here
           reviewers: |
-            AliceProxy
+            Alice-Lilith
 ```
 
-Replace `v0.4` with real branch name, and `AliceProxy` with the real name of RM.
+Replace `v0.4` with real branch name, and `Alice-Lilith` with the real name of RM.
 
 ## Minor Release
 

--- a/site/content/en/v0.6/contributions/CODEOWNERS.md
+++ b/site/content/en/v0.6/contributions/CODEOWNERS.md
@@ -5,7 +5,7 @@ description: "This section includes Maintainers of Envoy Gateway."
 
 ## The following maintainers, listed in alphabetical order, own everything
 
-- @AliceProxy
+- @Alice-Lilith
 - @arkodg
 - @Xunzhuo
 - @zirain

--- a/site/content/en/v0.6/contributions/RELEASING.md
+++ b/site/content/en/v0.6/contributions/RELEASING.md
@@ -100,10 +100,10 @@ Configuration looks like following:
             cherrypick/release-v0.4
           # put release manager here
           reviewers: |
-            AliceProxy
+            Alice-Lilith
 ```
 
-Replace `v0.4` with real branch name, and `AliceProxy` with the real name of RM.
+Replace `v0.4` with real branch name, and `Alice-Lilith` with the real name of RM.
 
 ## Minor Release
 

--- a/site/content/zh/contributions/CODEOWNERS.md
+++ b/site/content/zh/contributions/CODEOWNERS.md
@@ -5,7 +5,6 @@ description: "本部分包括 Envoy Gateway 的维护者。"
 
 ## 以下是拥有所有权限的维护者（按字母顺序排列） {#the-following-maintainers-listed-in-alphabetical-order-own-everything}
 
-- @AliceProxy
 - @arkodg
 - @qicz
 - @Xunzhuo
@@ -19,3 +18,4 @@ description: "本部分包括 Envoy Gateway 的维护者。"
 - @LukeShu
 - @skriss
 - @youngnick
+- @Alice-Lilith

--- a/site/content/zh/contributions/RELEASING.md
+++ b/site/content/zh/contributions/RELEASING.md
@@ -102,10 +102,10 @@ export GITHUB_REMOTE=origin
             cherrypick/release-v0.4
           # 将发布经理名字放在这里
           reviewers: |
-            AliceProxy
+            Alice-Lilith
 ```
 
-将 `v0.4` 替换为真实的分支名称，并将 `AliceProxy` 替换为 RM 的真实名称。
+将 `v0.4` 替换为真实的分支名称，并将 `Alice-Lilith` 替换为 RM 的真实名称。
 
 ## 次要版本 {#minor-release}
 

--- a/site/content/zh/news/releases/_index.md
+++ b/site/content/zh/news/releases/_index.md
@@ -32,7 +32,7 @@ Envoy Gateway 的稳定版本包括：
 |:-------:|:--------------------------------------------------------------:|
 | 2022 Q4 |    Daneyon Hansen ([danehans](https://github.com/danehans))    |
 | 2023 Q1 |    Xunzhuo Liu ([Xunzhuo](https://github.com/Xunzhuo))         |
-| 2023 Q2 |    Alice Wasko ([AliceProxy](https://github.com/AliceProxy))   |
+| 2023 Q2 |    Alice Wasko ([Alice-Lilith](https://github.com/Alice-Lilith))   |
 | 2023 Q3 |    Arko Dasgupta ([arkodg](https://github.com/arkodg))         |
 | 2023 Q4 |    Arko Dasgupta ([arkodg](https://github.com/arkodg))         |
 | 2024 Q1 |    Xunzhuo Liu ([Xunzhuo](https://github.com/Xunzhuo))         |


### PR DESCRIPTION
Removes myself from the active maintainers list and also updates any references to my previous GitHub username. 

It's been a good while since I've had any bandwidth to devote to contributing to or actively keeping up with events and reviews and I don't anticipate that I will be active enough to be considered a maintainer here any time soon either. I might still chime in with stray thoughts on the occasional PR or issue. 

Not sure about the docs ones. Didn't want to break any existing guides or historical references so other than renaming my username I left the older ones untouched.