### PR TITLE
api: adds AllowModeOverride for extproc

### DIFF
--- a/api/v1alpha1/ext_proc_types.go
+++ b/api/v1alpha1/ext_proc_types.go
@@ -90,6 +90,12 @@ type ExtProc struct {
 	//
 	// +optional
 	Metadata *ExtProcMetadata `json:"metadata,omitempty"`
+
+	// AllowModeOverride allows the external processor to override the processing mode set via the
+	// `mode_override` field in the gRPC response message. This defaults to false.
+	//
+	// +optional
+	AllowModeOverride bool `json:"allowModeOverride,omitempty"`
 }
 
 // ExtProcMetadata defines options related to the sending and receiving of dynamic metadata to and from the

--- a/api/v1alpha1/ext_proc_types.go
+++ b/api/v1alpha1/ext_proc_types.go
@@ -53,6 +53,12 @@ type ExtProcProcessingMode struct {
 	//
 	// +optional
 	Response *ProcessingModeOptions `json:"response,omitempty"`
+
+	// AllowModeOverride allows the external processor to override the processing mode set via the
+	// `mode_override` field in the gRPC response message. This defaults to false.
+	//
+	// +optional
+	AllowModeOverride bool `json:"allowModeOverride,omitempty"`
 }
 
 // ExtProc defines the configuration for External Processing filter.
@@ -90,12 +96,6 @@ type ExtProc struct {
 	//
 	// +optional
 	Metadata *ExtProcMetadata `json:"metadata,omitempty"`
-
-	// AllowModeOverride allows the external processor to override the processing mode set via the
-	// `mode_override` field in the gRPC response message. This defaults to false.
-	//
-	// +optional
-	AllowModeOverride bool `json:"allowModeOverride,omitempty"`
 }
 
 // ExtProcMetadata defines options related to the sending and receiving of dynamic metadata to and from the

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
@@ -54,11 +54,6 @@ spec:
                   description: ExtProc defines the configuration for External Processing
                     filter.
                   properties:
-                    allowModeOverride:
-                      description: |-
-                        AllowModeOverride allows the external processor to override the processing mode set via the
-                        `mode_override` field in the gRPC response message. This defaults to false.
-                      type: boolean
                     backendRef:
                       description: |-
                         BackendRef references a Kubernetes object that represents the
@@ -945,6 +940,11 @@ spec:
                         ProcessingMode defines how request and response body is processed
                         Default: header and body are not sent to the external processor
                       properties:
+                        allowModeOverride:
+                          description: |-
+                            AllowModeOverride allows the external processor to override the processing mode set via the
+                            `mode_override` field in the gRPC response message. This defaults to false.
+                          type: boolean
                         request:
                           description: |-
                             Defines processing mode for requests. If present, request headers are sent. Request body is processed according

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
@@ -54,6 +54,11 @@ spec:
                   description: ExtProc defines the configuration for External Processing
                     filter.
                   properties:
+                    allowModeOverride:
+                      description: |-
+                        AllowModeOverride allows the external processor to override the processing mode set via the
+                        `mode_override` field in the gRPC response message. This defaults to false.
+                      type: boolean
                     backendRef:
                       description: |-
                         BackendRef references a Kubernetes object that represents the

--- a/internal/gatewayapi/envoyextensionpolicy.go
+++ b/internal/gatewayapi/envoyextensionpolicy.go
@@ -497,6 +497,7 @@ func (t *Translator) buildExtProc(
 				extProcIR.ResponseAttributes = append(extProcIR.ResponseAttributes, extProc.ProcessingMode.Response.Attributes...)
 			}
 		}
+		extProcIR.AllowModeOverride = extProc.ProcessingMode.AllowModeOverride
 	}
 
 	if extProc.Metadata != nil {
@@ -511,7 +512,6 @@ func (t *Translator) buildExtProc(
 		}
 	}
 
-	extProcIR.AllowModeOverride = extProc.AllowModeOverride
 	return extProcIR, err
 }
 

--- a/internal/gatewayapi/envoyextensionpolicy.go
+++ b/internal/gatewayapi/envoyextensionpolicy.go
@@ -511,6 +511,7 @@ func (t *Translator) buildExtProc(
 		}
 	}
 
+	extProcIR.AllowModeOverride = extProc.AllowModeOverride
 	return extProcIR, err
 }
 

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.in.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.in.yaml
@@ -200,8 +200,8 @@ envoyExtensionPolicies:
       - Name: grpc-backend
         Namespace: envoy-gateway
         Port: 8000
-      allowModeOverride: true
       processingMode:
+        allowModeOverride: true
         request:
           body: Buffered
           attributes:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.in.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.in.yaml
@@ -200,6 +200,7 @@ envoyExtensionPolicies:
       - Name: grpc-backend
         Namespace: envoy-gateway
         Port: 8000
+      allowModeOverride: true
       processingMode:
         request:
           body: Buffered

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.out.yaml
@@ -105,7 +105,8 @@ envoyExtensionPolicies:
     namespace: default
   spec:
     extProc:
-    - backendRefs:
+    - allowModeOverride: true
+      backendRefs:
       - name: grpc-backend
         namespace: envoy-gateway
         port: 8000
@@ -357,7 +358,8 @@ xdsIR:
             weight: 1
         envoyExtensions:
           extProcs:
-          - authority: grpc-backend.envoy-gateway:8000
+          - allowModeOverride: true
+            authority: grpc-backend.envoy-gateway:8000
             destination:
               name: envoyextensionpolicy/default/policy-for-gateway/extproc/0
               settings:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.out.yaml
@@ -105,8 +105,7 @@ envoyExtensionPolicies:
     namespace: default
   spec:
     extProc:
-    - allowModeOverride: true
-      backendRefs:
+    - backendRefs:
       - name: grpc-backend
         namespace: envoy-gateway
         port: 8000
@@ -118,6 +117,7 @@ envoyExtensionPolicies:
         writableNamespaces:
         - envoy.filters.http.my_custom
       processingMode:
+        allowModeOverride: true
         request:
           attributes:
           - request.path

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -2787,6 +2787,9 @@ type ExtProc struct {
 
 	// ReceivingMetadataNamespaces are metadata namespaces updatable by external processor
 	ReceivingMetadataNamespaces []string `json:"receivingMetadataNamespaces,omitempty" yaml:"receivingMetadataNamespaces,omitempty"`
+
+	// AllowModeOverride allows the external processor to modify the processing mode.
+	AllowModeOverride bool `json:"allowModeOverride,omitempty" yaml:"allowModeOverride,omitempty"`
 }
 
 // Wasm holds the information associated with the Wasm extensions.

--- a/internal/xds/translator/extproc.go
+++ b/internal/xds/translator/extproc.go
@@ -168,7 +168,7 @@ func extProcConfig(extProc ir.ExtProc) *extprocv3.ExternalProcessor {
 			}
 		}
 	}
-
+	config.AllowModeOverride = extProc.AllowModeOverride
 	return config
 }
 

--- a/internal/xds/translator/testdata/in/xds-ir/ext-proc.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/ext-proc.yaml
@@ -31,6 +31,7 @@ http:
               responseAttributes:
                 - request.path
               responseBodyProcessingMode: Streamed
+              allowModeOverride: true
               authority: grpc-backend-4.default:4000
               forwardingMetadataNamespaces:
                 - envoy.filters.http.ext_authz

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc.listeners.yaml
@@ -18,6 +18,7 @@
           name: envoy.filters.http.ext_proc/envoyextensionpolicy/default/policy-for-route-2/extproc/0
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            allowModeOverride: true
             failureModeAllow: true
             grpcService:
               envoyGrpc:

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -1556,6 +1556,7 @@ _Appears in:_
 | `failOpen` | _boolean_ |  false  |  | FailOpen defines if requests or responses that cannot be processed due to connectivity to the<br />external processor are terminated or passed-through.<br />Default: false |
 | `processingMode` | _[ExtProcProcessingMode](#extprocprocessingmode)_ |  false  |  | ProcessingMode defines how request and response body is processed<br />Default: header and body are not sent to the external processor |
 | `metadata` | _[ExtProcMetadata](#extprocmetadata)_ |  false  |  | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `allowModeOverride` | _boolean_ |  false  |  | AllowModeOverride allows the external processor to override the processing mode set via the<br />`mode_override` field in the gRPC response message. This defaults to false. |
 
 
 #### ExtProcBodyProcessingMode

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -1556,7 +1556,6 @@ _Appears in:_
 | `failOpen` | _boolean_ |  false  |  | FailOpen defines if requests or responses that cannot be processed due to connectivity to the<br />external processor are terminated or passed-through.<br />Default: false |
 | `processingMode` | _[ExtProcProcessingMode](#extprocprocessingmode)_ |  false  |  | ProcessingMode defines how request and response body is processed<br />Default: header and body are not sent to the external processor |
 | `metadata` | _[ExtProcMetadata](#extprocmetadata)_ |  false  |  | Refer to Kubernetes API documentation for fields of `metadata`. |
-| `allowModeOverride` | _boolean_ |  false  |  | AllowModeOverride allows the external processor to override the processing mode set via the<br />`mode_override` field in the gRPC response message. This defaults to false. |
 
 
 #### ExtProcBodyProcessingMode
@@ -1605,6 +1604,7 @@ _Appears in:_
 | ---   | ---  | ---      | ---     | ---         |
 | `request` | _[ProcessingModeOptions](#processingmodeoptions)_ |  false  |  | Defines processing mode for requests. If present, request headers are sent. Request body is processed according<br />to the specified mode. |
 | `response` | _[ProcessingModeOptions](#processingmodeoptions)_ |  false  |  | Defines processing mode for responses. If present, response headers are sent. Response body is processed according<br />to the specified mode. |
+| `allowModeOverride` | _boolean_ |  false  |  | AllowModeOverride allows the external processor to override the processing mode set via the<br />`mode_override` field in the gRPC response message. This defaults to false. |
 
 
 #### ExtensionAPISettings

--- a/site/content/zh/latest/api/extension_types.md
+++ b/site/content/zh/latest/api/extension_types.md
@@ -1556,6 +1556,7 @@ _Appears in:_
 | `failOpen` | _boolean_ |  false  |  | FailOpen defines if requests or responses that cannot be processed due to connectivity to the<br />external processor are terminated or passed-through.<br />Default: false |
 | `processingMode` | _[ExtProcProcessingMode](#extprocprocessingmode)_ |  false  |  | ProcessingMode defines how request and response body is processed<br />Default: header and body are not sent to the external processor |
 | `metadata` | _[ExtProcMetadata](#extprocmetadata)_ |  false  |  | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `allowModeOverride` | _boolean_ |  false  |  | AllowModeOverride allows the external processor to override the processing mode set via the<br />`mode_override` field in the gRPC response message. This defaults to false. |
 
 
 #### ExtProcBodyProcessingMode

--- a/site/content/zh/latest/api/extension_types.md
+++ b/site/content/zh/latest/api/extension_types.md
@@ -1556,7 +1556,6 @@ _Appears in:_
 | `failOpen` | _boolean_ |  false  |  | FailOpen defines if requests or responses that cannot be processed due to connectivity to the<br />external processor are terminated or passed-through.<br />Default: false |
 | `processingMode` | _[ExtProcProcessingMode](#extprocprocessingmode)_ |  false  |  | ProcessingMode defines how request and response body is processed<br />Default: header and body are not sent to the external processor |
 | `metadata` | _[ExtProcMetadata](#extprocmetadata)_ |  false  |  | Refer to Kubernetes API documentation for fields of `metadata`. |
-| `allowModeOverride` | _boolean_ |  false  |  | AllowModeOverride allows the external processor to override the processing mode set via the<br />`mode_override` field in the gRPC response message. This defaults to false. |
 
 
 #### ExtProcBodyProcessingMode
@@ -1605,6 +1604,7 @@ _Appears in:_
 | ---   | ---  | ---      | ---     | ---         |
 | `request` | _[ProcessingModeOptions](#processingmodeoptions)_ |  false  |  | Defines processing mode for requests. If present, request headers are sent. Request body is processed according<br />to the specified mode. |
 | `response` | _[ProcessingModeOptions](#processingmodeoptions)_ |  false  |  | Defines processing mode for responses. If present, response headers are sent. Response body is processed according<br />to the specified mode. |
+| `allowModeOverride` | _boolean_ |  false  |  | AllowModeOverride allows the external processor to override the processing mode set via the<br />`mode_override` field in the gRPC response message. This defaults to false. |
 
 
 #### ExtensionAPISettings


### PR DESCRIPTION
**What type of PR is this?**

Adds a new API for external processor 

**What this PR does / why we need it**:

This adds AllowModeOverride boolean config
to the external processing config.


**Which issue(s) this PR fixes**:

N/A
