### PR TITLE
fix: recover from panics that occur during envoy gateway's reconciliation

### DIFF
--- a/internal/message/watchutil.go
+++ b/internal/message/watchutil.go
@@ -38,6 +38,27 @@ func (m Metadata) LabelValues() []metrics.LabelValue {
 	return labels
 }
 
+// handleWithCrashRecovery calls the provided handle function and gracefully recovers from any panics
+// that might occur when the handle function is called.
+func handleWithCrashRecovery[K comparable, V any](
+	handle func(updateFunc Update[K, V], errChans chan error),
+	update Update[K, V],
+	meta Metadata,
+	errChans chan error,
+) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.WithValues("runner", meta.Runner).Error(fmt.Errorf("%+v", r), "observed an panic",
+				"stackTrace", string(debug.Stack()))
+			watchableSubscribeTotal.WithFailure(metrics.ReasonError, meta.LabelValues()...).Increment()
+		}
+	}()
+	startHandleTime := time.Now()
+	handle(update, errChans)
+	watchableSubscribeTotal.WithSuccess(meta.LabelValues()...).Increment()
+	watchableSubscribeDurationSeconds.With(meta.LabelValues()...).Record(time.Since(startHandleTime).Seconds())
+}
+
 // HandleSubscription takes a channel returned by
 // watchable.Map.Subscribe() (or .SubscribeSubset()), and calls the
 // given function for each initial value in the map, and for any
@@ -60,32 +81,19 @@ func HandleSubscription[K comparable, V any](
 		}
 	}()
 	defer close(errChans)
-	defer func() {
-		if r := recover(); r != nil {
-			logger.WithValues("runner", meta.Runner).Error(fmt.Errorf("%+v", r), "observed an panic",
-				"stackTrace", string(debug.Stack()))
-			watchableSubscribeTotal.WithFailure(metrics.ReasonError, meta.LabelValues()...).Increment()
-		}
-	}()
 
 	if snapshot, ok := <-subscription; ok {
 		for k, v := range snapshot.State {
-			startHandleTime := time.Now()
-			handle(Update[K, V]{
+			handleWithCrashRecovery(handle, Update[K, V]{
 				Key:   k,
 				Value: v,
-			}, errChans)
-			watchableSubscribeTotal.WithSuccess(meta.LabelValues()...).Increment()
-			watchableSubscribeDurationSeconds.With(meta.LabelValues()...).Record(time.Since(startHandleTime).Seconds())
+			}, meta, errChans)
 		}
 	}
 	for snapshot := range subscription {
 		watchableDepth.With(meta.LabelValues()...).Record(float64(len(subscription)))
 		for _, update := range snapshot.Updates {
-			startHandleTime := time.Now()
-			handle(Update[K, V](update), errChans)
-			watchableSubscribeTotal.WithSuccess(meta.LabelValues()...).Increment()
-			watchableSubscribeDurationSeconds.With(meta.LabelValues()...).Record(time.Since(startHandleTime).Seconds())
+			handleWithCrashRecovery(handle, Update[K, V](update), meta, errChans)
 		}
 	}
 }

--- a/internal/message/watchutil_test.go
+++ b/internal/message/watchutil_test.go
@@ -30,6 +30,23 @@ func TestHandleSubscriptionAlreadyClosed(t *testing.T) {
 	assert.Equal(t, 0, calls)
 }
 
+func TestPanicInSubsscriptionHandler(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			assert.Fail(t, "recovered from an unexpected panic")
+		}
+	}()
+	var m watchable.Map[string, any]
+	m.Store("foo", "bar")
+	message.HandleSubscription[string, any](
+		message.Metadata{Runner: "demo", Message: "demo"},
+		m.Subscribe(context.Background()),
+		func(update message.Update[string, any], errChans chan error) {
+			panic("oops")
+		},
+	)
+}
+
 func TestHandleSubscriptionAlreadyInitialized(t *testing.T) {
 	var m watchable.Map[string, any]
 	m.Store("foo", "bar")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR catches panics that occur during calls to the watchable infrastructure. All the runners are affected, and panics that occur in them will be logged and reported instead of crashing Envoy Gateway.

Note that the Kubernetes client already recovered from panics caused during calls to the provider specific reconcile - this is the default behavior and the default was never changed.

**Which issue(s) this PR fixes**:
Fixes #4332

Release Notes: No