### PR TITLE
feat(helm): Add global imageRegistry and imagePullSecrets overrides

### DIFF
--- a/charts/gateway-helm/README.md
+++ b/charts/gateway-helm/README.md
@@ -62,9 +62,10 @@ To uninstall the chart:
 | certgen | object | `{"job":{"affinity":{},"annotations":{},"args":[],"nodeSelector":{},"resources":{},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}},"tolerations":[],"ttlSecondsAfterFinished":30},"rbac":{"annotations":{},"labels":{}}}` | Certgen is used to generate the certificates required by EnvoyGateway. If you want to construct a custom certificate, you can generate a custom certificate through Cert-Manager before installing EnvoyGateway. Certgen will not overwrite the custom certificate. Please do not manually modify `values.yaml` to disable certgen, it may cause EnvoyGateway OIDC,OAuth2,etc. to not work as expected. |
 | config.envoyGateway | object | `{"gateway":{"controllerName":"gateway.envoyproxy.io/gatewayclass-controller"},"logging":{"level":{"default":"info"}},"provider":{"type":"Kubernetes"}}` | EnvoyGateway configuration. Visit https://gateway.envoyproxy.io/docs/api/extension_types/#envoygateway to view all options. |
 | createNamespace | bool | `false` |  |
-| deployment.envoyGateway.image.repository | string | `""` |  |
-| deployment.envoyGateway.image.tag | string | `""` |  |
-| deployment.envoyGateway.imagePullPolicy | string | `""` |  |
+| deployment.envoyGateway.image.registry | string | `"docker.io"` | Default set via REGISTRY environment variable during chart build |
+| deployment.envoyGateway.image.repository | string | `"envoyproxy/gateway"` | Default set via REPOSITORY environment variable during chart build |
+| deployment.envoyGateway.image.tag | string | `"latest"` | Default set via TAG environment variable during chart build |
+| deployment.envoyGateway.imagePullPolicy | string | `"IfNotPresent"` | Default set via IMAGE_PULL_POLICY environment variable during chart build |
 | deployment.envoyGateway.imagePullSecrets | list | `[]` |  |
 | deployment.envoyGateway.resources.limits.memory | string | `"1024Mi"` |  |
 | deployment.envoyGateway.resources.requests.cpu | string | `"100m"` |  |
@@ -97,12 +98,8 @@ To uninstall the chart:
 | deployment.ports[3].targetPort | int | `19001` |  |
 | deployment.priorityClassName | string | `nil` |  |
 | deployment.replicas | int | `1` |  |
-| global.images.envoyGateway.image | string | `nil` |  |
-| global.images.envoyGateway.pullPolicy | string | `nil` |  |
-| global.images.envoyGateway.pullSecrets | list | `[]` |  |
-| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:master"` |  |
-| global.images.ratelimit.pullPolicy | string | `"IfNotPresent"` |  |
-| global.images.ratelimit.pullSecrets | list | `[]` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
 | hpa.behavior | object | `{}` |  |
 | hpa.enabled | bool | `false` |  |
 | hpa.maxReplicas | int | `1` |  |
@@ -110,6 +107,11 @@ To uninstall the chart:
 | hpa.minReplicas | int | `1` |  |
 | kubernetesClusterDomain | string | `"cluster.local"` |  |
 | podDisruptionBudget.minAvailable | int | `0` |  |
+| ratelimit.image.registry | string | `"docker.io"` | Default set via REGISTRY environment variable during chart build |
+| ratelimit.image.repository | string | `"envoyproxy/ratelimit"` | Default set via RATELIMIT_REPOSITORY environment variable during chart build |
+| ratelimit.image.tag | string | `"master"` | Default set via RATELIMIT_TAG environment variable during chart build |
+| ratelimit.imagePullPolicy | string | `"IfNotPresent"` |  |
+| ratelimit.imagePullSecrets | list | `[]` |  |
 | service.annotations | object | `{}` |  |
 | service.trafficDistribution | string | `""` |  |
 

--- a/charts/gateway-helm/templates/_helpers.tpl
+++ b/charts/gateway-helm/templates/_helpers.tpl
@@ -65,36 +65,55 @@ Create the name of the service account to use
 The name of the Envoy Gateway image.
 */}}
 {{- define "eg.image" -}}
-{{- if .Values.deployment.envoyGateway.image.repository }}
-{{- .Values.deployment.envoyGateway.image.repository }}:{{ .Values.deployment.envoyGateway.image.tag | default .Values.global.images.envoyGateway.tag | default .Chart.AppVersion }}
-{{- else if .Values.global.images.envoyGateway.image }}
-{{- .Values.global.images.envoyGateway.image }}
-{{- else }}
-docker.io/envoyproxy/gateway:{{ .Chart.Version }}
-{{- end }}
-{{- end }}
+{{- $registryName := default .Values.deployment.envoyGateway.image.registry ((.global).imageRegistry) -}}
+{{- $repositoryName := .Values.deployment.envoyGateway.image.repository -}}
+{{- $termination := .Values.deployment.envoyGateway.image.tag -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $termination -}}
+{{- end -}}
 
 {{/*
 Pull policy for the Envoy Gateway image.
 */}}
 {{- define "eg.image.pullPolicy" -}}
-{{ .Values.deployment.envoyGateway.imagePullPolicy | default .Values.global.images.envoyGateway.pullPolicy | default "IfNotPresent" }}
+{{ .Values.deployment.envoyGateway.imagePullPolicy }}
 {{- end }}
 
 {{/*
 Pull secrets for the Envoy Gateway image.
 */}}
 {{- define "eg.image.pullSecrets" -}}
-{{- if .Values.deployment.envoyGateway.imagePullSecrets -}}
-imagePullSecrets:
+{{- if .Values.global.imagePullSecrets -}}
+{{ toYaml .Values.global.imagePullSecrets }}
+{{- else if .Values.deployment.envoyGateway.imagePullSecrets -}}
 {{ toYaml .Values.deployment.envoyGateway.imagePullSecrets }}
-{{- else if .Values.global.images.envoyGateway.pullSecrets -}}
-imagePullSecrets:
-{{ toYaml .Values.global.images.envoyGateway.pullSecrets }}
 {{- else -}}
-imagePullSecrets: []
+[]
 {{- end }}
 {{- end }}
+
+{{/*
+The name of the Envoy Ratelimit image.
+*/}}
+{{- define "eg.ratelimit.image" -}}
+{{- $registryName := default .Values.ratelimit.image.registry ((.global).imageRegistry) -}}
+{{- $repositoryName := .Values.ratelimit.image.repository -}}
+{{- $termination := .Values.ratelimit.image.tag -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $termination -}}
+{{- end -}}
+
+{{/*
+Pull secrets for the Envoy Ratelimit image.
+*/}}
+{{- define "eg.ratelimit.image.pullSecrets" -}}
+{{- if .Values.global.imagePullSecrets -}}
+{{ toYaml .Values.global.imagePullSecrets }}
+{{- else if .Values.ratelimit.imagePullSecrets -}}
+{{ toYaml .Values.ratelimit.imagePullSecrets }}
+{{- else -}}
+{{ toYaml list }}
+{{- end }}
+{{- end }}
+
 
 {{/*
 The default Envoy Gateway configuration.
@@ -105,17 +124,9 @@ provider:
   kubernetes:
     rateLimitDeployment:
       container:
-        {{- if .Values.global.images.ratelimit.image }}
-        image: {{ .Values.global.images.ratelimit.image }}
-        {{- else }}
-        image: "docker.io/envoyproxy/ratelimit:master"
-        {{- end }}
-      {{- with .Values.global.images.ratelimit.pullSecrets }}
+        image: {{ include "eg.ratelimit.image" . }}
       pod:
-        imagePullSecrets:
-        {{- toYaml . | nindent 10 }}
-      {{- end }}
-      {{- with .Values.global.images.ratelimit.pullPolicy }}
+        imagePullSecrets: {{- include "eg.ratelimit.image.pullSecrets" . | nindent 10 }}
       patch:
         type: StrategicMerge
         value:
@@ -124,8 +135,7 @@ provider:
               spec:
                 containers:
                 - name: envoy-ratelimit
-                  imagePullPolicy: {{ . }}
-      {{- end }}
+                  imagePullPolicy: {{ .Values.ratelimit.imagePullPolicy }}
     shutdownManager:
       image: {{ include "eg.image" . }}
 {{- end }}

--- a/charts/gateway-helm/templates/certgen.yaml
+++ b/charts/gateway-helm/templates/certgen.yaml
@@ -48,7 +48,7 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.certgen.job.securityContext | nindent 10 }}
-      {{- include "eg.image.pullSecrets" . | nindent 6 }}
+      imagePullSecrets: {{- include "eg.image.pullSecrets" . | nindent 8 }}
       {{- with .Values.certgen.job.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
@@ -84,7 +84,7 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
-      {{- include "eg.image.pullSecrets" . | nindent 6 }}
+      imagePullSecrets: {{- include "eg.image.pullSecrets" . | nindent 8 }}
       {{- with .Values.deployment.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -1,33 +1,37 @@
-# The global settings for the Envoy Gateway Helm chart.
-# These values will be used if the values are not overridden in the other sections.
+# Global settings
+# If set, these override image-specific values: useful when installing the chart in a private registry environment.
+# Override image-specific values directly if a global override is not desired.
 global:
-  images:
-    envoyGateway:
-      # This is the full image name including the hub, repo, and tag.
-      image: ${GatewayImage}
-      # Specify image pull policy if default behavior isn't desired.
-      # Default behavior: latest images will be Always else IfNotPresent.
-      pullPolicy: ${GatewayImagePullPolicy}
-      # List of secrets in the same namespace of the component that can be used to pull images from private repositories.
-      pullSecrets: []
-    ratelimit:
-      # This is the full image name including the hub, repo, and tag.
-      image: "docker.io/envoyproxy/ratelimit:master"
-      # Specify image pull policy if default behavior isn't desired.
-      # Default behavior: latest images will be Always else IfNotPresent.
-      pullPolicy: IfNotPresent
-      # List of secrets in the same namespace of the component that can be used to pull images from private repositories.
-      pullSecrets: []
+  imageRegistry: ""
+  imagePullSecrets: []
+
 podDisruptionBudget:
   minAvailable: 0
   # maxUnavailable: 1
 
+ratelimit:
+  image:
+    # -- Default set via REGISTRY environment variable during chart build
+    registry: "${Registry}"
+    # -- Default set via RATELIMIT_REPOSITORY environment variable during chart build
+    repository: "${RatelimitRepository}"
+    # -- Default set via RATELIMIT_TAG environment variable during chart build
+    tag: "${RatelimitTag}"
+  imagePullSecrets: []
+  imagePullPolicy: "IfNotPresent"
+
+
 deployment:
   envoyGateway:
     image:
-      repository: ""
-      tag: ""
-    imagePullPolicy: ""
+      # -- Default set via REGISTRY environment variable during chart build
+      registry: "${Registry}"
+      # -- Default set via REPOSITORY environment variable during chart build
+      repository: "${GatewayRepository}"
+      # -- Default set via TAG environment variable during chart build
+      tag: "${GatewayTag}"
+    # -- Default set via IMAGE_PULL_POLICY environment variable during chart build
+    imagePullPolicy: "${GatewayImagePullPolicy}"
     imagePullSecrets: []
     resources:
       limits:

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -4,6 +4,7 @@ date: Pending
 breaking changes: |
   Use a dedicated listener port(19003) for envoy proxy readiness
   Uses the envoy JSON formatter for the default access log instead of text formatter.
+  Removed environment variables IMAGE, IMAGE_NAME used for building the image; use REGISTRY and REPOSITORY instead
 
 # Updates addressing vulnerabilities, security flaws, or compliance requirements.
 security updates: |
@@ -27,6 +28,7 @@ new features: |
   Added support for per-host circuit breaker thresholds
   Added support for egctl Websocket in addation to SPDY
   Added a configuration option in the Helm chart to set the TrafficDistribution field in the Envoy Gateway Service
+  Added support for global imageRegistry and imagePullSecrets to the Helm chart
 
 bug fixes: |
   Fix traffic splitting when filters are attached to the backendRef.

--- a/site/content/en/contributions/DEVELOP.md
+++ b/site/content/en/contributions/DEVELOP.md
@@ -60,14 +60,14 @@ __Note:__ The `golangci-lint` configuration resides [here](https://github.com/en
 
 ### Building and Pushing the Image
 
-* Run `IMAGE=docker.io/you/gateway-dev make image` to build the docker image.
-* Run `IMAGE=docker.io/you/gateway-dev make push-multiarch` to build and push the multi-arch docker image.
+* Run `REGISTRY=docker.io REPOSITORY=you/gateway-dev make image` to build the docker image.
+* Run `REGISTRY=docker.io REPOSITORY=you/gateway-dev make push-multiarch` to build and push the multi-arch docker image.
 
-__Note:__  Replace `IMAGE` with your registry's image name.
+__Note:__  Replace `REPOSITORY` with your registry's image name.
 
 ### Raising a PR
 
-* Run `make generate` and push the generated files along with your commit, if your PR contains any **API** changes (changes in `/api` folder), you've added some unit tests or you've updated the modules used in the project. 
+* Run `make generate` and push the generated files along with your commit, if your PR contains any **API** changes (changes in `/api` folder), you've added some unit tests or you've updated the modules used in the project.
 
 ### Deploying Envoy Gateway for Test/Dev
 
@@ -86,7 +86,7 @@ __Note:__  Replace `IMAGE` with your registry's image name.
 ### Deploying Envoy Gateway in Kubernetes
 
 * Run `TAG=latest make kube-deploy` to deploy Envoy Gateway using the latest image into a Kubernetes cluster (linked to
-  the current kube context). Preface the command with `IMAGE` or replace `TAG` to use a different Envoy Gateway image or
+  the current kube context). Preface the command with `REGISTRY` and `REPOSITORY` or replace `TAG` to use a different Envoy Gateway image or
   tag.
 * Run `make kube-undeploy` to uninstall Envoy Gateway from the cluster.
 
@@ -120,7 +120,7 @@ workarounds to run conformance tests:
   uninstall Envoy Gateway.
 * Install and run [Docker Mac Net Connect][mac_connect] and then run `TAG=latest make conformance`.
 
-__Note:__  Preface commands with `IMAGE` or replace `TAG` to use a different Envoy Gateway image or tag. If `TAG`
+__Note:__  Preface commands with `REGISTRY` and `REPOSITORY` or replace `TAG` to use a different Envoy Gateway image or tag. If `TAG`
 is unspecified, the short SHA of your current branch is used.
 
 ### Debugging the Envoy Config
@@ -162,13 +162,13 @@ The performance and scalability concerns come from several aspects for control-p
 - The consumption of memory and CPU.
 - The rate of configuration changes.
 
-The benchmark test is running on a [Kind][Kind] cluster, you can start a Kind cluster and 
+The benchmark test is running on a [Kind][Kind] cluster, you can start a Kind cluster and
 run benchmark test on it by executing `make benchmark`.
 
 The benchmark report will be included in the release artifacts, you can learn more by downloading
 the detailed benchmark report, namely `benchmark_report.zip`.
 
-Here are some brief benchmark reports about Envoy Gateway: 
+Here are some brief benchmark reports about Envoy Gateway:
 
 - It will take up nearly 550MiB memory and 11s total CPU time for (1 GatewayClass + 1 Gateway + 500 HTTRoutes) settings
 

--- a/site/content/en/latest/install/gateway-helm-api.md
+++ b/site/content/en/latest/install/gateway-helm-api.md
@@ -26,9 +26,10 @@ The Helm chart for Envoy Gateway
 | certgen | object | `{"job":{"affinity":{},"annotations":{},"args":[],"nodeSelector":{},"resources":{},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}},"tolerations":[],"ttlSecondsAfterFinished":30},"rbac":{"annotations":{},"labels":{}}}` | Certgen is used to generate the certificates required by EnvoyGateway. If you want to construct a custom certificate, you can generate a custom certificate through Cert-Manager before installing EnvoyGateway. Certgen will not overwrite the custom certificate. Please do not manually modify `values.yaml` to disable certgen, it may cause EnvoyGateway OIDC,OAuth2,etc. to not work as expected. |
 | config.envoyGateway | object | `{"gateway":{"controllerName":"gateway.envoyproxy.io/gatewayclass-controller"},"logging":{"level":{"default":"info"}},"provider":{"type":"Kubernetes"}}` | EnvoyGateway configuration. Visit https://gateway.envoyproxy.io/docs/api/extension_types/#envoygateway to view all options. |
 | createNamespace | bool | `false` |  |
-| deployment.envoyGateway.image.repository | string | `""` |  |
-| deployment.envoyGateway.image.tag | string | `""` |  |
-| deployment.envoyGateway.imagePullPolicy | string | `""` |  |
+| deployment.envoyGateway.image.registry | string | `"docker.io"` | Default set via REGISTRY environment variable during chart build |
+| deployment.envoyGateway.image.repository | string | `"envoyproxy/gateway"` | Default set via REPOSITORY environment variable during chart build |
+| deployment.envoyGateway.image.tag | string | `"latest"` | Default set via TAG environment variable during chart build |
+| deployment.envoyGateway.imagePullPolicy | string | `"IfNotPresent"` | Default set via IMAGE_PULL_POLICY environment variable during chart build |
 | deployment.envoyGateway.imagePullSecrets | list | `[]` |  |
 | deployment.envoyGateway.resources.limits.memory | string | `"1024Mi"` |  |
 | deployment.envoyGateway.resources.requests.cpu | string | `"100m"` |  |
@@ -61,12 +62,8 @@ The Helm chart for Envoy Gateway
 | deployment.ports[3].targetPort | int | `19001` |  |
 | deployment.priorityClassName | string | `nil` |  |
 | deployment.replicas | int | `1` |  |
-| global.images.envoyGateway.image | string | `nil` |  |
-| global.images.envoyGateway.pullPolicy | string | `nil` |  |
-| global.images.envoyGateway.pullSecrets | list | `[]` |  |
-| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:master"` |  |
-| global.images.ratelimit.pullPolicy | string | `"IfNotPresent"` |  |
-| global.images.ratelimit.pullSecrets | list | `[]` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
 | hpa.behavior | object | `{}` |  |
 | hpa.enabled | bool | `false` |  |
 | hpa.maxReplicas | int | `1` |  |
@@ -74,6 +71,11 @@ The Helm chart for Envoy Gateway
 | hpa.minReplicas | int | `1` |  |
 | kubernetesClusterDomain | string | `"cluster.local"` |  |
 | podDisruptionBudget.minAvailable | int | `0` |  |
+| ratelimit.image.registry | string | `"docker.io"` | Default set via REGISTRY environment variable during chart build |
+| ratelimit.image.repository | string | `"envoyproxy/ratelimit"` | Default set via RATELIMIT_REPOSITORY environment variable during chart build |
+| ratelimit.image.tag | string | `"master"` | Default set via RATELIMIT_TAG environment variable during chart build |
+| ratelimit.imagePullPolicy | string | `"IfNotPresent"` |  |
+| ratelimit.imagePullSecrets | list | `[]` |  |
 | service.annotations | object | `{}` |  |
 | service.trafficDistribution | string | `""` |  |
 

--- a/test/helm/gateway-helm/certgen-args.in.yaml
+++ b/test/helm/gateway-helm/certgen-args.in.yaml
@@ -1,8 +1,13 @@
 global:
-  images:
-    envoyGateway:
-      image: "docker.io/envoyproxy/gateway-dev:latest"
-      pullPolicy: Always
+  imageRegistry: "docker.io"
+
+deployment:
+  envoyGateway:
+    image:
+      repository: "envoyproxy/gateway-dev"
+      tag: "latest"
+    imagePullPolicy: Always
+
 certgen:
   job:
     args:

--- a/test/helm/gateway-helm/certgen-args.out.yaml
+++ b/test/helm/gateway-helm/certgen-args.out.yaml
@@ -47,6 +47,8 @@ data:
                     containers:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
+          pod:
+            imagePullSecrets: []
         shutdownManager:
           image: docker.io/envoyproxy/gateway-dev:latest
       type: Kubernetes
@@ -444,7 +446,8 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
       volumes:
@@ -570,7 +573,8 @@ spec:
           runAsUser: 65534
           seccompProfile:
             type: RuntimeDefault
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       restartPolicy: Never
       serviceAccountName: gateway-helm-certgen
   ttlSecondsAfterFinished: 30

--- a/test/helm/gateway-helm/certjen-custom-scheduling.in.yaml
+++ b/test/helm/gateway-helm/certjen-custom-scheduling.in.yaml
@@ -1,8 +1,13 @@
 global:
-  images:
-    envoyGateway:
-      image: "docker.io/envoyproxy/gateway-dev:latest"
-      pullPolicy: Always
+  imageRegistry: "docker.io"
+
+deployment:
+  envoyGateway:
+    image:
+      repository: "envoyproxy/gateway-dev"
+      tag: "latest"
+    imagePullPolicy: Always
+
 certgen:
   job:
     affinity:

--- a/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
+++ b/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
@@ -47,6 +47,8 @@ data:
                     containers:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
+          pod:
+            imagePullSecrets: []
         shutdownManager:
           image: docker.io/envoyproxy/gateway-dev:latest
       type: Kubernetes
@@ -444,7 +446,8 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
       volumes:
@@ -568,7 +571,8 @@ spec:
           runAsUser: 65534
           seccompProfile:
             type: RuntimeDefault
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/test/helm/gateway-helm/control-plane-with-pdb.in.yaml
+++ b/test/helm/gateway-helm/control-plane-with-pdb.in.yaml
@@ -1,8 +1,13 @@
 global:
-  images:
-    envoyGateway:
-      image: "docker.io/envoyproxy/gateway-dev:latest"
-      pullPolicy: Always
+  imageRegistry: "docker.io"
+
+deployment:
+  envoyGateway:
+    image:
+      repository: "envoyproxy/gateway-dev"
+      tag: "latest"
+    imagePullPolicy: Always
+
 podDisruptionBudget:
   minAvailable: 1
   maxUnavailable: 1

--- a/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
+++ b/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
@@ -62,6 +62,8 @@ data:
                     containers:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
+          pod:
+            imagePullSecrets: []
         shutdownManager:
           image: docker.io/envoyproxy/gateway-dev:latest
       type: Kubernetes
@@ -459,7 +461,8 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
       volumes:
@@ -583,7 +586,8 @@ spec:
           runAsUser: 65534
           seccompProfile:
             type: RuntimeDefault
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       restartPolicy: Never
       serviceAccountName: gateway-helm-certgen
   ttlSecondsAfterFinished: 30

--- a/test/helm/gateway-helm/default-config.in.yaml
+++ b/test/helm/gateway-helm/default-config.in.yaml
@@ -1,5 +1,9 @@
 global:
-  images:
-    envoyGateway:
-      image: "docker.io/envoyproxy/gateway-dev:latest"
-      pullPolicy: Always
+  imageRegistry: "docker.io"
+
+deployment:
+  envoyGateway:
+    image:
+      repository: "envoyproxy/gateway-dev"
+      tag: "latest"
+    imagePullPolicy: Always

--- a/test/helm/gateway-helm/default-config.out.yaml
+++ b/test/helm/gateway-helm/default-config.out.yaml
@@ -47,6 +47,8 @@ data:
                     containers:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
+          pod:
+            imagePullSecrets: []
         shutdownManager:
           image: docker.io/envoyproxy/gateway-dev:latest
       type: Kubernetes
@@ -444,7 +446,8 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
       volumes:
@@ -568,7 +571,8 @@ spec:
           runAsUser: 65534
           seccompProfile:
             type: RuntimeDefault
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       restartPolicy: Never
       serviceAccountName: gateway-helm-certgen
   ttlSecondsAfterFinished: 30

--- a/test/helm/gateway-helm/deployment-custom-topology.in.yaml
+++ b/test/helm/gateway-helm/deployment-custom-topology.in.yaml
@@ -1,9 +1,12 @@
 global:
-  images:
-    envoyGateway:
-      image: "docker.io/envoyproxy/gateway-dev:latest"
-      pullPolicy: Always
+  imageRegistry: "docker.io"
+
 deployment:
+  envoyGateway:
+    image:
+      repository: "envoyproxy/gateway-dev"
+      tag: "latest"
+    imagePullPolicy: Always
   pod:
     affinity:
       nodeAffinity:

--- a/test/helm/gateway-helm/deployment-custom-topology.out.yaml
+++ b/test/helm/gateway-helm/deployment-custom-topology.out.yaml
@@ -47,6 +47,8 @@ data:
                     containers:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
+          pod:
+            imagePullSecrets: []
         shutdownManager:
           image: docker.io/envoyproxy/gateway-dev:latest
       type: Kubernetes
@@ -472,7 +474,8 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
       volumes:
@@ -596,7 +599,8 @@ spec:
           runAsUser: 65534
           seccompProfile:
             type: RuntimeDefault
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       restartPolicy: Never
       serviceAccountName: gateway-helm-certgen
   ttlSecondsAfterFinished: 30

--- a/test/helm/gateway-helm/deployment-images-config.in.yaml
+++ b/test/helm/gateway-helm/deployment-images-config.in.yaml
@@ -3,7 +3,8 @@
 deployment:
   envoyGateway:
     image:
-      repository: private-hub/envoyproxy/gateway
+      registry: private-hub
+      repository: envoyproxy/gateway
       tag: abcdef12
     imagePullPolicy: IfNotPresent
     imagePullSecrets:

--- a/test/helm/gateway-helm/deployment-images-config.out.yaml
+++ b/test/helm/gateway-helm/deployment-images-config.out.yaml
@@ -47,6 +47,8 @@ data:
                     containers:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
+          pod:
+            imagePullSecrets: []
         shutdownManager:
           image: private-hub/envoyproxy/gateway:abcdef12
       type: Kubernetes
@@ -445,8 +447,8 @@ spec:
           name: certs
           readOnly: true
       imagePullSecrets:
-      - name: secret1
-      - name: secret2
+        - name: secret1
+        - name: secret2
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
       volumes:
@@ -571,8 +573,8 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       imagePullSecrets:
-      - name: secret1
-      - name: secret2
+        - name: secret1
+        - name: secret2
       restartPolicy: Never
       serviceAccountName: gateway-helm-certgen
   ttlSecondsAfterFinished: 30

--- a/test/helm/gateway-helm/deployment-priorityclass.in.yaml
+++ b/test/helm/gateway-helm/deployment-priorityclass.in.yaml
@@ -1,7 +1,10 @@
 global:
-  images:
-    envoyGateway:
-      image: "docker.io/envoyproxy/gateway-dev:latest"
-      pullPolicy: Always
+  imageRegistry: "docker.io"
+
 deployment:
+  envoyGateway:
+    image:
+      repository: "envoyproxy/gateway-dev"
+      tag: "latest"
+    imagePullPolicy: Always
   priorityClassName: system-cluster-critical

--- a/test/helm/gateway-helm/deployment-priorityclass.out.yaml
+++ b/test/helm/gateway-helm/deployment-priorityclass.out.yaml
@@ -47,6 +47,8 @@ data:
                     containers:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
+          pod:
+            imagePullSecrets: []
         shutdownManager:
           image: docker.io/envoyproxy/gateway-dev:latest
       type: Kubernetes
@@ -444,7 +446,8 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       priorityClassName: "system-cluster-critical"
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
@@ -569,7 +572,8 @@ spec:
           runAsUser: 65534
           seccompProfile:
             type: RuntimeDefault
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       restartPolicy: Never
       serviceAccountName: gateway-helm-certgen
   ttlSecondsAfterFinished: 30

--- a/test/helm/gateway-helm/deployment-securitycontext.in.yaml
+++ b/test/helm/gateway-helm/deployment-securitycontext.in.yaml
@@ -1,10 +1,12 @@
 global:
-  images:
-    envoyGateway:
-      image: "docker.io/envoyproxy/gateway-dev:latest"
-      pullPolicy: Always
+  imageRegistry: "docker.io"
+
 deployment:
   envoyGateway:
+    image:
+      repository: "envoyproxy/gateway-dev"
+      tag: "latest"
+    imagePullPolicy: Always
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/test/helm/gateway-helm/deployment-securitycontext.out.yaml
+++ b/test/helm/gateway-helm/deployment-securitycontext.out.yaml
@@ -47,6 +47,8 @@ data:
                     containers:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
+          pod:
+            imagePullSecrets: []
         shutdownManager:
           image: docker.io/envoyproxy/gateway-dev:latest
       type: Kubernetes
@@ -444,7 +446,8 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
       volumes:
@@ -568,7 +571,8 @@ spec:
           runAsUser: 1000
           seccompProfile:
             type: RuntimeDefault
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       restartPolicy: Never
       serviceAccountName: gateway-helm-certgen
   ttlSecondsAfterFinished: 30

--- a/test/helm/gateway-helm/envoy-gateway-config.in.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-config.in.yaml
@@ -1,8 +1,21 @@
 global:
-  images:
-    envoyGateway:
-      image: "docker.io/envoyproxy/gateway-dev:latest"
-      pullPolicy: Always
+  imageRegistry: "docker.io"
+
+deployment:
+  envoyGateway:
+    image:
+      repository: "envoyproxy/gateway-dev"
+      tag: "latest"
+    imagePullPolicy: Always
+
+# maybe nuke this
+ratelimit:
+  image:
+    registry: "private-hub"
+    repository: "envoyproxy/ratelimit"
+    tag: "master"
+  imagePullPolicy: Always
+
 config:
   envoyGateway:
     gateway:

--- a/test/helm/gateway-helm/envoy-gateway-config.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-config.out.yaml
@@ -47,8 +47,10 @@ data:
                 template:
                   spec:
                     containers:
-                    - imagePullPolicy: IfNotPresent
+                    - imagePullPolicy: Always
                       name: envoy-ratelimit
+          pod:
+            imagePullSecrets: []
         shutdownManager:
           image: docker.io/envoyproxy/gateway-dev:latest
       type: Kubernetes
@@ -446,7 +448,8 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
       volumes:
@@ -570,7 +573,8 @@ spec:
           runAsUser: 65534
           seccompProfile:
             type: RuntimeDefault
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       restartPolicy: Never
       serviceAccountName: gateway-helm-certgen
   ttlSecondsAfterFinished: 30

--- a/test/helm/gateway-helm/global-images-config.in.yaml
+++ b/test/helm/gateway-helm/global-images-config.in.yaml
@@ -1,14 +1,17 @@
 global:
-  images:
-    envoyGateway:
-      image: "private-hub/envoyproxy/gateway:abcdef12"
-      pullPolicy: Always
-      pullSecrets:
-        - name: "secret1"
-        - name: "secret2"
-    ratelimit:
-      image: "private-hub/envoyproxy/ratelimit:test"
-      pullPolicy: Always
-      pullSecrets:
-        - name: "secret3"
-        - name: "secret4"
+  imageRegistry: private-hub
+  imagePullSecrets:
+    - name: "secret1"
+    - name: "secret2"
+
+deployment:
+  envoyGateway:
+    image:
+      repository: "envoyproxy/gateway"
+      tag: "abcdef12"
+    imagePullPolicy: Always
+ratelimit:
+  image:
+    repository: "envoyproxy/ratelimit"
+    tag: "test"
+  imagePullPolicy: Always

--- a/test/helm/gateway-helm/global-images-config.out.yaml
+++ b/test/helm/gateway-helm/global-images-config.out.yaml
@@ -37,7 +37,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: private-hub/envoyproxy/ratelimit:test
+            image: docker.io/envoyproxy/ratelimit:test
           patch:
             type: StrategicMerge
             value:
@@ -49,10 +49,10 @@ data:
                       name: envoy-ratelimit
           pod:
             imagePullSecrets:
-            - name: secret3
-            - name: secret4
+            - name: secret1
+            - name: secret2
         shutdownManager:
-          image: private-hub/envoyproxy/gateway:abcdef12
+          image: docker.io/envoyproxy/gateway:abcdef12
       type: Kubernetes
 ---
 # Source: gateway-helm/templates/envoy-gateway-rbac.yaml
@@ -400,7 +400,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: private-hub/envoyproxy/gateway:abcdef12
+        image: docker.io/envoyproxy/gateway:abcdef12
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -449,8 +449,8 @@ spec:
           name: certs
           readOnly: true
       imagePullSecrets:
-      - name: secret1
-      - name: secret2
+        - name: secret1
+        - name: secret2
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
       volumes:
@@ -559,7 +559,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: private-hub/envoyproxy/gateway:abcdef12
+        image: docker.io/envoyproxy/gateway:abcdef12
         imagePullPolicy: Always
         name: envoy-gateway-certgen
         securityContext:
@@ -575,8 +575,8 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       imagePullSecrets:
-      - name: secret1
-      - name: secret2
+        - name: secret1
+        - name: secret2
       restartPolicy: Never
       serviceAccountName: gateway-helm-certgen
   ttlSecondsAfterFinished: 30

--- a/test/helm/gateway-helm/horizontal-pod-autoscaler.in.yaml
+++ b/test/helm/gateway-helm/horizontal-pod-autoscaler.in.yaml
@@ -1,8 +1,12 @@
 global:
-  images:
-    envoyGateway:
-      image: "docker.io/envoyproxy/gateway-dev:latest"
-      pullPolicy: Always
+  imageRegistry: "docker.io"
+
+deployment:
+  envoyGateway:
+    image:
+      repository: "envoyproxy/gateway-dev"
+      tag: "latest"
+    imagePullPolicy: Always
 
 hpa:
   enabled: true

--- a/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
+++ b/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
@@ -47,6 +47,8 @@ data:
                     containers:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
+          pod:
+            imagePullSecrets: []
         shutdownManager:
           image: docker.io/envoyproxy/gateway-dev:latest
       type: Kubernetes
@@ -444,7 +446,8 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
       volumes:
@@ -599,7 +602,8 @@ spec:
           runAsUser: 65534
           seccompProfile:
             type: RuntimeDefault
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       restartPolicy: Never
       serviceAccountName: gateway-helm-certgen
   ttlSecondsAfterFinished: 30

--- a/test/helm/gateway-helm/service-customization.in.yaml
+++ b/test/helm/gateway-helm/service-customization.in.yaml
@@ -1,8 +1,13 @@
 global:
-  images:
-    envoyGateway:
-      image: "docker.io/envoyproxy/gateway-dev:latest"
-      pullPolicy: Always
+  imageRegistry: "docker.io"
+
+deployment:
+  envoyGateway:
+    image:
+      repository: "envoyproxy/gateway-dev"
+      tag: "latest"
+    imagePullPolicy: Always
+
 service:
   trafficDistribution: PreferClose
   annotations:

--- a/test/helm/gateway-helm/service-customization.out.yaml
+++ b/test/helm/gateway-helm/service-customization.out.yaml
@@ -47,6 +47,8 @@ data:
                     containers:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
+          pod:
+            imagePullSecrets: []
         shutdownManager:
           image: docker.io/envoyproxy/gateway-dev:latest
       type: Kubernetes
@@ -447,7 +449,8 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       serviceAccountName: envoy-gateway
       terminationGracePeriodSeconds: 10
       volumes:
@@ -571,7 +574,8 @@ spec:
           runAsUser: 65534
           seccompProfile:
             type: RuntimeDefault
-      imagePullSecrets: []
+      imagePullSecrets:
+        []
       restartPolicy: Never
       serviceAccountName: gateway-helm-certgen
   ttlSecondsAfterFinished: 30

--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -129,7 +129,12 @@ helm-readme-gen.%:
 	$(eval CHART_NAME := $(COMMAND))
 	# use production ENV to generate helm api doc
 	@if test -f "charts/${CHART_NAME}/values.tmpl.yaml"; then \
-		ImageRepository=docker.io/envoyproxy/gateway ImageTag=latest ImagePullPolicy=IfNotPresent \
+  		Registry=docker.io\
+			GatewayRepository=envoyproxy/gateway\
+			GatewayTag=latest\
+			GatewayImagePullPolicy=IfNotPresent\
+			RatelimitRepository=envoyproxy/ratelimit\
+			RatelimitTag=master\
 		envsubst < charts/${CHART_NAME}/values.tmpl.yaml > ./charts/${CHART_NAME}/values.yaml; \
 	fi
 

--- a/tools/make/env.mk
+++ b/tools/make/env.mk
@@ -2,19 +2,28 @@
 #
 # This file does not contain any specific make targets.
 
-
-# Docker variables
+# Docker global variables
 
 # REGISTRY is the image registry to use for build and push image targets.
-REGISTRY ?= docker.io/envoyproxy
-# IMAGE_NAME is the name of EG image
-# Use gateway-dev in default when developing
-# Use gateway when releasing an image.
-IMAGE_NAME ?= gateway-dev
-# IMAGE is the image URL for build and push image targets.
-IMAGE ?= ${REGISTRY}/${IMAGE_NAME}
-# Tag is the tag to use for build and push image targets.
+REGISTRY ?= docker.io
+
+# Docker Envoy Gateway variables
+
+# REPOSITORY is the image repository
+# Use envoyproxy/gateway-dev when developing
+# Use envoyproxy/gateway when releasing an image.
+REPOSITORY ?= envoyproxy/gateway
+# REPOSITORY ?= envoyproxy/gateway-dev
+
+# TAG is the image tag, defaults to current revision
 TAG ?= $(REV)
+
+# Docker Envoy Ratelimit variables
+
+# RATELIMIT_REPOSITORY is the ratelimit repository
+RATELIMIT_REPOSITORY ?= envoyproxy/ratelimit
+# RATELIMIT_TAG is the ratelimit image tag
+RATELIMIT_TAG ?= master
 
 # Fuzzing variables
 

--- a/tools/make/helm.mk
+++ b/tools/make/helm.mk
@@ -52,7 +52,12 @@ helm-generate.%:
 	$(eval COMMAND := $(word 1,$(subst ., ,$*)))
 	$(eval CHART_NAME := $(COMMAND))
 	@if test -f "charts/${CHART_NAME}/values.tmpl.yaml"; then \
-  		GatewayImage=${IMAGE}:${TAG} GatewayImagePullPolicy=${IMAGE_PULL_POLICY} \
+  		Registry=${REGISTRY}\
+			GatewayRepository=${REPOSITORY}\
+			GatewayTag=${TAG}\
+			GatewayImagePullPolicy=${IMAGE_PULL_POLICY}\
+			RatelimitRepository=${RATELIMIT_REPOSITORY}\
+			RatelimitTag=${RATELIMIT_TAG}\
   		envsubst < charts/${CHART_NAME}/values.tmpl.yaml > ./charts/${CHART_NAME}/values.yaml; \
   	fi
 	helm dependency update charts/${CHART_NAME}
@@ -62,7 +67,7 @@ helm-generate.%:
 	@if [ ${CHART_NAME} == "gateway-addons-helm" ]; then \
   		$(call log, "Run jsonnet generate for dashboards in chart: ${CHART_NAME}!"); \
   		workDir="charts/${CHART_NAME}/dashboards"; \
-  		cd $$workDir && ../../../go tool jb install && cd ../../..; \
+  		cd $$workDir && go tool jb install && cd ../../..; \
   		for file in $$(find $${workDir} -maxdepth 1 -name '*.libsonnet'); do \
   		    name=$$(basename $$file .libsonnet); \
   		    go tool jsonnet -J $${workDir}/vendor $${workDir}/$${name}.libsonnet > $${workDir}/$${name}.gen.json; \
@@ -76,6 +81,6 @@ helm-generate.%:
   	  	if [ ${CHART_NAME} == "gateway-addons-helm" ]; then \
   	  		helm template ${CHART_NAME} charts/${CHART_NAME} -f $${file} > test/helm/${CHART_NAME}/$$output --namespace=monitoring; \
   	  	else \
-			helm template ${CHART_NAME} charts/${CHART_NAME} -f $${file} > test/helm/${CHART_NAME}/$$output --namespace=envoy-gateway-system; \
+				helm template ${CHART_NAME} charts/${CHART_NAME} -f $${file} > test/helm/${CHART_NAME}/$$output --namespace=envoy-gateway-system; \
   	  	fi; \
 	done

--- a/tools/make/image.mk
+++ b/tools/make/image.mk
@@ -43,8 +43,12 @@ image.build.%: image.verify go.build.linux_$(GOARCH).%
 	$(eval COMMAND := $(word 1,$(subst ., ,$*)))
 	$(eval IMAGES := $(COMMAND))
 	@$(call log, "Building image $(IMAGES):$(TAG) in linux/$(GOARCH)")
-	$(eval BUILD_SUFFIX := --pull --load -t $(IMAGE):$(TAG) -f $(ROOT_DIR)/tools/docker/$(IMAGES)/Dockerfile bin)
-	@$(call log, "Creating image tag $(REGISTRY)/$(IMAGES):$(TAG) in linux/$(GOARCH)")
+	$(eval BUILD_SUFFIX := --pull --load -t $(REGISTRY)/$(REPOSITORY):$(TAG) -f $(ROOT_DIR)/tools/docker/$(IMAGES)/Dockerfile bin)
+	$(eval __SECOND_TO_LAST_WORD_INDEX := $(shell expr $(words $(subst /, ,$(REPOSITORY))) - 1))
+	$(eval __REPOSITORY_WORDS := $(subst /, ,$(REPOSITORY)))
+	$(eval __REPOSITORY_ALL_BUT_LAST := $(wordlist 1,$(__SECOND_TO_LAST_WORD_INDEX),$(__REPOSITORY_WORDS)))
+	$(eval NAMESPACE := $(subst $() ,/,$(__REPOSITORY_ALL_BUT_LAST)))
+	@$(call log, "Creating image tag $(REGISTRY)/$(NAMESPACE)/$(IMAGES):$(TAG) in linux/$(GOARCH)")
 	$(DOCKER) buildx build --platform linux/$(GOARCH) $(BUILD_SUFFIX)
 
 .PHONY: image.push
@@ -56,8 +60,8 @@ image.push.%: image.build.%
 	$(eval COMMAND := $(word 1,$(subst ., ,$*)))
 	$(eval IMAGES := $(COMMAND))
 	@$(call log, "Pushing image $(IMAGES) $(TAG) to $(REGISTRY)")
-	@$(call log, "Pushing docker image tag $(IMAGE):$(TAG) in linux/$(GOARCH)")
-	$(DOCKER) push $(IMAGE):$(TAG)
+	@$(call log, "Pushing docker image tag $(REGISTRY)/$(REPOSITORY):$(TAG) in linux/$(GOARCH)")
+	$(DOCKER) push $(REGISTRY)/$(REPOSITORY):$(TAG)
 
 .PHONY: image.multiarch.verify
 image.multiarch.verify:
@@ -84,12 +88,12 @@ image.multiarch.setup: image.verify image.multiarch.verify image.multiarch.emula
 .PHONY: image.build.multiarch
 image.build.multiarch:
 	@$(LOG_TARGET)
-	docker buildx build bin -f "$(ROOT_DIR)/tools/docker/$(IMAGES)/Dockerfile" -t "${IMAGE}:${TAG}" --platform "${BUILDX_PLATFORMS}"
+	docker buildx build bin -f "$(ROOT_DIR)/tools/docker/$(IMAGES)/Dockerfile" -t "${REGISTRY}/${REPOSITORY}:${TAG}" --platform "${BUILDX_PLATFORMS}"
 
 .PHONY: image.push.multiarch
 image.push.multiarch:
 	@$(LOG_TARGET)
-	docker buildx build bin -f "$(ROOT_DIR)/tools/docker/$(IMAGES)/Dockerfile" -t "${IMAGE}:${TAG}" --platform "${BUILDX_PLATFORMS}" --sbom=false --provenance=false --push
+	docker buildx build bin -f "$(ROOT_DIR)/tools/docker/$(IMAGES)/Dockerfile" -t "${REGISTRY}/${REPOSITORY}:${TAG}" --platform "${BUILDX_PLATFORMS}" --sbom=false --provenance=false --push
 
 ##@ Image
 

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -247,9 +247,9 @@ create-cluster: ## Create a kind cluster suitable for running Gateway API confor
 	tools/hack/create-cluster.sh
 
 .PHONY: kube-install-image
-kube-install-image: image.build ## Install the EG image to a kind cluster using the provided $IMAGE and $TAG.
+kube-install-image: image.build ## Install the EG image to a kind cluster using the provided $REGISTRY, $REPOSITORY and $TAG.
 	@$(LOG_TARGET)
-	tools/hack/kind-load-image.sh $(IMAGE) $(TAG)
+	tools/hack/kind-load-image.sh $(REGISTRY)/$(REPOSITORY) $(TAG)
 
 .PHONY: run-conformance
 run-conformance: prepare-ip-family ## Run Gateway API conformance.


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR enables global container registry and pullSecrets overrides which makes it easier to use Envoy Gateway with private container registries.

**Which issue(s) this PR fixes**:
Fixes #5718

Release Notes: Yes

**Detailed description**:

Add global.imageRegistry and global.imagePullSecrets to gateway-helm chart values.

Invert override logic: globals take precedence if defined.

Decouple registry, repository and tag from each other.

Add new ENV vars: REPOSITORY, RATELIMIT_REPOSITORY, RATELIMIT_TAG -- REPOSITORY is added to not overcomplicate Makefiles with parsing logic that would be required to stay fully compatible with the current ways (like issuing `IMAGE=xyz make image`); RATELIMIT_REPOSITORY and RATELIMIT_TAG just felt logical to add to make things consistent and configurable in the same way.

Delete ENV vars: IMAGE_NAME, IMAGE -- these are replaced with REGISTRY and REPOSITORY, if default registry is used, just REPOSITORY suffices. This changes developer-side behaviour though, but I'm not sure what's better -- Makefile madness or this. Also, this maps better to `values.yaml`.