### PR TITLE
fix: httproute status.parents is not cleaned up

### DIFF
--- a/internal/provider/kubernetes/status_cleanup_test.go
+++ b/internal/provider/kubernetes/status_cleanup_test.go
@@ -1,0 +1,174 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func Test_mergeRouteParentStatusCleanup(t *testing.T) {
+	type args struct {
+		ns  string
+		old []gwapiv1.RouteParentStatus
+		new []gwapiv1.RouteParentStatus
+	}
+	tests := []struct {
+		name string
+		args args
+		want []gwapiv1.RouteParentStatus
+	}{
+		{
+			name: "remove old entries that are no longer referenced",
+			args: args{
+				ns: "default",
+				old: []gwapiv1.RouteParentStatus{
+					{
+						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+						ParentRef: gwapiv1.ParentReference{
+							Name:      "gateway1",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: "Accepted",
+							},
+						},
+					},
+					{
+						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+						ParentRef: gwapiv1.ParentReference{
+							Name:      "gateway2",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: "OldReason",
+							},
+						},
+					},
+				},
+				new: []gwapiv1.RouteParentStatus{
+					{
+						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+						ParentRef: gwapiv1.ParentReference{
+							Name:      "gateway1",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: "Accepted",
+							},
+						},
+					},
+					// gateway2 is removed from spec.parentRefs, so it should not appear in the merged result
+				},
+			},
+			want: []gwapiv1.RouteParentStatus{
+				{
+					ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+					ParentRef: gwapiv1.ParentReference{
+						Name:      "gateway1",
+						Namespace: ptr.To[gwapiv1.Namespace]("default"),
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gwapiv1.RouteConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "Accepted",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "update existing entry and keep only referenced entries",
+			args: args{
+				ns: "default",
+				old: []gwapiv1.RouteParentStatus{
+					{
+						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+						ParentRef: gwapiv1.ParentReference{
+							Name:      "gateway1",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: "OldReason",
+							},
+						},
+					},
+					{
+						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+						ParentRef: gwapiv1.ParentReference{
+							Name:      "gateway2",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: "OldReason",
+							},
+						},
+					},
+				},
+				new: []gwapiv1.RouteParentStatus{
+					{
+						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+						ParentRef: gwapiv1.ParentReference{
+							Name:      "gateway1",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: "NewReason",
+							},
+						},
+					},
+					// gateway2 is removed from spec.parentRefs, so it should not appear in the merged result
+				},
+			},
+			want: []gwapiv1.RouteParentStatus{
+				{
+					ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+					ParentRef: gwapiv1.ParentReference{
+						Name:      "gateway1",
+						Namespace: ptr.To[gwapiv1.Namespace]("default"),
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gwapiv1.RouteConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "NewReason",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergeRouteParentStatus(tt.args.ns, tt.args.old, tt.args.new); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mergeRouteParentStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/kubernetes/status_test.go
+++ b/internal/provider/kubernetes/status_test.go
@@ -16,6 +16,7 @@ import (
 
 func Test_mergeRouteParentStatus(t *testing.T) {
 	type args struct {
+		ns  string
 		old []gwapiv1.RouteParentStatus
 		new []gwapiv1.RouteParentStatus
 	}
@@ -27,6 +28,7 @@ func Test_mergeRouteParentStatus(t *testing.T) {
 		{
 			name: "merge old and new",
 			args: args{
+				ns: "default",
 				old: []gwapiv1.RouteParentStatus{
 					{
 						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
@@ -49,18 +51,54 @@ func Test_mergeRouteParentStatus(t *testing.T) {
 							},
 						},
 					},
+					{
+						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+						ParentRef: gwapiv1.ParentReference{
+							Name:      "gateway2",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: "OldReason",
+							},
+						},
+					},
 				},
 				new: []gwapiv1.RouteParentStatus{
 					{
 						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
 						ParentRef: gwapiv1.ParentReference{
-							Name: "gateway2",
+							Name:      "gateway2",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
 						},
 						Conditions: []metav1.Condition{
 							{
 								Type:   string(gwapiv1.RouteConditionAccepted),
 								Status: metav1.ConditionFalse,
 								Reason: "SomeReason",
+							},
+						},
+					},
+					{
+						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+						ParentRef: gwapiv1.ParentReference{
+							Name:        "gateway1",
+							Namespace:   ptr.To[gwapiv1.Namespace]("default"),
+							SectionName: ptr.To[gwapiv1.SectionName]("listener1"),
+							Port:        ptr.To[gwapiv1.PortNumber](80),
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: "Accepted",
+							},
+							{
+								Type:   string(gwapiv1.RouteConditionResolvedRefs),
+								Status: metav1.ConditionTrue,
+								Reason: "ResolvedRefs",
 							},
 						},
 					},
@@ -91,7 +129,8 @@ func Test_mergeRouteParentStatus(t *testing.T) {
 				{
 					ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
 					ParentRef: gwapiv1.ParentReference{
-						Name: "gateway2",
+						Name:      "gateway2",
+						Namespace: ptr.To[gwapiv1.Namespace]("default"),
 					},
 					Conditions: []metav1.Condition{
 						{
@@ -107,6 +146,7 @@ func Test_mergeRouteParentStatus(t *testing.T) {
 		{
 			name: "override an existing parent",
 			args: args{
+				ns: "default",
 				old: []gwapiv1.RouteParentStatus{
 					{
 						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
@@ -150,7 +190,8 @@ func Test_mergeRouteParentStatus(t *testing.T) {
 					{
 						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
 						ParentRef: gwapiv1.ParentReference{
-							Name: "gateway2",
+							Name:      "gateway2",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
 						},
 						Conditions: []metav1.Condition{
 							{
@@ -166,25 +207,8 @@ func Test_mergeRouteParentStatus(t *testing.T) {
 				{
 					ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
 					ParentRef: gwapiv1.ParentReference{
-						Name: "gateway1",
-					},
-					Conditions: []metav1.Condition{
-						{
-							Type:   string(gwapiv1.RouteConditionAccepted),
-							Status: metav1.ConditionTrue,
-							Reason: "Accepted",
-						},
-						{
-							Type:   string(gwapiv1.RouteConditionResolvedRefs),
-							Status: metav1.ConditionTrue,
-							Reason: "ResolvedRefs",
-						},
-					},
-				},
-				{
-					ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
-					ParentRef: gwapiv1.ParentReference{
-						Name: "gateway2",
+						Name:      "gateway2",
+						Namespace: ptr.To[gwapiv1.Namespace]("default"),
 					},
 					Conditions: []metav1.Condition{
 						{
@@ -200,6 +224,7 @@ func Test_mergeRouteParentStatus(t *testing.T) {
 		{
 			name: "nothing changed",
 			args: args{
+				ns: "default",
 				old: []gwapiv1.RouteParentStatus{
 					{
 						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
@@ -237,7 +262,8 @@ func Test_mergeRouteParentStatus(t *testing.T) {
 					{
 						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
 						ParentRef: gwapiv1.ParentReference{
-							Name: "gateway2",
+							Name:      "gateway2",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
 						},
 						Conditions: []metav1.Condition{
 							{
@@ -253,25 +279,8 @@ func Test_mergeRouteParentStatus(t *testing.T) {
 				{
 					ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
 					ParentRef: gwapiv1.ParentReference{
-						Name: "gateway1",
-					},
-					Conditions: []metav1.Condition{
-						{
-							Type:   string(gwapiv1.RouteConditionAccepted),
-							Status: metav1.ConditionTrue,
-							Reason: "Accepted",
-						},
-						{
-							Type:   string(gwapiv1.RouteConditionResolvedRefs),
-							Status: metav1.ConditionTrue,
-							Reason: "ResolvedRefs",
-						},
-					},
-				},
-				{
-					ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
-					ParentRef: gwapiv1.ParentReference{
-						Name: "gateway2",
+						Name:      "gateway2",
+						Namespace: ptr.To[gwapiv1.Namespace]("default"),
 					},
 					Conditions: []metav1.Condition{
 						{
@@ -283,10 +292,79 @@ func Test_mergeRouteParentStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "remove old entries that are no longer referenced",
+			args: args{
+				ns: "default",
+				old: []gwapiv1.RouteParentStatus{
+					{
+						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+						ParentRef: gwapiv1.ParentReference{
+							Name:      "gateway1",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: "Accepted",
+							},
+						},
+					},
+					{
+						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+						ParentRef: gwapiv1.ParentReference{
+							Name:      "gateway2",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: "Accepted",
+							},
+						},
+					},
+				},
+				new: []gwapiv1.RouteParentStatus{
+					{
+						ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+						ParentRef: gwapiv1.ParentReference{
+							Name:      "gateway1",
+							Namespace: ptr.To[gwapiv1.Namespace]("default"),
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gwapiv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+								Reason: "Accepted",
+							},
+						},
+					},
+					// gateway2 is removed from spec.parentRefs, so it should not appear in the merged result
+				},
+			},
+			want: []gwapiv1.RouteParentStatus{
+				{
+					ControllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+					ParentRef: gwapiv1.ParentReference{
+						Name:      "gateway1",
+						Namespace: ptr.To[gwapiv1.Namespace]("default"),
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gwapiv1.RouteConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "Accepted",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := mergeRouteParentStatus("default", tt.args.old, tt.args.new); !reflect.DeepEqual(got, tt.want) {
+			if got := mergeRouteParentStatus(tt.args.ns, tt.args.old, tt.args.new); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("mergeRouteParentStatus() = %v, want %v", got, tt.want)
 			}
 		})

--- a/test/e2e/testdata/httproute-parents-cleanup.yaml
+++ b/test/e2e/testdata/httproute-parents-cleanup.yaml
@@ -1,0 +1,41 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-1
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: envoy-gateway
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-2
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: envoy-gateway
+  listeners:
+  - name: http
+    port: 81
+    protocol: HTTP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-parents-cleanup
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-1
+  - name: gateway-2
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /test
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/test/e2e/tests/httproute_parents_cleanup.go
+++ b/test/e2e/tests/httproute_parents_cleanup.go
@@ -1,0 +1,94 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+//go:build e2e
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteParentsCleanupTest)
+}
+
+// HTTPRouteParentsCleanupTest tests that when a parentRef is removed from HTTPRoute spec.parentRefs,
+// the corresponding entry in status.parents is also removed.
+var HTTPRouteParentsCleanupTest = suite.ConformanceTest{
+	ShortName:   "HTTPRouteParentsCleanup",
+	Description: "Test HTTPRoute status.parents cleanup when parentRefs are removed",
+	Manifests:   []string{"testdata/httproute-parents-cleanup.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		t.Run("HTTPRoute status.parents should be cleaned up when parentRefs are removed", func(t *testing.T) {
+			ns := "gateway-conformance-infra"
+			routeNN := types.NamespacedName{Name: "httproute-parents-cleanup", Namespace: ns}
+			gw1NN := types.NamespacedName{Name: "gateway-1", Namespace: ns}
+			gw2NN := types.NamespacedName{Name: "gateway-2", Namespace: ns}
+
+			// Wait for the HTTPRoute to be accepted by both gateways
+			kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gw1NN), routeNN)
+			kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gw2NN), routeNN)
+
+			// Verify that the HTTPRoute has two entries in status.parents
+			route := &gwapiv1.HTTPRoute{}
+			err := suite.Client.Get(context.Background(), routeNN, route)
+			if err != nil {
+				t.Fatalf("Failed to get HTTPRoute: %v", err)
+			}
+
+			if len(route.Status.Parents) != 2 {
+				t.Fatalf("Expected HTTPRoute to have 2 parents in status, got %d", len(route.Status.Parents))
+			}
+
+			// Update the HTTPRoute to remove the second parentRef
+			route.Spec.ParentRefs = route.Spec.ParentRefs[:1] // Keep only the first parentRef
+			err = suite.Client.Update(context.Background(), route)
+			if err != nil {
+				t.Fatalf("Failed to update HTTPRoute: %v", err)
+			}
+
+			// Wait for the HTTPRoute status to be updated
+			err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, suite.TimeoutConfig.RouteMustHaveParents, true, func(ctx context.Context) (bool, error) {
+				updatedRoute := &gwapiv1.HTTPRoute{}
+				err := suite.Client.Get(ctx, routeNN, updatedRoute)
+				if err != nil {
+					return false, err
+				}
+
+				// Check if status.parents has been cleaned up
+				return len(updatedRoute.Status.Parents) == 1, nil
+			})
+			if err != nil {
+				t.Fatalf("Timed out waiting for HTTPRoute status.parents to be cleaned up: %v", err)
+			}
+
+			// Get the updated HTTPRoute
+			updatedRoute := &gwapiv1.HTTPRoute{}
+			err = suite.Client.Get(context.Background(), routeNN, updatedRoute)
+			if err != nil {
+				t.Fatalf("Failed to get updated HTTPRoute: %v", err)
+			}
+
+			// Verify that the remaining parent is for gateway-1
+			if len(updatedRoute.Status.Parents) != 1 {
+				t.Fatalf("Expected HTTPRoute to have 1 parent in status, got %d", len(updatedRoute.Status.Parents))
+			}
+
+			parent := updatedRoute.Status.Parents[0]
+			if string(parent.ParentRef.Name) != "gateway-1" {
+				t.Fatalf("Expected remaining parent to be gateway-1, got %s", parent.ParentRef.Name)
+			}
+		})
+	},
+}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

The fix ensures that the status.parents field accurately reflects the current state of the spec.parentRefs field.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #5656

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes/No
