### PR TITLE
chore: remove github.com/hashicorp/go-multierror dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/google/cel-go v0.22.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.20.3
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/miekg/dns v1.1.65
 	github.com/ohler55/ojg v1.26.3
 	github.com/pkg/errors v0.9.1
@@ -277,6 +276,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/internal/wasm/imagefetcher.go
+++ b/internal/wasm/imagefetcher.go
@@ -39,7 +39,6 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/envoyproxy/gateway/internal/logging"
 )
@@ -163,7 +162,7 @@ func (o *ImageFetcher) PrepareFetch(url string) (binaryFetcher func() ([]byte, e
 
 		// We failed to parse the image in any format, so wrap the errors and return.
 		return nil, fmt.Errorf("the given image is in invalid format as an OCI image: %w",
-			multierror.Append(err,
+			errors.Join(err,
 				fmt.Errorf("could not parse as compat variant: %w", errCompat),
 				fmt.Errorf("could not parse as oci variant: %w", errOCI),
 			),

--- a/tools/linter/golangci-lint/.golangci.yml
+++ b/tools/linter/golangci-lint/.golangci.yml
@@ -79,6 +79,8 @@ linters:
               desc: "use k8s.io/utils/ptr instead"
             - pkg: github.com/tetratelabs/multierror
               desc: "use errors instead"
+            - pkg: github.com/hashicorp/go-multierror
+              desc: "use errors instead"
     goheader:
       # Note that because the format is different (this needs no comment markers),
       # updating this text means also updating /tools/boilerplate.txt so that


### PR DESCRIPTION
**What type of PR is this?**

chore: remove `github.com/hashicorp/go-multierror` dependency

**What this PR does / why we need it**:

`github.com/hashicorp/go-multierror` is under MPL-2.0 License which is not approved in CNCF Allowlist

Release Notes: Yes/No
