### PR TITLE
benchmark: more accurate metrics and profiles

### DIFF
--- a/test/benchmark/suite/render.go
+++ b/test/benchmark/suite/render.go
@@ -28,11 +28,12 @@ func RenderReport(writer io.Writer, name, description string, titleLevel int, re
 		return err
 	}
 
-	writeSection(writer, "Metrics", titleLevel+1, "")
+	writeSection(writer, "Metrics", titleLevel+1,
+		"The CPU usage statistics of both control-plane and data-plane are the CPU usage per second over the past 30 seconds.")
 	renderMetricsTable(writer, reports)
 
 	writeSection(writer, "Profiles", titleLevel+1, renderProfilesNote())
-	renderProfilesTable(writer, "Heap/Memory", "heap", titleLevel+2, reports)
+	renderProfilesTable(writer, "Heap", "heap", titleLevel+2, reports)
 
 	return nil
 }
@@ -88,10 +89,10 @@ func renderMetricsTable(writer io.Writer, reports []*BenchmarkReport) {
 	// write headers
 	headers := []string{
 		"Test Name",
-		"Envoy Gateway Memory (MiB)\nmin/max/means",
-		"Envoy Gateway CPU (%)\nmin/max/means",
-		"Averaged Envoy Proxy Memory (MiB)\nmin/max/means",
-		"Averaged Envoy Proxy CPU (%)\nmin/max/means",
+		"Envoy Gateway Memory (MiB) <br> min/max/means",
+		"Envoy Gateway CPU (%) <br> min/max/means",
+		"Averaged Envoy Proxy Memory (MiB) <br> min/max/means",
+		"Averaged Envoy Proxy CPU (%) <br> min/max/means",
 	}
 	writeTableHeader(table, headers)
 

--- a/test/benchmark/suite/render.go
+++ b/test/benchmark/suite/render.go
@@ -19,10 +19,6 @@ import (
 	"text/tabwriter"
 )
 
-const (
-	benchmarkEnvPrefix = "BENCHMARK_"
-)
-
 // RenderReport renders a report out of given list of benchmark report in Markdown format.
 func RenderReport(writer io.Writer, name, description string, titleLevel int, reports []*BenchmarkReport) error {
 	writeSection(writer, "Test: "+name, titleLevel, description)
@@ -57,7 +53,15 @@ func renderEnvSettingsTable(writer io.Writer) {
 		"Memory Limits (MiB)",
 	}
 	writeTableHeader(table, headers)
-	writeTableRow(table, headers)
+
+	data := []string{
+		os.Getenv("BENCHMARK_RPS"),
+		os.Getenv("BENCHMARK_CONNECTIONS"),
+		os.Getenv("BENCHMARK_DURATION"),
+		os.Getenv("BENCHMARK_CPU_LIMITS"),
+		os.Getenv("BENCHMARK_MEMORY_LIMITS"),
+	}
+	writeTableRow(table, data)
 
 	_ = table.Flush()
 }
@@ -186,21 +190,21 @@ func writeTableDelimiter(table *tabwriter.Writer, n int) {
 
 func getSamplesMinMaxMeans(samples []BenchmarkMetricSample) []string {
 	cpMem := make([]float64, 0, len(samples))
-	cpCpu := make([]float64, 0, len(samples))
+	cpCPU := make([]float64, 0, len(samples))
 	dpMem := make([]float64, 0, len(samples))
-	dpCpu := make([]float64, 0, len(samples))
+	dpCPU := make([]float64, 0, len(samples))
 	for _, sample := range samples {
 		cpMem = append(cpMem, sample.ControlPlaneMem)
-		cpCpu = append(cpCpu, sample.ControlPlaneCpu)
+		cpCPU = append(cpCPU, sample.ControlPlaneCPU)
 		dpMem = append(dpMem, sample.DataPlaneMem)
-		dpCpu = append(dpCpu, sample.DataPlaneCpu)
+		dpCPU = append(dpCPU, sample.DataPlaneCPU)
 	}
 
 	return []string{
 		getMetricsMinMaxMeans(cpMem),
-		getMetricsMinMaxMeans(cpCpu),
+		getMetricsMinMaxMeans(cpCPU),
 		getMetricsMinMaxMeans(dpMem),
-		getMetricsMinMaxMeans(dpCpu),
+		getMetricsMinMaxMeans(dpCPU),
 	}
 }
 

--- a/test/benchmark/suite/render.go
+++ b/test/benchmark/suite/render.go
@@ -89,9 +89,9 @@ func renderMetricsTable(writer io.Writer, reports []*BenchmarkReport) {
 	headers := []string{
 		"Test Name",
 		"Envoy Gateway Memory (MiB)\nmin/max/means",
-		"Envoy Gateway CPU (Seconds)\nmin/max/means",
+		"Envoy Gateway CPU (%)\nmin/max/means",
 		"Averaged Envoy Proxy Memory (MiB)\nmin/max/means",
-		"Averaged Envoy Proxy CPU (Seconds)\nmin/max/means",
+		"Averaged Envoy Proxy CPU (%)\nmin/max/means",
 	}
 	writeTableHeader(table, headers)
 
@@ -209,11 +209,18 @@ func getSamplesMinMaxMeans(samples []BenchmarkMetricSample) []string {
 }
 
 func getMetricsMinMaxMeans(metrics []float64) string {
-	var min, max, sum float64 = metrics[0], 0, 0
+	var min, max, avg float64 = math.MaxFloat64, 0, 0
 	for _, v := range metrics {
 		min = math.Min(v, min)
 		max = math.Max(v, max)
-		sum += v
+		avg += v
 	}
-	return fmt.Sprintf("%.2f / %.2f / %.2f", min, max, sum/float64(len(metrics)))
+	if min == math.MaxFloat64 {
+		min = 0
+	}
+	if len(metrics) > 0 {
+		avg /= float64(len(metrics))
+	}
+
+	return fmt.Sprintf("%.2f / %.2f / %.2f", min, max, avg)
 }

--- a/test/benchmark/suite/report.go
+++ b/test/benchmark/suite/report.go
@@ -25,9 +25,9 @@ import (
 
 const (
 	controlPlaneMemQL = `process_resident_memory_bytes{namespace="envoy-gateway-system", control_plane="envoy-gateway"}/1024/1024`
-	controlPlaneCPUQL = `rate(process_cpu_seconds_total{namespace="envoy-gateway-system", control_plane="envoy-gateway"}[1m])*100`
-	dataPlaneMemQL    = `container_memory_working_set_bytes{namespace="envoy-gateway-system",container="envoy"}/1024/1024`
-	dataPlaneCPUQL    = `rate(container_cpu_usage_seconds_total{namespace="envoy-gateway-system",container="envoy"}[1m])*100`
+	controlPlaneCPUQL = `rate(process_cpu_seconds_total{namespace="envoy-gateway-system", control_plane="envoy-gateway"}[30s])*100`
+	dataPlaneMemQL    = `container_memory_working_set_bytes{namespace="envoy-gateway-system", container="envoy"}/1024/1024`
+	dataPlaneCPUQL    = `rate(container_cpu_usage_seconds_total{namespace="envoy-gateway-system", container="envoy"}[30s])*100`
 )
 
 // BenchmarkMetricSample contains sampled metrics and profiles data.

--- a/test/benchmark/suite/report.go
+++ b/test/benchmark/suite/report.go
@@ -12,10 +12,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"path"
-	"strconv"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,45 +22,56 @@ import (
 	prom "github.com/envoyproxy/gateway/test/utils/prometheus"
 )
 
+const (
+	controlPlaneMemQL = `process_resident_memory_bytes{namespace="envoy-gateway-system", control_plane="envoy-gateway"}/1024/1024`
+	controlPlaneCpuQL = `rate(process_cpu_seconds_total{namespace="envoy-gateway-system", control_plane="envoy-gateway"}[3s])`
+	dataPlaneMemQL    = `container_memory_working_set_bytes{namespace="envoy-gateway-system",container="envoy"}/1024/1024`
+	dataPlaneCpuQL    = `rate(container_cpu_usage_seconds_total{namespace="envoy-gateway-system",container="envoy"}[3s])`
+)
+
+// BenchmarkMetricSample contains sampled metrics and profiles data.
+type BenchmarkMetricSample struct {
+	ControlPlaneMem float64
+	ControlPlaneCpu float64
+	DataPlaneMem    float64
+	DataPlaneCpu    float64
+
+	HeapProfile []byte
+}
+
 type BenchmarkReport struct {
 	Name              string
-	Result            []byte
-	Metrics           map[string]float64 // metricTableHeaderName:metricValue
-	ProfilesPath      map[string]string  // profileKey:profileFilepath
 	ProfilesOutputDir string
+	// Nighthawk benchmark result
+	Result []byte
+	// Prometheus metrics and pprof profiles sampled data
+	Samples []BenchmarkMetricSample
 
 	kubeClient kube.CLIClient
 	promClient *prom.Client
 }
 
-func NewBenchmarkReport(name, profilesOutputDir string, kubeClient kube.CLIClient, promClient *prom.Client) (*BenchmarkReport, error) {
-	if err := createDirIfNotExist(profilesOutputDir); err != nil {
-		return nil, err
-	}
-
+func NewBenchmarkReport(name, profilesOutputDir string, kubeClient kube.CLIClient, promClient *prom.Client) *BenchmarkReport {
 	return &BenchmarkReport{
 		Name:              name,
-		Metrics:           make(map[string]float64),
-		ProfilesPath:      make(map[string]string),
 		ProfilesOutputDir: profilesOutputDir,
 		kubeClient:        kubeClient,
 		promClient:        promClient,
-	}, nil
+	}
 }
 
-func (r *BenchmarkReport) Collect(ctx context.Context, job *types.NamespacedName) error {
-	if err := r.GetProfiles(ctx); err != nil {
+func (r *BenchmarkReport) Sample(ctx context.Context) error {
+	sample := BenchmarkMetricSample{}
+
+	if err := r.sampleProfiles(ctx, &sample); err != nil {
 		return err
 	}
 
-	if err := r.GetMetrics(ctx); err != nil {
+	if err := r.sampleMetrics(ctx, &sample); err != nil {
 		return err
 	}
 
-	if err := r.GetResult(ctx, job); err != nil {
-		return err
-	}
-
+	r.Samples = append(r.Samples, sample)
 	return nil
 }
 
@@ -97,34 +104,35 @@ func (r *BenchmarkReport) GetResult(ctx context.Context, job *types.NamespacedNa
 	return nil
 }
 
-func (r *BenchmarkReport) GetMetrics(ctx context.Context) error {
-	for _, h := range metricsTableHeader {
-		if len(h.promQL) == 0 {
-			continue
-		}
-
-		var (
-			v   float64
-			err error
-		)
-		switch h.queryType {
-		case querySum:
-			v, err = r.promClient.QuerySum(ctx, h.promQL)
-		case queryAvg:
-			v, err = r.promClient.QueryAvg(ctx, h.promQL)
-		default:
-			return fmt.Errorf("unsupported query type: %s", h.queryType)
-		}
-
-		if err == nil {
-			r.Metrics[h.name], _ = strconv.ParseFloat(fmt.Sprintf("%.2f", v), 64)
-		}
+func (r *BenchmarkReport) sampleMetrics(ctx context.Context, sample *BenchmarkMetricSample) error {
+	// Sample memory
+	cpMem, err := r.promClient.QuerySum(ctx, controlPlaneMemQL)
+	if err != nil {
+		return fmt.Errorf("failed to query control plane memory: %w", err)
+	}
+	dpMem, err := r.promClient.QueryAvg(ctx, dataPlaneMemQL)
+	if err != nil {
+		return fmt.Errorf("failed to query data plane memory: %w", err)
 	}
 
+	// Sample cpu
+	cpCpu, err := r.promClient.QuerySum(ctx, controlPlaneCpuQL)
+	if err != nil {
+		return fmt.Errorf("failed to query control plane cpu: %w", err)
+	}
+	dpCpu, err := r.promClient.QueryAvg(ctx, dataPlaneCpuQL)
+	if err != nil {
+		return fmt.Errorf("failed to query data plane memory: %w", err)
+	}
+
+	sample.ControlPlaneMem = cpMem
+	sample.ControlPlaneCpu = cpCpu
+	sample.DataPlaneMem = dpMem
+	sample.DataPlaneCpu = dpCpu
 	return nil
 }
 
-func (r *BenchmarkReport) GetProfiles(ctx context.Context) error {
+func (r *BenchmarkReport) sampleProfiles(ctx context.Context, sample *BenchmarkMetricSample) error {
 	egPod, err := r.fetchEnvoyGatewayPod(ctx)
 	if err != nil {
 		return err
@@ -138,16 +146,7 @@ func (r *BenchmarkReport) GetProfiles(ctx context.Context) error {
 		return err
 	}
 
-	heapProfPath := path.Join(r.ProfilesOutputDir, fmt.Sprintf("heap.%s.pprof", r.Name))
-	if err = os.WriteFile(heapProfPath, heapProf, 0o600); err != nil {
-		return fmt.Errorf("failed to write profiles %s: %w", heapProfPath, err)
-	}
-
-	// Remove parent output report dir.
-	splits := strings.SplitN(heapProfPath, "/", 2)[0]
-	heapProfPath = strings.TrimPrefix(heapProfPath, splits+"/")
-	r.ProfilesPath["heap"] = heapProfPath
-
+	sample.HeapProfile = heapProf
 	return nil
 }
 

--- a/test/benchmark/suite/report.go
+++ b/test/benchmark/suite/report.go
@@ -24,17 +24,17 @@ import (
 
 const (
 	controlPlaneMemQL = `process_resident_memory_bytes{namespace="envoy-gateway-system", control_plane="envoy-gateway"}/1024/1024`
-	controlPlaneCpuQL = `rate(process_cpu_seconds_total{namespace="envoy-gateway-system", control_plane="envoy-gateway"}[3s])`
+	controlPlaneCPUQL = `rate(process_cpu_seconds_total{namespace="envoy-gateway-system", control_plane="envoy-gateway"}[1m])`
 	dataPlaneMemQL    = `container_memory_working_set_bytes{namespace="envoy-gateway-system",container="envoy"}/1024/1024`
-	dataPlaneCpuQL    = `rate(container_cpu_usage_seconds_total{namespace="envoy-gateway-system",container="envoy"}[3s])`
+	dataPlaneCPUQL    = `rate(container_cpu_usage_seconds_total{namespace="envoy-gateway-system",container="envoy"}[1m])`
 )
 
 // BenchmarkMetricSample contains sampled metrics and profiles data.
 type BenchmarkMetricSample struct {
 	ControlPlaneMem float64
-	ControlPlaneCpu float64
+	ControlPlaneCPU float64
 	DataPlaneMem    float64
-	DataPlaneCpu    float64
+	DataPlaneCPU    float64
 
 	HeapProfile []byte
 }
@@ -116,19 +116,19 @@ func (r *BenchmarkReport) sampleMetrics(ctx context.Context, sample *BenchmarkMe
 	}
 
 	// Sample cpu
-	cpCpu, err := r.promClient.QuerySum(ctx, controlPlaneCpuQL)
+	cpCPU, err := r.promClient.QuerySum(ctx, controlPlaneCPUQL)
 	if err != nil {
 		return fmt.Errorf("failed to query control plane cpu: %w", err)
 	}
-	dpCpu, err := r.promClient.QueryAvg(ctx, dataPlaneCpuQL)
+	dpCPU, err := r.promClient.QueryAvg(ctx, dataPlaneCPUQL)
 	if err != nil {
 		return fmt.Errorf("failed to query data plane memory: %w", err)
 	}
 
 	sample.ControlPlaneMem = cpMem
-	sample.ControlPlaneCpu = cpCpu
+	sample.ControlPlaneCPU = cpCPU
 	sample.DataPlaneMem = dpMem
-	sample.DataPlaneCpu = dpCpu
+	sample.DataPlaneCPU = dpCPU
 	return nil
 }
 

--- a/test/benchmark/suite/suite.go
+++ b/test/benchmark/suite/suite.go
@@ -229,8 +229,9 @@ func (b *BenchmarkTestSuite) Benchmark(t *testing.T, ctx context.Context, jobNam
 		t.Logf("Job %s still not complete", jobName)
 
 		// Sample the metrics and profiles at runtime.
+		// Do not consider it as an error, fail sampling should not affect test running.
 		if err := report.Sample(ctx); err != nil {
-			t.Errorf("Failed to sample metrics or profiles: %v", err)
+			t.Logf("Error occurs while sampling metrics or profiles: %v", err)
 		}
 
 		return false, nil

--- a/test/benchmark/suite/suite.go
+++ b/test/benchmark/suite/suite.go
@@ -230,7 +230,7 @@ func (b *BenchmarkTestSuite) Benchmark(t *testing.T, ctx context.Context, jobNam
 
 		// Sample the metrics and profiles at runtime.
 		if err := report.Sample(ctx); err != nil {
-			t.Errorf("Failed to sample metrics and profiles: %v", err)
+			t.Errorf("Failed to sample metrics or profiles: %v", err)
 		}
 
 		return false, nil

--- a/test/benchmark/suite/suite.go
+++ b/test/benchmark/suite/suite.go
@@ -32,9 +32,10 @@ import (
 )
 
 const (
-	BenchmarkTestScaledKey = "benchmark-test/scaled"
-	BenchmarkTestClientKey = "benchmark-test/client"
-	DefaultControllerName  = "gateway.envoyproxy.io/gatewayclass-controller"
+	BenchmarkTestScaledKey     = "benchmark-test/scaled"
+	BenchmarkTestClientKey     = "benchmark-test/client"
+	BenchmarkMetricsSampleTick = 3 * time.Second
+	DefaultControllerName      = "gateway.envoyproxy.io/gatewayclass-controller"
 )
 
 type BenchmarkTest struct {
@@ -200,8 +201,14 @@ func (b *BenchmarkTestSuite) Benchmark(t *testing.T, ctx context.Context, jobNam
 		return nil, err
 	}
 
+	profilesOutputDir := path.Join(b.ReportSaveDir, "profiles")
+	if err := createDirIfNotExist(profilesOutputDir); err != nil {
+		return nil, err
+	}
+
 	// Wait from benchmark test job to complete.
-	if err = wait.PollUntilContextTimeout(ctx, 6*time.Second, time.Duration(duration*10)*time.Second, true, func(ctx context.Context) (bool, error) {
+	report := NewBenchmarkReport(resultTitle, profilesOutputDir, b.kubeClient, b.promClient)
+	if err = wait.PollUntilContextTimeout(ctx, BenchmarkMetricsSampleTick, time.Duration(duration*10)*time.Second, true, func(ctx context.Context) (bool, error) {
 		job := new(batchv1.Job)
 		if err = b.Client.Get(ctx, *jobNN, job); err != nil {
 			return false, err
@@ -221,6 +228,11 @@ func (b *BenchmarkTestSuite) Benchmark(t *testing.T, ctx context.Context, jobNam
 
 		t.Logf("Job %s still not complete", jobName)
 
+		// Sample the metrics and profiles at runtime.
+		if err := report.Sample(ctx); err != nil {
+			t.Errorf("Failed to sample metrics and profiles: %v", err)
+		}
+
 		return false, nil
 	}); err != nil {
 		t.Errorf("Failed to run benchmark test: %v", err)
@@ -230,13 +242,8 @@ func (b *BenchmarkTestSuite) Benchmark(t *testing.T, ctx context.Context, jobNam
 
 	t.Logf("Running benchmark test: %s successfully", resultTitle)
 
-	report, err := NewBenchmarkReport(resultTitle, path.Join(b.ReportSaveDir, "profiles"), b.kubeClient, b.promClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create benchmark report: %w", err)
-	}
-
-	// Get all the reports from this benchmark test run.
-	if err = report.Collect(ctx, jobNN); err != nil {
+	// Get nighthaw result from this benchmark test run.
+	if err = report.GetResult(ctx, jobNN); err != nil {
 		return nil, err
 	}
 

--- a/test/benchmark/suite/suite.go
+++ b/test/benchmark/suite/suite.go
@@ -243,7 +243,7 @@ func (b *BenchmarkTestSuite) Benchmark(t *testing.T, ctx context.Context, jobNam
 
 	t.Logf("Running benchmark test: %s successfully", resultTitle)
 
-	// Get nighthaw result from this benchmark test run.
+	// Get nighthawk result from this benchmark test run.
 	if err = report.GetResult(ctx, jobNN); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

We used to collect metrics and profiles at the end of one benchmark test, the result may not be accurate, becasue the metrics like 
- `process_resident_memory_bytes` and `container_memory_working_set_bytes` are instant value, they only reflect the status at the time of our promql request, same as pprof profiles.
- `process_cpu_seconds_total` and `container_cpu_usage_seconds_total` are cumulative value, we should use `rate()` to get its value during a time range

So this PR samples metrics and profiles at test runtime, and report the min/max/mean of mem and cpu during the test run (ditto for pprof profiles), in order to make the benchmark result more accurate and trustworthy.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

ref: #4516, #4498

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
