### PR TITLE
update v1.2 release note

### DIFF
--- a/site/content/en/news/releases/notes/v1.2.0.md
+++ b/site/content/en/news/releases/notes/v1.2.0.md
@@ -7,6 +7,7 @@ Date: November 06, 2024
 
 ## Breaking Changes
 - Gateway API GRPCRoute and ReferenceGrant v1alpha2 have been removed
+- The Experimental supportedFeatures field in GatewayClass status has changed from being a list of strings to being a list of objects structs with a name field
 - Please refer to the [Gateway API v1.2.0 documentation](https://github.com/kubernetes-sigs/gateway-api/releases) for more information
 - Removed default CPU limit of the Envoy Gateway deployment, to eliminate CPU throttling
 - Changed default Envoy shutdown settings: drain strategy has been changed to immediate, default minDrainDuration, drainTimeout and terminationGracePeriodSeconds have been set to 10s, 60s and 360s respectively
@@ -68,7 +69,7 @@ Date: November 06, 2024
 - Added support for egctl x collect to collect information from the cluster for debugging
 - Added support for a native prometheus metrics endpoint in the ratelimit server
 
-## Bug Fixes 
+## Bug Fixes
 - Fixed xDS translation failing when the WASM HTTP code source was configured without an SHA
 - Fixed unsupported listener protocol types causing errors while updating Gateway status
 - Fixed unsupported listener protocol types causing errors while updating Gateway status
@@ -102,7 +103,7 @@ Date: November 06, 2024
 - Fixed BackendTlsPolicy specifying multiple targetRefs for the same service, to work
 
 
-### Performance Improvements 
+### Performance Improvements
 - Optimize memory usage by only storing distinct resources
 - SecurityPolicy translation failures will now cause routes referenced by the policy to return an immediate 500 response
 - Gateway-API BackendTLSPolicy v1alpha3 is incompatible with previous versions of the CRD

--- a/site/content/en/news/releases/v1.2.md
+++ b/site/content/en/news/releases/v1.2.md
@@ -25,7 +25,8 @@ The release adds a ton of features and functionality. Here are some highlights:
 
 ## 🚨 Breaking Changes
 
-- **Gateway API Updates**: Removed support for the v1alpha2 versions for `GRPCRoute` and `ReferenceGrant`. [See the Gateway API v1.2.0 documentation](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.2.0) for details.
+- **Gateway API Updates**: Removed support for the v1alpha2 versions for `GRPCRoute` and `ReferenceGrant`. The Experimental supportedFeatures field in GatewayClass status has changed from being a list of strings to being a list of objects/structs with a name
+field. [See the Gateway API v1.2.0 documentation](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.2.0) for details.
 - **CPU Limits**: Removed default CPU limit for Envoy Gateway deployment to avoid throttling.
 - **Envoy Shutdown Settings**: Drain strategy set to immediate, with default values as follows:
   - `minDrainDuration`: 10s


### PR DESCRIPTION
Add the missing broken change: the Experimental supportedFeatures field in GatewayClass status has changed from being a list of strings to being a list of objects structs with a name field.