### PR TITLE
fix certgen job race condition

### DIFF
--- a/charts/gateway-helm/templates/certgen-rbac.yaml
+++ b/charts/gateway-helm/templates/certgen-rbac.yaml
@@ -10,6 +10,7 @@ metadata:
   {{- end }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
   {{- if .Values.certgen.rbac.annotations }}
     {{- toYaml .Values.certgen.rbac.annotations | nindent 4 -}}
   {{- end }}
@@ -26,6 +27,7 @@ metadata:
   {{- end }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
   {{- if .Values.certgen.rbac.annotations }}
     {{- toYaml .Values.certgen.rbac.annotations | nindent 4 -}}
   {{- end }}
@@ -51,6 +53,7 @@ metadata:
   {{- end }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
   {{- if .Values.certgen.rbac.annotations }}
     {{- toYaml .Values.certgen.rbac.annotations | nindent 4 -}}
   {{- end }}

--- a/charts/gateway-helm/templates/certgen-rbac.yaml
+++ b/charts/gateway-helm/templates/certgen-rbac.yaml
@@ -8,10 +8,8 @@ metadata:
   {{- if .Values.certgen.rbac.labels }}
   {{- toYaml .Values.certgen.rbac.labels | nindent 4 }}
   {{- end }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
   {{- if .Values.certgen.rbac.annotations }}
+  annotations:
     {{- toYaml .Values.certgen.rbac.annotations | nindent 4 -}}
   {{- end }}
 ---
@@ -25,10 +23,8 @@ metadata:
   {{- if .Values.certgen.rbac.labels }}
   {{- toYaml .Values.certgen.rbac.labels | nindent 4 }}
   {{- end }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
   {{- if .Values.certgen.rbac.annotations }}
+  annotations:
     {{- toYaml .Values.certgen.rbac.annotations | nindent 4 -}}
   {{- end }}
 rules:
@@ -51,10 +47,8 @@ metadata:
   {{- if .Values.certgen.rbac.labels }}
   {{- toYaml .Values.certgen.rbac.labels | nindent 4 }}
   {{- end }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
   {{- if .Values.certgen.rbac.annotations }}
+  annotations:
     {{- toYaml .Values.certgen.rbac.annotations | nindent 4 -}}
   {{- end }}
 roleRef:

--- a/charts/gateway-helm/templates/certgen.yaml
+++ b/charts/gateway-helm/templates/certgen.yaml
@@ -7,7 +7,6 @@ metadata:
   {{- include "eg.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "0"
   {{- if .Values.certgen.job.annotations }}
     {{- toYaml .Values.certgen.job.annotations | nindent 4 -}}
   {{- end }}

--- a/charts/gateway-helm/templates/certgen.yaml
+++ b/charts/gateway-helm/templates/certgen.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- include "eg.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
   {{- if .Values.certgen.job.annotations }}
     {{- toYaml .Values.certgen.job.annotations | nindent 4 -}}
   {{- end }}

--- a/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
+++ b/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: gateway-helm/templates/envoy-gateway-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -186,6 +199,28 @@ subjects:
   name: 'envoy-gateway'
   namespace: 'envoy-gateway-system'
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -279,6 +314,27 @@ rules:
   verbs:
   - create
   - patch
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'gateway-helm-certgen'
+  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -455,62 +511,6 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: 'gateway-helm-certgen'
-subjects:
-- kind: ServiceAccount
-  name: 'gateway-helm-certgen'
-  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/certgen.yaml
 apiVersion: batch/v1

--- a/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
+++ b/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
@@ -468,9 +468,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -484,9 +481,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -509,9 +503,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -535,7 +526,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
+++ b/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
@@ -470,6 +470,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -485,6 +486,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -509,6 +511,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -532,6 +535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
+++ b/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
@@ -14,6 +14,19 @@ spec:
       app.kubernetes.io/name: gateway-helm
       app.kubernetes.io/instance: gateway-helm
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: gateway-helm/templates/envoy-gateway-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -201,6 +214,28 @@ subjects:
   name: 'envoy-gateway'
   namespace: 'envoy-gateway-system'
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -294,6 +329,27 @@ rules:
   verbs:
   - create
   - patch
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'gateway-helm-certgen'
+  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -470,62 +526,6 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: 'gateway-helm-certgen'
-subjects:
-- kind: ServiceAccount
-  name: 'gateway-helm-certgen'
-  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/certgen.yaml
 apiVersion: batch/v1

--- a/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
+++ b/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
@@ -485,6 +485,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -500,6 +501,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -524,6 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -547,6 +550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
+++ b/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
@@ -483,9 +483,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -499,9 +496,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -524,9 +518,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -550,7 +541,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/default-config.out.yaml
+++ b/test/helm/gateway-helm/default-config.out.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: gateway-helm/templates/envoy-gateway-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -186,6 +199,28 @@ subjects:
   name: 'envoy-gateway'
   namespace: 'envoy-gateway-system'
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -279,6 +314,27 @@ rules:
   verbs:
   - create
   - patch
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'gateway-helm-certgen'
+  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -455,62 +511,6 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: 'gateway-helm-certgen'
-subjects:
-- kind: ServiceAccount
-  name: 'gateway-helm-certgen'
-  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/certgen.yaml
 apiVersion: batch/v1

--- a/test/helm/gateway-helm/default-config.out.yaml
+++ b/test/helm/gateway-helm/default-config.out.yaml
@@ -468,9 +468,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -484,9 +481,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -509,9 +503,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -535,7 +526,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/default-config.out.yaml
+++ b/test/helm/gateway-helm/default-config.out.yaml
@@ -470,6 +470,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -485,6 +486,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -509,6 +511,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -532,6 +535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/deployment-custom-topology.out.yaml
+++ b/test/helm/gateway-helm/deployment-custom-topology.out.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: gateway-helm/templates/envoy-gateway-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -186,6 +199,28 @@ subjects:
   name: 'envoy-gateway'
   namespace: 'envoy-gateway-system'
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -279,6 +314,27 @@ rules:
   verbs:
   - create
   - patch
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'gateway-helm-certgen'
+  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -483,62 +539,6 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: 'gateway-helm-certgen'
-subjects:
-- kind: ServiceAccount
-  name: 'gateway-helm-certgen'
-  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/certgen.yaml
 apiVersion: batch/v1

--- a/test/helm/gateway-helm/deployment-custom-topology.out.yaml
+++ b/test/helm/gateway-helm/deployment-custom-topology.out.yaml
@@ -496,9 +496,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -512,9 +509,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -537,9 +531,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -563,7 +554,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/deployment-custom-topology.out.yaml
+++ b/test/helm/gateway-helm/deployment-custom-topology.out.yaml
@@ -498,6 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -513,6 +514,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -537,6 +539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -560,6 +563,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/deployment-images-config.out.yaml
+++ b/test/helm/gateway-helm/deployment-images-config.out.yaml
@@ -470,9 +470,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -486,9 +483,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -511,9 +505,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -537,7 +528,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/deployment-images-config.out.yaml
+++ b/test/helm/gateway-helm/deployment-images-config.out.yaml
@@ -472,6 +472,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -487,6 +488,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -511,6 +513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -534,6 +537,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/deployment-images-config.out.yaml
+++ b/test/helm/gateway-helm/deployment-images-config.out.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: gateway-helm/templates/envoy-gateway-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -186,6 +199,28 @@ subjects:
   name: 'envoy-gateway'
   namespace: 'envoy-gateway-system'
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -279,6 +314,27 @@ rules:
   verbs:
   - create
   - patch
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'gateway-helm-certgen'
+  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -457,62 +513,6 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: 'gateway-helm-certgen'
-subjects:
-- kind: ServiceAccount
-  name: 'gateway-helm-certgen'
-  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/certgen.yaml
 apiVersion: batch/v1

--- a/test/helm/gateway-helm/deployment-priorityclass.out.yaml
+++ b/test/helm/gateway-helm/deployment-priorityclass.out.yaml
@@ -471,6 +471,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -486,6 +487,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -510,6 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -533,6 +536,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/deployment-priorityclass.out.yaml
+++ b/test/helm/gateway-helm/deployment-priorityclass.out.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: gateway-helm/templates/envoy-gateway-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -186,6 +199,28 @@ subjects:
   name: 'envoy-gateway'
   namespace: 'envoy-gateway-system'
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -279,6 +314,27 @@ rules:
   verbs:
   - create
   - patch
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'gateway-helm-certgen'
+  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -456,62 +512,6 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: 'gateway-helm-certgen'
-subjects:
-- kind: ServiceAccount
-  name: 'gateway-helm-certgen'
-  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/certgen.yaml
 apiVersion: batch/v1

--- a/test/helm/gateway-helm/deployment-priorityclass.out.yaml
+++ b/test/helm/gateway-helm/deployment-priorityclass.out.yaml
@@ -469,9 +469,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -485,9 +482,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -510,9 +504,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -536,7 +527,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/deployment-securitycontext.out.yaml
+++ b/test/helm/gateway-helm/deployment-securitycontext.out.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: gateway-helm/templates/envoy-gateway-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -186,6 +199,28 @@ subjects:
   name: 'envoy-gateway'
   namespace: 'envoy-gateway-system'
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -279,6 +314,27 @@ rules:
   verbs:
   - create
   - patch
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'gateway-helm-certgen'
+  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -455,62 +511,6 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: 'gateway-helm-certgen'
-subjects:
-- kind: ServiceAccount
-  name: 'gateway-helm-certgen'
-  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/certgen.yaml
 apiVersion: batch/v1

--- a/test/helm/gateway-helm/deployment-securitycontext.out.yaml
+++ b/test/helm/gateway-helm/deployment-securitycontext.out.yaml
@@ -468,9 +468,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -484,9 +481,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -509,9 +503,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -535,7 +526,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/deployment-securitycontext.out.yaml
+++ b/test/helm/gateway-helm/deployment-securitycontext.out.yaml
@@ -470,6 +470,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -485,6 +486,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -509,6 +511,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -532,6 +535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/envoy-gateway-config.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-config.out.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: gateway-helm/templates/envoy-gateway-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -188,6 +201,28 @@ subjects:
   name: 'envoy-gateway'
   namespace: 'envoy-gateway-system'
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -281,6 +316,27 @@ rules:
   verbs:
   - create
   - patch
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'gateway-helm-certgen'
+  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -457,62 +513,6 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: 'gateway-helm-certgen'
-subjects:
-- kind: ServiceAccount
-  name: 'gateway-helm-certgen'
-  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/certgen.yaml
 apiVersion: batch/v1

--- a/test/helm/gateway-helm/envoy-gateway-config.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-config.out.yaml
@@ -470,9 +470,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -486,9 +483,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -511,9 +505,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -537,7 +528,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/envoy-gateway-config.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-config.out.yaml
@@ -472,6 +472,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -487,6 +488,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -511,6 +513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -534,6 +537,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/global-images-config.out.yaml
+++ b/test/helm/gateway-helm/global-images-config.out.yaml
@@ -474,9 +474,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -490,9 +487,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -515,9 +509,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -541,7 +532,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/global-images-config.out.yaml
+++ b/test/helm/gateway-helm/global-images-config.out.yaml
@@ -476,6 +476,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -491,6 +492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -515,6 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -538,6 +541,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/global-images-config.out.yaml
+++ b/test/helm/gateway-helm/global-images-config.out.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: gateway-helm/templates/envoy-gateway-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -190,6 +203,28 @@ subjects:
   name: 'envoy-gateway'
   namespace: 'envoy-gateway-system'
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -283,6 +318,27 @@ rules:
   verbs:
   - create
   - patch
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'gateway-helm-certgen'
+  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -461,62 +517,6 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: 'gateway-helm-certgen'
-subjects:
-- kind: ServiceAccount
-  name: 'gateway-helm-certgen'
-  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/certgen.yaml
 apiVersion: batch/v1

--- a/test/helm/gateway-helm/service-annotations.out.yaml
+++ b/test/helm/gateway-helm/service-annotations.out.yaml
@@ -470,9 +470,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -486,9 +483,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -511,9 +505,6 @@ metadata:
     app.kubernetes.io/instance: gateway-helm
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -537,7 +528,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/service-annotations.out.yaml
+++ b/test/helm/gateway-helm/service-annotations.out.yaml
@@ -472,6 +472,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 ---
 # Source: gateway-helm/templates/certgen-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -487,6 +488,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 rules:
 - apiGroups:
   - ""
@@ -511,6 +513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -534,6 +537,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   backoffLimit: 1
   completions: 1

--- a/test/helm/gateway-helm/service-annotations.out.yaml
+++ b/test/helm/gateway-helm/service-annotations.out.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: gateway-helm/templates/envoy-gateway-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -186,6 +199,28 @@ subjects:
   name: 'envoy-gateway'
   namespace: 'envoy-gateway-system'
 ---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -279,6 +314,27 @@ rules:
   verbs:
   - create
   - patch
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-certgen
+  namespace: 'envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'gateway-helm-certgen'
+  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/infra-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -457,62 +513,6 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
----
-# Source: gateway-helm/templates/certgen-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: gateway-helm-certgen
-  namespace: 'envoy-gateway-system'
-  labels:
-    helm.sh/chart: gateway-helm-v0.0.0-latest
-    app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/instance: gateway-helm
-    app.kubernetes.io/version: "latest"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: 'gateway-helm-certgen'
-subjects:
-- kind: ServiceAccount
-  name: 'gateway-helm-certgen'
-  namespace: 'envoy-gateway-system'
 ---
 # Source: gateway-helm/templates/certgen.yaml
 apiVersion: batch/v1


### PR DESCRIPTION
Envoy-gateway certgen job frequently goes into a crash loop when running a sync using ArgoCD in our environment with the following error:

```
envoy-gateway-gateway-helm-certgen-pxnd7 envoy-gateway-certgen failed to output certificates: failed to create or update secrets: failed to get secret infra-routing/envoy-gateway: failed to get API group resources: unable to retrieve the complete list of server APIs: v1: Unauthorized
```

Though, sometimes this job succeeds with no problems...

I believe this inconsistency is due to a race condition between the RBAC resources and the certgen job (both installed with `pre-install`). Since the RBAC resources do not exist continuously, and are only applied on installation and then removed, I believe the job Is trying to start before the permissions are available. After setting the `hook-weight` annotation in our environment we no longer see this problem.

Another solution could be to have the RBAC resources exist continuously without the `pre-hook` but I imagine this was a conscious security decision.

