### PR TITLE
fix release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
         shell: bash
         run: |
           echo "release_tag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
-          echo "without_v_release_tag=${release_tag:1}" >> $GITHUB_ENV
+          echo "without_v_release_tag=$(echo ${GITHUB_REF##*/v})" >> $GITHUB_ENV
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Login to DockerHub


### PR DESCRIPTION
Fix the `without_v_release_tag` release tag.

Tested locally:
```
➜  gateway git:(fix-release-build) ✗ export  GITHUB_REF=refs/tags/v1.2.0             
➜  gateway git:(fix-release-build) ✗ without_v_release_tag=$(echo ${GITHUB_REF##*/v})
➜  gateway git:(fix-release-build) ✗ echo $without_v_release_tag                     
1.2.0
```

