### PR TITLE
update the lastVersionTag of the upgrade test

### DIFF
--- a/test/e2e/tests/eg_upgrade.go
+++ b/test/e2e/tests/eg_upgrade.go
@@ -52,7 +52,7 @@ var EGUpgradeTest = suite.ConformanceTest{
 			chartPath := "../../../charts/gateway-helm"
 			relName := "eg"
 			depNS := "envoy-gateway-system"
-			lastVersionTag := "v1.1.2" // Default version tag if not specified
+			lastVersionTag := "v1.2.1" //  the latest prior release
 
 			t.Logf("Upgrading from version: %s", lastVersionTag)
 


### PR DESCRIPTION
Update the `lastVersionTag` in the upgrade test to reflect the latest prior release. 

Release Notes: No
