### PR TITLE
docs: Set GA4 ID

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -53,7 +53,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-00000000-0"
+id = "G-DXJEH1ZRXX"
 
 # Language configuration
 


### PR DESCRIPTION
* Use the same as the envoy proxy and envoy mobile websites

Relates to https://github.com/envoyproxy/envoy-website/issues/273 & https://github.com/envoyproxy/envoy-mobile/issues/2680
