### PR TITLE
test: add fuzzers for `egctl.translateGatewayAPIToIR`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	fortio.org/fortio v1.68.0
 	fortio.org/log v1.17.1
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/andybalholm/brotli v1.1.1
 	github.com/avast/retry-go v3.0.0+incompatible
@@ -107,7 +108,6 @@ require (
 	fortio.org/version v1.0.4 // indirect
 	github.com/4meepo/tagalign v1.4.1 // indirect
 	github.com/Abirdcfly/dupword v0.1.3 // indirect
-	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/Antonboom/errname v1.0.0 // indirect
 	github.com/Antonboom/nilnil v1.0.1 // indirect
 	github.com/Antonboom/testifylint v1.5.2 // indirect

--- a/internal/cmd/egctl/translate.go
+++ b/internal/cmd/egctl/translate.go
@@ -246,7 +246,7 @@ func translate(w io.Writer, inFile, inType string, outTypes []string, output, re
 				result.Xds = res
 			}
 			if outType == irType {
-				res, err := translateGatewayAPIToIR(resources)
+				res, err := TranslateGatewayAPIToIR(resources)
 				if err != nil {
 					return err
 				}
@@ -265,7 +265,7 @@ func translate(w io.Writer, inFile, inType string, outTypes []string, output, re
 	return fmt.Errorf("unable to find translate from input type %s to output type %s", inType, outTypes)
 }
 
-func translateGatewayAPIToIR(resources *resource.Resources) (*gatewayapi.TranslateResult, error) {
+func TranslateGatewayAPIToIR(resources *resource.Resources) (*gatewayapi.TranslateResult, error) {
 	if resources.GatewayClass == nil {
 		return nil, fmt.Errorf("the GatewayClass resource is required")
 	}

--- a/test/fuzz/ir_fuzz_test.go
+++ b/test/fuzz/ir_fuzz_test.go
@@ -17,13 +17,13 @@ import (
 
 func FuzzGatewayAPIToIR(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		fuzzConsumer := fuzz.NewConsumer(data)
+		fc := fuzz.NewConsumer(data)
 		resources := &resource.Resources{}
-		if err := fuzzConsumer.GenerateStruct(resources); err != nil {
+		if err := fc.GenerateStruct(resources); err != nil {
 			return
 		}
-
-		if resources.GatewayClass == nil {
+		addMissingResources, err := fc.GetBool()
+		if err != nil {
 			return
 		}
 
@@ -32,7 +32,7 @@ func FuzzGatewayAPIToIR(f *testing.F) {
 		if err != nil {
 			return
 		}
-		rs, err := resource.LoadResourcesFromYAMLBytes(yamlBytes, true)
+		rs, err := resource.LoadResourcesFromYAMLBytes(yamlBytes, addMissingResources)
 		if err != nil {
 			return
 		}

--- a/test/fuzz/ir_fuzz_test.go
+++ b/test/fuzz/ir_fuzz_test.go
@@ -1,0 +1,42 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package fuzz
+
+import (
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"sigs.k8s.io/yaml"
+
+	"github.com/envoyproxy/gateway/internal/cmd/egctl"
+	"github.com/envoyproxy/gateway/internal/gatewayapi/resource"
+)
+
+func FuzzGatewayAPIToIR(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzConsumer := fuzz.NewConsumer(data)
+		resources := &resource.Resources{}
+		if err := fuzzConsumer.GenerateStruct(resources); err != nil {
+			return
+		}
+
+		if resources.GatewayClass == nil {
+			return
+		}
+
+		// Populate default values
+		yamlBytes, err := yaml.Marshal(resources)
+		if err != nil {
+			return
+		}
+		rs, err := resource.LoadResourcesFromYAMLBytes(yamlBytes, true)
+		if err != nil {
+			return
+		}
+
+		_, _ = egctl.TranslateGatewayAPIToIR(rs)
+	})
+}

--- a/tools/make/env.mk
+++ b/tools/make/env.mk
@@ -15,3 +15,8 @@ IMAGE_NAME ?= gateway-dev
 IMAGE ?= ${REGISTRY}/${IMAGE_NAME}
 # Tag is the tag to use for build and push image targets.
 TAG ?= $(REV)
+
+# Fuzzing variables
+
+# FUZZ_TIME is the time to run the fuzzer for
+FUZZ_TIME ?= 5s

--- a/tools/make/golang.mk
+++ b/tools/make/golang.mk
@@ -39,6 +39,15 @@ go.build: $(addprefix go.build., $(addprefix $(PLATFORM)., $(BINS)))
 .PHONY: go.build.multiarch
 go.build.multiarch: $(foreach p,$(PLATFORMS),$(addprefix go.build., $(addprefix $(p)., $(BINS))))
 
+.PHONY: go.test.fuzz
+go.test.fuzz: ## Run all fuzzers in the test/fuzz folder one by one
+	@$(LOG_TARGET)
+	@for dir in $$(go list -f '{{.Dir}}' ./test/fuzz/...); do \
+		for test in $$(go test -list=Fuzz.* $$dir | grep ^Fuzz); do \
+			echo "go test -fuzz=$$test -fuzztime=$(FUZZ_TIME)"; \
+			(cd $$dir && go test -fuzz=$$test -fuzztime=$(FUZZ_TIME)) || exit 1; \
+		done; \
+	done
 
 .PHONY: go.test.unit
 go.test.unit: ## Run go unit tests


### PR DESCRIPTION
**What type of PR is this?**

Implement fuzzers to target translateGatewayAPIToIR. 

- Use [go-fuzz-headers](https://github.com/AdaLogics/go-fuzz-headers) to generate pseudo-random Resources structs.


**Which issue(s) this PR fixes**:

Fixes #5428

Release Notes: No
