### PR TITLE
Propagate contexts from root to subcommands

### DIFF
--- a/cmd/envoy-gateway/main.go
+++ b/cmd/envoy-gateway/main.go
@@ -9,11 +9,13 @@ import (
 	"fmt"
 	"os"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	"github.com/envoyproxy/gateway/cmd/envoy-gateway/root"
 )
 
 func main() {
-	if err := root.GetRootCommand().Execute(); err != nil {
+	if err := root.GetRootCommand().ExecuteContext(ctrl.SetupSignalHandler()); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/internal/cmd/certgen.go
+++ b/internal/cmd/certgen.go
@@ -12,7 +12,6 @@ import (
 	"path"
 
 	"github.com/spf13/cobra"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clicfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -37,7 +36,7 @@ func GetCertGenCommand() *cobra.Command {
 		Use:   "certgen",
 		Short: "Generate Control Plane Certificates",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return certGen(local)
+			return certGen(cmd.Context(), local)
 		},
 	}
 
@@ -49,7 +48,7 @@ func GetCertGenCommand() *cobra.Command {
 }
 
 // certGen generates control plane certificates.
-func certGen(local bool) error {
+func certGen(ctx context.Context, local bool) error {
 	cfg, err := config.New()
 	if err != nil {
 		return err
@@ -68,7 +67,7 @@ func certGen(local bool) error {
 			return fmt.Errorf("failed to create controller-runtime client: %w", err)
 		}
 
-		if err = outputCertsForKubernetes(ctrl.SetupSignalHandler(), cli, cfg, overwriteControlPlaneCerts, certs); err != nil {
+		if err = outputCertsForKubernetes(ctx, cli, cfg, overwriteControlPlaneCerts, certs); err != nil {
 			return fmt.Errorf("failed to output certificates: %w", err)
 		}
 	} else {

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -9,7 +9,6 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/admin"
@@ -38,7 +37,7 @@ func GetServerCommand() *cobra.Command {
 		Aliases: []string{"serve"},
 		Short:   "Serve Envoy Gateway",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return server()
+			return server(cmd.Context())
 		},
 	}
 	cmd.PersistentFlags().StringVarP(&cfgPath, "config-path", "c", "",
@@ -48,13 +47,12 @@ func GetServerCommand() *cobra.Command {
 }
 
 // server serves Envoy Gateway.
-func server() error {
+func server(ctx context.Context) error {
 	cfg, err := getConfig()
 	if err != nil {
 		return err
 	}
 
-	ctx := ctrl.SetupSignalHandler()
 	hook := func(c context.Context, cfg *config.Server) error {
 		cfg.Logger.Info("Setup runners")
 		if err := setupRunners(c, cfg); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

Refactors cmd packages

**What this PR does / why we need it**:

Previously, the context was locally created inside the subcommand, and the context set to the cobra.Cmd was ignored. This made it difficult to use the root command as a library since the only way to cancel the command is sending the real OS singals hence it was impossible to write a unit tests around it.


Release Notes: No