### PR TITLE
e2e: fix EnvoyGatewayBackend/TLSRouteBackendIP test not working on IPv6 first cluster

### DIFF
--- a/test/e2e/testdata/httproute-to-backend-ip.yaml
+++ b/test/e2e/testdata/httproute-to-backend-ip.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   selector:
     app: infra-backend-v1
-  clusterIP: 10.96.96.96
   ports:
   - protocol: TCP
     port: 8080
@@ -34,14 +33,3 @@ spec:
     - group: gateway.envoyproxy.io
       kind: Backend
       name: backend-ip
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: backend-ip
-  namespace: gateway-conformance-infra
-spec:
-  endpoints:
-  - ip:
-      address: 10.96.96.96
-      port: 8080

--- a/test/e2e/testdata/tlsroute-to-backend-ip.yaml
+++ b/test/e2e/testdata/tlsroute-to-backend-ip.yaml
@@ -13,7 +13,7 @@ spec:
   - backendRefs:
     - group: gateway.envoyproxy.io
       kind: Backend
-      name: backend-ip
+      name: backend-tls-ip
 ---
 apiVersion: v1
 kind: Service

--- a/test/e2e/testdata/tlsroute-to-backend-ip.yaml
+++ b/test/e2e/testdata/tlsroute-to-backend-ip.yaml
@@ -15,17 +15,6 @@ spec:
       kind: Backend
       name: backend-ip
 ---
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: backend-ip
-  namespace: gateway-conformance-infra
-spec:
-  endpoints:
-  - ip:
-      address: 10.96.96.96
-      port: 443
----
 apiVersion: v1
 kind: Service
 metadata:
@@ -34,7 +23,6 @@ metadata:
 spec:
   selector:
     app: tls-backend-2
-  clusterIP: 10.96.96.96
   ports:
   - protocol: TCP
     port: 443

--- a/test/e2e/tests/httproute_with_backend.go
+++ b/test/e2e/tests/httproute_with_backend.go
@@ -62,7 +62,7 @@ var EnvoyGatewayBackendTest = suite.ConformanceTest{
 
 			backendIPName := "backend-ip"
 			ns := "gateway-conformance-infra"
-			err = CreateBackend(suite.Client, types.NamespacedName{Name: backendIPName, Namespace: ns}, svc.Spec.ClusterIP)
+			err = CreateBackend(suite.Client, types.NamespacedName{Name: backendIPName, Namespace: ns}, svc.Spec.ClusterIP, 8080)
 			if err != nil {
 				t.Fatalf("failed to create backend %s: %v", backendIPName, err)
 			}

--- a/test/e2e/tests/httproute_with_backend.go
+++ b/test/e2e/tests/httproute_with_backend.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 var EnvoyGatewayBackendTest = suite.ConformanceTest{
-	ShortName:   "EnvoyGatewayBackendTest",
+	ShortName:   "EnvoyGatewayBackend",
 	Description: "Routes with a backend ref to a backend",
 	Manifests: []string{
 		"testdata/httproute-to-backend-fqdn.yaml",
@@ -51,11 +51,29 @@ var EnvoyGatewayBackendTest = suite.ConformanceTest{
 		})
 
 		t.Run("of type IP", func(t *testing.T) {
+			svcNN := types.NamespacedName{
+				Name:      "infra-backend-v1-clusterip",
+				Namespace: "gateway-conformance-infra",
+			}
+			svc, err := GetService(suite.Client, svcNN)
+			if err != nil {
+				t.Fatalf("failed to get service %s: %v", svcNN, err)
+			}
+
+			backendIPName := "backend-ip"
 			ns := "gateway-conformance-infra"
+			err = CreateBackend(suite.Client, types.NamespacedName{Name: backendIPName, Namespace: ns}, svc.Spec.ClusterIP)
+			if err != nil {
+				t.Fatalf("failed to create backend %s: %v", backendIPName, err)
+			}
+			if err != nil {
+				t.Fatalf("failed to create backend %s: %v", backendIPName, err)
+			}
+
 			routeNN := types.NamespacedName{Name: "httproute-to-backend-ip", Namespace: ns}
 			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
-			BackendMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "backend-ip", Namespace: ns})
+			BackendMustBeAccepted(t, suite.Client, types.NamespacedName{Name: backendIPName, Namespace: ns})
 
 			expectedResponse := http.ExpectedResponse{
 				Request: http.Request{

--- a/test/e2e/tests/httproute_with_backend.go
+++ b/test/e2e/tests/httproute_with_backend.go
@@ -66,9 +66,11 @@ var EnvoyGatewayBackendTest = suite.ConformanceTest{
 			if err != nil {
 				t.Fatalf("failed to create backend %s: %v", backendIPName, err)
 			}
-			if err != nil {
-				t.Fatalf("failed to create backend %s: %v", backendIPName, err)
-			}
+			t.Cleanup(func() {
+				if err := DeleteBackend(suite.Client, types.NamespacedName{Name: backendIPName, Namespace: ns}); err != nil {
+					t.Fatalf("failed to delete backend %s: %v", backendIPName, err)
+				}
+			})
 
 			routeNN := types.NamespacedName{Name: "httproute-to-backend-ip", Namespace: ns}
 			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}

--- a/test/e2e/tests/tlsroute_with_backend.go
+++ b/test/e2e/tests/tlsroute_with_backend.go
@@ -57,6 +57,11 @@ var TLSRouteBackendIPTest = suite.ConformanceTest{
 			if err != nil {
 				t.Fatalf("failed to create backend %s: %v", backendIPName, err)
 			}
+			t.Cleanup(func() {
+				if err := DeleteBackend(suite.Client, types.NamespacedName{Name: backendIPName, Namespace: ns}); err != nil {
+					t.Fatalf("failed to delete backend %s: %v", backendIPName, err)
+				}
+			})
 			testTLSRouteWithBackend(t, suite, "tlsroute-to-backend-ip", backendIPName)
 		})
 	},

--- a/test/e2e/tests/tlsroute_with_backend.go
+++ b/test/e2e/tests/tlsroute_with_backend.go
@@ -51,9 +51,9 @@ var TLSRouteBackendIPTest = suite.ConformanceTest{
 				t.Fatalf("failed to get service %s: %v", svcNN, err)
 			}
 
-			backendIPName := "backend-ip"
+			backendIPName := "backend-tls-ip"
 			ns := "gateway-conformance-infra"
-			err = CreateBackend(suite.Client, types.NamespacedName{Name: backendIPName, Namespace: ns}, svc.Spec.ClusterIP)
+			err = CreateBackend(suite.Client, types.NamespacedName{Name: backendIPName, Namespace: ns}, svc.Spec.ClusterIP, 443)
 			if err != nil {
 				t.Fatalf("failed to create backend %s: %v", backendIPName, err)
 			}

--- a/test/e2e/tests/tlsroute_with_backend.go
+++ b/test/e2e/tests/tlsroute_with_backend.go
@@ -35,14 +35,29 @@ var TLSRouteBackendFQDNTest = suite.ConformanceTest{
 }
 
 var TLSRouteBackendIPTest = suite.ConformanceTest{
-	ShortName:   "TLSRouteBackendIPTest",
+	ShortName:   "TLSRouteBackendIP",
 	Description: "TLSRoutes with a backend ref to a Backend",
 	Manifests: []string{
 		"testdata/tlsroute-to-backend-ip.yaml",
 	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		t.Run("TLSRoute with a IP type Backend", func(t *testing.T) {
-			testTLSRouteWithBackend(t, suite, "tlsroute-to-backend-ip", "backend-ip")
+			svcNN := types.NamespacedName{
+				Name:      "tls-backend-2-clusterip",
+				Namespace: "gateway-conformance-infra",
+			}
+			svc, err := GetService(suite.Client, svcNN)
+			if err != nil {
+				t.Fatalf("failed to get service %s: %v", svcNN, err)
+			}
+
+			backendIPName := "backend-ip"
+			ns := "gateway-conformance-infra"
+			err = CreateBackend(suite.Client, types.NamespacedName{Name: backendIPName, Namespace: ns}, svc.Spec.ClusterIP)
+			if err != nil {
+				t.Fatalf("failed to create backend %s: %v", backendIPName, err)
+			}
+			testTLSRouteWithBackend(t, suite, "tlsroute-to-backend-ip", backendIPName)
 		})
 	},
 }

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -702,7 +702,7 @@ func GetService(c client.Client, nn types.NamespacedName) (*corev1.Service, erro
 	return svc, nil
 }
 
-func CreateBackend(c client.Client, nn types.NamespacedName, clusterIP string) error {
+func CreateBackend(c client.Client, nn types.NamespacedName, clusterIP string, port int32) error {
 	backend := &egv1a1.Backend{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: nn.Namespace,
@@ -713,7 +713,7 @@ func CreateBackend(c client.Client, nn types.NamespacedName, clusterIP string) e
 				{
 					IP: &egv1a1.IPEndpoint{
 						Address: clusterIP,
-						Port:    8080,
+						Port:    port,
 					},
 				},
 			},

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -693,3 +693,31 @@ func CollectAndDump(t *testing.T, rest *rest.Config) {
 		tlog.Logf(t, "\ndata: \n%s", data)
 	}
 }
+
+func GetService(c client.Client, nn types.NamespacedName) (*corev1.Service, error) {
+	svc := &corev1.Service{}
+	if err := c.Get(context.Background(), nn, svc); err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+func CreateBackend(c client.Client, nn types.NamespacedName, clusterIP string) error {
+	backend := &egv1a1.Backend{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: nn.Namespace,
+			Name:      nn.Name,
+		},
+		Spec: egv1a1.BackendSpec{
+			Endpoints: []egv1a1.BackendEndpoint{
+				{
+					IP: &egv1a1.IPEndpoint{
+						Address: clusterIP,
+						Port:    8080,
+					},
+				},
+			},
+		},
+	}
+	return c.Create(context.TODO(), backend)
+}

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -721,3 +721,11 @@ func CreateBackend(c client.Client, nn types.NamespacedName, clusterIP string) e
 	}
 	return c.Create(context.TODO(), backend)
 }
+
+func DeleteBackend(c client.Client, nn types.NamespacedName) error {
+	backend := &egv1a1.Backend{}
+	if err := c.Get(context.Background(), nn, backend); err != nil {
+		return err
+	}
+	return c.Delete(context.Background(), backend)
+}


### PR DESCRIPTION
Fixed v4 cluster IP will not working on IPv6 first cluster