### PR TITLE
fix: remove the default retry policy for jwks fetch

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -515,8 +515,7 @@
                                         "cluster": "raw_githubusercontent_com_443",
                                         "timeout": "10s",
                                         "uri": "https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/jwt/jwks.json"
-                                      },
-                                      "retryPolicy": {}
+                                      }
                                     }
                                   }
                                 },

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -307,7 +307,6 @@ xds:
                               cluster: raw_githubusercontent_com_443
                               timeout: 10s
                               uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/jwt/jwks.json
-                            retryPolicy: {}
                       requirementMap:
                         httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com:
                           providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
@@ -61,7 +61,6 @@ xds:
                             cluster: raw_githubusercontent_com_443
                             timeout: 10s
                             uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/jwt/jwks.json
-                          retryPolicy: {}
                     requirementMap:
                       httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com:
                         providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example

--- a/internal/xds/translator/jwt.go
+++ b/internal/xds/translator/jwt.go
@@ -120,7 +120,6 @@ func buildJWTAuthn(irListener *ir.HTTPListener) (*jwtauthnv3.JwtAuthentication, 
 					},
 					CacheDuration: &durationpb.Duration{Seconds: 5 * 60},
 					AsyncFetch:    &jwtauthnv3.JwksAsyncFetch{},
-					RetryPolicy:   &corev3.RetryPolicy{},
 				},
 			}
 

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.listeners.yaml
@@ -35,7 +35,6 @@
                     cluster: two_example_com_443
                     timeout: 10s
                     uri: https://two.example.com/jwt/public-key/jwks.json
-                  retryPolicy: {}
               httproute/default/httproute-2/rule/0/match/0/www_example_com/example1:
                 audiences:
                 - one.foo.com
@@ -52,7 +51,6 @@
                     cluster: one_example_com_443
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
-                  retryPolicy: {}
             requirementMap:
               httproute/default/httproute-1/rule/0/match/0/www_example_com:
                 providerName: httproute/default/httproute-1/rule/0/match/0/www_example_com/example1

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.listeners.yaml
@@ -35,7 +35,6 @@
                     cluster: two_example_com_443
                     timeout: 10s
                     uri: https://two.example.com/jwt/public-key/jwks.json
-                  retryPolicy: {}
               httproute/default/httproute-2/rule/0/match/0/www_example_com/example1:
                 audiences:
                 - one.foo.com
@@ -52,7 +51,6 @@
                     cluster: one_example_com_443
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
-                  retryPolicy: {}
             requirementMap:
               httproute/default/httproute-1/rule/0/match/0/www_example_com:
                 providerName: httproute/default/httproute-1/rule/0/match/0/www_example_com/example1

--- a/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
@@ -85,7 +85,6 @@
                     cluster: one_example_com_443
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
-                  retryPolicy: {}
               httproute/envoy-gateway/httproute-1/rule/0/match/0/www_example_com/example2:
                 audiences:
                 - two.foo.com
@@ -105,7 +104,6 @@
                     cluster: two_example_com_80
                     timeout: 10s
                     uri: http://two.example.com/jwt/public-key/jwks.json
-                  retryPolicy: {}
             requirementMap:
               httproute/envoy-gateway/httproute-1/rule/0/match/0/www_example_com:
                 requiresAny:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
@@ -42,7 +42,6 @@
                     cluster: localhost_443
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
-                  retryPolicy: {}
             requirementMap:
               first-route:
                 providerName: first-route/example

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
@@ -38,7 +38,6 @@
                     cluster: localhost_80
                     timeout: 10s
                     uri: http://localhost/jwt/public-key/jwks.json
-                  retryPolicy: {}
               first-route-www.test.com/example2:
                 audiences:
                 - one.foo.com
@@ -62,7 +61,6 @@
                     cluster: "192_168_1_250_8080"
                     timeout: 10s
                     uri: https://192.168.1.250:8080/jwt/public-key/jwks.json
-                  retryPolicy: {}
               second-route-www.test.com/example:
                 audiences:
                 - foo.com
@@ -82,7 +80,6 @@
                     cluster: localhost_80
                     timeout: 10s
                     uri: http://localhost/jwt/public-key/jwks.json
-                  retryPolicy: {}
               second-route-www.test.com/example2:
                 audiences:
                 - one.foo.com
@@ -100,7 +97,6 @@
                     cluster: "192_168_1_250_8080"
                     timeout: 10s
                     uri: https://192.168.1.250:8080/jwt/public-key/jwks.json
-                  retryPolicy: {}
             requirementMap:
               first-route-www.test.com:
                 requiresAny:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
@@ -60,7 +60,6 @@
                     cluster: localhost_443
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
-                  retryPolicy: {}
               second-route/example:
                 audiences:
                 - foo.com
@@ -77,7 +76,6 @@
                     cluster: localhost_443
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
-                  retryPolicy: {}
             requirementMap:
               first-route:
                 providerName: first-route/example

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
@@ -42,7 +42,6 @@
                     cluster: localhost_443
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
-                  retryPolicy: {}
             requirementMap:
               first-route:
                 requiresAny:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
@@ -35,7 +35,6 @@
                     cluster: "192_168_1_250_443"
                     timeout: 10s
                     uri: https://192.168.1.250/jwt/public-key/jwks.json
-                  retryPolicy: {}
             requirementMap:
               first-route:
                 providerName: first-route/example

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
@@ -35,7 +35,6 @@
                     cluster: localhost_443
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
-                  retryPolicy: {}
             requirementMap:
               first-route:
                 providerName: first-route/example

--- a/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.listeners.yaml
@@ -81,7 +81,6 @@
                     cluster: oidc_example_com_443
                     timeout: 10s
                     uri: https://oidc.example.com/auth/realms/example/protocol/openid-connect/certs
-                  retryPolicy: {}
             requirementMap:
               httproute/default/httproute-1/rule/0/match/0/www_example_com:
                 providerName: httproute/default/httproute-1/rule/0/match/0/www_example_com/exjwt

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -17,7 +17,7 @@ new features: |
 
 # Fixes for bugs identified in previous versions.
 bug fixes: |
-  Fixed two many requests sent to the JWKs endpoint when retry policy is enabled for the JWT provider.
+  Disabled the retry policy for the JWT provider to reduce requests sent to the JWKS endpoint. Failed async fetches will retry every 1s.
 
 # Enhancements that improve performance.
 performance improvements: |

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -17,7 +17,7 @@ new features: |
 
 # Fixes for bugs identified in previous versions.
 bug fixes: |
-  Add a bug fix here
+  Fixed two many requests sent to the JWKs endpoint when retry policy is enabled for the JWT provider.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
The current jwt implementation in the SecurityPolicy uses a default retry policy. While this default is reasonable from the perspective of a single Envoy, it could potentially overwhelm the JWKS server if multiple Envoys and SecurityPolicy instances are configured with the same JWKS.

This default retry policy can be removed as EG already enables https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#extensions-filters-http-jwt-authn-v3-jwksasyncfetch with a failed_refetch_duration of 1s, which will refetch the jwks every 1s if failed.

Fixes #4791

Release Notes: Yes
