### PR TITLE
Revert "build(deps): bump codecov/codecov-action from 4.6.0 to 5.0.2"

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Run Coverage Tests
       run: make go.test.coverage
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@5c47607acb93fed5485fdbf7232e8a31425f672a  # v5.0.2
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4.6.0
       with:
         fail_ci_if_error: true
         files: ./coverage.xml


### PR DESCRIPTION
Reverts envoyproxy/gateway#4732

This is blocking CI: https://github.com/envoyproxy/gateway/actions/runs/12025151771/job/33521814999?pr=4754