### PR TITLE
refactor(make): use helm upgrade --install in e2e tests

### DIFF
--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -93,19 +93,19 @@ endif
 .PHONY: kube-deploy
 kube-deploy: manifests helm-generate.gateway-helm ## Install Envoy Gateway into the Kubernetes cluster specified in ~/.kube/config.
 	@$(LOG_TARGET)
-	helm install eg charts/gateway-helm --set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) -n envoy-gateway-system --create-namespace --debug --timeout='$(WAIT_TIMEOUT)' --wait --wait-for-jobs
+	helm upgrade --install eg charts/gateway-helm --set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) -n envoy-gateway-system --create-namespace --debug --timeout='$(WAIT_TIMEOUT)' --wait --wait-for-jobs
 
 .PHONY: kube-deploy-for-benchmark-test
 kube-deploy-for-benchmark-test: manifests helm-generate ## Install Envoy Gateway and prometheus-server for benchmark test purpose only.
 	@$(LOG_TARGET)
 	# Install Envoy Gateway
-	helm install eg charts/gateway-helm --set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) \
+	helm upgrade --install eg charts/gateway-helm --set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) \
 		--set deployment.envoyGateway.resources.limits.cpu=$(BENCHMARK_CPU_LIMITS) \
 		--set deployment.envoyGateway.resources.limits.memory=$(BENCHMARK_MEMORY_LIMITS) \
 		--set config.envoyGateway.admin.enablePprof=true \
 		-n envoy-gateway-system --create-namespace --debug --timeout='$(WAIT_TIMEOUT)' --wait --wait-for-jobs
 	# Install Prometheus-server only
-	helm install eg-addons charts/gateway-addons-helm --set loki.enabled=false \
+	helm upgrade --install eg-addons charts/gateway-addons-helm --set loki.enabled=false \
 		--set tempo.enabled=false \
 		--set grafana.enabled=false \
 		--set fluent-bit.enabled=false \


### PR DESCRIPTION
This change replaces all helm install commands with helm upgrade --install in the e2e testing process. Using helm upgrade --install provides idempotent deployment behavior, automatically handling both initial installations and subsequent updates without requiring manual namespace deletion between test runs.

Previously, failed e2e tests required manual cleanup of the envoy-gateway-system namespace before retrying, significantly slowing down the development workflow. This change streamlines the testing process, allowing for continuous make e2e runs without manual intervention.

Benefits of helm upgrade --install:
- Eliminates need to manually delete namespaces between test runs
- Properly handles both new installs and upgrades with a single command
- Maintains release history for easier debugging
- Handles failed installations more gracefully
- Significantly improves developer experience during iterative testing

**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

This PR replaces all helm install commands with helm upgrade --install in the e2e testing process. During development, when running make e2e repeatedly, the current implementation requires manual deletion of the envoy-gateway-system namespace between runs if tests fail. This creates unnecessary friction in the development workflow.

Using helm upgrade --install provides idempotent behavior that automatically handles both initial installations and updates, eliminating the need for manual namespace deletion between test runs. This significantly improves the developer experience by allowing continuous make e2e runs without manual intervention.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes
