### PR TITLE
fix: outlier detection disabled by default

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -781,7 +781,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: httproute/default/backend/rule/0
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
       - cluster:
@@ -801,7 +800,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: grpcroute/default/backend/rule/0
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
           typedExtensionProtocolOptions:
@@ -828,7 +826,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: tcproute/default/backend/rule/-1
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
       - cluster:
@@ -848,7 +845,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: tlsroute/default/backend/rule/-1
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
       - cluster:
@@ -868,7 +864,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: udproute/default/backend/rule/-1
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
     - '@type': type.googleapis.com/envoy.admin.v3.ListenersConfigDump

--- a/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
@@ -109,6 +109,5 @@ xds:
         ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: httproute/envoy-gateway-system/backend/rule/0
-        outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -469,7 +469,6 @@
                 "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "httproute/default/backend/rule/0",
-                "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS"
               }
@@ -499,7 +498,6 @@
                 "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "grpcroute/default/backend/rule/0",
-                "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS",
                 "typedExtensionProtocolOptions": {
@@ -540,7 +538,6 @@
                 "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "tcproute/default/backend/rule/-1",
-                "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS"
               }
@@ -570,7 +567,6 @@
                 "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "tlsroute/default/backend/rule/-1",
-                "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS"
               }
@@ -600,7 +596,6 @@
                 "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "udproute/default/backend/rule/-1",
-                "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS"
               }

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -260,7 +260,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: httproute/default/backend/rule/0
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
       - cluster:
@@ -280,7 +279,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: grpcroute/default/backend/rule/0
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
           typedExtensionProtocolOptions:
@@ -307,7 +305,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: tcproute/default/backend/rule/-1
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
       - cluster:
@@ -327,7 +324,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: tlsroute/default/backend/rule/-1
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
       - cluster:
@@ -347,7 +343,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: udproute/default/backend/rule/-1
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
     - '@type': type.googleapis.com/envoy.admin.v3.ListenersConfigDump

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
@@ -19,7 +19,6 @@ xds:
         ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: httproute/default/backend/rule/0
-        outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS
     - cluster:
@@ -39,7 +38,6 @@ xds:
         ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: grpcroute/default/backend/rule/0
-        outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS
         typedExtensionProtocolOptions:
@@ -66,7 +64,6 @@ xds:
         ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: tcproute/default/backend/rule/-1
-        outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS
     - cluster:
@@ -86,7 +83,6 @@ xds:
         ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: tlsroute/default/backend/rule/-1
-        outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS
     - cluster:
@@ -106,6 +102,5 @@ xds:
         ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: udproute/default/backend/rule/-1
-        outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -361,7 +361,6 @@
                 "ignoreHealthOnHostRemoval": true,
                 "lbPolicy": "LEAST_REQUEST",
                 "name": "httproute/envoy-gateway-system/backend/rule/0",
-                "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "type": "EDS"
               }
@@ -408,7 +407,6 @@
                   ]
                 },
                 "name": "raw_githubusercontent_com_443",
-                "outlierDetection": {},
                 "perConnectionBufferLimitBytes": 32768,
                 "respectDnsTtl": true,
                 "transportSocket": {

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -204,7 +204,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: httproute/envoy-gateway-system/backend/rule/0
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
       - cluster:
@@ -232,7 +231,6 @@ xds:
               locality:
                 region: raw_githubusercontent_com_443/backend/0
           name: raw_githubusercontent_com_443
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           respectDnsTtl: true
           transportSocket:

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
@@ -19,7 +19,6 @@ xds:
         ignoreHealthOnHostRemoval: true
         lbPolicy: LEAST_REQUEST
         name: httproute/envoy-gateway-system/backend/rule/0
-        outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         type: EDS
     - cluster:
@@ -47,7 +46,6 @@ xds:
             locality:
               region: raw_githubusercontent_com_443/backend/0
         name: raw_githubusercontent_com_443
-        outlierDetection: {}
         perConnectionBufferLimitBytes: 32768
         respectDnsTtl: true
         transportSocket:

--- a/internal/cmd/egctl/testdata/translate/out/no-service-cluster-ip.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/no-service-cluster-ip.all.yaml
@@ -204,7 +204,6 @@ xds:
           ignoreHealthOnHostRemoval: true
           lbPolicy: LEAST_REQUEST
           name: httproute/envoy-gateway-system/routes/rule/0
-          outlierDetection: {}
           perConnectionBufferLimitBytes: 32768
           type: EDS
     - '@type': type.googleapis.com/envoy.admin.v3.ListenersConfigDump

--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -103,7 +103,6 @@ func buildXdsCluster(args *xdsClusterArgs) *clusterv3.Cluster {
 				LocalityWeightedLbConfig: &clusterv3.Cluster_CommonLbConfig_LocalityWeightedLbConfig{},
 			},
 		},
-		OutlierDetection:              &clusterv3.OutlierDetection{},
 		PerConnectionBufferLimitBytes: buildBackandConnectionBufferLimitBytes(args.backendConnection),
 	}
 

--- a/internal/xds/translator/testdata/out/extension-xds-ir/extensionpolicy-tcp-udp-http.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/extensionpolicy-tcp-udp-http.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: http-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: udp-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - loadAssignment:

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - loadAssignment:

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - loadAssignment:

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-cel.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-cel.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -39,7 +38,6 @@
       locality:
         region: accesslog-0/backend/0
   name: accesslog-0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   trackClusterStats:
     perEndpointStats: true
@@ -41,7 +40,6 @@
       locality:
         region: accesslog-0/backend/0
   name: accesslog-0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   trackClusterStats:

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -39,7 +38,6 @@
       locality:
         region: accesslog-0/backend/0
   name: accesslog-0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-multi-cel.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-multi-cel.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -39,7 +38,6 @@
       locality:
         region: accesslog-0/backend/0
   name: accesslog-0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-types.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-types.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_0_1
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -56,7 +54,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_0_2
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -81,7 +78,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_1_1
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -106,7 +102,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_1_2
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -131,7 +126,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_2_1
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -156,7 +150,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog_als_2_2
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -189,7 +182,6 @@
       locality:
         region: accesslog_otel_0_3/backend/0
   name: accesslog_otel_0_3
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS
@@ -223,7 +215,6 @@
       locality:
         region: accesslog_otel_1_3/backend/0
   name: accesslog_otel_1_3
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS
@@ -257,7 +248,6 @@
       locality:
         region: accesslog_otel_2_3/backend/0
   name: accesslog_otel_2_3
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-without-format.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-without-format.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog/monitoring/envoy-als/port/9000
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -64,7 +62,6 @@
       locality:
         region: accesslog-0/backend/0
   name: accesslog-0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: accesslog/monitoring/envoy-als/port/9000
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -64,7 +62,6 @@
       locality:
         region: accesslog-0/backend/0
   name: accesslog-0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-client-cidr.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-client-cidr.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-3/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,6 +47,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -57,7 +55,6 @@
       locality:
         region: two_example_com_443/backend/0
   name: two_example_com_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:
@@ -93,7 +90,6 @@
       locality:
         region: one_example_com_443/backend/0
   name: one_example_com_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -57,7 +55,6 @@
       locality:
         region: two_example_com_443/backend/0
   name: two_example_com_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:
@@ -93,7 +90,6 @@
       locality:
         region: one_example_com_443/backend/0
   name: one_example_com_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-multiple-principals.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-multiple-principals.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/authorization.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization.clusters.yaml
@@ -12,7 +12,6 @@
     serviceName: httproute/default/httproute-3/rule/0
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-3/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -29,7 +28,6 @@
     serviceName: httproute/default/httproute-1/rule/0
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -46,6 +44,5 @@
     serviceName: httproute/default/httproute-2/rule/0
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 100000000
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 100000000
   type: EDS
 - circuitBreakers:
@@ -49,6 +47,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: udp-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/backend-priority.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-priority.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: envoyextensionpolicy/default/policy-for-http-route/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   transportSocketMatches:
   - match:

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/1
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,6 +47,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.clusters.yaml
@@ -16,7 +16,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:

--- a/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,6 +30,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,6 +47,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,6 +30,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/cors.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/cors.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.clusters.yaml
@@ -21,7 +21,6 @@
       locality:
         region: one_example_com_443/backend/0
   name: one_example_com_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:
@@ -57,7 +56,6 @@
       locality:
         region: two_example_com_80/backend/0
   name: two_example_com_80
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/custom-response.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-response.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/1
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -75,7 +72,6 @@
       locality:
         region: securitypolicy/default/policy-for-http-route-1/default/grpc-backend/backend/0
   name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS
@@ -109,7 +105,6 @@
       locality:
         region: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend/backend/0
   name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-body.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-body.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/1
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -75,7 +72,6 @@
       locality:
         region: securitypolicy/default/policy-for-http-route-1/default/grpc-backend/backend/0
   name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS
@@ -109,7 +105,6 @@
       locality:
         region: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend/backend/0
   name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/1
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -75,7 +72,6 @@
       locality:
         region: securitypolicy/default/policy-for-http-route-1/default/grpc-backend/backend/0
   name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS
@@ -109,7 +105,6 @@
       locality:
         region: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend/backend/0
   name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/1
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,7 +64,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -92,6 +88,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: envoyextensionpolicy/default/policy-for-route-2/0/grpc-backend-4
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -74,7 +71,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: envoyextensionpolicy/default/policy-for-route-1/0/grpc-backend-2
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -99,7 +95,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: envoyextensionpolicy/envoy-gateway/policy-for-gateway-2/0/grpc-backend-3
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -124,7 +119,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: envoyextensionpolicy/envoy-gateway/policy-for-gateway-1/0/grpc-backend
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:

--- a/internal/xds/translator/testdata/out/xds-ir/fault-injection.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/fault-injection.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,7 +64,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -85,6 +81,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fifth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-x-request-id.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-x-request-id.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,6 +30,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-underscores-action.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-underscores-action.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,6 +64,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/health-check.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check.clusters.yaml
@@ -165,6 +165,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fifth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-early-header-mutation.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-early-header-mutation.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -41,6 +40,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-endpoint-stats.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   trackClusterStats:
     perEndpointStats: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-health-check.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-health-check.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-preserve-client-protocol.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-preserve-client-protocol.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:

--- a/internal/xds/translator/testdata/out/xds-ir/http-req-resp-sizes-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-req-resp-sizes-stats.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   trackClusterStats:
     requestResponseSizes: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-direct-response.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.clusters.yaml
@@ -27,7 +27,6 @@
       locality:
         region: first-route-dest/backend/0
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,7 +64,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -85,7 +81,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fifth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -103,7 +98,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: sixth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -121,6 +115,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: seventh-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: mirror-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,6 +47,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: mirror-route-dest1
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: valid-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: redirect-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: regex-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: request-header-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: response-header-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: response-header-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: response-header-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-sufixx-with-slash-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-sufixx-with-slash-url-prefix.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-regex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-regex.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: rewrite-route
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: regex-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,6 +47,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-uds-ip.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-uds-ip.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-filters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-filters.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,6 +30,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-clientcert.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-clientcert.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/envoy-gateway/httproute-btls/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   transportSocketMatches:
   - match:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-metadata.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-metadata.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,6 +30,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-stripped-host-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-stripped-host-port.clusters.yaml
@@ -8,6 +8,5 @@
       resourceApiVersion: V3
     serviceName: first-route
   name: first-route
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/envoy-gateway/httproute-btls/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   transportSocketMatches:
   - match:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle-multiple-certs.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle-multiple-certs.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/envoy-gateway/httproute-btls/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   transportSocketMatches:
   - match:
@@ -72,7 +71,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/envoy-gateway/httproute-btls-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   transportSocket:
     name: envoy.transport_sockets.upstream_proxy_protocol

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/envoy-gateway/httproute-btls/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   transportSocketMatches:
   - match:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -41,7 +40,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:

--- a/internal/xds/translator/testdata/out/xds-ir/http1-trailers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-trailers.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:

--- a/internal/xds/translator/testdata/out/xds-ir/http10.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http10.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -40,7 +39,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -65,7 +63,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:
@@ -93,6 +90,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http2.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http3.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http3.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.clusters.yaml
@@ -12,6 +12,5 @@
     serviceName: first-route-dest
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.clusters.yaml
@@ -12,6 +12,5 @@
     serviceName: first-route-dest
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.clusters.yaml
@@ -12,6 +12,5 @@
     serviceName: first-route-dest
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.clusters.yaml
@@ -12,6 +12,5 @@
     serviceName: first-route-dest
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - connectTimeout: 10s

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -39,7 +38,6 @@
       locality:
         region: localhost_443/backend/0
   name: localhost_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-www.test.com-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-www.test.com-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -57,7 +55,6 @@
       locality:
         region: localhost_80/backend/0
   name: localhost_80
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS
@@ -76,7 +73,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: "192_168_1_250_8080"
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   transportSocket:
     name: envoy.transport_sockets.tls

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -57,7 +55,6 @@
       locality:
         region: localhost_443/backend/0
   name: localhost_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -39,7 +38,6 @@
       locality:
         region: localhost_443/backend/0
   name: localhost_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,7 +64,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: "192_168_1_250_443"
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   transportSocket:
     name: envoy.transport_sockets.tls
@@ -102,7 +98,6 @@
       locality:
         region: ratelimit_cluster/backend/0
   name: ratelimit_cluster
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -39,7 +38,6 @@
       locality:
         region: localhost_443/backend/0
   name: localhost_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/listener-connection-limit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-connection-limit.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,6 +64,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,6 +30,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,6 +64,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
@@ -12,7 +12,6 @@
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -30,7 +29,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: RANDOM
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -48,7 +46,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -66,7 +63,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: MAGLEV
   name: fourth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -87,7 +83,6 @@
     slowStartConfig:
       slowStartWindow: 60s
   name: fifth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -104,7 +99,6 @@
     serviceName: sixth-route-dest
   ignoreHealthOnHostRemoval: true
   name: sixth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   roundRobinLbConfig:
     slowStartConfig:
@@ -125,7 +119,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: MAGLEV
   name: seventh-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -145,7 +138,6 @@
   maglevLbConfig:
     tableSize: "524287"
   name: eighth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -163,7 +155,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: MAGLEV
   name: ninth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -181,6 +172,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: MAGLEV
   name: tenth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,6 +47,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: securitypolicy/default/policy-for-http-route-2/envoy-gateway/http-backend
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,7 +64,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-3/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -93,7 +89,6 @@
       locality:
         region: oauth_foo_com_443/backend/0
   name: oauth_foo_com_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,7 +64,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -85,7 +81,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -103,6 +98,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-1-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-2-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,7 +64,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-3-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -85,6 +81,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-4-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,7 +64,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -85,6 +81,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fifth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,7 +64,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -85,6 +81,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fifth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,6 +30,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-terminate-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,6 +30,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-terminate-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-backencluster-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-backencluster-provider.clusters.yaml
@@ -12,7 +12,6 @@
     serviceName: third-route-dest
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -38,7 +37,6 @@
       locality:
         region: securitypolicy/envoy-gateway/policy-for-gateway/0/backend/0
   name: securitypolicy/envoy-gateway/policy-for-gateway/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -39,7 +38,6 @@
       locality:
         region: securitypolicy/envoy-gateway/policy-for-gateway/0/backend/0
   name: securitypolicy/envoy-gateway/policy-for-gateway/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -57,7 +55,6 @@
       locality:
         region: oauth_foo_com_443/backend/0
   name: oauth_foo_com_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:
@@ -93,7 +90,6 @@
       locality:
         region: oauth_bar_com_443/backend/0
   name: oauth_bar_com_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/path-settings.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/path-settings.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   transportSocket:
     name: envoy.transport_sockets.upstream_proxy_protocol

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -75,7 +72,6 @@
       locality:
         region: ratelimit_cluster/backend/0
   name: ratelimit_cluster
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -75,7 +72,6 @@
       locality:
         region: ratelimit_cluster/backend/0
   name: ratelimit_cluster
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   trackClusterStats:
     perEndpointStats: true
@@ -33,7 +32,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   trackClusterStats:
     perEndpointStats: true
@@ -53,7 +51,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   trackClusterStats:
     perEndpointStats: true
@@ -81,7 +78,6 @@
       locality:
         region: ratelimit_cluster/backend/0
   name: ratelimit_cluster
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   trackClusterStats:

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -75,7 +72,6 @@
       locality:
         region: ratelimit_cluster/backend/0
   name: ratelimit_cluster
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,7 +64,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -93,7 +89,6 @@
       locality:
         region: ratelimit_cluster/backend/0
   name: ratelimit_cluster
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,7 +30,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: second-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -49,7 +47,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: third-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -67,7 +64,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: fourth-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -93,7 +89,6 @@
       locality:
         region: ratelimit_cluster/backend/0
   name: ratelimit_cluster
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -39,7 +38,6 @@
       locality:
         region: oidc_example_com_443/backend/0
   name: oidc_example_com_443
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-endpoint-stats.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   trackClusterStats:
     perEndpointStats: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-listener-ipfamily.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-listener-ipfamily.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-dual-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-req-resp-sizes-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-req-resp-sizes-stats.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   trackClusterStats:
     requestResponseSizes: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-complex-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-simple-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-terminate-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,6 +30,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-terminate-hostname-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tcp-route-weighted-backend-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/timeout.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   typedExtensionProtocolOptions:

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-passthrough-foo-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -39,7 +38,6 @@
       locality:
         region: tls-passthrough-bar-dest/backend/0
   name: tls-passthrough-bar-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,6 +30,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: tls-terminate-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-datadog.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-datadog.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -39,7 +38,6 @@
       locality:
         region: tracing-0/backend/0
   name: tracing-0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   trackClusterStats:
     perEndpointStats: true
@@ -41,7 +40,6 @@
       locality:
         region: tracing-0/backend/0
   name: tracing-0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   trackClusterStats:

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-zipkin.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-zipkin.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -39,7 +38,6 @@
       locality:
         region: tracing-0/backend/0
   name: tracing-0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   respectDnsTtl: true
   type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: direct-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:

--- a/internal/xds/translator/testdata/out/xds-ir/udp-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-endpoint-stats.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: udp-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   trackClusterStats:
     perEndpointStats: true

--- a/internal/xds/translator/testdata/out/xds-ir/udp-req-resp-sizes-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-req-resp-sizes-stats.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: udp-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   trackClusterStats:
     requestResponseSizes: true

--- a/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
@@ -13,6 +13,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: udp-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: first-route-dest
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
   upstreamConnectionOptions:

--- a/internal/xds/translator/testdata/out/xds-ir/wasm.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/wasm.clusters.yaml
@@ -13,7 +13,6 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-1/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS
 - circuitBreakers:
@@ -31,6 +30,5 @@
   ignoreHealthOnHostRemoval: true
   lbPolicy: LEAST_REQUEST
   name: httproute/default/httproute-2/rule/0
-  outlierDetection: {}
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -5,6 +5,8 @@ breaking changes: |
   The Container `ports` field of the gateway instance has been removed, which will cause the gateway Pod to be rebuilt when upgrading the version.
   ClientTrafficPolicy previously treated an empty TLS ALPNProtocols list as being undefined and applied Envoy Gateway defaults.
   An empty TLS ALPNProtocols list is now treated as user-defined disablement of the TLS ALPN extension.
+  Outlier detection (passive health check) is now disabled by default.
+  refer to https://gateway.envoyproxy.io/docs/api/extension_types/#backendtrafficpolicy for working with passive health checks.
 
 # Updates addressing vulnerabilities, security flaws, or compliance requirements.
 security updates: |


### PR DESCRIPTION
**What type of PR is this?**
* "fix(translator): outlier detection need to be explicit enabled by a BTP"
<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
disable passive health check if not explicitly enabled by a BTP. It's misleading for users that passive health check is enabled with default values without user knowing.

Use case where you don't need outlier detection:
If you users have tiers of proxies (envoy have clusters backends which is also proxies), outlier detection shouldn't be enabled. 

**Which issue(s) this PR fixes**:
Fixes #4854

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
