### PR TITLE
docs: Fix Podname used as command in HTTPRoute Docs (Latest)

### DIFF
--- a/site/content/en/latest/tasks/traffic/http-routing.md
+++ b/site/content/en/latest/tasks/traffic/http-routing.md
@@ -277,8 +277,9 @@ Test routing to the `foo-svc` backend by specifying a JWT Token with a claim `na
 
 ```shell
 curl -sS -H "Host: foo.example.com" -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/login" | jq .pod
-"foo-backend-6df8cc6b9f-fmwcg"
 ```
+The request should return the pod name, for example `foo-backend-6df8cc6b9f-fmwcg`
+
 
 Get another JWT used for testing request authentication:
 
@@ -290,8 +291,9 @@ Test HTTP routing to the `bar-svc` backend by specifying a JWT Token with a clai
 
 ```shell
 curl -sS -H "Host: bar.example.com" -H "Authorization: Bearer $TOKEN" "http://${GATEWAY_HOST}/" | jq .pod
-"bar-backend-6688b8944c-s8htr"
 ```
+The request should return the pod name, for example `bar-backend-6688b8944c-s8htr`
+
 
 [HTTPRoute]: https://gateway-api.sigs.k8s.io/api-types/httproute/
 [Gateway API documentation]: https://gateway-api.sigs.k8s.io/


### PR DESCRIPTION
**What type of PR is this?**
Removes the podname outputs from commands in the HTTPRoute docs.


**What this PR does / why we need it**:
If the user copied the command as is, it would fail. Removing the podname helps resolve this issue. 

**Which issue(s) this PR fixes**:
Fixes: N/A

Release Notes: No
