### PR TITLE
fix: do not add tls inspector filter to quic listener

### DIFF
--- a/internal/xds/translator/server_names_match_test.go
+++ b/internal/xds/translator/server_names_match_test.go
@@ -11,7 +11,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddServerNamesMatch(t *testing.T) {
@@ -98,14 +98,14 @@ func TestAddServerNamesMatch(t *testing.T) {
 			filterChain := &listenerv3.FilterChain{}
 
 			err := addServerNamesMatch(tt.xdsListener, filterChain, tt.hostnames)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Check if filter chain match was added
 			if tt.expectFilterChain {
-				assert.NotNil(t, filterChain.FilterChainMatch)
-				assert.Equal(t, tt.expectServerNames, filterChain.FilterChainMatch.ServerNames)
+				require.NotNil(t, filterChain.FilterChainMatch)
+				require.Equal(t, tt.expectServerNames, filterChain.FilterChainMatch.ServerNames)
 			} else {
-				assert.Nil(t, filterChain.FilterChainMatch)
+				require.Nil(t, filterChain.FilterChainMatch)
 			}
 
 			// Check if TLS inspector was added
@@ -117,7 +117,7 @@ func TestAddServerNamesMatch(t *testing.T) {
 						break
 					}
 				}
-				assert.True(t, hasTLSInspector, "TLS inspector filter should be added")
+				require.True(t, hasTLSInspector, "TLS inspector filter should be added")
 			} else if tt.xdsListener != nil {
 				// For non-nil listeners that shouldn't have TLS inspector
 				hasTLSInspector := false
@@ -127,7 +127,7 @@ func TestAddServerNamesMatch(t *testing.T) {
 						break
 					}
 				}
-				assert.False(t, hasTLSInspector, "TLS inspector filter should not be added")
+				require.False(t, hasTLSInspector, "TLS inspector filter should not be added")
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

These changes ensure that when HTTP/3 is enabled through a ClientTrafficPolicy, the TLS inspector filter is only added to TCP listeners, not to UDP (QUIC) listeners, which prevents the nil pointer dereference.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #5660

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes/No
