### PR TITLE
chore: move envoy gateway config out of redis example

### DIFF
--- a/examples/redis/redis.yaml
+++ b/examples/redis/redis.yaml
@@ -62,9 +62,6 @@ data:
       type: Kubernetes
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    extensionApis:
-      enableEnvoyPatchPolicy: true
-      enableBackend: true
     rateLimit:
       backend:
         type: Redis

--- a/test/config/envoy-gateway-config.yaml
+++ b/test/config/envoy-gateway-config.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-gateway-config
+  namespace: envoy-gateway-system
+data:
+  envoy-gateway.yaml: |
+    apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: EnvoyGateway
+    provider:
+      type: Kubernetes
+    gateway:
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    extensionApis:
+      enableEnvoyPatchPolicy: true
+      enableBackend: true
+    rateLimit:
+      backend:
+        type: Redis
+        redis:
+          url: redis.redis-system.svc.cluster.local:6379

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -191,6 +191,7 @@ e2e-prepare: prepare-ip-family ## Prepare the environment for running e2e tests
 	@$(LOG_TARGET)
 	kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-ratelimit --for=condition=Available
 	kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
+	kubectl apply -f test/config/envoy-gateway-config.yaml
 	kubectl apply -f test/config/gatewayclass.yaml
 
 .PHONY: run-e2e


### PR DESCRIPTION
move e2e envoy gateway config out of redis example.