### PR TITLE
fix: trigger a resync to avoid missing any status updates

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -135,7 +135,10 @@ func newGatewayAPIController(mgr manager.Manager, cfg *config.Server, su Updater
 		controller.Options{
 			Reconciler:         r,
 			SkipNameValidation: skipNameValidation(),
-			NewQueue: func(_ string, _ workqueue.TypedRateLimiter[reconcile.Request]) workqueue.TypedRateLimitingInterface[reconcile.Request] {
+			NewQueue: func(
+				_ string,
+				_ workqueue.TypedRateLimiter[reconcile.Request],
+			) workqueue.TypedRateLimitingInterface[reconcile.Request] {
 				return queue
 			},
 		})
@@ -152,8 +155,8 @@ func newGatewayAPIController(mgr manager.Manager, cfg *config.Server, su Updater
 		return nil, fmt.Errorf("error watching resources: %w", err)
 	}
 
-	// Trigger a resync of the controller
 	return func() {
+		// Trigger a reconciliation to update the status of all resources.
 		queue.AddRateLimited(reconcile.Request{})
 	}, nil
 }

--- a/internal/provider/kubernetes/kubernetes.go
+++ b/internal/provider/kubernetes/kubernetes.go
@@ -100,7 +100,7 @@ func New(cfg *rest.Config, svr *ec.Server, resources *message.ProviderResources)
 		return nil, fmt.Errorf("failted to create gatewayapi controller: %w", err)
 	}
 
-	// Trigger a resync after updateHandler is started to ensure we don't miss any updates.
+	// Trigger a reconciliation after updateHandler is started to ensure we don't miss any updates.
 	updateHandler.addPostStart(resync)
 
 	// Add health check health probes.

--- a/internal/provider/kubernetes/status_updater.go
+++ b/internal/provider/kubernetes/status_updater.go
@@ -137,7 +137,7 @@ func (u *UpdateHandler) Start(ctx context.Context) error {
 	// Enable Updaters to start sending updates to this handler.
 	close(u.sendUpdates)
 
-	// Trigger a resync to ensure we don't miss any updates.
+	// Trigger a reconciliation to ensure we don't miss any updates.
 	if u.postStart != nil {
 		u.postStart()
 	}

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -12,13 +12,14 @@ security updates: |
 
 # New features or capabilities added in this release.
 new features: |
-  Added support for trusted CIDRs in the ClientIPDetectionSettings API
-  Added support for sending attributes to external processor in EnvoyExtensionPolicy API
+  Added support for trusted CIDRs in the ClientIPDetectionSettings API.
+  Added support for sending attributes to external processor in EnvoyExtensionPolicy API.
 
 # Fixes for bugs identified in previous versions.
 bug fixes: |
-  Fixed BackendTLSPolicy didn't support using port name as the sectionName in the targetRefs
-  Fixed reference grant from EnvoyExtensionPolicy to referenced ext-proc backend not respected
+  Fixed BackendTLSPolicy didn't support using port name as the sectionName in the targetRefs.
+  Fixed reference grant from EnvoyExtensionPolicy to referenced ext-proc backend not respected.
+  Fixed Envoy proxies connected to the secondary gateway didn't receive configuration.
 
 # Enhancements that improve performance.
 performance improvements: |
@@ -30,4 +31,4 @@ deprecations: |
 
 # Other notable changes not covered by the above sections.
 Other changes: |
-  [SecurityPolicy] Modify the JWT Provider Issuer validation constraint
+  [SecurityPolicy] Modify the JWT Provider Issuer validation constraint.


### PR DESCRIPTION
This PR does two things:
* Remove wait to make sure the status updater won't block the reconcile loop in a non-leader scenario.
* Trigger a reconciliation after starting the status updater to avoid missing any status updates.

Fixes: #4845

Release Note: Yes