### PR TITLE
docs: update backend-traffic-policy.md(remove targetRef.namespace)

### DIFF
--- a/site/content/en/contributions/design/backend-traffic-policy.md
+++ b/site/content/en/contributions/design/backend-traffic-policy.md
@@ -104,7 +104,6 @@ spec:
     group: gateway.networking.k8s.io
     kind: Gateway
     name: eg
-    namespace: default
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
@@ -118,7 +117,6 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: ipv6-route
-    namespace: default
 ```
 
 ## Features / API Fields


### PR DESCRIPTION
As of version v1.3.1, `BackendTrafficPolicy.spec.targetRef` does not contain any `namespace` field.

**What type of PR is this?**
* "fix: fix docs"

**What this PR does / why we need it**:
As of version v1.3.1, BackendTrafficPolicy.spec.targetRef does not contain a namespace field.
This PR updates the documentation and API references to clarify this behavior.

Release Notes: No
