### PR TITLE
Fixes race condition on provider/runner

### DIFF
--- a/internal/provider/runner/runner.go
+++ b/internal/provider/runner/runner.go
@@ -61,7 +61,7 @@ func (r *Runner) Start(ctx context.Context) (err error) {
 
 	r.Logger.Info("Running provider", "type", p.Type())
 	go func() {
-		if err = p.Start(ctx); err != nil {
+		if err := p.Start(ctx); err != nil {
 			r.Logger.Error(err, "unable to start provider")
 		}
 	}()


### PR DESCRIPTION
**What type of PR is this?**
fix: race condition

**What this PR does / why we need it**:

There's a race condition in provider/runner.Start where it writes values into `err` variable from multiple goroutines.

**Which issue(s) this PR fixes**:

Fixes #5505

Release Notes: No
