### PR TITLE
fix: Wasm cache directory on macOS host

### DIFF
--- a/internal/gatewayapi/runner/runner_test.go
+++ b/internal/gatewayapi/runner/runner_test.go
@@ -8,6 +8,7 @@ package runner
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -303,4 +304,10 @@ func TestDeleteAllStatusKeys(t *testing.T) {
 	require.Equal(t, 0, r.ProviderResources.TCPRouteStatuses.Len())
 	require.Equal(t, 0, r.ProviderResources.UDPRouteStatuses.Len())
 	require.Equal(t, 0, r.ProviderResources.BackendStatuses.Len())
+}
+
+func Test_getWasmCacheDir(t *testing.T) {
+	res, err := getWasmCacheDir()
+	require.NoError(t, err)
+	require.True(t, strings.HasSuffix(res, ".eg/wasm"))
 }

--- a/internal/gatewayapi/runner/runner_test.go
+++ b/internal/gatewayapi/runner/runner_test.go
@@ -7,7 +7,6 @@ package runner
 
 import (
 	"context"
-	"path"
 	"reflect"
 	"testing"
 	"time"
@@ -304,12 +303,4 @@ func TestDeleteAllStatusKeys(t *testing.T) {
 	require.Equal(t, 0, r.ProviderResources.TCPRouteStatuses.Len())
 	require.Equal(t, 0, r.ProviderResources.UDPRouteStatuses.Len())
 	require.Equal(t, 0, r.ProviderResources.BackendStatuses.Len())
-}
-
-func Test_getWasmCacheDir(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
-	res, err := getWasmCacheDir()
-	require.NoError(t, err)
-	require.Equal(t, path.Join(tmpDir, ".eg", "wasm"), res)
 }

--- a/internal/gatewayapi/runner/runner_test.go
+++ b/internal/gatewayapi/runner/runner_test.go
@@ -7,8 +7,8 @@ package runner
 
 import (
 	"context"
+	"path"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -307,7 +307,9 @@ func TestDeleteAllStatusKeys(t *testing.T) {
 }
 
 func Test_getWasmCacheDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
 	res, err := getWasmCacheDir()
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(res, ".eg/wasm"))
+	require.Equal(t, path.Join(tmpDir, ".eg", "wasm"), res)
 }


### PR DESCRIPTION
**What type of PR is this?**

fix: permission error on startWasmCache


**What this PR does / why we need it**:

Previously, the cache directory for Wasm binaries is hardcoded to /var/lib/eg/wasm but it's not writable without root permission on macOS. This fixes it by making it default to ~/.eg/wasm.