### PR TITLE
chore: sync make target

### DIFF
--- a/tools/make/common.mk
+++ b/tools/make/common.mk
@@ -39,6 +39,7 @@ REV=$(shell git rev-parse --short HEAD)
 
 # Supported Platforms for building multiarch binaries.
 PLATFORMS ?= darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64 windows_arm64
+IMAGE_PLATFORMS ?= ${PLATFORMS}
 
 # Set a specific PLATFORM
 ifeq ($(origin PLATFORM), undefined)

--- a/tools/make/image.mk
+++ b/tools/make/image.mk
@@ -15,7 +15,7 @@ IMAGE_PLATFORMS ?= linux_amd64 linux_arm64
 
 BUILDX_CONTEXT = gateway-build-tools-builder
 # Convert to linux/arm64,linux/amd64
-$(eval BUILDX_PLATFORMS = $(shell echo "${IMAGE_PLATFORMS}" | sed "s# #,#;s#_#/#g"))
+$(eval BUILDX_PLATFORMS = $(shell echo "${IMAGE_PLATFORMS}" | sed "s# #,#g;s#_#/#g"))
 EMULATE_PLATFORMS = amd64 arm64
 EMULATE_TARGETS = $(addprefix image.multiarch.emulate.,$(EMULATE_PLATFORMS))
 


### PR DESCRIPTION
**What type of PR is this?**

Now `make image-multiarch` will build go binary of all platforms due to different default value.

Another fix is to change the default value for go build.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes/No
