### PR TITLE
rm overwriteControlPlaneCerts from the EnvoyGateway API

### DIFF
--- a/api/v1alpha1/envoygateway_types.go
+++ b/api/v1alpha1/envoygateway_types.go
@@ -215,9 +215,6 @@ type EnvoyGatewayKubernetesProvider struct {
 	// should be deployed
 	// +optional
 	Deploy *KubernetesDeployMode `json:"deploy,omitempty"`
-	// OverwriteControlPlaneCerts updates the secrets containing the control plane certs, when set.
-	// +optional
-	OverwriteControlPlaneCerts *bool `json:"overwriteControlPlaneCerts,omitempty"`
 	// LeaderElection specifies the configuration for leader election.
 	// If it's not set up, leader election will be active by default, using Kubernetes' standard settings.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1611,11 +1611,6 @@ func (in *EnvoyGatewayKubernetesProvider) DeepCopyInto(out *EnvoyGatewayKubernet
 		*out = new(KubernetesDeployMode)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.OverwriteControlPlaneCerts != nil {
-		in, out := &in.OverwriteControlPlaneCerts, &out.OverwriteControlPlaneCerts
-		*out = new(bool)
-		**out = **in
-	}
 	if in.LeaderElection != nil {
 		in, out := &in.LeaderElection, &out.LeaderElection
 		*out = new(LeaderElection)

--- a/internal/cmd/certgen.go
+++ b/internal/cmd/certgen.go
@@ -12,7 +12,6 @@ import (
 	"path"
 
 	"github.com/spf13/cobra"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clicfg "sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -57,10 +56,6 @@ func certGen(local bool) error {
 	}
 	log := cfg.Logger
 
-	if overwriteControlPlaneCerts {
-		cfg.EnvoyGateway.Provider.Kubernetes.OverwriteControlPlaneCerts = ptr.To(true)
-	}
-
 	certs, err := crypto.GenerateCerts(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to generate certificates: %w", err)
@@ -73,7 +68,7 @@ func certGen(local bool) error {
 			return fmt.Errorf("failed to create controller-runtime client: %w", err)
 		}
 
-		if err = outputCertsForKubernetes(ctrl.SetupSignalHandler(), cli, cfg, certs); err != nil {
+		if err = outputCertsForKubernetes(ctrl.SetupSignalHandler(), cli, cfg, overwriteControlPlaneCerts, certs); err != nil {
 			return fmt.Errorf("failed to output certificates: %w", err)
 		}
 	} else {
@@ -87,15 +82,8 @@ func certGen(local bool) error {
 }
 
 // outputCertsForKubernetes outputs the provided certs to a secret in namespace ns.
-func outputCertsForKubernetes(ctx context.Context, cli client.Client, cfg *config.Server, certs *crypto.Certificates) error {
-	var updateSecrets bool
-	if cfg.EnvoyGateway != nil &&
-		cfg.EnvoyGateway.Provider != nil &&
-		cfg.EnvoyGateway.Provider.Kubernetes != nil &&
-		cfg.EnvoyGateway.Provider.Kubernetes.OverwriteControlPlaneCerts != nil &&
-		*cfg.EnvoyGateway.Provider.Kubernetes.OverwriteControlPlaneCerts {
-		updateSecrets = true
-	}
+func outputCertsForKubernetes(ctx context.Context, cli client.Client, cfg *config.Server,
+	updateSecrets bool, certs *crypto.Certificates) error {
 	secrets, err := kubernetes.CreateOrUpdateSecrets(ctx, cli, kubernetes.CertsToSecret(cfg.Namespace, certs), updateSecrets)
 	log := cfg.Logger
 

--- a/internal/cmd/certgen.go
+++ b/internal/cmd/certgen.go
@@ -83,7 +83,8 @@ func certGen(local bool) error {
 
 // outputCertsForKubernetes outputs the provided certs to a secret in namespace ns.
 func outputCertsForKubernetes(ctx context.Context, cli client.Client, cfg *config.Server,
-	updateSecrets bool, certs *crypto.Certificates) error {
+	updateSecrets bool, certs *crypto.Certificates,
+) error {
 	secrets, err := kubernetes.CreateOrUpdateSecrets(ctx, cli, kubernetes.CertsToSecret(cfg.Namespace, certs), updateSecrets)
 	log := cfg.Logger
 

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -1174,7 +1174,6 @@ _Appears in:_
 | `rateLimitHpa` | _[KubernetesHorizontalPodAutoscalerSpec](#kuberneteshorizontalpodautoscalerspec)_ |  false  |  | RateLimitHpa defines the Horizontal Pod Autoscaler settings for Envoy ratelimit Deployment.<br />If the HPA is set, Replicas field from RateLimitDeployment will be ignored. |
 | `watch` | _[KubernetesWatchMode](#kuberneteswatchmode)_ |  false  |  | Watch holds configuration of which input resources should be watched and reconciled. |
 | `deploy` | _[KubernetesDeployMode](#kubernetesdeploymode)_ |  false  |  | Deploy holds configuration of how output managed resources such as the Envoy Proxy data plane<br />should be deployed |
-| `overwriteControlPlaneCerts` | _boolean_ |  false  |  | OverwriteControlPlaneCerts updates the secrets containing the control plane certs, when set. |
 | `leaderElection` | _[LeaderElection](#leaderelection)_ |  false  |  | LeaderElection specifies the configuration for leader election.<br />If it's not set up, leader election will be active by default, using Kubernetes' standard settings. |
 | `shutdownManager` | _[ShutdownManager](#shutdownmanager)_ |  false  |  | ShutdownManager defines the configuration for the shutdown manager. |
 

--- a/site/content/zh/latest/api/extension_types.md
+++ b/site/content/zh/latest/api/extension_types.md
@@ -1174,7 +1174,6 @@ _Appears in:_
 | `rateLimitHpa` | _[KubernetesHorizontalPodAutoscalerSpec](#kuberneteshorizontalpodautoscalerspec)_ |  false  |  | RateLimitHpa defines the Horizontal Pod Autoscaler settings for Envoy ratelimit Deployment.<br />If the HPA is set, Replicas field from RateLimitDeployment will be ignored. |
 | `watch` | _[KubernetesWatchMode](#kuberneteswatchmode)_ |  false  |  | Watch holds configuration of which input resources should be watched and reconciled. |
 | `deploy` | _[KubernetesDeployMode](#kubernetesdeploymode)_ |  false  |  | Deploy holds configuration of how output managed resources such as the Envoy Proxy data plane<br />should be deployed |
-| `overwriteControlPlaneCerts` | _boolean_ |  false  |  | OverwriteControlPlaneCerts updates the secrets containing the control plane certs, when set. |
 | `leaderElection` | _[LeaderElection](#leaderelection)_ |  false  |  | LeaderElection specifies the configuration for leader election.<br />If it's not set up, leader election will be active by default, using Kubernetes' standard settings. |
 | `shutdownManager` | _[ShutdownManager](#shutdownmanager)_ |  false  |  | ShutdownManager defines the configuration for the shutdown manager. |
 


### PR DESCRIPTION
it was not implemented previously and instead must be specified as a cmd line arg for `certgen`