### PR TITLE
chore: typo in docs HTTPRoute command

### DIFF
--- a/site/content/en/v1.3/tasks/traffic/http-routing.md
+++ b/site/content/en/v1.3/tasks/traffic/http-routing.md
@@ -277,8 +277,9 @@ Test routing to the `foo-svc` backend by specifying a JWT Token with a claim `na
 
 ```shell
 curl -sS -H "Host: foo.example.com" -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/login" | jq .pod
-"foo-backend-6df8cc6b9f-fmwcg"
 ```
+The request should return the pod name, for example `foo-backend-6df8cc6b9f-fmwcg`
+
 
 Get another JWT used for testing request authentication:
 
@@ -290,8 +291,8 @@ Test HTTP routing to the `bar-svc` backend by specifying a JWT Token with a clai
 
 ```shell
 curl -sS -H "Host: bar.example.com" -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/" | jq .pod
-"bar-backend-6688b8944c-s8htr"
 ```
+The request should return the pod name, for example `bar-backend-6688b8944c-s8htr`
 
 [HTTPRoute]: https://gateway-api.sigs.k8s.io/api-types/httproute/
 [Gateway API documentation]: https://gateway-api.sigs.k8s.io/


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
chore/docs/
-->
* "docs: fix command error" on page https://gateway.envoyproxy.io/docs/tasks/traffic/http-routing/


**What this PR does / why we need it**:

Typo in docs HTTPRoute: When the shell block gets copied from the website, the pod name was copied too, which isn't a valid command in it's own. Changed this to be description instead of a command.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes none

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
