### PR TITLE
translator: use the correct Namespace accessor for HTTPRouteFilter

### DIFF
--- a/internal/cmd/egctl/testdata/translate/in/backend-endpoint.yaml
+++ b/internal/cmd/egctl/testdata/translate/in/backend-endpoint.yaml
@@ -34,6 +34,12 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      filters:
+        - extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: host-rewrite
+          type: ExtensionRef
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend
@@ -75,3 +81,12 @@ spec:
         request: {}
         response:
           body: Streamed
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: host-rewrite
+spec:
+  urlRewrite:
+    hostname:
+      type: Backend

--- a/internal/cmd/egctl/testdata/translate/out/backend-endpoint.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/backend-endpoint.all.yaml
@@ -154,6 +154,12 @@ httpRoutes:
         kind: Backend
         name: backend
         weight: 1
+      filters:
+      - extensionRef:
+          group: gateway.envoyproxy.io
+          kind: HTTPRouteFilter
+          name: host-rewrite
+        type: ExtensionRef
       matches:
       - path:
           type: PathPrefix

--- a/internal/gatewayapi/filters.go
+++ b/internal/gatewayapi/filters.go
@@ -791,7 +791,7 @@ func (t *Translator) processExtensionRefHTTPFilter(extFilter *gwapiv1.LocalObjec
 	if string(extFilter.Kind) == egv1a1.KindHTTPRouteFilter {
 		found := false
 		for _, hrf := range resources.HTTPRouteFilters {
-			if hrf.Namespace == filterNs && hrf.Name == string(extFilter.Name) {
+			if hrf.GetNamespace() == filterNs && hrf.Name == string(extFilter.Name) {
 				found = true
 				if hrf.Spec.URLRewrite != nil {
 


### PR DESCRIPTION
**What type of PR is this?**

translator: use the correct Namespace accessor for HTTPRouteFilter

**What this PR does / why we need it**:

Previously, `HTTPRouteFilter.Namespace` was used directly to match the namespace of the Route referencing it. However, the search target was defined via `HTTPRouteFilter.GetNamespace` and that is a bug as when the namespace is not defined the former becomes empty string vs the latter is always `envoy-gateway-system`. This fixes the inconsistency and use the GetNamespace function when looking for a matched filter.

This was the root cause of why HTTPRouteFilter was not working in the standalone mode.

Release Notes: No
