### PR TITLE
Release News for v1.2.0

### DIFF
--- a/site/content/en/news/releases/_index.md
+++ b/site/content/en/news/releases/_index.md
@@ -35,8 +35,8 @@ communications with the Envoy Gateway community, and the mechanics of the releas
 | 2023 Q3 |    Arko Dasgupta ([arkodg](https://github.com/arkodg))         |
 | 2023 Q4 |    Arko Dasgupta ([arkodg](https://github.com/arkodg))         |
 | 2024 Q1 |    Xunzhuo Liu ([Xunzhuo](https://github.com/Xunzhuo))         |
-| 2024 Q2 |    Guy Daich ([guydc](https://github.com/guydc))               |
-| 2024 Q3 |    Huabing Zhao ([zhaohuabing](https://github.com/zhaohuabing))|
+| 2024 Q3 |    Guy Daich ([guydc](https://github.com/guydc))               |
+| 2024 Q4 |    Huabing Zhao ([zhaohuabing](https://github.com/zhaohuabing))|
 
 ## Release Schedule
 
@@ -50,9 +50,9 @@ In order to align with the Envoy Proxy [release schedule][], Envoy Gateway relea
 |  0.4.0  | 2023/04/22  | 2023/04/24  |   +2 days   |  2023/10/24 |
 |  0.5.0  | 2023/07/22  | 2023/08/02  |   +10 days  |  2024/01/02 |
 |  0.6.0  | 2023/10/22  | 2023/11/02  |   +10 days  |  2024/05/02 |
-|  1.0.0  | 2024/03/06  | 2023/03/13  |   +7 days   |  2024/09/13 |
-|  1.1.0  | 2024/07/16	| 2024/07/22  |   +6 days   |  2024/01/22 |
-|  1.2.0  | 2024/10/22	|             |             |             |
+|  1.0.x  | 2024/03/06  | 2023/03/13  |   +7 days   |  2024/09/13 |
+|  1.1.x  | 2024/07/16	| 2024/07/22  |   +6 days   |  2024/01/22 |
+|  1.2.x  | 2024/10/22	| 2024/11/06  |   +14 days  |  2025/05/06 |
 
 [v2.0.0 spec]: https://semver.org/spec/v2.0.0.html
 [release guide]: ../../contributions/releasing

--- a/site/content/en/news/releases/notes/v1.2.0.md
+++ b/site/content/en/news/releases/notes/v1.2.0.md
@@ -3,83 +3,142 @@ title: "v1.2.0"
 publishdate: 2024-11-06
 ---
 
-## Envoy Gateway v1.2.0 Release Notes
+Date: November 06, 2024
 
-**Release Date:** November 6, 2024
+## Breaking Changes
+- Gateway API GRPCRoute and ReferenceGrant v1alpha2 have been removed
+- Please refer to the [Gateway API v1.2.0 documentation](https://github.com/kubernetes-sigs/gateway-api/releases) for more information
+- Removed default CPU limit of the Envoy Gateway deployment, to eliminate CPU throttling
+- Changed default Envoy shutdown settings: drain strategy has been changed to immediate, default minDrainDuration, drainTimeout and terminationGracePeriodSeconds have been set to 10s, 60s and 360s respectively
+- Set `ignore_health_on_host_removal` to true for clusters with static endpoints This was done to speed up removal of static endpoints by the control plane when active health check is configured
+- Xds and Infra IR logs are logged at Debug level instead of Info level. They will now not be seen by default in Envoy Gateway logs. You can change the logging level to `default: debug` to view them
 
-The Envoy Gateway v1.2.0 release brings a host of new features, performance improvements, and critical bug fixes to enhance networking, traffic management, and security. Explore the latest changes below.
+## New Features
+- Added support for Gateway-API v1.2.0
+- Added support for IPv4/IPv6 Dual Stack for EnvoyProxy fleet and BackendRef resources
+- Added experimental support for EG standalone(host deployment) mode
+- Added support for JWT claims based Authorization in SecurityPolicy CRD
+- Added support for Response Override in BackendTrafficPolicy CRD
+- Added support for RequestTimeout in BackendTrafficPolicy CRD
+- Added support for inverting header matches for Rate Limit in BackendTrafficPolicy CRD
+- Added support for client TLS session resumption in ClientTrafficPolicy CRD
+- Added support for HTTPRouteFilter and path regex rewrite
+- Added support for host header rewrite in HTTPRouteFilter CRD
+- Added support for Listener Access Log in EnvoyProxy CRD
+- Added support for Datadog tracing support in EnvoyProxy CRD
+- Added support for request response sizes stats in EnvoyProxy CRD
+- Added support for modifying container SecurityContext for Envoy Gateway deployment in Helm
+- Added support for wildcard matching for CORS AllowMethods and AllowHeaders settings in SecurityPolicy CRD
+- Added support for match conditions for access log in EnvoyProxy CRD
+- Added support for using BackendCluster to represent OIDCProvider
+- Added support for RecomputeRoute for ExtAuth in SecurityPolicy CRD
+- Added support for sharing token cookies between multiple domains in SecurityPolicy CRD
+- Added support for JSONPatches for proxy bootstrap modifications in EnvoyProxy CRD
+- Added support for Active Passive Failover Backends
+- Added support for configuring the GRPC Health Checker in the BackendTrafficPolicy CRD
+- Added support for early request header mutation in the ClientTrafficPolicy CRD
+- Added support for JsonPath in the EnvoyPatchPolicy CRD
+- Added support for cluster settings for tracing and access log backends in EnvoyProxy CRD
+- Added support for cluster settings for non xRoute-generated backend refs
+- Added support for socket buffer limit field in ClientTrafficPolicy and BackendTrafficPolicy CRD
+- Added support for http2 upstream settings in BackendTrafficPolicy CRD
+- Added support for DNS resolution settings in BackendTrafficPolicy CRD
+- Added support for configuring service annotations in the Envoy Gateway helm chart
+- Added support for configuring priorityClassName to Envoy Gateway helm chart
+- Added support for ratelimit metrics monitoring in grafana in the addons helm chart
+- Added support for default user group and user id for the SecurityContexts in the Envoy Gateway helm chart
+- Added support for maxUnavailable in the PodDisruptionBudget in the Envoy Gateway helm chart
+- Added support for configuring NodeSelector in the Envoy Gateway helm chart
+- Added support for nonce in the OIDC auth flow
+- Added support for choosing an HTTPRoute's non-wildcard hostname as the default Host
+- Added support for returning 500 when EnvoyExtensionTrafficPolicy translation fails
+- Added support for returning 500 when SecurityPolicy translation fails
+- Added support for multiple backendRefs for ExtAuth and ExtProc
+- Added support for session persistence in HTTPRoute rules
+- Added support for the Backend resource for ExtAuth
+- Added support for target selectors on Envoy Gateway Extension Server policies
+- Added support for non-Kubernetes Backends for TLSRoute
+- Added support for fallback to the Backend API
+- Added support for reloadable EnvoyGateway configuration
+- Added support for adding Labels to the Envoy Service
+- Added support for custom name for ratelimit deployment
+- Added default SecurityContext for EG components
+- Added startupProbe to all provisioned containers
+- Added support for local validations for egctl translate and file provider
+- Added support for egctl x collect to collect information from the cluster for debugging
+- Added support for a native prometheus metrics endpoint in the ratelimit server
 
----
-
-## 🚨 Breaking Changes
-
-- **Gateway API Updates**: Removed `GRPCRoute` and `ReferenceGrant` v1alpha2. [See the Gateway API v1.2.0 documentation](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.2.0) for details.
-- **CPU Limits**: Removed default CPU limit for Envoy Gateway deployment to avoid throttling.
-- **Envoy Shutdown Settings**: Drain strategy set to immediate, with default values as follows:
-  - `minDrainDuration`: 10s
-  - `drainTimeout`: 60s
-  - `terminationGracePeriodSeconds`: 360s
-- **Endpoint Health Removal**: Enabled `ignore_health_on_host_removal` for clusters with static endpoints to improve removal speed.
-- **Logging Level Adjustment**: Set xDS and Infra IR logs to Debug level instead of Info, so they will no longer appear in Envoy Gateway logs by default. Change logging level to `debug` to view them.
-
----
-
-## ✨ New Features
-
-### API & Traffic Management Enhancements
-- **Gateway-API v1.2.0 Support**: Fully compatible with the latest Gateway-API standards.
-- **IPv4/IPv6 Dual Stack**: Now available for EnvoyProxy fleet and `BackendRef` resources.
-- **Standalone Mode**: Experimental support for Envoy Gateway standalone (host deployment) mode.
-- **JWT Authorization**: Added JWT claims-based authorization in [`SecurityPolicy`](https://gateway.envoyproxy.io/latest/api/extension_types/#securitypolicy) CRD.
-- **Response Override**: Added support for `Response Override` and `RequestTimeout` in [`BackendTrafficPolicy`](https://gateway.envoyproxy.io/latest/api/extension_types/#backendtrafficpolicy).
-- **Active Passive Failover**: Supported with the new `fallback` field in the [Backend](https://gateway.envoyproxy.io/latest/api/extension_types/#backend) API.
-- **Session Persistence in HTTPRoute**: Session persistence is supported in [`HTTPRoute`](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRoute) rules for stateful traffic management.
-- **HTTPRouteFilter**: Adds support for Direct Response and Path Regex Rewrites in [`HTTPRouteFilter`](https://gateway.envoyproxy.io/latest/api/extension_types/#httproutefilter)
-
-### Security Enhancements
-- **JWT Claims-Based Authorization**: Advanced security control with claims-based policies in [`SecurityPolicy`](https://gateway.envoyproxy.io/latest/api/extension_types/#securitypolicy).
-- **CORS Wildcard Matching**: Wildcard matching for `AllowMethods` and `AllowHeaders` settings.
-- **OIDC Flow Support**: Added nonce support for OIDC authorization.
-
-### Observability & Tracing
-- **Datadog Tracing Integration**: Improved support for Datadog tracing in [`EnvoyProxy`](https://gateway.envoyproxy.io/latest/api/extension_types/#envoyproxy) CRD.
-- **Access Log Matching**: Filter logs based on custom criteria using `match conditions` in EnvoyProxy.
-- **Native Prometheus Metrics**: Introduced a Prometheus metrics endpoint for rate limit monitoring.
-
-### Helm Customization
-- **SecurityContext Options**: Customizable security context for improved deployment.
-- **NodeSelector and PriorityClassName**: Added for more granular deployment configuration.
-
----
-
-## 🐞 Bug Fixes
-
-- Fixed xDS translation failure when the WASM HTTP code source was configured without an SHA.
-- Resolved unsupported listener protocol types causing errors in Gateway status updates.
-- Fixed `BackendTLSPolicy` causing crashes due to invalid `sectionName` in `Backend` configurations.
-- Fixed propagation delays in `SecurityPolicy` updates for `HTTPRoute` when using `targetSelectors`.
-- Improved `JSONPath` to `JSONPatch` translation accuracy.
-- Fixed unwanted `/` appearing in paths when using prefix rewrites.
-- Corrected nil pointer errors when configuring hash load balancing.
-- Fixed active health check issues where `expectedStatuses` was not functioning properly.
-- Ensured correct status updates for `Backend` resources and `HTTPRoute`.
-
----
-
-## 🚀 Performance Improvements
-
-- **Memory Optimization**: Enhanced memory usage by eliminating redundant resource storage.
-
----
-
-## ⚙️ Other Notable Changes
-
-- **Envoy Upgrade**: Now using Envoy [v1.32.1](https://www.envoyproxy.io/docs/envoy/v1.32.1/version_history/v1.32/v1.32.1) for added stability and performance.
-- **Optional Alpha CRD Watching**: Allows Envoy Gateway to run with older Gateway API versions.
+## Bug Fixes 
+- Fixed xDS translation failing when the WASM HTTP code source was configured without an SHA
+- Fixed unsupported listener protocol types causing errors while updating Gateway status
+- Fixed unsupported listener protocol types causing errors while updating Gateway status
+- Fixed invalid sectionName in BackendTLSPolicy for Backend
+- Fixed Delay in SecurityPolicy change propagation for HTTPRoute when using targetSelectors
+- Fixed JSONPath not being correctly translated to JSONPatch paths
+- Fixed allowing an empty slowStart value when using LeastRequest
+- Fixed updating the HTTPRoute status correctly when the linked Backend resource is invalid
+- Fixed timeout settings originating from the route being lost when translating the backend traffic policy
+- Fixed Backend resources not receiving status updates
+- Fixed active health checks requiring the expectedStatuses field to function correctly
+- Fixed HTTPHeaderFilter processing not correctly supporting multiple header values
+- Fixed reconciling multiple ReferenceGrants within the same namespace
+- Fixed unwanted / appearing in the Path when using Prefix Rewrites
+- Fixed incorrect gateway being selected as the HTTPRoute parent
+- Fixed override issues for EnvoyExtensionPolicy
+- Fixed nil pointer error when translating hash load balancing
+- Fixed nil pointer if backedtls.minVersion is set but backedtls.maxVersion is not
+- Fixed empty connection limits causing xDS rejection
+- Fixed rate limiting not working with both headers and CIDR matches
+- Fixed EDS not updating when deployments were created after services
+- Fixed RBAC issue for deleting infrastructure resources
+- Fixed gateways never reaching ready/programmed status when running Envoy as a Daemonset
+- Fixed rate limit deployment ignoring pod labels and annotation merges
+- Fixed the API Server receives unnecessary requests
+- Fixed egctl experimental translate using an incorrect namespace
+- Fixed reconciliation not being triggered for Secret updates referenced by a BackendTLSPolicy
+- Fixed xDS translation failure when WASM HTTP code source was configured without an SHA
+- Fixed HTTPRoute status displaying only one parent when targeting multiple gateways from different GatewayClasses
+- Fixed Route with multiple parents having an incorrect namespace in the parentRef status
+- Fixed BackendTlsPolicy specifying multiple targetRefs for the same service, to work
 
 
-For more information and full API documentation, please visit the [Envoy Gateway Documentation](https://gateway.envoyproxy.io/docs/).
+### Performance Improvements 
+- Optimize memory usage by only storing distinct resources
+- SecurityPolicy translation failures will now cause routes referenced by the policy to return an immediate 500 response
+- Gateway-API BackendTLSPolicy v1alpha3 is incompatible with previous versions of the CRD
+- xPolicy targetRefs can no longer specify a namespace, since Gateway-API v1.1.0 uses LocalPolicyTargetReferenceWithSectionName in Policy resources
 
----
-
-This release strengthens Envoy Gateway with enhanced API support, security policies, and observability features to better serve high-demand environments.
+### Other changes
+- Upgraded Envoy Proxy to v1.32.1
+- Reduced the amount of configuration logging, and make it line-delimited friendly
+- Made watching alpha CRDs optional, so that Envoy Gateway can run with older Gateway Api versions
+- Removed grafana test framework from the addons helm chart
+- Disabled ALPN for non-HTTP routes
+- Added statPrefix for HCM and TCPProxy
+- Enabled GatewayHTTPListenerIsolation conformance test
+- Enabled GRPC conformance profile
+- Enabled HTTPRouteBackendRequestHeaderModifier conformance test
+- Added e2e test for Daemonset mode
+- Fixed OVS scanner wrong license warnings
+- Added e2e test for Gateway with EnvoyProxy
+- Added e2e test for TLS session resumption
+- Added heap profile into benchmark report
+- Added e2e test for RecomputeRoute in ExtAuth
+- Added benchmark memory profiles into report
+- Fixed flaky gateway_with_conflicted_listener_cannot_be_merged e2e test
+- Fixed flaky Zipkin Tracing e2e test
+- Added e2e test for cookie based consistent hash load balancing
+- Added e2e test for load balancing
+- Fixed flaky authorization tests
+- Enabled upgrade test
+- Fixed flaky basic auth e2e test
+- Enabled use-client-protocol e2e test
+- Added performance benchmarking test for 1000 HTTPRoutes
+- Added e2e test for Datadog tracing
+- Added e2e tests for ratelimit invert matching headers
+- Reduced readinessProbe failureThreshold and periodSeconds
+- Bumped go-control-plane to v0.13.1
+- Enabled e2e tests for dual stack
+- Use grafana alloy instead of fluent-bit for e2e tests
+- Push tags without the v prefix for helm charts to support Flux HelmReleases
+- Use a stable label selector when creating Envoy Proxy fleet pods

--- a/site/content/en/news/releases/v1.2.md
+++ b/site/content/en/news/releases/v1.2.md
@@ -89,7 +89,7 @@ The release adds a ton of features and functionality. Here are some highlights:
 - **Optional Alpha CRD Watching**: Allows Envoy Gateway to run with older Gateway API versions.
 
 
-[Release Notes]: ./notes/v2.1.0
+[Release Notes]: ./notes/v1.2.0
 [matrix]: ./matrix
 [docs]: /v1.2/
 [Download]: https://github.com/envoyproxy/gateway/releases/tag/v1.2.0

--- a/site/content/en/news/releases/v1.2.md
+++ b/site/content/en/news/releases/v1.2.md
@@ -1,0 +1,95 @@
+---
+title: Announcing Envoy Gateway v1.2
+subtitle: Minor Update
+linktitle: Release v1.2
+description: Envoy Gateway v1.2 release announcement.
+publishdate: 2024-11-06
+release: v1.2.0
+skip_list: true
+---
+
+We are thrilled to announce the arrival of Envoy Gateway v1.2.0.
+
+This release represents a significant achievement, and we extend our heartfelt gratitude to the entire Envoy Gateway community for their contributions, dedication, and support. Your collaborative efforts have been instrumental in reaching this pivotal release.
+
+Thank you for being an integral part of this journey. We are excited to see how Envoy Gateway v1.2.0 will empower your operations and look forward to continuing our work together to drive the future of Cloud Native API Gateway.
+
+| [Release Notes][] | [Docs][docs] | [Compatibility Matrix][matrix] | [Download][] |
+|-------------------|--------------|--------------------------------|--------------|
+
+## What's New
+
+The release adds a ton of features and functionality. Here are some highlights:
+
+---
+
+## 🚨 Breaking Changes
+
+- **Gateway API Updates**: Removed support for the v1alpha2 versions for `GRPCRoute` and `ReferenceGrant`. [See the Gateway API v1.2.0 documentation](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.2.0) for details.
+- **CPU Limits**: Removed default CPU limit for Envoy Gateway deployment to avoid throttling.
+- **Envoy Shutdown Settings**: Drain strategy set to immediate, with default values as follows:
+  - `minDrainDuration`: 10s
+  - `drainTimeout`: 60s
+  - `terminationGracePeriodSeconds`: 360s
+- **Endpoint Health On Host Removal**: Enabled `ignore_health_on_host_removal` for clusters with static endpoints to allow faster removal of endpoints that have been deleted by the control plane, without waiting for the results of an active health check.
+- **Logging Level Adjustment**: Set xDS and Infra IR logs to Debug level instead of Info, so they will no longer appear in Envoy Gateway logs by default. You can change the logging level to `debug` to view them.
+
+---
+
+## ✨ New Features
+
+### API & Traffic Management Enhancements
+- **Gateway-API v1.2.0 Support**: Fully compatible with the latest Gateway-API standards.
+- **IPv4/IPv6 Dual Stack**: Now available for EnvoyProxy fleet and `BackendRef` resources.
+- **Standalone Mode**: Experimental support for Envoy Gateway standalone (host deployment) mode.
+- **Response Override**: Added support for `Response Override` and `RequestTimeout` in [BackendTrafficPolicy](https://gateway.envoyproxy.io/docs/api/extension_types/#backendtrafficpolicy).
+- **Active Passive Failover**: Supported with the new `fallback` field in the [Backend](https://gateway.envoyproxy.io/docs/api/extension_types/#backend) API.
+- **Session Persistence in HTTPRoute**: Session persistence is supported in [HTTPRoute](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRoute) rules for stateful traffic management.
+- **HTTPRouteFilter**: Adds support for Direct Response and Path Regex Rewrites in [HTTPRouteFilter](https://gateway.envoyproxy.io/docs/api/extension_types/#httproutefilter)
+
+### Security Enhancements
+- **JWT Claims-Based Authorization**: Advanced security control with claims-based policies in [SecurityPolicy](https://gateway.envoyproxy.io/docs/api/extension_types/#securitypolicy).
+- **CORS Wildcard Matching**: Wildcard matching for `AllowMethods` and `AllowHeaders` settings.
+- **OIDC Flow Support**: Added nonce support for OIDC authorization.
+
+### Observability & Tracing
+- **Datadog Tracing Integration**: Improved support for Datadog tracing in [EnvoyProxy](https://gateway.envoyproxy.io/docs/api/extension_types/#envoyproxy) CRD.
+- **Listener Access Logs**: Adds support for configuring Listener level Access Logs for EnvoyProxy.
+- **Native Prometheus Metrics**: Introduced a Prometheus metrics endpoint for rate limit monitoring.
+
+### Helm Customization
+- **SecurityContext Options**: Customizable security context for improved deployment.
+- **NodeSelector and PriorityClassName**: Added for more granular deployment configuration.
+
+---
+
+## 🐞 Bug Fixes
+
+- Fixed xDS translation failure when the WASM HTTP code source was configured without an SHA.
+- Resolved unsupported listener protocol types causing errors in Gateway status updates.
+- Fixed `BackendTLSPolicy` causing crashes due to invalid `sectionName` in `Backend` configurations.
+- Fixed propagation delays in `SecurityPolicy` updates for `HTTPRoute` when using `targetSelectors`.
+- Improved `JSONPath` to `JSONPatch` translation accuracy.
+- Fixed unwanted `/` appearing in paths when using prefix rewrites.
+- Corrected nil pointer errors when configuring hash load balancing.
+- Fixed active health check issues where `expectedStatuses` was not functioning properly.
+- Ensured correct status updates for `Backend` resources and `HTTPRoute`.
+
+---
+
+## 🚀 Performance Improvements
+
+- **Memory Optimization**: Enhanced memory usage by eliminating redundant resource storage.
+
+---
+
+## ⚙️ Other Notable Changes
+
+- **Envoy Upgrade**: Now using Envoy [v1.32.1](https://www.envoyproxy.io/docs/envoy/v1.32.1/version_history/v1.32/v1.32.1) for added stability and performance.
+- **Optional Alpha CRD Watching**: Allows Envoy Gateway to run with older Gateway API versions.
+
+
+[Release Notes]: ./notes/v2.1.0
+[matrix]: ./matrix
+[docs]: /v1.2/
+[Download]: https://github.com/envoyproxy/gateway/releases/tag/v1.2.0


### PR DESCRIPTION
* Updates Release Notes on Website with Release Note content from https://github.com/envoyproxy/gateway/blob/main/release-notes/v1.2.0.yaml

* Updated Release News with the release summary

* Updated the Release Schedule matrix