### PR TITLE
e2e: skip some test on IPv6/non-dual

### DIFF
--- a/test/e2e/tests/backend_dualstack.go
+++ b/test/e2e/tests/backend_dualstack.go
@@ -9,7 +9,6 @@
 package tests
 
 import (
-	"os"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -20,11 +19,7 @@ import (
 
 // If the environment is not dual, the IPv6 manifest cannot be applied, so the test will be skipped.
 func init() {
-	if os.Getenv("IP_FAMILY") == "dual" {
-		ConformanceTests = append(ConformanceTests, BackendDualStackTest)
-	} else {
-		ConformanceTests = append(ConformanceTests, SkipBackendDualStackTest)
-	}
+	ConformanceTests = append(ConformanceTests, BackendDualStackTest)
 }
 
 var BackendDualStackTest = suite.ConformanceTest{
@@ -32,6 +27,10 @@ var BackendDualStackTest = suite.ConformanceTest{
 	Description: "Test IPv6 and Dual Stack support for backends",
 	Manifests:   []string{"testdata/backend-dualstack.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		if ipFamily != "dual" {
+			t.Skip("Skipping test as IP_FAMILY is not dual")
+		}
+
 		ns := "gateway-conformance-infra"
 		gwNN := types.NamespacedName{Name: "dualstack-gateway", Namespace: ns}
 
@@ -62,12 +61,4 @@ func runBackendDualStackTest(t *testing.T, suite *suite.ConformanceTestSuite, ns
 	}
 
 	http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
-}
-
-var SkipBackendDualStackTest = suite.ConformanceTest{
-	ShortName:   "BackendDualStack",
-	Description: "Skipping BackendDualStack test as IP_FAMILY is not dual",
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
-		t.Skip("Skipping BackendDualStack test as IP_FAMILY is not dual")
-	},
 }

--- a/test/e2e/tests/httproute_dualstack.go
+++ b/test/e2e/tests/httproute_dualstack.go
@@ -9,7 +9,6 @@
 package tests
 
 import (
-	"os"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -18,13 +17,8 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 )
 
-// If the environment is not dual, the IPv6 manifest cannot be applied, so the test will be skipped.
 func init() {
-	if os.Getenv("IP_FAMILY") == "dual" {
-		ConformanceTests = append(ConformanceTests, HTTPRouteDualStackTest)
-	} else {
-		ConformanceTests = append(ConformanceTests, SkipHTTPRouteDualStackTest)
-	}
+	ConformanceTests = append(ConformanceTests, HTTPRouteDualStackTest)
 }
 
 var HTTPRouteDualStackTest = suite.ConformanceTest{
@@ -32,6 +26,10 @@ var HTTPRouteDualStackTest = suite.ConformanceTest{
 	Description: "Test HTTPRoute support for IPv6 only, dual-stack, and IPv4 only services",
 	Manifests:   []string{"testdata/httproute-dualstack.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		if ipFamily != "dual" {
+			t.Skip("Skipping test as IP_FAMILY is not dual")
+		}
+
 		ns := "gateway-conformance-infra"
 		gwNN := types.NamespacedName{Name: "dualstack-gateway", Namespace: ns}
 
@@ -62,12 +60,4 @@ func runHTTPRouteTest(t *testing.T, suite *suite.ConformanceTestSuite, ns string
 	}
 
 	http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
-}
-
-var SkipHTTPRouteDualStackTest = suite.ConformanceTest{
-	ShortName:   "HTTPRouteDualStack",
-	Description: "Skipping HTTPRouteDualStack test as IP_FAMILY is not dual",
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
-		t.Skip("Skipping HTTPRouteDualStack test as IP_FAMILY is not dual")
-	},
 }

--- a/test/e2e/tests/ratelimit.go
+++ b/test/e2e/tests/ratelimit.go
@@ -37,6 +37,10 @@ var RateLimitCIDRMatchTest = suite.ConformanceTest{
 	Description: "Limit all requests that match CIDR",
 	Manifests:   []string{"testdata/ratelimit-cidr-match.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		if ipFamily == "ipv6" {
+			t.Skip("Skipping test as IP_FAMILY is IPv6")
+		}
+
 		t.Run("block all ips", func(t *testing.T) {
 			ns := "gateway-conformance-infra"
 			routeNN := types.NamespacedName{Name: "cidr-ratelimit", Namespace: ns}
@@ -484,6 +488,10 @@ var RateLimitMultipleListenersTest = suite.ConformanceTest{
 	Description: "Limit requests on multiple listeners",
 	Manifests:   []string{"testdata/ratelimit-multiple-listeners.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		if ipFamily == "ipv6" {
+			t.Skip("Skipping test as IP_FAMILY is IPv6")
+		}
+
 		t.Run("block all ips on listener 80 and 8080", func(t *testing.T) {
 			ns := "gateway-conformance-infra"
 			routeNN := types.NamespacedName{Name: "cidr-ratelimit", Namespace: ns}
@@ -549,6 +557,10 @@ var RateLimitHeadersAndCIDRMatchTest = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("all matched both headers and cidr can got limited", func(t *testing.T) {
+			if ipFamily == "ipv6" {
+				t.Skip("Skipping test as IP_FAMILY is IPv6")
+			}
+
 			requestHeaders := map[string]string{
 				"x-user-id":  "one",
 				"x-user-org": "acme",

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -43,6 +44,8 @@ import (
 	"github.com/envoyproxy/gateway/internal/kubernetes"
 	tb "github.com/envoyproxy/gateway/internal/troubleshoot"
 )
+
+var ipFamily = os.Getenv("IP_FAMILY")
 
 const defaultServiceStartupTimeout = 5 * time.Minute
 


### PR DESCRIPTION
for RateLimit tests, it's because of 
```yaml
            - sourceCIDR:
                value: 0.0.0.0/0
                type: Distinct
```