### PR TITLE
fix: skip reconciles on endpoint slices when endpoint routing not in use

### DIFF
--- a/internal/provider/kubernetes/predicates.go
+++ b/internal/provider/kubernetes/predicates.go
@@ -623,8 +623,8 @@ func (r *gatewayAPIReconciler) hasRouteWithEndpointRouting(nsName *types.Namespa
 		r.log.Error(err, "failed to find associated HTTPRoutes")
 		return false
 	}
-	for _, route := range httpRouteList.Items {
-		if r.hasEndpointRouting(route.Namespace, route.Spec.CommonRouteSpec) {
+	for i := range httpRouteList.Items {
+		if r.hasEndpointRouting(httpRouteList.Items[i].Spec.CommonRouteSpec) {
 			return true
 		}
 	}
@@ -637,8 +637,8 @@ func (r *gatewayAPIReconciler) hasRouteWithEndpointRouting(nsName *types.Namespa
 			r.log.Error(err, "failed to find associated GRPCRoutes")
 			return false
 		}
-		for _, route := range grpcRouteList.Items {
-			if r.hasEndpointRouting(route.Namespace, route.Spec.CommonRouteSpec) {
+		for i := range grpcRouteList.Items {
+			if r.hasEndpointRouting(grpcRouteList.Items[i].Spec.CommonRouteSpec) {
 				return true
 			}
 		}
@@ -652,8 +652,8 @@ func (r *gatewayAPIReconciler) hasRouteWithEndpointRouting(nsName *types.Namespa
 			r.log.Error(err, "failed to find associated TLSRoutes")
 			return false
 		}
-		for _, route := range tlsRouteList.Items {
-			if r.hasEndpointRouting(route.Namespace, route.Spec.CommonRouteSpec) {
+		for i := range tlsRouteList.Items {
+			if r.hasEndpointRouting(tlsRouteList.Items[i].Spec.CommonRouteSpec) {
 				return true
 			}
 		}
@@ -667,8 +667,8 @@ func (r *gatewayAPIReconciler) hasRouteWithEndpointRouting(nsName *types.Namespa
 			r.log.Error(err, "failed to find associated TCPRoutes")
 			return false
 		}
-		for _, route := range tcpRouteList.Items {
-			if r.hasEndpointRouting(route.Namespace, route.Spec.CommonRouteSpec) {
+		for i := range tcpRouteList.Items {
+			if r.hasEndpointRouting(tcpRouteList.Items[i].Spec.CommonRouteSpec) {
 				return true
 			}
 		}
@@ -682,8 +682,8 @@ func (r *gatewayAPIReconciler) hasRouteWithEndpointRouting(nsName *types.Namespa
 			r.log.Error(err, "failed to find associated UDPRoutes")
 			return false
 		}
-		for _, route := range udpRouteList.Items {
-			if r.hasEndpointRouting(route.Namespace, route.Spec.CommonRouteSpec) {
+		for i := range udpRouteList.Items {
+			if r.hasEndpointRouting(udpRouteList.Items[i].Spec.CommonRouteSpec) {
 				return true
 			}
 		}
@@ -693,14 +693,11 @@ func (r *gatewayAPIReconciler) hasRouteWithEndpointRouting(nsName *types.Namespa
 }
 
 // hasEndpointRouting checks that the associated egv1a1.EnvoyProxy has endpoint routing.
-func (r *gatewayAPIReconciler) hasEndpointRouting(namespace string, spec gwapiv1.CommonRouteSpec) bool {
+func (r *gatewayAPIReconciler) hasEndpointRouting(spec gwapiv1.CommonRouteSpec) bool {
 	ctx := context.Background()
 	for _, ref := range spec.ParentRefs {
 		if ptr.Deref(ref.Kind, resource.KindGateway) != resource.KindGateway {
 			return false
-		}
-		if ref.Namespace != nil {
-			namespace = string(*ref.Namespace)
 		}
 
 		gw := gwapiv1.Gateway{

--- a/internal/provider/kubernetes/predicates_test.go
+++ b/internal/provider/kubernetes/predicates_test.go
@@ -561,7 +561,17 @@ func TestValidateSecretForReconcile(t *testing.T) {
 // TestValidateEndpointSliceForReconcile tests the validateEndpointSliceForReconcile
 // predicate function.
 func TestValidateEndpointSliceForReconcile(t *testing.T) {
-	sampleGatewayClass := test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, nil)
+	sampleEP := test.GetEnvoyProxy(types.NamespacedName{Name: "test-ep"}, false)
+	sampleEPRef := &test.GroupKindNamespacedName{
+		Group:     gwapiv1.Group(sampleEP.GroupVersionKind().Group),
+		Kind:      gwapiv1.Kind(sampleEP.GroupVersionKind().Kind),
+		Namespace: gwapiv1.Namespace(sampleEP.Namespace),
+		Name:      gwapiv1.ObjectName(sampleEP.Name),
+	}
+	sampleEPWithServiceRouting := sampleEP.DeepCopy()
+	sampleEPWithServiceRouting.Spec.RoutingType = ptr.To(egv1a1.ServiceRoutingType)
+
+	sampleGatewayClass := test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, sampleEPRef)
 	sampleGateway := test.GetGateway(types.NamespacedName{Namespace: "default", Name: "scheduled-status-test"}, "test-gc", 8080)
 	sampleServiceBackendRef := test.GetServiceBackendRef(types.NamespacedName{Name: "service"}, 80)
 	sampleServiceImportBackendRef := test.GetServiceImportBackendRef(types.NamespacedName{Name: "imported-service"}, 80)
@@ -577,6 +587,7 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 			configs: []client.Object{
 				sampleGatewayClass,
 				sampleGateway,
+				sampleEP,
 			},
 			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "service", false),
 			expect:        false,
@@ -586,16 +597,18 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 			configs: []client.Object{
 				sampleGatewayClass,
 				sampleGateway,
+				sampleEP,
 				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", sampleServiceBackendRef, ""),
 			},
 			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "other-service", false),
 			expect:        false,
 		},
 		{
-			name: "http route service routes exist",
+			name: "http route service routes exist with endpoint routing",
 			configs: []client.Object{
 				sampleGatewayClass,
 				sampleGateway,
+				sampleEP,
 				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", sampleServiceBackendRef, ""),
 			},
 			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "service", false),
@@ -606,6 +619,7 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 			configs: []client.Object{
 				sampleGatewayClass,
 				sampleGateway,
+				sampleEP,
 				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", sampleServiceImportBackendRef, ""),
 			},
 			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "imported-service", true),
@@ -614,8 +628,9 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 		{
 			name: "mirrored backend route exists",
 			configs: []client.Object{
-				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, nil),
+				sampleGatewayClass,
 				sampleGateway,
+				sampleEP,
 				&gwapiv1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "httproute-test",
@@ -656,6 +671,52 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 			},
 			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "mirror-service", false),
 			expect:        true,
+		},
+		{
+			name: "http route service routes exist with service routing",
+			configs: []client.Object{
+				sampleGatewayClass,
+				sampleGateway,
+				sampleEPWithServiceRouting,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", sampleServiceBackendRef, ""),
+			},
+			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "service", false),
+			expect:        false,
+		},
+		{
+			name: "http route service routes exist without endpoints when parent ref is unknown",
+			configs: []client.Object{
+				sampleGatewayClass,
+				sampleGateway,
+				sampleEP,
+				func() client.Object {
+					route := test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", sampleServiceBackendRef, "")
+					route.Spec.ParentRefs[0].Kind = gatewayapi.KindPtr("unknown")
+					return route
+				}(),
+			},
+			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "service", false),
+			expect:        false,
+		},
+		{
+			name: "http route service routes exist without endpoints when gatewayclass is not found",
+			configs: []client.Object{
+				sampleGateway,
+				sampleEP,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", sampleServiceBackendRef, ""),
+			},
+			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "service", false),
+			expect:        false,
+		},
+		{
+			name: "http route service routes exist without endpoints when gateway is not found",
+			configs: []client.Object{
+				sampleGatewayClass,
+				sampleEP,
+				test.GetHTTPRoute(types.NamespacedName{Name: "httproute-test"}, "scheduled-status-test", sampleServiceBackendRef, ""),
+			},
+			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "service", false),
+			expect:        false,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As the title states this PR skips unnecessary reconciles on endpoint slice events when endpoint routing is not used by the given gateway.

**Which issue(s) this PR fixes**:
This addresses the issue here however I wouldn't necessary close it with this fix as there are likely additional issues that could be addressed to improve the overall robustness of the controller.

https://github.com/envoyproxy/gateway/issues/5344

Release Notes: No
