### PR TITLE
fix: allow users to set empty retriable status codes

### DIFF
--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -640,9 +640,7 @@ func buildRetryPolicy(route *ir.HTTPRoute) (*routev3.RetryPolicy, error) {
 			}
 		}
 
-		if len(rr.RetryOn.HTTPStatusCodes) > 0 {
-			rp.RetriableStatusCodes = buildRetryStatusCodes(rr.RetryOn.HTTPStatusCodes)
-		}
+		rp.RetriableStatusCodes = buildRetryStatusCodes(rr.RetryOn.HTTPStatusCodes)
 	}
 
 	if rr.PerRetry != nil {

--- a/internal/xds/translator/testdata/in/xds-ir/retry.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/retry.yaml
@@ -52,3 +52,19 @@ http:
         - host: "1.2.3.4"
           port: 50000
         name: "first-route-dest/backend/0"
+  - name: "third-route-only-triggers"
+    hostname: "foo"
+    traffic:
+      retry:
+        numRetries: 5
+        retryOn:
+          triggers:
+          - reset
+          - connect-failure
+    destination:
+      name: "first-route-dest"
+      settings:
+      - endpoints:
+        - host: "1.2.3.4"
+          port: 50000
+        name: "first-route-dest/backend/0"

--- a/internal/xds/translator/testdata/out/xds-ir/retry.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry.routes.yaml
@@ -45,3 +45,18 @@
           retryOn: connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes
         upgradeConfigs:
         - upgradeType: websocket
+    - match:
+        prefix: /
+      name: third-route-only-triggers
+      route:
+        cluster: first-route-dest
+        retryPolicy:
+          hostSelectionRetryMaxAttempts: "5"
+          numRetries: 5
+          retryHostPredicate:
+          - name: envoy.retry_host_predicates.previous_hosts
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
+          retryOn: reset,connect-failure
+        upgradeConfigs:
+        - upgradeType: websocket

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -47,6 +47,7 @@ bug fixes: |
   Fix an issue that SamplingFraction was not working.
   Fix kubernetes resources not being deleted when the customized name used.
   Do not treat essential resource like namespace as the missing resource while loading from file.
+  Do not set retriable status codes to 503 when RetryOn is configured in BackendTrafficPolicy.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
- When retryOn is set to an empty struct, existing defaults work as before.
- When users customize retryOn and leave retryOn.httpStatusCodes unset, the xds retriableStatusCodes will remain unset.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #5691

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes
