### PR TITLE
Make file provider errors useful

### DIFF
--- a/internal/provider/file/resources.go
+++ b/internal/provider/file/resources.go
@@ -21,7 +21,7 @@ func loadFromFilesAndDirs(files, dirs []string) ([]*resource.Resources, error) {
 	for _, file := range files {
 		r, err := loadFromFile(file)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to load resources from file %s: %w", file, err)
 		}
 		rs = append(rs, r)
 	}
@@ -67,10 +67,10 @@ func loadFromDir(path string) ([]*resource.Resources, error) {
 		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
 			continue
 		}
-
-		r, err := loadFromFile(filepath.Join(path, entry.Name()))
+		full := filepath.Join(path, entry.Name())
+		r, err := loadFromFile(full)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to load resources from file %s: %w", full, err)
 		}
 
 		rs = append(rs, r)

--- a/internal/provider/file/resources_test.go
+++ b/internal/provider/file/resources_test.go
@@ -7,10 +7,11 @@ package file
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_loadFromFilesAndDirs(t *testing.T) {
@@ -20,7 +21,7 @@ func Test_loadFromFilesAndDirs(t *testing.T) {
 	})
 	t.Run("invalid content in a file", func(t *testing.T) {
 		tmpfile := t.TempDir() + "/invalid.yaml"
-		err := os.WriteFile(tmpfile, []byte("invalid"), 0644)
+		err := os.WriteFile(tmpfile, []byte("invalid"), 0o600)
 		require.NoError(t, err)
 		_, err = loadFromFilesAndDirs([]string{tmpfile}, nil)
 		require.ErrorContains(t, err,
@@ -32,7 +33,7 @@ func Test_loadFromFilesAndDirs(t *testing.T) {
 	})
 	t.Run("invalid content in a file in a directory", func(t *testing.T) {
 		tmpdir := t.TempDir()
-		err := os.WriteFile(filepath.Join(tmpdir, "invalid.yaml"), []byte("invalid"), 0644)
+		err := os.WriteFile(filepath.Join(tmpdir, "invalid.yaml"), []byte("invalid"), 0o600)
 		require.NoError(t, err)
 		_, err = loadFromFilesAndDirs(nil, []string{tmpdir})
 		require.ErrorContains(t, err,
@@ -47,7 +48,7 @@ metadata:
   name: aigw-run
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller
-`), 0644)
+`), 0o644)
 		require.NoError(t, err)
 		rs, err := loadFromFilesAndDirs([]string{tmpfile}, nil)
 		require.NoError(t, err)
@@ -62,7 +63,7 @@ func Test_loadFromDir(t *testing.T) {
 	})
 	t.Run("invalid content in a file", func(t *testing.T) {
 		tmpdir := t.TempDir()
-		err := os.WriteFile(filepath.Join(tmpdir, "invalid.yaml"), []byte("invalid"), 0644)
+		err := os.WriteFile(filepath.Join(tmpdir, "invalid.yaml"), []byte("invalid"), 0o600)
 		require.NoError(t, err)
 		_, err = loadFromDir(tmpdir)
 		require.ErrorContains(t, err,
@@ -77,7 +78,7 @@ metadata:
   name: aigw-run
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller
-`), 0644)
+`), 0o600)
 		require.NoError(t, err)
 		rs, err := loadFromDir(tmpdir)
 		require.NoError(t, err)

--- a/internal/provider/file/resources_test.go
+++ b/internal/provider/file/resources_test.go
@@ -48,7 +48,7 @@ metadata:
   name: aigw-run
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller
-`), 0o644)
+`), 0o600)
 		require.NoError(t, err)
 		rs, err := loadFromFilesAndDirs([]string{tmpfile}, nil)
 		require.NoError(t, err)

--- a/internal/provider/file/resources_test.go
+++ b/internal/provider/file/resources_test.go
@@ -1,0 +1,86 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package file
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_loadFromFilesAndDirs(t *testing.T) {
+	t.Run("non-existent file", func(t *testing.T) {
+		_, err := loadFromFilesAndDirs([]string{"non-existent-file"}, nil)
+		require.ErrorContains(t, err, "file non-existent-file is not exist")
+	})
+	t.Run("invalid content in a file", func(t *testing.T) {
+		tmpfile := t.TempDir() + "/invalid.yaml"
+		err := os.WriteFile(tmpfile, []byte("invalid"), 0644)
+		require.NoError(t, err)
+		_, err = loadFromFilesAndDirs([]string{tmpfile}, nil)
+		require.ErrorContains(t, err,
+			fmt.Sprintf("failed to load resources from file %s", tmpfile))
+	})
+	t.Run("non-existent directory", func(t *testing.T) {
+		_, err := loadFromFilesAndDirs(nil, []string{"non-existent-directory"})
+		require.ErrorContains(t, err, "no such file or directory")
+	})
+	t.Run("invalid content in a file in a directory", func(t *testing.T) {
+		tmpdir := t.TempDir()
+		err := os.WriteFile(filepath.Join(tmpdir, "invalid.yaml"), []byte("invalid"), 0644)
+		require.NoError(t, err)
+		_, err = loadFromFilesAndDirs(nil, []string{tmpdir})
+		require.ErrorContains(t, err,
+			fmt.Sprintf("failed to load resources from file %s", filepath.Join(tmpdir, "invalid.yaml")))
+	})
+	t.Run("ok", func(t *testing.T) {
+		tmpfile := t.TempDir() + "/valid.yaml"
+		err := os.WriteFile(tmpfile, []byte(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: aigw-run
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+`), 0644)
+		require.NoError(t, err)
+		rs, err := loadFromFilesAndDirs([]string{tmpfile}, nil)
+		require.NoError(t, err)
+		require.Len(t, rs, 1)
+	})
+}
+
+func Test_loadFromDir(t *testing.T) {
+	t.Run("non-existent directory", func(t *testing.T) {
+		_, err := loadFromDir("non-existent-directory")
+		require.ErrorContains(t, err, "no such file or directory")
+	})
+	t.Run("invalid content in a file", func(t *testing.T) {
+		tmpdir := t.TempDir()
+		err := os.WriteFile(filepath.Join(tmpdir, "invalid.yaml"), []byte("invalid"), 0644)
+		require.NoError(t, err)
+		_, err = loadFromDir(tmpdir)
+		require.ErrorContains(t, err,
+			fmt.Sprintf("failed to load resources from file %s", filepath.Join(tmpdir, "invalid.yaml")))
+	})
+	t.Run("ok", func(t *testing.T) {
+		tmpdir := t.TempDir()
+		err := os.WriteFile(filepath.Join(tmpdir, "valid.yaml"), []byte(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: aigw-run
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+`), 0644)
+		require.NoError(t, err)
+		rs, err := loadFromDir(tmpdir)
+		require.NoError(t, err)
+		require.Len(t, rs, 1)
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

Enhances error message with file provider.

**What this PR does / why we need it**:

Previously, the file provider doesn't log any information about which file is wrong, so this fixes it and adds the missing test coverage.