### PR TITLE
chore: fix osv license scan config and add license override

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -23,5 +23,5 @@ jobs:
         scan-args: |-
           --skip-git
           --experimental-licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib
-          --config tools/osv-scanner/license-scan-config.yaml
+          --config tools/osv-scanner/license-scan-config.toml
           ./

--- a/tools/osv-scanner/license-scan-config.toml
+++ b/tools/osv-scanner/license-scan-config.toml
@@ -1,7 +1,8 @@
 # Ignore vulnerabilities on license scan
 [[PackageOverrides]]
 ecosystem = "Go"
-vulnerability.ignore = true
+# TODO uncomment once osv-scanner-action is updated to v1.9.1
+# vulnerability.ignore = true
 
 [[PackageOverrides]]
 name = "github.com/AdaLogics/go-fuzz-headers"
@@ -79,6 +80,13 @@ version = "0.0.0-20241129210726-2c02b8208cf8"
 ecosystem = "Go"
 license.override = ["Apache-2.0"]
 reason = "Unidentified license, remove once https://github.com/google/deps.dev/issues/119 is resolved"
+
+[[PackageOverrides]]
+name = "golang.org/x/crypto"
+version = "0.31.0"
+ecosystem = "Go"
+license.override = ["BSD-3-Clause"]
+reason = "Unidentified license, remove once https://github.com/google/deps.dev/issues/120 is resolved"
 
 [[PackageOverrides]]
 name = "stdlib"

--- a/tools/osv-scanner/license-scan-config.toml
+++ b/tools/osv-scanner/license-scan-config.toml
@@ -2,7 +2,7 @@
 [[PackageOverrides]]
 ecosystem = "Go"
 # TODO uncomment once osv-scanner-action is updated to v1.9.1
-vulnerability.ignore = true
+# vulnerability.ignore = true
 
 [[PackageOverrides]]
 name = "github.com/AdaLogics/go-fuzz-headers"

--- a/tools/osv-scanner/license-scan-config.toml
+++ b/tools/osv-scanner/license-scan-config.toml
@@ -2,7 +2,7 @@
 [[PackageOverrides]]
 ecosystem = "Go"
 # TODO uncomment once osv-scanner-action is updated to v1.9.1
-# vulnerability.ignore = true
+vulnerability.ignore = true
 
 [[PackageOverrides]]
 name = "github.com/AdaLogics/go-fuzz-headers"


### PR DESCRIPTION
**What this PR does / why we need it**:
* Fix file name in `--config` arg - I used `yaml` instead of `toml` by mistake.
* Comment out `vulnerability.ignore` flag which was added [here](https://github.com/envoyproxy/gateway/pull/4895) since it's only supported in `osv-scanner` [v1.9.1](https://github.com/google/osv-scanner/releases/tag/v1.9.1). The current `osv-scanner-action` is `v1.9.0`. I opened an [issue](https://github.com/google/osv-scanner-action/issues/51) to release a new version.
* Add license override for `golang.org/x/crypto` since it doesn't appear yet on [deps.dev](https://deps.dev/).
Opened an [issue](https://github.com/google/deps.dev/issues/120).

BTW the workflow didn't fail because `127` status code is redirected to `0` when running inside osv-scanner container.
I opened an [issue](https://github.com/google/osv-scanner/issues/1221) a long time ago.

Release Notes: No
