### PR TITLE
fix: check before setting cookie TTL in sessionPersistence

### DIFF
--- a/internal/xds/translator/session_persistence.go
+++ b/internal/xds/translator/session_persistence.go
@@ -17,7 +17,6 @@ import (
 	cookiev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/cookie/v3"
 	headerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/header/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/type/http/v3"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -61,28 +60,41 @@ func (s *sessionPersistence) patchHCM(mgr *hcmv3.HttpConnectionManager, irListen
 			continue
 		}
 
-		var sessionCfg proto.Message
-		var configName string
+		var (
+			sessionCfgAny *anypb.Any
+			err           error
+			configName    string
+		)
 		switch {
 		case sp.Cookie != nil:
 			configName = cookieConfigName
-			sessionCfg = &cookiev3.CookieBasedSessionState{
+			sessionCfg := &cookiev3.CookieBasedSessionState{
 				Cookie: &httpv3.Cookie{
 					Name: sp.Cookie.Name,
 					Path: routePathToCookiePath(route.PathMatch),
-					Ttl:  durationpb.New(sp.Cookie.TTL.Duration),
 				},
 			}
+
+			if sp.Cookie.TTL != nil {
+				sessionCfg.Cookie.Ttl = durationpb.New(sp.Cookie.TTL.Duration)
+			}
+
+			sessionCfgAny, err = anypb.New(sessionCfg)
+			if err != nil {
+				return fmt.Errorf("failed to marshal %s config: %w", egv1a1.EnvoyFilterSessionPersistence.String(), err)
+			}
+
 		case sp.Header != nil:
 			configName = headerConfigName
-			sessionCfg = &headerv3.HeaderBasedSessionState{
+			sessionCfg := &headerv3.HeaderBasedSessionState{
 				Name: sp.Header.Name,
 			}
-		}
 
-		sessionCfgAny, err := anypb.New(sessionCfg)
-		if err != nil {
-			return fmt.Errorf("failed to marshal %s config: %w", egv1a1.EnvoyFilterSessionPersistence.String(), err)
+			sessionCfgAny, err = anypb.New(sessionCfg)
+			if err != nil {
+				return fmt.Errorf("failed to marshal %s config: %w", egv1a1.EnvoyFilterSessionPersistence.String(), err)
+			}
+
 		}
 
 		cfg := &statefulsessionv3.StatefulSession{

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-session-persistence.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-session-persistence.yaml
@@ -43,7 +43,6 @@ http:
     sessionPersistence:
       cookie:
         name: "session-header"
-        ttl: "1h"
     destination:
       name: "regex-route-dest"
       settings:

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.listeners.yaml
@@ -46,7 +46,6 @@
                 cookie:
                   name: session-header
                   path: /v2/
-                  ttl: 3600s
         - disabled: true
           name: envoy.filters.http.stateful_session/cookie-based-session-persistence-route-exact
           typedConfig:


### PR DESCRIPTION
Fixes a null ptr exception when the cookie ttl is nil but was being accessed without checking if its valid or not