### PR TITLE
[release/v1.2] fix panic in provider when the direct response body is nil (#4647)

### DIFF
--- a/internal/provider/kubernetes/filters.go
+++ b/internal/provider/kubernetes/filters.go
@@ -66,6 +66,7 @@ func (r *gatewayAPIReconciler) processRouteFilterConfigMapRef(
 	resourceMap *resourceMappings, resourceTree *resource.Resources,
 ) {
 	if filter.Spec.DirectResponse != nil &&
+		filter.Spec.DirectResponse.Body != nil &&
 		filter.Spec.DirectResponse.Body.ValueRef != nil &&
 		string(filter.Spec.DirectResponse.Body.ValueRef.Kind) == resource.KindConfigMap {
 		configMap := new(corev1.ConfigMap)

--- a/test/e2e/testdata/direct-response.yaml
+++ b/test/e2e/testdata/direct-response.yaml
@@ -27,6 +27,17 @@ spec:
         group: gateway.envoyproxy.io
         kind: HTTPRouteFilter
         name: direct-response-value-ref
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /401
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: gateway.envoyproxy.io
+        kind: HTTPRouteFilter
+        name: direct-response-status
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -62,3 +73,12 @@ spec:
         group: ""
         kind: ConfigMap
         name: value-ref-response
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: direct-response-status
+  namespace: gateway-conformance-infra
+spec:
+  directResponse:
+    statusCode: 401

--- a/test/e2e/tests/direct-response.go
+++ b/test/e2e/tests/direct-response.go
@@ -31,8 +31,9 @@ var DirectResponseTest = suite.ConformanceTest{
 			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 			kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
-			verifyCustomResponse(t, suite.TimeoutConfig, gwAddr, "/inline", "text/plain", "Oops! Your request is not found.")
-			verifyCustomResponse(t, suite.TimeoutConfig, gwAddr, "/value-ref", "application/json", `{"error": "Internal Server Error"}`)
+			verifyCustomResponse(t, suite.TimeoutConfig, gwAddr, "/inline", "text/plain", "Oops! Your request is not found.", 200)
+			verifyCustomResponse(t, suite.TimeoutConfig, gwAddr, "/value-ref", "application/json", `{"error": "Internal Server Error"}`, 200)
+			verifyCustomResponse(t, suite.TimeoutConfig, gwAddr, "/401", "", ``, 401)
 		})
 	},
 }


### PR DESCRIPTION
body is an optional field, it may be nil


(cherry picked from commit ad518329bd6025fb56493ff75b39029263de2d02)