### PR TITLE
fix: flaky k8s provider test

### DIFF
--- a/internal/provider/kubernetes/kubernetes.go
+++ b/internal/provider/kubernetes/kubernetes.go
@@ -35,6 +35,9 @@ type Provider struct {
 	manager manager.Manager
 }
 
+// Exposed to allow disabling health probe listener in tests.
+var healthProbeBindAddress = ":8081"
+
 // New creates a new Provider from the provided EnvoyGateway.
 func New(ctx context.Context, restCfg *rest.Config, svrCfg *ec.Server, resources *message.ProviderResources) (*Provider, error) {
 	// TODO: Decide which mgr opts should be exposed through envoygateway.provider.kubernetes API.
@@ -42,7 +45,7 @@ func New(ctx context.Context, restCfg *rest.Config, svrCfg *ec.Server, resources
 	mgrOpts := manager.Options{
 		Scheme:                  envoygateway.GetScheme(),
 		Logger:                  svrCfg.Logger.Logger,
-		HealthProbeBindAddress:  ":8081",
+		HealthProbeBindAddress:  healthProbeBindAddress,
 		LeaderElectionID:        "5b9825d2.gateway.envoyproxy.io",
 		LeaderElectionNamespace: svrCfg.Namespace,
 	}

--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -51,6 +51,7 @@ func TestMain(m *testing.M) {
 	skipNameValidation = func() *bool {
 		return ptr.To(true)
 	}
+	healthProbeBindAddress = "" // Disable health probe listener to avoid "address already in use" error.
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes flaky k8s provider test by disabling health probe listener.

**Which issue(s) this PR fixes**:
Fixes #5601

