### PR TITLE
test: add an error simulator fuzzer.

### DIFF
--- a/test/fuzz/oss_fuzz_build.sh
+++ b/test/fuzz/oss_fuzz_build.sh
@@ -34,5 +34,6 @@ go mod tidy
 
 # compile native-format fuzzers
 compile_native_go_fuzzer github.com/envoyproxy/gateway/test/fuzz FuzzGatewayAPIToXDS FuzzGatewayAPIToXDS
-compile_native_go_fuzzer github.com/envoyproxy/gateway/test/fuzz FuzzGatewayAPIToXDSWithGatewayClass FuzzGatewayAPIToXDSWithGatewayClass
+compile_native_go_fuzzer github.com/envoyproxy/gateway/test/fuzz FuzzGatewayClassToXDS FuzzGatewayClassToXDS
+compile_native_go_fuzzer github.com/envoyproxy/gateway/test/fuzz FuzzReverseStringBugSimulator FuzzReverseStringBugSimulator
 

--- a/test/fuzz/xds_fuzz_test.go
+++ b/test/fuzz/xds_fuzz_test.go
@@ -7,6 +7,7 @@ package fuzz
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,7 +56,7 @@ func FuzzGatewayAPIToXDS(f *testing.F) {
 	})
 }
 
-func FuzzGatewayAPIToXDSWithGatewayClass(f *testing.F) {
+func FuzzGatewayClassToXDS(f *testing.F) {
 	f.Fuzz(func(t *testing.T, name, controllerName, namespace, dnsDomain, resourceType string) {
 		resources := &resource.Resources{
 			GatewayClass: &gwapiv1.GatewayClass{
@@ -70,5 +71,31 @@ func FuzzGatewayAPIToXDSWithGatewayClass(f *testing.F) {
 		}
 
 		_, _ = egctl.TranslateGatewayAPIToXds(namespace, dnsDomain, resourceType, resources)
+	})
+}
+
+// Following code implements a temporary fuzzer to simulate an error to verify OSS-Fuzz integration
+// this test will be removed once the OSS-Fuzz integration is complete
+// This example is based on the Go fuzzing example: https://go.dev/doc/tutorial/fuzz#code_to_test
+// This test should generate errors when the input string is not a valid UTF-8 string
+
+func ReverseStringBugSimulator(s string) string {
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < len(b)/2; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+func FuzzReverseStringBugSimulator(f *testing.F) {
+	f.Fuzz(func(t *testing.T, orig string) {
+		rev := ReverseStringBugSimulator(orig)
+		doubleRev := ReverseStringBugSimulator(rev)
+		if orig != doubleRev {
+			t.Errorf("Before: %q, after: %q", orig, doubleRev)
+		}
+		if utf8.ValidString(orig) && !utf8.ValidString(rev) {
+			t.Errorf("Reverse produced invalid UTF-8 string %q", rev)
+		}
 	})
 }


### PR DESCRIPTION
To test the oss-fuzz integration, a temporary bug sumulator fuzzer is added.

- [x] added a temporary bug simulator
- [x]  renamed fuzzer to avoid using overlapping names for [this](https://github.com/google/oss-fuzz/pull/13220) reason