### PR TITLE
fix: do not log error when wasm cache server properly closed

### DIFF
--- a/internal/wasm/httpserver.go
+++ b/internal/wasm/httpserver.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -126,7 +127,7 @@ func (s *HTTPServer) Start(ctx context.Context) {
 		} else {
 			err = s.server.ListenAndServe()
 		}
-		if err != nil {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			s.logger.Error(err, "Failed to start Wasm HTTP server")
 			return
 		}


### PR DESCRIPTION
**What type of PR is this?**

fix: incorrect handling of err returned by ListenAndServe.

**What this PR does / why we need it**:

Previously, the error returned by `ListenAndServe` was unconditionally treated as an error hence a log saying like "failed to start server etc" was emitted when the envoy-gateway is properly shutdown. `ErrServerClosed` is always returned by ListenAndServe and its variant so this make the change to ignore that error.


Release Notes:No
