### PR TITLE
api(oidc): Add validation fields to OIDCProvider

### DIFF
--- a/api/v1alpha1/oidc_types.go
+++ b/api/v1alpha1/oidc_types.go
@@ -144,7 +144,7 @@ type OIDCProvider struct {
 	//
 	// If set, the ID token will be validated using the RemoteJWKS, Issuer, and Audiences fields
 	// +optional
-	RemoteJWKS RemoteJWKS `json:"remoteJWKS"`
+	RemoteJWKS *RemoteJWKS `json:"remoteJWKS,omitempty"`
 
 	// The OIDC Provider's [authorization endpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint).
 	// If not provided, EG will try to discover it from the provider's [Well-Known Configuration Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse).

--- a/api/v1alpha1/oidc_types.go
+++ b/api/v1alpha1/oidc_types.go
@@ -125,10 +125,26 @@ type OIDCProvider struct {
 	// Issuer MUST be a URI RFC 3986 [RFC3986] with a scheme component that MUST
 	// be https, a host component, and optionally, port and path components and
 	// no query or fragment components.
+	//
+	// Note: RemoteJWKS field must be set to enable ID token validation
 	// +kubebuilder:validation:MinLength=1
 	Issuer string `json:"issuer"`
 
-	// TODO zhaohuabing validate the issuer
+	// Audiences is a list of JWT audiences allowed access. For additional details, see
+	// https://tools.ietf.org/html/rfc7519#section-4.1.3. If not provided, JWT audiences
+	// are not checked.
+	//
+	// Note: RemoteJWKS field must be set to enable ID token validation
+	// +kubebuilder:validation:MaxItems=8
+	// +optional
+	Audiences []string `json:"audiences,omitempty"`
+
+	// RemoteJWKS defines how to fetch and cache JSON Web Key Sets (JWKS) from a remote
+	// HTTP/HTTPS endpoint.
+	//
+	// If set, the ID token will be validated using the RemoteJWKS, Issuer, and Audiences fields
+	// +optional
+	RemoteJWKS RemoteJWKS `json:"remoteJWKS"`
 
 	// The OIDC Provider's [authorization endpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint).
 	// If not provided, EG will try to discover it from the provider's [Well-Known Configuration Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse).

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -4220,7 +4220,11 @@ func (in *OIDCProvider) DeepCopyInto(out *OIDCProvider) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	in.RemoteJWKS.DeepCopyInto(&out.RemoteJWKS)
+	if in.RemoteJWKS != nil {
+		in, out := &in.RemoteJWKS, &out.RemoteJWKS
+		*out = new(RemoteJWKS)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AuthorizationEndpoint != nil {
 		in, out := &in.AuthorizationEndpoint, &out.AuthorizationEndpoint
 		*out = new(string)

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -4215,6 +4215,12 @@ func (in *OIDCCookieNames) DeepCopy() *OIDCCookieNames {
 func (in *OIDCProvider) DeepCopyInto(out *OIDCProvider) {
 	*out = *in
 	in.BackendCluster.DeepCopyInto(&out.BackendCluster)
+	if in.Audiences != nil {
+		in, out := &in.Audiences, &out.Audiences
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	in.RemoteJWKS.DeepCopyInto(&out.RemoteJWKS)
 	if in.AuthorizationEndpoint != nil {
 		in, out := &in.AuthorizationEndpoint, &out.AuthorizationEndpoint
 		*out = new(string)

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -3025,7 +3025,9 @@ _Appears in:_
 | `backendRef` | _[BackendObjectReference](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.BackendObjectReference)_ |  false  |  | BackendRef references a Kubernetes object that represents the<br />backend server to which the authorization request will be sent.<br />Deprecated: Use BackendRefs instead. |
 | `backendRefs` | _[BackendRef](#backendref) array_ |  false  |  | BackendRefs references a Kubernetes object that represents the<br />backend server to which the authorization request will be sent. |
 | `backendSettings` | _[ClusterSettings](#clustersettings)_ |  false  |  | BackendSettings holds configuration for managing the connection<br />to the backend. |
-| `issuer` | _string_ |  true  |  | The OIDC Provider's [issuer identifier](https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery).<br />Issuer MUST be a URI RFC 3986 [RFC3986] with a scheme component that MUST<br />be https, a host component, and optionally, port and path components and<br />no query or fragment components. |
+| `issuer` | _string_ |  true  |  | The OIDC Provider's [issuer identifier](https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery).<br />Issuer MUST be a URI RFC 3986 [RFC3986] with a scheme component that MUST<br />be https, a host component, and optionally, port and path components and<br />no query or fragment components.<br />Note: RemoteJWKS field must be set to enable ID token validation |
+| `audiences` | _string array_ |  false  |  | Audiences is a list of JWT audiences allowed access. For additional details, see<br />https://tools.ietf.org/html/rfc7519#section-4.1.3. If not provided, JWT audiences<br />are not checked.<br />Note: RemoteJWKS field must be set to enable ID token validation |
+| `remoteJWKS` | _[RemoteJWKS](#remotejwks)_ |  false  |  | RemoteJWKS defines how to fetch and cache JSON Web Key Sets (JWKS) from a remote<br />HTTP/HTTPS endpoint.<br />If set, the ID token will be validated using the RemoteJWKS, Issuer, and Audiences fields |
 | `authorizationEndpoint` | _string_ |  false  |  | The OIDC Provider's [authorization endpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint).<br />If not provided, EG will try to discover it from the provider's [Well-Known Configuration Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse). |
 | `tokenEndpoint` | _string_ |  false  |  | The OIDC Provider's [token endpoint](https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint).<br />If not provided, EG will try to discover it from the provider's [Well-Known Configuration Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse). |
 
@@ -3868,6 +3870,7 @@ RemoteJWKS defines how to fetch and cache JSON Web Key Sets (JWKS) from a remote
 
 _Appears in:_
 - [JWTProvider](#jwtprovider)
+- [OIDCProvider](#oidcprovider)
 
 | Field | Type | Required | Default | Description |
 | ---   | ---  | ---      | ---     | ---         |


### PR DESCRIPTION
<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

This PR is the start of adding ID token validation when using OIDC authentication.

It adds the `RemoteJWKS` and `Audience` fields to the OIDCProvider.

The future intention is that when `RemoteJWKS` is set, the `Issuer` `Audience` and `RemoteJWKS` fields will be used to configure a JWT Filter that will validate the ID Token (using IdToken cookie)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Reference #5414

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
