### PR TITLE
remove any explicit userIds in Dockerfile steps

### DIFF
--- a/tools/docker/envoy-gateway/Dockerfile
+++ b/tools/docker/envoy-gateway/Dockerfile
@@ -6,8 +6,8 @@ RUN mkdir -p /var/lib/eg
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/base-nossl:nonroot@sha256:d1fc914c43cea489c26c896721344a49a1761b9bb678bcba1758772d22913302
 ARG TARGETPLATFORM
-COPY --chown=65532:65532 $TARGETPLATFORM/envoy-gateway /usr/local/bin/
-COPY --from=source --chown=65532:65532 /var/lib /var/lib
+COPY $TARGETPLATFORM/envoy-gateway /usr/local/bin/
+COPY --from=source /var/lib /var/lib
 
 USER 65532:65532
 


### PR DESCRIPTION
it will allow a user in k8s to override the USER
directive with `runAsUser` if they'd like to