### PR TITLE
update grafana dashboard and exported metrics doc for watchable_panics_recovered_total

### DIFF
--- a/charts/gateway-addons-helm/dashboards/envoy-gateway-global.json
+++ b/charts/gateway-addons-helm/dashboards/envoy-gateway-global.json
@@ -456,7 +456,6 @@
         "wideLayout": false
       },
       "pluginVersion": "11.0.0",
-      "repeat": "Runner",
       "repeatDirection": "v",
       "targets": [
         {

--- a/charts/gateway-addons-helm/dashboards/envoy-gateway-global.json
+++ b/charts/gateway-addons-helm/dashboards/envoy-gateway-global.json
@@ -408,6 +408,82 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "description": "Total number of panics recovered in the system.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 0,
+        "y": 8
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "11.0.0",
+      "repeat": "Runner",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(runner) (watchable_panics_recovered_total{runner=~\"$Runner\", namespace=\"$Namespace\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Recovered Panics",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Recovered Panics",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "description": "How long a status update takes to finish for all Kind.",
       "fieldConfig": {
         "defaults": {

--- a/charts/gateway-addons-helm/dashboards/envoy-gateway-global.json
+++ b/charts/gateway-addons-helm/dashboards/envoy-gateway-global.json
@@ -466,7 +466,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(runner) (watchable_panics_recovered_total{runner=~\"$Runner\", namespace=\"$Namespace\"})",
+          "expr": "sum(watchable_panics_recovered_total{namespace=\"$Namespace\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,

--- a/site/content/en/docs/tasks/observability/gateway-exported-metrics.md
+++ b/site/content/en/docs/tasks/observability/gateway-exported-metrics.md
@@ -22,6 +22,7 @@ Envoy Gateway collects the following metrics in Watching Components:
 | `watchable_depth`                      | Current depth of watchable map.                              |
 | `watchable_subscribe_duration_seconds` | How long in seconds a subscribed watchable queue is handled. |
 | `watchable_subscribe_total`            | Total number of subscribed watchable queue.                  |
+| `watchable_panics_recovered_total`     | Total recovered panics in the watchable infrastructure.      |
 
 Each metric includes the `runner` label to identify the corresponding components,
 the relationship between label values and components is as follows:

--- a/site/content/en/docs/tasks/observability/gateway-exported-metrics.md
+++ b/site/content/en/docs/tasks/observability/gateway-exported-metrics.md
@@ -22,7 +22,6 @@ Envoy Gateway collects the following metrics in Watching Components:
 | `watchable_depth`                      | Current depth of watchable map.                              |
 | `watchable_subscribe_duration_seconds` | How long in seconds a subscribed watchable queue is handled. |
 | `watchable_subscribe_total`            | Total number of subscribed watchable queue.                  |
-| `watchable_panics_recovered_total`     | Total recovered panics in the watchable infrastructure.      |
 
 Each metric includes the `runner` label to identify the corresponding components,
 the relationship between label values and components is as follows:

--- a/site/content/en/latest/tasks/observability/gateway-exported-metrics.md
+++ b/site/content/en/latest/tasks/observability/gateway-exported-metrics.md
@@ -22,6 +22,7 @@ Envoy Gateway collects the following metrics in Watching Components:
 | `watchable_depth`                      | Current depth of watchable map.                              |
 | `watchable_subscribe_duration_seconds` | How long in seconds a subscribed watchable queue is handled. |
 | `watchable_subscribe_total`            | Total number of subscribed watchable queue.                  |
+| `watchable_panics_recovered_total`     | Total recovered panics in the watchable infrastructure.      |
 
 Each metric includes the `runner` label to identify the corresponding components,
 the relationship between label values and components is as follows:

--- a/test/helm/gateway-addons-helm/default.out.yaml
+++ b/test/helm/gateway-addons-helm/default.out.yaml
@@ -2772,6 +2772,81 @@ data:
               "type": "prometheus",
               "uid": "$datasource"
             },
+            "description": "Total number of panics recovered in the system.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "none"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 7,
+              "x": 0,
+              "y": 8
+            },
+            "id": 25,
+            "options": {
+              "colorMode": "value",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "value_and_name",
+              "wideLayout": false
+            },
+            "pluginVersion": "11.0.0",
+            "repeatDirection": "v",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+                },
+                "disableTextWrap": false,
+                "editorMode": "builder",
+                "expr": "sum(watchable_panics_recovered_total{namespace=\"$Namespace\"})",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "instant": false,
+                "legendFormat": "Recovered Panics",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
+              }
+            ],
+            "title": "Recovered Panics",
+            "type": "stat"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "$datasource"
+            },
             "description": "How long a status update takes to finish for all Kind.",
             "fieldConfig": {
               "defaults": {

--- a/test/helm/gateway-addons-helm/e2e.out.yaml
+++ b/test/helm/gateway-addons-helm/e2e.out.yaml
@@ -2854,6 +2854,81 @@ data:
               "type": "prometheus",
               "uid": "$datasource"
             },
+            "description": "Total number of panics recovered in the system.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "none"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 7,
+              "x": 0,
+              "y": 8
+            },
+            "id": 25,
+            "options": {
+              "colorMode": "value",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "value_and_name",
+              "wideLayout": false
+            },
+            "pluginVersion": "11.0.0",
+            "repeatDirection": "v",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+                },
+                "disableTextWrap": false,
+                "editorMode": "builder",
+                "expr": "sum(watchable_panics_recovered_total{namespace=\"$Namespace\"})",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "instant": false,
+                "legendFormat": "Recovered Panics",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
+              }
+            ],
+            "title": "Recovered Panics",
+            "type": "stat"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "$datasource"
+            },
             "description": "How long a status update takes to finish for all Kind.",
             "fieldConfig": {
               "defaults": {


### PR DESCRIPTION
**What type of PR is this?**

Update Grafana dashboard and exported metrics doc for watchable_panics_recovered_total

**What this PR does / why we need it**:

This PR updates the Grafana Dashboard to include the newly introduced metric watchable_panics_recovered_total, which tracks the total number of panics recovered in the Envoy Gateway system. It also updates the Exported Metrics Documentation to reflect the new metric and provide users with guidance on its use.

**Which issue(s) this PR fixes**:

fix #4728
