### PR TITLE
[release/v1.1] dont run docs workflows on release branches (#4755)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,14 +3,12 @@ on:
   push:
     branches:
     - "main"
-    - "release/v*"
     paths:
     - 'site/**'
     - 'tools/make/docs.mk'
   pull_request:
     branches:
     - "main"
-    - "release/v*"
     paths:
     - 'site/**'
     - 'tools/make/docs.mk'


### PR DESCRIPTION
Docs are based off `main`


(cherry picked from commit f8c7056378043cc422552d5728a1bfb76a6711b1)
