### PR TITLE
Update CSS to address non-clickable links before td-content>h2

### DIFF
--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -1018,7 +1018,6 @@ footer {
     color: $dark;
     margin-top: 4rem;
     margin-bottom: 2rem;
-    position: relative;
 
     &::after {
       content: '';


### PR DESCRIPTION
**What type of PR is this?**
* docs: fix rendering of .td-content>h2 titles, which are overlapping with preceding sections, thus making links non-clickable.

This is impacting all pages where the h2 block is overlapping a links, e.g https://gateway.envoyproxy.io/latest/tasks/traffic/backend/, https://gateway.envoyproxy.io/latest/tasks/traffic/client-traffic-policy/, https://gateway.envoyproxy.io/latest/tasks/security/backend-tls/

See this video to better understand it (I first refresh the page, then try to click/double-click the link, which shows the title being highlighted):

https://github.com/user-attachments/assets/b4c029be-f32c-4c1a-8eba-2f16797a0ed8


**What this PR does / why we need it**:
This fixes non-clickable links due to the title overlapping (with higher z-index)

**Which issue(s) this PR fixes**:

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
