### PR TITLE
Support ServiceImport AppProtocol parsing

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -1407,11 +1407,9 @@ func (t *Translator) processServiceImportDestinationSetting(
 		}
 	}
 
-	// TODO(#5485): Should these protocols be supported for ServiceImport?
-	//
-	// if servicePort.AppProtocol != nil {
-	// 	protocol = serviceAppProtocolToIRAppProtocol(*servicePort.AppProtocol)
-	// }
+	if servicePort.AppProtocol != nil {
+		protocol = serviceAppProtocolToIRAppProtocol(*servicePort.AppProtocol, protocol, false)
+	}
 
 	// Route to endpoints by default
 	if !t.IsEnvoyServiceRouting(envoyProxy) {
@@ -1458,7 +1456,7 @@ func (t *Translator) processServiceDestinationSetting(
 
 	// support HTTPRouteBackendProtocolH2C/GRPC
 	if servicePort.AppProtocol != nil {
-		protocol = serviceAppProtocolToIRAppProtocol(*servicePort.AppProtocol, protocol /*supportLegacy=*/, true)
+		protocol = serviceAppProtocolToIRAppProtocol(*servicePort.AppProtocol, protocol, true)
 	}
 
 	// Route to endpoints by default

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -1848,13 +1848,13 @@ func (t *Translator) processBackendDestinationSetting(name string, backendRef gw
 
 // serviceAppProtocolToIRAppProtocol translates the appProtocol string into an ir.AppProtocol.
 //
-// When supportLegacy is enabled, `grpc` will be parsed as a valid option for HTTP2.
+// When grpcCompatibility is enabled, `grpc` will be parsed as a valid option for HTTP2.
 // See https://github.com/envoyproxy/gateway/issues/5485#issuecomment-2731322578.
-func serviceAppProtocolToIRAppProtocol(ap string, defaultProtocol ir.AppProtocol, supportLegacy bool) ir.AppProtocol {
+func serviceAppProtocolToIRAppProtocol(ap string, defaultProtocol ir.AppProtocol, grpcCompatibility bool) ir.AppProtocol {
 	switch {
 	case ap == "kubernetes.io/h2c":
 		return ir.HTTP2
-	case ap == "grpc" && supportLegacy:
+	case ap == "grpc" && grpcCompatibility:
 		return ir.GRPC
 	default:
 		return defaultProtocol

--- a/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.in.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.in.yaml
@@ -71,7 +71,7 @@ serviceImports:
           protocol: TCP
           appProtocol: kubernetes.io/h2c # This takes effect.
         - port: 9000
-          name: http
+          name: grpc
           protocol: TCP
           appProtocol: grpc # This is NOOP.
 
@@ -108,6 +108,10 @@ backendTLSPolicies:
           kind: ServiceImport
           name: service-import-1
           sectionName: http
+        - group: multicluster.x-k8s.io
+          kind: ServiceImport
+          name: service-import-1
+          sectionName: grpc
       validation:
         wellKnownCACertificates: System
         hostname: example.com

--- a/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.in.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.in.yaml
@@ -35,6 +35,11 @@ httpRoutes:
               name: service-import-1
               namespace: default
               port: 8080
+            - group: multicluster.x-k8s.io
+              kind: ServiceImport
+              name: service-import-1
+              namespace: default
+              port: 9000
 
 referenceGrants:
   - apiVersion: gateway.networking.k8s.io/v1alpha2
@@ -64,7 +69,11 @@ serviceImports:
         - port: 8080
           name: http
           protocol: TCP
-          appProtocol: kubernetes.io/h2c
+          appProtocol: kubernetes.io/h2c # This takes effect.
+        - port: 9000
+          name: http
+          protocol: TCP
+          appProtocol: grpc # This is NOOP.
 
 endpointSlices:
   - apiVersion: discovery.k8s.io/v1
@@ -79,6 +88,9 @@ endpointSlices:
       - name: http
         protocol: TCP
         port: 8080
+      - name: grpc
+        protocol: TCP
+        port: 9000
     endpoints:
       - addresses:
           - "10.244.0.11"

--- a/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.in.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.in.yaml
@@ -64,6 +64,7 @@ serviceImports:
         - port: 8080
           name: http
           protocol: TCP
+          appProtocol: kubernetes.io/h2c
 
 endpointSlices:
   - apiVersion: discovery.k8s.io/v1

--- a/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.in.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.in.yaml
@@ -69,11 +69,11 @@ serviceImports:
         - port: 8080
           name: http
           protocol: TCP
-          appProtocol: kubernetes.io/h2c # This takes effect.
+          appProtocol: kubernetes.io/h2c  # This takes effect.
         - port: 9000
           name: grpc
           protocol: TCP
-          appProtocol: grpc # This is NOOP.
+          appProtocol: grpc  # This is NOOP.
 
 endpointSlices:
   - apiVersion: discovery.k8s.io/v1

--- a/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
@@ -87,6 +87,11 @@ httpRoutes:
         name: service-import-1
         namespace: default
         port: 8080
+      - group: multicluster.x-k8s.io
+        kind: ServiceImport
+        name: service-import-1
+        namespace: default
+        port: 9000
       matches:
       - path:
           type: Exact
@@ -150,6 +155,15 @@ xdsIR:
           name: httproute/envoy-gateway/httproute-btls/rule/0
           settings:
           - name: httproute/envoy-gateway/httproute-btls/rule/0/backend/0
+            protocol: HTTP2
+            tls:
+              alpnProtocols: null
+              caCertificate:
+                name: policy-btls/default-ca
+              sni: example.com
+              useSystemTrustStore: true
+            weight: 1
+          - name: httproute/envoy-gateway/httproute-btls/rule/0/backend/1
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
@@ -11,6 +11,10 @@ backendTLSPolicies:
       kind: ServiceImport
       name: service-import-1
       sectionName: http
+    - group: multicluster.x-k8s.io
+      kind: ServiceImport
+      name: service-import-1
+      sectionName: grpc
     validation:
       hostname: example.com
       wellKnownCACertificates: System

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -23,6 +23,7 @@ new features: |
   Added support for HTTP Methods and Headers based authorization in SecurityPolicy
   Added support for zone aware routing
   Added support for BackendTLSPolicy to target ServiceImport
+  Added support for kubernetes.io/h2c application protocol in ServiceImport
   Added support for per-host circuit breaker thresholds
   Added support for egctl Websocket in addation to SPDY
   Added a configuration option in the Helm chart to set the TrafficDistribution field in the Envoy Gateway Service


### PR DESCRIPTION
## Problem

ServiceImport `appProtocol` is currently not honored.

## Solution

This PR add support for the user to specify `appProtocol = kubernetes.io/h2c` to configure xDS in H2 mode.

As discussed in https://github.com/envoyproxy/gateway/issues/5485#issuecomment-2737809512, we will **not** support the legacy `grpc` value. Only `kubernetes.io/h2c` is supported for `ServiceImport`. 

No changes are made to pre-existing behavior for `Service` `appProtocol` parsing.

## Additional Info

Fixes https://github.com/envoyproxy/gateway/issues/5485

Release Notes: Yes
