### PR TITLE
feat(default-memory-limits): set default memory limits 

### DIFF
--- a/api/v1alpha1/envoyproxy_helpers.go
+++ b/api/v1alpha1/envoyproxy_helpers.go
@@ -155,6 +155,9 @@ func DefaultShutdownManagerContainerResourceRequirements() *corev1.ResourceRequi
 			corev1.ResourceCPU:    resource.MustParse(DefaultShutdownManagerCPUResourceRequests),
 			corev1.ResourceMemory: resource.MustParse(DefaultShutdownManagerMemoryResourceRequests),
 		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse(DefaultShutdownManagerMemoryResourceLimits),
+		},
 	}
 }
 

--- a/api/v1alpha1/kubernetes_helpers.go
+++ b/api/v1alpha1/kubernetes_helpers.go
@@ -76,6 +76,9 @@ func DefaultResourceRequirements() *corev1.ResourceRequirements {
 			corev1.ResourceCPU:    resource.MustParse(DefaultDeploymentCPUResourceRequests),
 			corev1.ResourceMemory: resource.MustParse(DefaultDeploymentMemoryResourceRequests),
 		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse(DefaultDeploymentMemoryResourceLimits),
+		},
 	}
 }
 

--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -21,12 +21,16 @@ const (
 	DefaultDeploymentCPUResourceRequests = "100m"
 	// DefaultDeploymentMemoryResourceRequests for deployment memory resource
 	DefaultDeploymentMemoryResourceRequests = "512Mi"
+	// DefaultDeploymentMemoryResourceLimits for deployment memory resource limits
+	DefaultDeploymentMemoryResourceLimits = "512Mi"
 	// DefaultEnvoyProxyImage is the default image used by envoyproxy
 	DefaultEnvoyProxyImage = "docker.io/envoyproxy/envoy:distroless-dev"
 	// DefaultShutdownManagerCPUResourceRequests for shutdown manager cpu resource
 	DefaultShutdownManagerCPUResourceRequests = "10m"
 	// DefaultShutdownManagerMemoryResourceRequests for shutdown manager memory resource
 	DefaultShutdownManagerMemoryResourceRequests = "32Mi"
+	// DefaultShutdownManagerMemoryResourceLimits for shutdown manager memory resource limits
+	DefaultShutdownManagerMemoryResourceLimits = "32Mi"
 	// DefaultShutdownManagerImage is the default image used for the shutdown manager.
 	DefaultShutdownManagerImage = "docker.io/envoyproxy/gateway-dev:latest"
 	// DefaultRateLimitImage is the default image used by ratelimit.

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
@@ -79,6 +79,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -155,6 +157,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
@@ -332,6 +332,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
@@ -331,6 +331,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
@@ -206,6 +206,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -246,6 +261,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -322,6 +339,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
@@ -180,6 +180,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -216,6 +231,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -292,6 +309,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
@@ -335,6 +335,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
@@ -215,6 +215,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -255,6 +270,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -331,6 +348,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
@@ -206,6 +206,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -246,6 +261,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -322,6 +339,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
@@ -206,6 +206,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -246,6 +261,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
@@ -335,6 +335,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
@@ -211,6 +211,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -251,6 +266,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -327,6 +344,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
@@ -79,6 +79,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -155,6 +157,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
@@ -206,6 +206,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -248,6 +263,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -324,6 +341,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
@@ -206,6 +206,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -246,6 +261,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -322,6 +339,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
@@ -206,6 +206,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -246,6 +261,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -322,6 +339,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
@@ -206,6 +206,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -246,6 +261,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -322,6 +339,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
@@ -206,6 +206,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -246,6 +261,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -322,6 +339,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -82,6 +82,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -158,6 +160,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -83,6 +83,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -159,6 +161,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -337,6 +337,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -339,6 +339,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -336,6 +336,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -210,6 +210,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -250,6 +265,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -326,6 +343,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -184,6 +184,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -220,6 +235,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -296,6 +313,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
@@ -211,6 +211,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -251,6 +266,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -327,6 +344,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -340,6 +340,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
@@ -210,6 +210,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -250,6 +265,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -326,6 +343,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -219,6 +219,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -259,6 +274,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -335,6 +352,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -210,6 +210,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -250,6 +265,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -326,6 +343,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -210,6 +210,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -250,6 +265,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -340,6 +340,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -215,6 +215,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -255,6 +270,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -331,6 +348,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -83,6 +83,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -159,6 +161,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -325,6 +325,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -210,6 +210,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -252,6 +267,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -328,6 +345,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -210,6 +210,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -250,6 +265,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -326,6 +343,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
@@ -210,6 +210,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -250,6 +265,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -326,6 +343,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -210,6 +210,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -250,6 +265,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -326,6 +343,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -210,6 +210,21 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
+            - name: "envoy.resource_monitors.fixed_heap"
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+                max_heap_size_bytes: 429496729
+            actions:
+            - name: "envoy.overload_actions.shrink_heap"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.95
+            - name: "envoy.overload_actions.stop_accepting_requests"
+              triggers:
+              - name: "envoy.resource_monitors.fixed_heap"
+                threshold:
+                  value: 0.98
         - --log-level warn
         - --cpuset-threads
         - --drain-strategy immediate
@@ -250,6 +265,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 512Mi
           requests:
             cpu: 100m
             memory: 512Mi
@@ -326,6 +343,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
@@ -106,6 +106,8 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+          limits:
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/disable-prometheus.yaml
@@ -96,6 +96,8 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+          limits:
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing-custom.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing-custom.yaml
@@ -121,6 +121,8 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+          limits:
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing.yaml
@@ -121,6 +121,8 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+          limits:
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-annotations.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-annotations.yaml
@@ -108,6 +108,8 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+          limits:
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-labels.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-labels.yaml
@@ -108,6 +108,8 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+          limits:
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment.yaml
@@ -106,6 +106,8 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+          limits:
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-node-selector.yaml
@@ -106,6 +106,8 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+          limits:
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-topology-spread-constraints.yaml
@@ -106,6 +106,8 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+          limits:
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/gateway/issues/4882

- sets default memory limits for shutdown manager to 32Mi and default containers to 512Mi ([== to limit](https://github.com/envoyproxy/gateway/issues/4882#issuecomment-2529629806))
- applied [calculated max heap size](https://github.com/envoyproxy/gateway/blob/2a10d474fdfe2f3a9689266355fa6d89a042daac/internal/infrastructure/kubernetes/proxy/resource.go#L356-L369) envoy config to test data for new limit (512Mi) 