### PR TITLE
docs: explain panic mode

### DIFF
--- a/api/v1alpha1/healthcheck_types.go
+++ b/api/v1alpha1/healthcheck_types.go
@@ -9,6 +9,11 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // HealthCheck configuration to decide which endpoints
 // are healthy and can be used for routing.
+//
+// Please note that Envoy load balancer may behave differently when lots of endpoints are unhealthy because of the "panic mode".
+// When the percentage of unhealthy endpoints exceeds 50%, Envoy will disregard health status and balance across all endpoints.
+// This is called "panic mode". It's designed to prevent a situation in which host failures cascade throughout the cluster
+// as load increases.
 type HealthCheck struct {
 	// Active health check configuration
 	// +optional

--- a/api/v1alpha1/healthcheck_types.go
+++ b/api/v1alpha1/healthcheck_types.go
@@ -10,8 +10,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // HealthCheck configuration to decide which endpoints
 // are healthy and can be used for routing.
 //
-// Please note that Envoy load balancer may behave differently when lots of endpoints are unhealthy because of the "panic mode".
-// When the percentage of unhealthy endpoints exceeds 50%, Envoy will disregard health status and balance across all endpoints.
+// Note: Once the overall health of the backendRef drops below 50% (e.g. a backendRef having 10 endpoints
+// with more than 5 unhealthy endpoints), Envoy will disregard health status and balance across all endpoints.
 // This is called "panic mode". It's designed to prevent a situation in which host failures cascade throughout the cluster
 // as load increases.
 type HealthCheck struct {

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -2166,8 +2166,8 @@ HealthCheck configuration to decide which endpoints
 are healthy and can be used for routing.
 
 
-Please note that Envoy load balancer may behave differently when lots of endpoints are unhealthy because of the "panic mode".
-When the percentage of unhealthy endpoints exceeds 50%, Envoy will disregard health status and balance across all endpoints.
+Note: Once the overall health of the backendRef drops below 50% (e.g. a backendRef having 10 endpoints
+with more than 5 unhealthy endpoints), Envoy will disregard health status and balance across all endpoints.
 This is called "panic mode". It's designed to prevent a situation in which host failures cascade throughout the cluster
 as load increases.
 

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -2165,6 +2165,12 @@ _Appears in:_
 HealthCheck configuration to decide which endpoints
 are healthy and can be used for routing.
 
+
+Please note that Envoy load balancer may behave differently when lots of endpoints are unhealthy because of the "panic mode".
+When the percentage of unhealthy endpoints exceeds 50%, Envoy will disregard health status and balance across all endpoints.
+This is called "panic mode". It's designed to prevent a situation in which host failures cascade throughout the cluster
+as load increases.
+
 _Appears in:_
 - [BackendTrafficPolicySpec](#backendtrafficpolicyspec)
 - [ClusterSettings](#clustersettings)

--- a/site/content/zh/latest/api/extension_types.md
+++ b/site/content/zh/latest/api/extension_types.md
@@ -2166,8 +2166,8 @@ HealthCheck configuration to decide which endpoints
 are healthy and can be used for routing.
 
 
-Please note that Envoy load balancer may behave differently when lots of endpoints are unhealthy because of the "panic mode".
-When the percentage of unhealthy endpoints exceeds 50%, Envoy will disregard health status and balance across all endpoints.
+Note: Once the overall health of the backendRef drops below 50% (e.g. a backendRef having 10 endpoints
+with more than 5 unhealthy endpoints), Envoy will disregard health status and balance across all endpoints.
 This is called "panic mode". It's designed to prevent a situation in which host failures cascade throughout the cluster
 as load increases.
 

--- a/site/content/zh/latest/api/extension_types.md
+++ b/site/content/zh/latest/api/extension_types.md
@@ -2165,6 +2165,12 @@ _Appears in:_
 HealthCheck configuration to decide which endpoints
 are healthy and can be used for routing.
 
+
+Please note that Envoy load balancer may behave differently when lots of endpoints are unhealthy because of the "panic mode".
+When the percentage of unhealthy endpoints exceeds 50%, Envoy will disregard health status and balance across all endpoints.
+This is called "panic mode". It's designed to prevent a situation in which host failures cascade throughout the cluster
+as load increases.
+
 _Appears in:_
 - [BackendTrafficPolicySpec](#backendtrafficpolicyspec)
 - [ClusterSettings](#clustersettings)


### PR DESCRIPTION
Explain the "panic mode" where failed endpoints exceeds 50% as users were asking why requests were sent to unhealth endpoints.