### PR TITLE
chore: support trace log level

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -330,10 +330,13 @@ type KubernetesServiceSpec struct {
 }
 
 // LogLevel defines a log level for Envoy Gateway and EnvoyProxy system logs.
-// +kubebuilder:validation:Enum=debug;info;error;warn
+// +kubebuilder:validation:Enum=trace;debug;info;warn;error
 type LogLevel string
 
 const (
+	// LogLevelTrace defines the "Trace" logging level.
+	LogLevelTrace LogLevel = "trace"
+
 	// LogLevelDebug defines the "debug" logging level.
 	LogLevelDebug LogLevel = "debug"
 

--- a/api/v1alpha1/validation/envoygateway_validate.go
+++ b/api/v1alpha1/validation/envoygateway_validate.go
@@ -146,9 +146,9 @@ func validateEnvoyGatewayLogging(logging *egv1a1.EnvoyGatewayLogging) error {
 			egv1a1.LogComponentInfrastructureRunner,
 			egv1a1.LogComponentGlobalRateLimitRunner:
 			switch logLevel {
-			case egv1a1.LogLevelDebug, egv1a1.LogLevelError, egv1a1.LogLevelWarn, egv1a1.LogLevelInfo:
+			case egv1a1.LogLevelTrace, egv1a1.LogLevelDebug, egv1a1.LogLevelError, egv1a1.LogLevelWarn, egv1a1.LogLevelInfo:
 			default:
-				return fmt.Errorf("envoy gateway logging level invalid. valid options: info/debug/warn/error")
+				return fmt.Errorf("envoy gateway logging level invalid. valid options: trace/debug/info/warn/error")
 			}
 		default:
 			return fmt.Errorf("envoy gateway logging components invalid. valid options: system/provider/gateway-api/xds-translator/xds-server/infrastructure")

--- a/api/v1alpha1/validation/envoygateway_validate.go
+++ b/api/v1alpha1/validation/envoygateway_validate.go
@@ -146,9 +146,9 @@ func validateEnvoyGatewayLogging(logging *egv1a1.EnvoyGatewayLogging) error {
 			egv1a1.LogComponentInfrastructureRunner,
 			egv1a1.LogComponentGlobalRateLimitRunner:
 			switch logLevel {
-			case egv1a1.LogLevelTrace, egv1a1.LogLevelDebug, egv1a1.LogLevelError, egv1a1.LogLevelWarn, egv1a1.LogLevelInfo:
+			case egv1a1.LogLevelDebug, egv1a1.LogLevelError, egv1a1.LogLevelWarn, egv1a1.LogLevelInfo:
 			default:
-				return fmt.Errorf("envoy gateway logging level invalid. valid options: trace/debug/info/warn/error")
+				return fmt.Errorf("envoy gateway logging level invalid. valid options: info/debug/warn/error")
 			}
 		default:
 			return fmt.Errorf("envoy gateway logging components invalid. valid options: system/provider/gateway-api/xds-translator/xds-server/infrastructure")

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
@@ -423,10 +423,11 @@ spec:
                       description: LogLevel defines a log level for Envoy Gateway
                         and EnvoyProxy system logs.
                       enum:
+                      - trace
                       - debug
                       - info
-                      - error
                       - warn
+                      - error
                       type: string
                     default:
                       default: warn

--- a/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
@@ -374,7 +374,7 @@ func TestDeployment(t *testing.T) {
 			infra:    newTestInfra(),
 			deploy:   nil,
 			proxyLogging: map[egv1a1.ProxyLogComponent]egv1a1.LogLevel{
-				egv1a1.LogComponentDefault: egv1a1.LogLevelError,
+				egv1a1.LogComponentDefault: egv1a1.LogLevelTrace,
 				egv1a1.LogComponentFilter:  egv1a1.LogLevelInfo,
 			},
 			bootstrap: `test bootstrap config`,

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -42,7 +42,7 @@ spec:
         - --service-cluster default
         - --service-node $(ENVOY_POD_NAME)
         - --config-yaml test bootstrap config
-        - --log-level error
+        - --log-level trace
         - --cpuset-threads
         - --drain-strategy immediate
         - --component-log-level filter:info

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -26,7 +26,8 @@ new features: |
   Added support for per-host circuit breaker thresholds
   Added support for egctl Websocket in addation to SPDY
   Added a configuration option in the Helm chart to set the TrafficDistribution field in the Envoy Gateway Service
-
+  Added support for setting the log level to trace for the Envoy Proxy
+  
 bug fixes: |
   Fix traffic splitting when filters are attached to the backendRef.
   Added support for Secret and ConfigMap parsing in Standalone mode.

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -27,7 +27,7 @@ new features: |
   Added support for egctl Websocket in addation to SPDY
   Added a configuration option in the Helm chart to set the TrafficDistribution field in the Envoy Gateway Service
   Added support for setting the log level to trace for the Envoy Proxy
-  
+
 bug fixes: |
   Fix traffic splitting when filters are attached to the backendRef.
   Added support for Secret and ConfigMap parsing in Standalone mode.

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -2920,6 +2920,7 @@ _Appears in:_
 
 | Value | Description |
 | ----- | ----------- |
+| `trace` | LogLevelTrace defines the "Trace" logging level.<br /> | 
 | `debug` | LogLevelDebug defines the "debug" logging level.<br /> | 
 | `info` | LogLevelInfo defines the "Info" logging level.<br /> | 
 | `warn` | LogLevelWarn defines the "Warn" logging level.<br /> | 


### PR DESCRIPTION
Support setting log level to `trace` for the Envoy Proxy fleet. This is often required for debugging purposes.

Release Notes: Yes
