### PR TITLE
dont run docs workflows on release branches

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,14 +3,12 @@ on:
   push:
     branches:
     - "main"
-    - "release/v*"
     paths:
     - 'site/**'
     - 'tools/make/docs.mk'
   pull_request:
     branches:
     - "main"
-    - "release/v*"
     paths:
     - 'site/**'
     - 'tools/make/docs.mk'


### PR DESCRIPTION
Docs are based off `main`