### PR TITLE
fix: store one copy of HTTPRoute Extension Filters

### DIFF
--- a/internal/provider/kubernetes/filters.go
+++ b/internal/provider/kubernetes/filters.go
@@ -50,13 +50,12 @@ func (r *gatewayAPIReconciler) getExtensionRefFilters(ctx context.Context) ([]un
 	return resourceItems, nil
 }
 
-func (r *gatewayAPIReconciler) getHTTPRouteFilters(ctx context.Context) ([]egv1a1.HTTPRouteFilter, error) {
-	httpFilterList := new(egv1a1.HTTPRouteFilterList)
-	if err := r.client.List(ctx, httpFilterList); err != nil {
-		return nil, fmt.Errorf("failed to list HTTPRouteFilters: %w", err)
+func (r *gatewayAPIReconciler) getHTTPRouteFilter(ctx context.Context, name, namespace string) (*egv1a1.HTTPRouteFilter, error) {
+	hrf := new(egv1a1.HTTPRouteFilter)
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, hrf); err != nil {
+		return nil, fmt.Errorf("failed to get HTTPRouteFilter: %w", err)
 	}
-
-	return httpFilterList.Items, nil
+	return hrf, nil
 }
 
 // processRouteFilterConfigMapRef adds the referenced ConfigMap in a HTTPRouteFilter

--- a/internal/provider/kubernetes/resource.go
+++ b/internal/provider/kubernetes/resource.go
@@ -64,32 +64,36 @@ type resourceMappings struct {
 	// httpRouteFilters is a map of HTTPRouteFilters, where the key is the namespaced name,
 	// group and kind of the HTTPFilter.
 	httpRouteFilters map[utils.NamespacedNameWithGroupKind]*egv1a1.HTTPRouteFilter
+	// Set for storing HTTPRouteExtensions (Envoy Gateway or Custom) NamespacedNames referenced by various
+	// route rules objects.
+	allAssociatedHTTPRouteExtensionFilters sets.Set[utils.NamespacedNameWithGroupKind]
 }
 
 func newResourceMapping() *resourceMappings {
 	return &resourceMappings{
-		allAssociatedGateways:               sets.New[string](),
-		allAssociatedReferenceGrants:        sets.New[string](),
-		allAssociatedServiceImports:         sets.New[string](),
-		allAssociatedEndpointSlices:         sets.New[string](),
-		allAssociatedBackends:               sets.New[string](),
-		allAssociatedSecrets:                sets.New[string](),
-		allAssociatedConfigMaps:             sets.New[string](),
-		allAssociatedNamespaces:             sets.New[string](),
-		allAssociatedEnvoyProxies:           sets.New[string](),
-		allAssociatedEnvoyPatchPolicies:     sets.New[string](),
-		allAssociatedTLSRoutes:              sets.New[string](),
-		allAssociatedHTTPRoutes:             sets.New[string](),
-		allAssociatedGRPCRoutes:             sets.New[string](),
-		allAssociatedTCPRoutes:              sets.New[string](),
-		allAssociatedUDPRoutes:              sets.New[string](),
-		allAssociatedBackendRefs:            sets.New[gwapiv1.BackendObjectReference](),
-		allAssociatedClientTrafficPolicies:  sets.New[string](),
-		allAssociatedBackendTrafficPolicies: sets.New[string](),
-		allAssociatedSecurityPolicies:       sets.New[string](),
-		allAssociatedBackendTLSPolicies:     sets.New[string](),
-		allAssociatedEnvoyExtensionPolicies: sets.New[string](),
-		extensionRefFilters:                 map[utils.NamespacedNameWithGroupKind]unstructured.Unstructured{},
-		httpRouteFilters:                    map[utils.NamespacedNameWithGroupKind]*egv1a1.HTTPRouteFilter{},
+		allAssociatedGateways:                  sets.New[string](),
+		allAssociatedReferenceGrants:           sets.New[string](),
+		allAssociatedServiceImports:            sets.New[string](),
+		allAssociatedEndpointSlices:            sets.New[string](),
+		allAssociatedBackends:                  sets.New[string](),
+		allAssociatedSecrets:                   sets.New[string](),
+		allAssociatedConfigMaps:                sets.New[string](),
+		allAssociatedNamespaces:                sets.New[string](),
+		allAssociatedEnvoyProxies:              sets.New[string](),
+		allAssociatedEnvoyPatchPolicies:        sets.New[string](),
+		allAssociatedTLSRoutes:                 sets.New[string](),
+		allAssociatedHTTPRoutes:                sets.New[string](),
+		allAssociatedGRPCRoutes:                sets.New[string](),
+		allAssociatedTCPRoutes:                 sets.New[string](),
+		allAssociatedUDPRoutes:                 sets.New[string](),
+		allAssociatedBackendRefs:               sets.New[gwapiv1.BackendObjectReference](),
+		allAssociatedClientTrafficPolicies:     sets.New[string](),
+		allAssociatedBackendTrafficPolicies:    sets.New[string](),
+		allAssociatedSecurityPolicies:          sets.New[string](),
+		allAssociatedBackendTLSPolicies:        sets.New[string](),
+		allAssociatedEnvoyExtensionPolicies:    sets.New[string](),
+		extensionRefFilters:                    map[utils.NamespacedNameWithGroupKind]unstructured.Unstructured{},
+		httpRouteFilters:                       map[utils.NamespacedNameWithGroupKind]*egv1a1.HTTPRouteFilter{},
+		allAssociatedHTTPRouteExtensionFilters: sets.New[utils.NamespacedNameWithGroupKind](),
 	}
 }

--- a/internal/provider/kubernetes/resource.go
+++ b/internal/provider/kubernetes/resource.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/utils"
 )
 
@@ -61,9 +60,6 @@ type resourceMappings struct {
 	// The key is the namespaced name, group and kind of the filter and the value is the
 	// unstructured form of the resource.
 	extensionRefFilters map[utils.NamespacedNameWithGroupKind]unstructured.Unstructured
-	// httpRouteFilters is a map of HTTPRouteFilters, where the key is the namespaced name,
-	// group and kind of the HTTPFilter.
-	httpRouteFilters map[utils.NamespacedNameWithGroupKind]*egv1a1.HTTPRouteFilter
 	// Set for storing HTTPRouteExtensions (Envoy Gateway or Custom) NamespacedNames referenced by various
 	// route rules objects.
 	allAssociatedHTTPRouteExtensionFilters sets.Set[utils.NamespacedNameWithGroupKind]
@@ -93,7 +89,6 @@ func newResourceMapping() *resourceMappings {
 		allAssociatedBackendTLSPolicies:        sets.New[string](),
 		allAssociatedEnvoyExtensionPolicies:    sets.New[string](),
 		extensionRefFilters:                    map[utils.NamespacedNameWithGroupKind]unstructured.Unstructured{},
-		httpRouteFilters:                       map[utils.NamespacedNameWithGroupKind]*egv1a1.HTTPRouteFilter{},
 		allAssociatedHTTPRouteExtensionFilters: sets.New[utils.NamespacedNameWithGroupKind](),
 	}
 }

--- a/internal/provider/kubernetes/routes.go
+++ b/internal/provider/kubernetes/routes.go
@@ -404,15 +404,17 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 
 					switch string(filter.ExtensionRef.Kind) {
 					case egv1a1.KindHTTPRouteFilter:
-						httpFilter, err := r.getHTTPRouteFilter(ctx, key.Name, key.Namespace)
-						if err != nil {
-							r.log.Error(err, "HTTPRouteFilters not found; bypassing rule", "index", i)
-							continue
-						}
-						if !resourceMap.allAssociatedHTTPRouteExtensionFilters.Has(key) {
-							r.processRouteFilterConfigMapRef(ctx, httpFilter, resourceMap, resourceTree)
-							resourceMap.allAssociatedHTTPRouteExtensionFilters.Insert(key)
-							resourceTree.HTTPRouteFilters = append(resourceTree.HTTPRouteFilters, httpFilter)
+						if r.hrfCRDExists {
+							httpFilter, err := r.getHTTPRouteFilter(ctx, key.Name, key.Namespace)
+							if err != nil {
+								r.log.Error(err, "HTTPRouteFilters not found; bypassing rule", "index", i)
+								continue
+							}
+							if !resourceMap.allAssociatedHTTPRouteExtensionFilters.Has(key) {
+								r.processRouteFilterConfigMapRef(ctx, httpFilter, resourceMap, resourceTree)
+								resourceMap.allAssociatedHTTPRouteExtensionFilters.Insert(key)
+								resourceTree.HTTPRouteFilters = append(resourceTree.HTTPRouteFilters, httpFilter)
+							}
 						}
 					default:
 						extRefFilter, ok := resourceMap.extensionRefFilters[key]

--- a/internal/provider/kubernetes/routes.go
+++ b/internal/provider/kubernetes/routes.go
@@ -421,7 +421,10 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 							r.log.Error(err, "HTTPRouteFilters not found; bypassing rule", "index", i)
 							continue
 						}
-						resourceTree.HTTPRouteFilters = append(resourceTree.HTTPRouteFilters, httpFilter)
+						if !resourceMap.allAssociatedHTTPRouteExtensionFilters.Has(key) {
+							resourceMap.allAssociatedHTTPRouteExtensionFilters.Insert(key)
+							resourceTree.HTTPRouteFilters = append(resourceTree.HTTPRouteFilters, httpFilter)
+						}
 					default:
 						extRefFilter, ok := resourceMap.extensionRefFilters[key]
 						if !ok {
@@ -433,7 +436,10 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 							continue
 						}
 
-						resourceTree.ExtensionRefFilters = append(resourceTree.ExtensionRefFilters, extRefFilter)
+						if !resourceMap.allAssociatedHTTPRouteExtensionFilters.Has(key) {
+							resourceMap.allAssociatedHTTPRouteExtensionFilters.Insert(key)
+							resourceTree.ExtensionRefFilters = append(resourceTree.ExtensionRefFilters, extRefFilter)
+						}
 					}
 				}
 			}

--- a/internal/provider/kubernetes/routes_test.go
+++ b/internal/provider/kubernetes/routes_test.go
@@ -75,6 +75,7 @@ func TestProcessHTTPRoutes(t *testing.T) {
 		routes             []*gwapiv1.HTTPRoute
 		extensionFilters   []*unstructured.Unstructured
 		extensionAPIGroups []schema.GroupVersionKind
+		httpRouteFilters   []*egv1a1.HTTPRouteFilter
 		expected           bool
 	}{
 		{
@@ -338,6 +339,253 @@ func TestProcessHTTPRoutes(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "multiple httproute with same extension filter",
+			routes: []*gwapiv1.HTTPRoute{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: httpRouteNS,
+						Name:      "test",
+					},
+					Spec: gwapiv1.HTTPRouteSpec{
+						CommonRouteSpec: gwapiv1.CommonRouteSpec{
+							ParentRefs: []gwapiv1.ParentReference{
+								{
+									Name: "test",
+								},
+							},
+						},
+						Rules: []gwapiv1.HTTPRouteRule{
+							{
+								Matches: []gwapiv1.HTTPRouteMatch{
+									{
+										Path: &gwapiv1.HTTPPathMatch{
+											Type:  ptr.To(gwapiv1.PathMatchPathPrefix),
+											Value: ptr.To("/1"),
+										},
+									},
+								},
+								Filters: []gwapiv1.HTTPRouteFilter{
+									{
+										Type: gwapiv1.HTTPRouteFilterExtensionRef,
+										ExtensionRef: &gwapiv1.LocalObjectReference{
+											Group: gwapiv1.Group("gateway.example.io"),
+											Kind:  gwapiv1.Kind("Bar"),
+											Name:  gwapiv1.ObjectName("test"),
+										},
+									},
+								},
+								BackendRefs: []gwapiv1.HTTPBackendRef{
+									{
+										BackendRef: gwapiv1.BackendRef{
+											BackendObjectReference: gwapiv1.BackendObjectReference{
+												Group: gatewayapi.GroupPtr(corev1.GroupName),
+												Kind:  gatewayapi.KindPtr(resource.KindService),
+												Name:  "test",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: httpRouteNS,
+						Name:      "test-2",
+					},
+					Spec: gwapiv1.HTTPRouteSpec{
+						CommonRouteSpec: gwapiv1.CommonRouteSpec{
+							ParentRefs: []gwapiv1.ParentReference{
+								{
+									Name: "test",
+								},
+							},
+						},
+						Rules: []gwapiv1.HTTPRouteRule{
+							{
+								Matches: []gwapiv1.HTTPRouteMatch{
+									{
+										Path: &gwapiv1.HTTPPathMatch{
+											Type:  ptr.To(gwapiv1.PathMatchPathPrefix),
+											Value: ptr.To("/2"),
+										},
+									},
+								},
+								Filters: []gwapiv1.HTTPRouteFilter{
+									{
+										Type: gwapiv1.HTTPRouteFilterExtensionRef,
+										ExtensionRef: &gwapiv1.LocalObjectReference{
+											Group: gwapiv1.Group("gateway.example.io"),
+											Kind:  gwapiv1.Kind("Bar"),
+											Name:  gwapiv1.ObjectName("test"),
+										},
+									},
+								},
+								BackendRefs: []gwapiv1.HTTPBackendRef{
+									{
+										BackendRef: gwapiv1.BackendRef{
+											BackendObjectReference: gwapiv1.BackendObjectReference{
+												Group: gatewayapi.GroupPtr(corev1.GroupName),
+												Kind:  gatewayapi.KindPtr(resource.KindService),
+												Name:  "test",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			extensionFilters: []*unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "gateway.example.io/v1alpha1",
+						"kind":       "Bar",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": httpRouteNS,
+						},
+					},
+				},
+			},
+			extensionAPIGroups: []schema.GroupVersionKind{
+				{
+					Group:   "gateway.example.io",
+					Version: "v1alpha1",
+					Kind:    "Bar",
+				},
+				{
+					Group:   "gateway.example.io",
+					Version: "v1alpha1",
+					Kind:    "Foo",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "multiple httproute with same extension filter: Envoy Gateway HTTPRouteFilter",
+			routes: []*gwapiv1.HTTPRoute{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: httpRouteNS,
+						Name:      "test",
+					},
+					Spec: gwapiv1.HTTPRouteSpec{
+						CommonRouteSpec: gwapiv1.CommonRouteSpec{
+							ParentRefs: []gwapiv1.ParentReference{
+								{
+									Name: "test",
+								},
+							},
+						},
+						Rules: []gwapiv1.HTTPRouteRule{
+							{
+								Matches: []gwapiv1.HTTPRouteMatch{
+									{
+										Path: &gwapiv1.HTTPPathMatch{
+											Type:  ptr.To(gwapiv1.PathMatchPathPrefix),
+											Value: ptr.To("/1"),
+										},
+									},
+								},
+								Filters: []gwapiv1.HTTPRouteFilter{
+									{
+										Type: gwapiv1.HTTPRouteFilterExtensionRef,
+										ExtensionRef: &gwapiv1.LocalObjectReference{
+											Group: gwapiv1.Group(egv1a1.GroupName),
+											Kind:  gwapiv1.Kind(egv1a1.KindHTTPRouteFilter),
+											Name:  gwapiv1.ObjectName("test"),
+										},
+									},
+								},
+								BackendRefs: []gwapiv1.HTTPBackendRef{
+									{
+										BackendRef: gwapiv1.BackendRef{
+											BackendObjectReference: gwapiv1.BackendObjectReference{
+												Group: gatewayapi.GroupPtr(corev1.GroupName),
+												Kind:  gatewayapi.KindPtr(resource.KindService),
+												Name:  "test",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: httpRouteNS,
+						Name:      "test-2",
+					},
+					Spec: gwapiv1.HTTPRouteSpec{
+						CommonRouteSpec: gwapiv1.CommonRouteSpec{
+							ParentRefs: []gwapiv1.ParentReference{
+								{
+									Name: "test",
+								},
+							},
+						},
+						Rules: []gwapiv1.HTTPRouteRule{
+							{
+								Matches: []gwapiv1.HTTPRouteMatch{
+									{
+										Path: &gwapiv1.HTTPPathMatch{
+											Type:  ptr.To(gwapiv1.PathMatchPathPrefix),
+											Value: ptr.To("/2"),
+										},
+									},
+								},
+								Filters: []gwapiv1.HTTPRouteFilter{
+									{
+										Type: gwapiv1.HTTPRouteFilterExtensionRef,
+										ExtensionRef: &gwapiv1.LocalObjectReference{
+											Group: gwapiv1.Group(egv1a1.GroupName),
+											Kind:  gwapiv1.Kind(egv1a1.KindHTTPRouteFilter),
+											Name:  gwapiv1.ObjectName("test"),
+										},
+									},
+								},
+								BackendRefs: []gwapiv1.HTTPBackendRef{
+									{
+										BackendRef: gwapiv1.BackendRef{
+											BackendObjectReference: gwapiv1.BackendObjectReference{
+												Group: gatewayapi.GroupPtr(corev1.GroupName),
+												Kind:  gatewayapi.KindPtr(resource.KindService),
+												Name:  "test",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			httpRouteFilters: []*egv1a1.HTTPRouteFilter{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       egv1a1.KindHTTPRouteFilter,
+						APIVersion: egv1a1.GroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: httpRouteNS,
+						Name:      "test",
+					},
+					Spec: egv1a1.HTTPRouteFilterSpec{
+						URLRewrite: &egv1a1.HTTPURLRewriteFilter{
+							Hostname: &egv1a1.HTTPHostnameModifier{
+								Type: egv1a1.BackendHTTPHostnameModifier,
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
 	}
 
 	for i := range testCases {
@@ -355,6 +603,7 @@ func TestProcessHTTPRoutes(t *testing.T) {
 			r := &gatewayAPIReconciler{
 				log:             logger,
 				classController: gcCtrlName,
+				hrfCRDExists:    true,
 			}
 
 			// Add the test case objects to the reconciler client.
@@ -366,6 +615,9 @@ func TestProcessHTTPRoutes(t *testing.T) {
 			}
 			if len(tc.extensionAPIGroups) > 0 {
 				r.extGVKs = append(r.extGVKs, tc.extensionAPIGroups...)
+			}
+			for _, filter := range tc.httpRouteFilters {
+				objs = append(objs, filter)
 			}
 			r.client = fakeclient.NewClientBuilder().
 				WithScheme(envoygateway.GetScheme()).
@@ -390,6 +642,8 @@ func TestProcessHTTPRoutes(t *testing.T) {
 				require.NoError(t, err)
 				// Ensure the resource tree and map are as expected.
 				require.Equal(t, tc.routes, resourceTree.HTTPRoutes)
+				require.Equal(t, len(tc.extensionFilters), len(resourceTree.ExtensionRefFilters))
+				require.Equal(t, len(tc.httpRouteFilters), len(resourceTree.HTTPRouteFilters))
 				if tc.extensionFilters != nil {
 					for _, filter := range tc.extensionFilters {
 						key := utils.NamespacedNameWithGroupKind{

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -22,6 +22,7 @@ new features: |
 # Fixes for bugs identified in previous versions.
 bug fixes: |
   Fixed a nil pointer error that occurs when a SecurityPolicy refers to a UDS backend
+  Fixed validation failure when multiple HTTPRoutes refer to the same extension filter
 
 # Enhancements that improve performance.
 performance improvements: |

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -22,7 +22,7 @@ new features: |
 # Fixes for bugs identified in previous versions.
 bug fixes: |
   Fixed a nil pointer error that occurs when a SecurityPolicy refers to a UDS backend
-  Fixed validation failure when multiple HTTPRoutes refer to the same extension filter
+  Fixed a validation failure when multiple HTTPRoutes refer to the same extension filter
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
Currently, EG accumulates multiple copies of extension filters (one for each reference). As a result, multiple matching filters can be found when processing routes, leading to the reported issue. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4989

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes
