### PR TITLE
feat(healthz-server): add option to customize port

### DIFF
--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -41,8 +41,9 @@ import (
 )
 
 const (
-	defaultWait = time.Second * 60
-	defaultTick = time.Millisecond * 20
+	defaultWait       = time.Second * 60
+	defaultTick       = time.Millisecond * 20
+	healthServerzPort = 8082
 )
 
 func TestMain(m *testing.M) {
@@ -65,6 +66,7 @@ func TestProvider(t *testing.T) {
 	resources := new(message.ProviderResources)
 	provider, err := New(context.Background(), cliCfg, svr, resources)
 	require.NoError(t, err)
+	provider.SetHealthzProbeServerPort(healthServerzPort)
 	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
 	go func() {
 		require.NoError(t, provider.Start(ctx))
@@ -1276,6 +1278,7 @@ func TestNamespacedProvider(t *testing.T) {
 	resources := new(message.ProviderResources)
 	provider, err := New(context.Background(), cliCfg, svr, resources)
 	require.NoError(t, err)
+	provider.SetHealthzProbeServerPort(healthServerzPort)
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		require.NoError(t, provider.Start(ctx))
@@ -1336,6 +1339,7 @@ func TestNamespaceSelectorProvider(t *testing.T) {
 	resources := new(message.ProviderResources)
 	provider, err := New(context.Background(), cliCfg, svr, resources)
 	require.NoError(t, err)
+	provider.SetHealthzProbeServerPort(healthServerzPort)
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		require.NoError(t, provider.Start(ctx))

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -30,6 +30,7 @@ new features: |
   Added support for GEP-1731 (HTTPRoute Retries)
   Added support for routing to Backend resources in the GRPCRoute, TCPRoute and UDPRoute APIs
   Added support for configuring Max GRPC message size for the Extension Manager in EnvoyGateway config
+  Added support to configure the Healthz Probe server port in FileProvider API
 
 bug fixes: |
   Fixed the ability to overwrite control plane certs with the certgen command by using a new command arg (-o)


### PR DESCRIPTION
**What type of PR is this?**
Adds option to customize the port for health server, while maintaining the default one to be 8081.

**What this PR does / why we need it**:
The same port for the health server causes port conflicts in parallel test runs.

**Which issue(s) this PR fixes**:
Fixes #5149 

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes
