### PR TITLE
ci(fix): osv-scanner PR mode

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -33,7 +33,7 @@ jobs:
 
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@764c91816374ff2d8fc2095dab36eecd42d61638"  # v1.9.2
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@764c91816374ff2d8fc2095dab36eecd42d61638"  # v1.9.2
     with:
       scan-args: |-
         --skip-git


### PR DESCRIPTION
**What this PR does / why we need it**:
`osv-scanner-reusable-pr.yml` should be called when workflow is triggered from PR so scan will fail only if new vulnerabilities were introduced. It was renamed by accident to `osv-scanner-reusable.yml` [here](https://github.com/envoyproxy/gateway/pull/4956).

Release Notes: No
