### PR TITLE
docs: fix config for api key

### DIFF
--- a/site/content/en/docs/tasks/security/apikey-auth.md
+++ b/site/content/en/docs/tasks/security/apikey-auth.md
@@ -33,7 +33,6 @@ kind: Secret
 type: Opaque
 metadata:
   name: apikey-secret
-  namespace: envoy-gateway-system
 stringData:
   client1: supersecret
 EOF
@@ -50,7 +49,6 @@ kind: Secret
 type: Opaque
 metadata:
   name: apikey-secret
-  namespace: envoy-gateway-system
 stringData:
   client1: supersecret
 ```
@@ -82,7 +80,6 @@ spec:
     - group: ""
       kind: Secret
       name: apikey-secret
-      namespace: envoy-gateway-system
     extractFrom:
     - headers:
       - x-api-key
@@ -109,7 +106,6 @@ spec:
     - group: ""
       kind: Secret
       name: apikey-secret
-      namespace: envoy-gateway-system
     extractFrom:
     - headers:
       - x-api-key

--- a/site/content/en/latest/tasks/security/apikey-auth.md
+++ b/site/content/en/latest/tasks/security/apikey-auth.md
@@ -33,7 +33,6 @@ kind: Secret
 type: Opaque
 metadata:
   name: apikey-secret
-  namespace: envoy-gateway-system
 stringData:
   client1: supersecret
 EOF
@@ -50,7 +49,6 @@ kind: Secret
 type: Opaque
 metadata:
   name: apikey-secret
-  namespace: envoy-gateway-system
 stringData:
   client1: supersecret
 ```
@@ -82,7 +80,6 @@ spec:
     - group: ""
       kind: Secret
       name: apikey-secret
-      namespace: envoy-gateway-system
     extractFrom:
     - headers:
       - x-api-key
@@ -109,7 +106,6 @@ spec:
     - group: ""
       kind: Secret
       name: apikey-secret
-      namespace: envoy-gateway-system
     extractFrom:
     - headers:
       - x-api-key

--- a/site/content/en/v1.3/tasks/security/apikey-auth.md
+++ b/site/content/en/v1.3/tasks/security/apikey-auth.md
@@ -33,7 +33,6 @@ kind: Secret
 type: Opaque
 metadata:
   name: apikey-secret
-  namespace: envoy-gateway-system
 stringData:
   client1: supersecret
 EOF
@@ -50,7 +49,6 @@ kind: Secret
 type: Opaque
 metadata:
   name: apikey-secret
-  namespace: envoy-gateway-system
 stringData:
   client1: supersecret
 ```
@@ -82,7 +80,6 @@ spec:
     - group: ""
       kind: Secret
       name: apikey-secret
-      namespace: envoy-gateway-system
     extractFrom:
     - headers:
       - x-api-key
@@ -109,7 +106,6 @@ spec:
     - group: ""
       kind: Secret
       name: apikey-secret
-      namespace: envoy-gateway-system
     extractFrom:
     - headers:
       - x-api-key


### PR DESCRIPTION
the namespace of the secret was set to `envoy-gateway-system` and was set in a different namespace than the SecurityPolicy

Fixes: https://github.com/envoyproxy/gateway/issues/5245