### PR TITLE
e2e: fix trusted cidr e2e tests for ipv6

### DIFF
--- a/test/e2e/testdata/authorization-client-ip-trusted-cidrs.yaml
+++ b/test/e2e/testdata/authorization-client-ip-trusted-cidrs.yaml
@@ -45,8 +45,9 @@ spec:
   clientIPDetection:
     xForwardedFor:
       trustedCIDRs:
-      - "172.16.0.0/12"
-      - "10.0.1.0/24"
+      - "172.0.0.0/8"
+      - "10.0.0.0/8"
+      - "::/0" # trust all IPv6 addresses for E2E
   targetRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway

--- a/test/e2e/tests/authorization_client_ip.go
+++ b/test/e2e/tests/authorization_client_ip.go
@@ -23,8 +23,7 @@ import (
 
 func init() {
 	ConformanceTests = append(ConformanceTests, AuthorizationClientIPTest)
-	// Uncomment once https://github.com/envoyproxy/gateway/issues/5063 is fixed
-	// ConformanceTests = append(ConformanceTests, AuthorizationClientIPTrustedCidrsTest)
+	ConformanceTests = append(ConformanceTests, AuthorizationClientIPTrustedCidrsTest)
 }
 
 var AuthorizationClientIPTest = suite.ConformanceTest{


### PR DESCRIPTION
Fixes #5063