### PR TITLE
chore: bump golang to 1.24.2

### DIFF
--- a/examples/envoy-ext-auth/Dockerfile
+++ b/examples/envoy-ext-auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.1 AS builder
+FROM golang:1.24.2 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/envoy-ext-auth/go.mod
+++ b/examples/envoy-ext-auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-grcp-ext-auth
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4

--- a/examples/extension-server/go.mod
+++ b/examples/extension-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/exampleorg/envoygateway-extension
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/envoyproxy/gateway v1.3.1

--- a/examples/grpc-ext-proc/Dockerfile
+++ b/examples/grpc-ext-proc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.1 AS builder
+FROM golang:1.24.2 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/grpc-ext-proc/go.mod
+++ b/examples/grpc-ext-proc/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-grpc-ext-proc
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4

--- a/examples/preserve-case-backend/Dockerfile
+++ b/examples/preserve-case-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.1 AS builder
+FROM golang:1.24.2 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/preserve-case-backend/go.mod
+++ b/examples/preserve-case-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-preserve-case-backend
 
-go 1.24.1
+go 1.24.2
 
 require github.com/valyala/fasthttp v1.59.0
 

--- a/examples/static-file-server/Dockerfile
+++ b/examples/static-file-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.1 AS builder
+FROM golang:1.24.2 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/static-file-server/go.mod
+++ b/examples/static-file-server/go.mod
@@ -1,3 +1,3 @@
 module github.com/envoyproxy/static-file-server
 
-go 1.24.1
+go 1.24.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway
 
-go 1.24.1
+go 1.24.2
 
 require (
 	fortio.org/fortio v1.68.1

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/docsy-example
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 // indirect


### PR DESCRIPTION
xref: https://github.com/envoyproxy/gateway/actions/runs/14369743939/job/40290456459