### PR TITLE
standalone: propagate signal to Envoy procs

### DIFF
--- a/internal/infrastructure/host/proxy_infra.go
+++ b/internal/infrastructure/host/proxy_infra.go
@@ -69,8 +69,8 @@ func (i *Infra) CreateOrUpdateProxyInfra(ctx context.Context, infra *ir.Infra) e
 	}
 
 	// Create a new context for up-running proxy.
-	pCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	i.proxyContextMap[proxyName] = &proxyContext{ctx: pCtx, cancel: stop}
+	pCtx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	i.proxyContextMap[proxyName] = &proxyContext{ctx: pCtx, cancel: cancel}
 	return funcE.Run(pCtx, args, funcE.HomeDir(i.HomeDir))
 }
 

--- a/internal/infrastructure/host/proxy_infra.go
+++ b/internal/infrastructure/host/proxy_infra.go
@@ -69,9 +69,9 @@ func (i *Infra) CreateOrUpdateProxyInfra(ctx context.Context, infra *ir.Infra) e
 	}
 
 	// Create a new context for up-running proxy.
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	i.proxyContextMap[proxyName] = &proxyContext{ctx: ctx, cancel: stop}
-	return funcE.Run(ctx, args, funcE.HomeDir(i.HomeDir))
+	pCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	i.proxyContextMap[proxyName] = &proxyContext{ctx: pCtx, cancel: stop}
+	return funcE.Run(pCtx, args, funcE.HomeDir(i.HomeDir))
 }
 
 // DeleteProxyInfra removes the managed host process, if it doesn't exist.


### PR DESCRIPTION
**What type of PR is this?**

Fixes standalone mode to handle signals correctly.

**What this PR does / why we need it**:

Previously, the signals to envoy-proxy CLI hadn't been propagated to Envoy processes. Therefore, they resulted in orphans.

Release Notes:No
