### PR TITLE
docs: rm sectionName from some of the examples

### DIFF
--- a/site/content/en/docs/tasks/extensibility/ext-proc.md
+++ b/site/content/en/docs/tasks/extensibility/ext-proc.md
@@ -173,7 +173,6 @@ spec:
   - group: ''
     kind: Service
     name: grpc-ext-proc
-    sectionName: "9002"
   validation:
     caCertificateRefs:
     - name: grpc-ext-proc-ca
@@ -198,7 +197,6 @@ spec:
     - group: ''
       kind: Service
       name: grpc-ext-proc
-      sectionName: "9002"
   validation:
     caCertificateRefs:
       - name: grpc-ext-proc-ca

--- a/site/content/en/docs/tasks/security/ext-auth.md
+++ b/site/content/en/docs/tasks/security/ext-auth.md
@@ -349,7 +349,6 @@ spec:
   - group: ''
     kind: Service
     name: grpc-ext-auth
-    sectionName: "9002"
   validation:
     caCertificateRefs:
     - name: grpc-ext-auth-ca
@@ -374,7 +373,6 @@ spec:
   - group: ''
     kind: Service
     name: grpc-ext-auth
-    sectionName: "9002"
   validation:
     caCertificateRefs:
     - name: grpc-ext-auth-ca

--- a/site/content/en/docs/tasks/security/oidc.md
+++ b/site/content/en/docs/tasks/security/oidc.md
@@ -456,7 +456,6 @@ spec:
   - group: gateway.envoyproxy.io
     kind: Backend
     name: backend-keycloak
-    sectionName: "443"
   validation:
     caCertificateRefs:
     - name: backend-tls-certificate
@@ -525,7 +524,6 @@ spec:
   - group: gateway.envoyproxy.io
     kind: Backend
     name: backend-keycloak
-    sectionName: "443"
   validation:
     caCertificateRefs:
     - name: backend-tls-certificate

--- a/site/content/en/latest/tasks/extensibility/ext-proc.md
+++ b/site/content/en/latest/tasks/extensibility/ext-proc.md
@@ -173,7 +173,6 @@ spec:
   - group: ''
     kind: Service
     name: grpc-ext-proc
-    sectionName: "9002"
   validation:
     caCertificateRefs:
     - name: grpc-ext-proc-ca
@@ -198,7 +197,6 @@ spec:
     - group: ''
       kind: Service
       name: grpc-ext-proc
-      sectionName: "9002"
   validation:
     caCertificateRefs:
       - name: grpc-ext-proc-ca

--- a/site/content/en/latest/tasks/security/ext-auth.md
+++ b/site/content/en/latest/tasks/security/ext-auth.md
@@ -349,7 +349,6 @@ spec:
   - group: ''
     kind: Service
     name: grpc-ext-auth
-    sectionName: "9002"
   validation:
     caCertificateRefs:
     - name: grpc-ext-auth-ca
@@ -374,7 +373,6 @@ spec:
   - group: ''
     kind: Service
     name: grpc-ext-auth
-    sectionName: "9002"
   validation:
     caCertificateRefs:
     - name: grpc-ext-auth-ca

--- a/site/content/en/latest/tasks/security/oidc.md
+++ b/site/content/en/latest/tasks/security/oidc.md
@@ -456,7 +456,6 @@ spec:
   - group: gateway.envoyproxy.io
     kind: Backend
     name: backend-keycloak
-    sectionName: "443"
   validation:
     caCertificateRefs:
     - name: backend-tls-certificate
@@ -525,7 +524,6 @@ spec:
   - group: gateway.envoyproxy.io
     kind: Backend
     name: backend-keycloak
-    sectionName: "443"
   validation:
     caCertificateRefs:
     - name: backend-tls-certificate

--- a/site/content/en/v1.2/tasks/extensibility/ext-proc.md
+++ b/site/content/en/v1.2/tasks/extensibility/ext-proc.md
@@ -173,7 +173,6 @@ spec:
   - group: ''
     kind: Service
     name: grpc-ext-proc
-    sectionName: "9002"
   validation:
     caCertificateRefs:
     - name: grpc-ext-proc-ca
@@ -198,7 +197,6 @@ spec:
     - group: ''
       kind: Service
       name: grpc-ext-proc
-      sectionName: "9002"
   validation:
     caCertificateRefs:
       - name: grpc-ext-proc-ca

--- a/site/content/en/v1.2/tasks/security/ext-auth.md
+++ b/site/content/en/v1.2/tasks/security/ext-auth.md
@@ -349,7 +349,6 @@ spec:
   - group: ''
     kind: Service
     name: grpc-ext-auth
-    sectionName: "9002"
   validation:
     caCertificateRefs:
     - name: grpc-ext-auth-ca
@@ -374,7 +373,6 @@ spec:
   - group: ''
     kind: Service
     name: grpc-ext-auth
-    sectionName: "9002"
   validation:
     caCertificateRefs:
     - name: grpc-ext-auth-ca

--- a/site/content/en/v1.2/tasks/security/oidc.md
+++ b/site/content/en/v1.2/tasks/security/oidc.md
@@ -456,7 +456,6 @@ spec:
   - group: gateway.envoyproxy.io
     kind: Backend
     name: backend-keycloak
-    sectionName: "443"
   validation:
     caCertificateRefs:
     - name: backend-tls-certificate
@@ -525,7 +524,6 @@ spec:
   - group: gateway.envoyproxy.io
     kind: Backend
     name: backend-keycloak
-    sectionName: "443"
   validation:
     caCertificateRefs:
     - name: backend-tls-certificate


### PR DESCRIPTION
adds whats left from https://github.com/envoyproxy/gateway/pull/4868

deleted the sectionName in these examples because the Service spec does not define a port `Name`
