### PR TITLE
docs: fixed the documentation for multiple request mirrorfilter docs 

### DIFF
--- a/site/content/en/contributions/CONTRIBUTING.md
+++ b/site/content/en/contributions/CONTRIBUTING.md
@@ -46,7 +46,7 @@ to the following guidelines for all code, APIs, and documentation:
 * Tests will automatically run for you.
 * We will **not** merge any PR that is not passing tests.
 * PRs are expected to have 100% test coverage for added code. This can be verified with a coverage
-  build. If your PR cannot have 100% coverage for some reason please clearly explain why when you
+  build. If your PR cannot have 100% coverage for some reason please clearly explain why, when you
   open it.
 * Any PR that changes user-facing behavior **must** have associated documentation in the [docs](https://github.com/envoyproxy/gateway/tree/main/site) folder of the repo as
   well as the [changelog](./RELEASING).
@@ -54,7 +54,7 @@ to the following guidelines for all code, APIs, and documentation:
   If you are not a fluent English speaker (or a bad writer ;-)) please let us know and we will try
   to find some help but there are no guarantees.
 * Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary 
-  and summary followed by a colon. format `chore/docs/feat/fix/refactor/style/test: summary`.
+  and summary followed by a colon format `chore/docs/feat/fix/refactor/style/test: summary`.
   Examples:
   * "docs: fix grammar error"
   * "feat(translator): add new feature"

--- a/site/content/en/latest/tasks/traffic/http-request-mirroring.md
+++ b/site/content/en/latest/tasks/traffic/http-request-mirroring.md
@@ -138,6 +138,7 @@ spec:
 
 {{% /tab %}}
 {{< /tabpane >}}
+
 Then create an `HTTPRoute` that uses a `HTTPRequestMirrorFilter` to send requests to the original
 service from the quickstart, and mirror request to the service that was just deployed.
 
@@ -146,6 +147,7 @@ service from the quickstart, and mirror request to the service that was just dep
 
 ```shell
 cat <<EOF | kubectl apply -f -
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -350,7 +352,7 @@ spec:
 
 ## Multiple HTTPRequestMirrorFilters
 
-Multiple `HTTPRequestMirrorFilters` are not supported on the same `HTTPRoute` `rule`. When attempting to do so, the admission webhook will reject the configuration.
+Multiple `HTTPRequestMirrorFilters` can be configured on the same `HTTPRoute` rule. Traffic splitting will work as expected, with mirrored requests being directed to `backendRefs` with `HTTPRequestMirrorFilter` filter and the actual requests to main `backendRefs`.
 
 {{< tabpane text=true >}}
 {{% tab header="Apply from stdin" %}}
@@ -435,9 +437,6 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-```console
-Error from server: error when creating "STDIN": admission webhook "validate.gateway.networking.k8s.io" denied the request: spec.rules[0].filters: Invalid value: "RequestMirror": cannot be used multiple times in the same rule
-```
 
 [Traffic Splitting]: ../http-traffic-splitting/
 [HTTPRoute]: https://gateway-api.sigs.k8s.io/api-types/httproute/


### PR DESCRIPTION
**What type of PR is this?**
docs: fixed the docs for multiple request mirrorfilters and other typos

**What this PR does / why we need it**:
This PR contains the required documentation updates for the `Multiple HTTPRequestMirrorFilters` 

**Which issue(s) this PR fixes**:
Fixes #5205

Release Notes: No
