### PR TITLE
Draft: feat(translation): expand sources of JWKS required to validate JWTs

### DIFF
--- a/api/v1alpha1/validation/securitypolicy_validate_test.go
+++ b/api/v1alpha1/validation/securitypolicy_validate_test.go
@@ -58,7 +58,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "test",
 								Issuer:    "https://www.test.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 							},
@@ -86,7 +86,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "test",
 								Issuer:    "test@test.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 							},
@@ -114,7 +114,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "test",
 								Issuer:    "test@test.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 								ClaimToHeaders: []egv1a1.ClaimToHeader{
@@ -148,7 +148,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "unqualified_...",
 								Issuer:    "https://www.test.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 							},
@@ -176,7 +176,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "",
 								Issuer:    "https://www.test.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 							},
@@ -204,7 +204,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "unique",
 								Issuer:    "https://www.test.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 							},
@@ -212,7 +212,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "non-unique",
 								Issuer:    "https://www.test.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 							},
@@ -220,7 +220,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "non-unique",
 								Issuer:    "https://www.test.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 							},
@@ -248,7 +248,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "test",
 								Issuer:    "http://invalid url.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "http://www.test.local",
 								},
 							},
@@ -276,7 +276,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "test",
 								Issuer:    "test@!123...",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 							},
@@ -304,7 +304,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "test",
 								Issuer:    "http://www.test.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "invalid/local",
 								},
 							},
@@ -331,7 +331,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 							{
 								Name:      "test",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "",
 								},
 							},
@@ -359,7 +359,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "test",
 								Issuer:    "test@test.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 								ClaimToHeaders: []egv1a1.ClaimToHeader{
@@ -393,7 +393,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 								Name:      "test",
 								Issuer:    "test@test.local",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 								ClaimToHeaders: []egv1a1.ClaimToHeader{
@@ -426,7 +426,7 @@ func TestValidateSecurityPolicy(t *testing.T) {
 							{
 								Name:      "test",
 								Audiences: []string{"test.local"},
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 							},
@@ -453,7 +453,34 @@ func TestValidateSecurityPolicy(t *testing.T) {
 							{
 								Name:   "test",
 								Issuer: "https://www.test.local",
-								RemoteJWKS: egv1a1.RemoteJWKS{
+								RemoteJWKS: &egv1a1.RemoteJWKS{
+									URI: "https://test.local/jwt/public-key/jwks.json",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "unspecified audiences",
+			policy: &egv1a1.SecurityPolicy{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       egv1a1.KindSecurityPolicy,
+					APIVersion: egv1a1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+				Spec: egv1a1.SecurityPolicySpec{
+					JWT: &egv1a1.JWT{
+						Providers: []egv1a1.JWTProvider{
+							{
+								Name:   "test",
+								Issuer: "https://www.test.local",
+								RemoteJWKS: &egv1a1.RemoteJWKS{
 									URI: "https://test.local/jwt/public-key/jwks.json",
 								},
 							},

--- a/internal/ir/xds_test.go
+++ b/internal/ir/xds_test.go
@@ -503,7 +503,7 @@ var (
 				Providers: []egv1a1.JWTProvider{
 					{
 						Name: "test1",
-						RemoteJWKS: egv1a1.RemoteJWKS{
+						RemoteJWKS: &egv1a1.RemoteJWKS{
 							URI: "https://test1.local",
 						},
 					},
@@ -1256,7 +1256,7 @@ func TestValidateJWT(t *testing.T) {
 						Name:      "test",
 						Issuer:    "https://test.local",
 						Audiences: []string{"test1", "test2"},
-						RemoteJWKS: egv1a1.RemoteJWKS{
+						RemoteJWKS: &egv1a1.RemoteJWKS{
 							URI: "https://test.local",
 						},
 					},


### PR DESCRIPTION
Currently only HTTPS endpoints are supported via remoteJWKS field of the JWTProvider. This is deprecated in favour of a jwksSource field that expands the available locations JWKS content can be retrieved from. Sources include an inline string in the source resource, a local file in the Gateway Container or from a Configmap/Secret.

This is a draft of the proposed JWKSource structure for discussion ahead of implentation.

 Fixes https://github.com/envoyproxy/gateway/issues/2419
