### PR TITLE
fix: fixing some misleading unit test case names

### DIFF
--- a/api/v1alpha1/kubernetes_helpers.go
+++ b/api/v1alpha1/kubernetes_helpers.go
@@ -239,10 +239,10 @@ func (service *KubernetesServiceSpec) ApplyMergePatch(old *corev1.Service) (*cor
 	var patchedJSON []byte
 	var err error
 
-	// Serialize the current deployment to JSON
+	// Serialize the current service to JSON
 	originalJSON, err := json.Marshal(old)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling original deployment: %w", err)
+		return nil, fmt.Errorf("error marshaling original service: %w", err)
 	}
 
 	switch {

--- a/api/v1alpha1/validation/envoyproxy_validate_test.go
+++ b/api/v1alpha1/validation/envoyproxy_validate_test.go
@@ -522,7 +522,7 @@ func TestValidateEnvoyProxy(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "should be invalid when pdb type not set",
+			name: "should be valid when pdb type not set",
 			proxy: &egv1a1.EnvoyProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
@@ -534,14 +534,16 @@ func TestValidateEnvoyProxy(t *testing.T) {
 						Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
 							EnvoyPDB: &egv1a1.KubernetesPodDisruptionBudgetSpec{
 								Patch: &egv1a1.KubernetesPatchSpec{
-									Type: ptr.To(egv1a1.StrategicMerge),
+									Value: apiextensionsv1.JSON{
+										Raw: []byte("{}"),
+									},
 								},
 							},
 						},
 					},
 				},
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			name: "should be valid when hpa patch and type are empty",
@@ -615,7 +617,7 @@ func TestValidateEnvoyProxy(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "should be invalid when hpa type not set",
+			name: "should be valid when hpa type not set",
 			proxy: &egv1a1.EnvoyProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
@@ -627,17 +629,19 @@ func TestValidateEnvoyProxy(t *testing.T) {
 						Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
 							EnvoyHpa: &egv1a1.KubernetesHorizontalPodAutoscalerSpec{
 								Patch: &egv1a1.KubernetesPatchSpec{
-									Type: ptr.To(egv1a1.StrategicMerge),
+									Value: apiextensionsv1.JSON{
+										Raw: []byte("{}"),
+									},
 								},
 							},
 						},
 					},
 				},
 			},
-			expected: false,
+			expected: true,
 		},
 		{
-			name: "should invalid when patch object is empty",
+			name: "should invalid when deployment patch object is empty",
 			proxy: &egv1a1.EnvoyProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
@@ -659,7 +663,7 @@ func TestValidateEnvoyProxy(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "should valid when patch type and object are both not empty",
+			name: "should valid when deployment patch type and object are both not empty",
 			proxy: &egv1a1.EnvoyProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
@@ -684,7 +688,7 @@ func TestValidateEnvoyProxy(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "should valid when patch type is empty and object is not empty",
+			name: "should valid when deployment patch type is empty and object is not empty",
 			proxy: &egv1a1.EnvoyProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",

--- a/api/v1alpha1/validation/envoyproxy_validate_test.go
+++ b/api/v1alpha1/validation/envoyproxy_validate_test.go
@@ -500,7 +500,7 @@ func TestValidateEnvoyProxy(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "should be invalid when pdb patch not set",
+			name: "should be invalid when pdb patch object is empty",
 			proxy: &egv1a1.EnvoyProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
@@ -595,7 +595,7 @@ func TestValidateEnvoyProxy(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "should be invalid when hpa patch not set",
+			name: "should be invalid when hpa patch object is empty",
 			proxy: &egv1a1.EnvoyProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",

--- a/api/v1alpha1/validation/envoyproxy_validate_test.go
+++ b/api/v1alpha1/validation/envoyproxy_validate_test.go
@@ -403,7 +403,7 @@ func TestValidateEnvoyProxy(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "should be invalid when service patch type is empty",
+			name: "should be valid when service patch is empty",
 			proxy: &egv1a1.EnvoyProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
@@ -427,7 +427,7 @@ func TestValidateEnvoyProxy(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "should be invalid when deployment patch type is empty",
+			name: "should be valid when deployment patch is empty",
 			proxy: &egv1a1.EnvoyProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->
Fix

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
Some of the test cases in `api/v1alpha1/validation/envoyproxy_validate_test.go` were misleading.

I initially noticed a couple test cases were named "invalid" but they were actually valid scenarios, and were being checked as such with the `expected: true` field in the test table. This was for e.g. `should be invalid when service patch type is empty`

Upon this, also realized there two tests were not testing what they were supposed to be. E.g. `should be invalid when pdb type not set` should be valid, and was only invalid because the test did have the patch type set and did not the patch object, causing the invalid result. The correct thing to test for would be a valid case where `type` is not set, but `patch` is.

Also added more specific test names for the deployment cases, since we test patches for all `deployment,daemonset,service,hpa,pdb` in the validation tests, as well as fixed a misleading comment/log message in `kubernetes_helpers.go` that was related to similar codepaths.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4933

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
