### PR TITLE
chore: revert ratelimit per-rout config

### DIFF
--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.routes.yaml
@@ -10,60 +10,52 @@
       name: first-route
       route:
         cluster: first-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: first-route
+              descriptorValue: first-route
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
           requirementName: first-route
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: first-route
-                descriptorValue: first-route
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: one
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: second-route
+              descriptorValue: second-route
+          - requestHeaders:
+              descriptorKey: rule-0-match-0
+              headerName: x-user-id
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: second-route
-                descriptorValue: second-route
-            - requestHeaders:
-                descriptorKey: rule-0-match-0
-                headerName: x-user-id
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: third-route
+              descriptorValue: third-route
+          - genericKey:
+              descriptorKey: rule-0-match--1
+              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: third-route
-                descriptorValue: third-route
-            - genericKey:
-                descriptorKey: rule-0-match--1
-                descriptorValue: rule-0-match--1

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.routes.yaml
@@ -10,57 +10,48 @@
       name: first-route
       route:
         cluster: first-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: first-route
+              descriptorValue: first-route
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: first-route
-                descriptorValue: first-route
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: one
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: second-route
+              descriptorValue: second-route
+          - requestHeaders:
+              descriptorKey: rule-0-match-0
+              headerName: x-user-id
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: second-route
-                descriptorValue: second-route
-            - requestHeaders:
-                descriptorKey: rule-0-match-0
-                headerName: x-user-id
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: third-route
+              descriptorValue: third-route
+          - genericKey:
+              descriptorKey: rule-0-match--1
+              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: third-route
-                descriptorValue: third-route
-            - genericKey:
-                descriptorKey: rule-0-match--1
-                descriptorValue: rule-0-match--1

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.routes.yaml
@@ -10,57 +10,48 @@
       name: first-route
       route:
         cluster: first-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: first-route
+              descriptorValue: first-route
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: first-route
-                descriptorValue: first-route
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: one
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: second-route
+              descriptorValue: second-route
+          - requestHeaders:
+              descriptorKey: rule-0-match-0
+              headerName: x-user-id
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: second-route
-                descriptorValue: second-route
-            - requestHeaders:
-                descriptorKey: rule-0-match-0
-                headerName: x-user-id
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: third-route
+              descriptorValue: third-route
+          - genericKey:
+              descriptorKey: rule-0-match--1
+              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: third-route
-                descriptorValue: third-route
-            - genericKey:
-                descriptorKey: rule-0-match--1
-                descriptorValue: rule-0-match--1

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.routes.yaml
@@ -10,57 +10,48 @@
       name: first-route
       route:
         cluster: first-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: first-route
+              descriptorValue: first-route
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: first-route
-                descriptorValue: first-route
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: one
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: second-route
+              descriptorValue: second-route
+          - requestHeaders:
+              descriptorKey: rule-0-match-0
+              headerName: x-user-id
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: second-route
-                descriptorValue: second-route
-            - requestHeaders:
-                descriptorKey: rule-0-match-0
-                headerName: x-user-id
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: third-route
+              descriptorValue: third-route
+          - genericKey:
+              descriptorKey: rule-0-match--1
+              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: third-route
-                descriptorValue: third-route
-            - genericKey:
-                descriptorKey: rule-0-match--1
-                descriptorValue: rule-0-match--1

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-global-shared.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-global-shared.routes.yaml
@@ -10,90 +10,78 @@
       name: first-route
       route:
         cluster: first-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: test-policy-1/test-namespace
+              descriptorValue: test-policy-1/test-namespace
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit/test-policy-1/test-namespace:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: test-policy-1/test-namespace
-                descriptorValue: test-policy-1/test-namespace
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: one
     - match:
         path: foo/baz
       name: second-route
       route:
         cluster: second-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: test-policy-1/test-namespace
+              descriptorValue: test-policy-1/test-namespace
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit/test-policy-1/test-namespace:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: test-policy-1/test-namespace
-                descriptorValue: test-policy-1/test-namespace
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: one
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: test-policy-2/test-namespace
+              descriptorValue: test-policy-2/test-namespace
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: two
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit/test-policy-2/test-namespace:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: test-policy-2/test-namespace
-                descriptorValue: test-policy-2/test-namespace
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: two
     - match:
         path: foo/bar
       name: fourth-route
       route:
         cluster: fourth-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: fourth-route
+              descriptorValue: fourth-route
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: two
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: fourth-route
-                descriptorValue: fourth-route
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: two

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.routes.yaml
@@ -10,88 +10,79 @@
       name: first-route
       route:
         cluster: first-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: first-route
+              descriptorValue: first-route
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: one
+          - maskedRemoteAddress:
+              v4PrefixMaskLen: 16
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: first-route
-                descriptorValue: first-route
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: one
-            - maskedRemoteAddress:
-                v4PrefixMaskLen: 16
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: second-route
+              descriptorValue: second-route
+          - requestHeaders:
+              descriptorKey: rule-0-match-0
+              headerName: x-user-id
+          - requestHeaders:
+              descriptorKey: rule-0-match-1
+              headerName: foobar
+          - maskedRemoteAddress:
+              v4PrefixMaskLen: 16
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: second-route
-                descriptorValue: second-route
-            - requestHeaders:
-                descriptorKey: rule-0-match-0
-                headerName: x-user-id
-            - requestHeaders:
-                descriptorKey: rule-0-match-1
-                headerName: foobar
-            - maskedRemoteAddress:
-                v4PrefixMaskLen: 16
     - match:
         prefix: /
       name: third-route
       route:
         cluster: third-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: third-route
+              descriptorValue: third-route
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: one
+          - maskedRemoteAddress:
+              v4PrefixMaskLen: 16
+        - actions:
+          - genericKey:
+              descriptorKey: third-route
+              descriptorValue: third-route
+          - headerValueMatch:
+              descriptorKey: rule-1-match-0
+              descriptorValue: rule-1-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: two
+          - requestHeaders:
+              descriptorKey: rule-1-match-1
+              headerName: foobar
+          - maskedRemoteAddress:
+              v4PrefixMaskLen: 16
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: third-route
-                descriptorValue: third-route
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: one
-            - maskedRemoteAddress:
-                v4PrefixMaskLen: 16
-          - actions:
-            - genericKey:
-                descriptorKey: third-route
-                descriptorValue: third-route
-            - headerValueMatch:
-                descriptorKey: rule-1-match-0
-                descriptorValue: rule-1-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: two
-            - requestHeaders:
-                descriptorKey: rule-1-match-1
-                headerName: foobar
-            - maskedRemoteAddress:
-                v4PrefixMaskLen: 16

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.routes.yaml
@@ -10,68 +10,56 @@
       name: first-route
       route:
         cluster: first-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: first-route
+              descriptorValue: first-route
+          - maskedRemoteAddress:
+              v4PrefixMaskLen: 16
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: first-route
-                descriptorValue: first-route
-            - maskedRemoteAddress:
-                v4PrefixMaskLen: 16
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: second-route
+              descriptorValue: second-route
+          - maskedRemoteAddress:
+              v4PrefixMaskLen: 24
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: second-route
-                descriptorValue: second-route
-            - maskedRemoteAddress:
-                v4PrefixMaskLen: 24
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: third-route
+              descriptorValue: third-route
+          - genericKey:
+              descriptorKey: rule-0-match--1
+              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: third-route
-                descriptorValue: third-route
-            - genericKey:
-                descriptorKey: rule-0-match--1
-                descriptorValue: rule-0-match--1
     - match:
         path: distinct
       name: fourth-route
       route:
         cluster: fourth-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: fourth-route
+              descriptorValue: fourth-route
+          - maskedRemoteAddress:
+              v4PrefixMaskLen: 16
+          - remoteAddress: {}
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: fourth-route
-                descriptorValue: fourth-route
-            - maskedRemoteAddress:
-                v4PrefixMaskLen: 16
-            - remoteAddress: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.routes.yaml
@@ -10,83 +10,71 @@
       name: first-route
       route:
         cluster: first-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: first-route
+              descriptorValue: first-route
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: true
+              headers:
+              - name: x-user-id
+                stringMatch:
+                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: first-route
-                descriptorValue: first-route
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: true
-                headers:
-                - name: x-user-id
-                  stringMatch:
-                    exact: one
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: second-route
+              descriptorValue: second-route
+          - requestHeaders:
+              descriptorKey: rule-0-match-0
+              headerName: x-user-id
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: second-route
-                descriptorValue: second-route
-            - requestHeaders:
-                descriptorKey: rule-0-match-0
-                headerName: x-user-id
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: third-route
+              descriptorValue: third-route
+          - genericKey:
+              descriptorKey: rule-0-match--1
+              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: third-route
-                descriptorValue: third-route
-            - genericKey:
-                descriptorKey: rule-0-match--1
-                descriptorValue: rule-0-match--1
     - match:
         path: foo/bar/login
       name: fourth-route
       route:
         cluster: fourth-route-dest
+        rateLimits:
+        - actions:
+          - genericKey:
+              descriptorKey: fourth-route
+              descriptorValue: fourth-route
+          - headerValueMatch:
+              descriptorKey: rule-0-match-0
+              descriptorValue: rule-0-match-0
+              expectMatch: false
+              headers:
+              - name: x-org-id
+                stringMatch:
+                  exact: admin
         upgradeConfigs:
         - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ratelimit:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
-          rateLimits:
-          - actions:
-            - genericKey:
-                descriptorKey: fourth-route
-                descriptorValue: fourth-route
-            - headerValueMatch:
-                descriptorKey: rule-0-match-0
-                descriptorValue: rule-0-match-0
-                expectMatch: false
-                headers:
-                - name: x-org-id
-                  stringMatch:
-                    exact: admin
     - match:
         path: foo/bar
       name: req-and-resp-cost


### PR DESCRIPTION
Revert https://github.com/envoyproxy/gateway/pull/5072

Some existing users may choose to keep using an old version of envoy while upgrading to new version of Envoy Gateway. To maintain compatibility, we're reverting this change so that rate limit configuration continues to work with older Envoy versions.

We can revisit this in a few versions, once we're confident that older Envoy versions are no longer in use.