### PR TITLE
Fix: frequent 503 errors when connecting to a Service experiencing high Pod churn

### DIFF
--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -20,6 +20,7 @@ bug fixes: |
   Fixed failed to update SecurityPolicy resources with the `backendRef` field specified
   Fixed Envoy rejecting TCP Listeners that have no attached TCPRoutes
   Fixed xDS translation failed when oidc tokenEndpoint and jwt remoteJWKS are specified in the same SecurityPolicy and using the same hostname
+  Fixed frequent 503 errors when connecting to a Service experiencing high Pod churn
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
Reverts envoyproxy/gateway#4337
Fixes: https://github.com/envoyproxy/gateway/issues/4685

Release Note: Yes

To avoid regression of the bug fixed by #4337, a temporary buffer has been added to store events received before the Updater is enabled.
These events will be sent to the update channel once the Updater is enabled.

Tested the fix in my local env:

```bash
➜  k -n envoy-gateway-system logs envoy-gateway-7f7d68bd-q74m6 |grep "status update"                        
2024-11-26T05:56:03.461Z        INFO    provider        kubernetes/status_updater.go:185        received a status update while disabled, storing for later      {"runner": "provider", "event": {
"name":"ha-gateway","namespace":"gateway-upgrade-infra"}}
2024-11-26T05:56:03.764Z        INFO    provider        kubernetes/status_updater.go:185        received a status update while disabled, storing for later      {"runner": "provider", "event": {
"name":"upgrade"}}                                                                              
2024-11-26T05:56:03.767Z        INFO    provider        kubernetes/status_updater.go:185        received a status update while disabled, storing for later      {"runner": "provider", "event": {
"name":"http-backend-eg-upgrade","namespace":"gateway-upgrade-infra"}}
2024-11-26T05:56:03.767Z        INFO    provider        kubernetes/status_updater.go:185        received a status update while disabled, storing for later      {"runner": "provider", "event": {
"name":"ha-gateway","namespace":"gateway-upgrade-infra"}}
2024-11-26T05:56:28.146Z        INFO    provider        kubernetes/status_updater.go:139        started status update handler   {"runner": "provider"}
2024-11-26T05:56:28.146Z        INFO    provider        kubernetes/status_updater.go:197        sending stored status update    {"runner": "provider", "event": {"name":"ha-gateway","namespace":
"gateway-upgrade-infra"}}       
2024-11-26T05:56:28.146Z        INFO    provider        kubernetes/status_updater.go:197        sending stored status update    {"runner": "provider", "event": {"name":"upgrade"}}
2024-11-26T05:56:28.146Z        INFO    provider        kubernetes/status_updater.go:197        sending stored status update    {"runner": "provider", "event": {"name":"http-backend-eg-upgrade"
,"namespace":"gateway-upgrade-infra"}}  
2024-11-26T05:56:28.146Z        INFO    provider        kubernetes/status_updater.go:197        sending stored status update    {"runner": "provider", "event": {"name":"ha-gateway","namespace":
"gateway-upgrade-infra"}}       

```
If anyone wants to verify this PR, you can do so by using this image zhaohuabing/gateway-dev:52e6d8577