### PR TITLE
fix(translator): Early status push for headless Service

### DIFF
--- a/internal/gatewayapi/route_test.go
+++ b/internal/gatewayapi/route_test.go
@@ -9,11 +9,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/envoyproxy/gateway/internal/gatewayapi/resource"
+	"github.com/envoyproxy/gateway/internal/gatewayapi/status"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/envoyproxy/gateway/internal/ir"
 )
@@ -223,6 +226,100 @@ func TestGetIREndpointsFromEndpointSlices(t *testing.T) {
 			fmt.Println()
 			require.Equal(t, tt.expectedEndpoints, endpoints)
 			require.Equal(t, tt.expectedAddrType, *addrType)
+		})
+	}
+}
+
+func TestValidateDestinationSettings(t *testing.T) {
+	svcKind := gwapiv1.Kind(resource.KindService)
+
+	tests := []struct {
+		name                    string
+		ds                      *ir.DestinationSetting
+		endpointRoutingDisabled bool
+		kind                    *gwapiv1.Kind
+		wantErr                 bool
+		wantReason              gwapiv1.RouteConditionReason
+	}{
+		{
+			name: "headless service rejected when endpointRoutingDisabled=true",
+			ds: &ir.DestinationSetting{
+				Name:      "headless",
+				Endpoints: []*ir.DestinationEndpoint{{Host: "None"}},
+			},
+			endpointRoutingDisabled: true,
+			kind:                    &svcKind,
+			wantErr:                 true,
+			wantReason:              status.RouteReasonUnsupportedSetting,
+		},
+		{
+			name: "normal service allowed with ClusterIP routing",
+			ds: &ir.DestinationSetting{
+				Name:      "normal",
+				Endpoints: []*ir.DestinationEndpoint{{Host: "10.0.0.1"}},
+			},
+			endpointRoutingDisabled: true,
+			kind:                    &svcKind,
+			wantErr:                 false,
+		},
+		{
+			name: "mixed address type rejected when EndpointSlice routing",
+			ds: &ir.DestinationSetting{
+				Name:        "mixed",
+				Endpoints:   []*ir.DestinationEndpoint{{Host: "10.0.0.1"}},
+				AddressType: ptr.To(ir.MIXED),
+			},
+			endpointRoutingDisabled: false,
+			kind:                    &svcKind,
+			wantErr:                 true,
+			wantReason:              status.RouteReasonUnsupportedAddressType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDestinationSettings(tt.ds, tt.endpointRoutingDisabled, tt.kind)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, tt.wantReason, err.Reason())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+func TestIsHeadlessService(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoints []*ir.DestinationEndpoint
+		want      bool
+	}{
+		{
+			name: "headless Service",
+			endpoints: []*ir.DestinationEndpoint{
+				{Host: "None"},
+			},
+			want: true,
+		},
+		{
+			name: "non headless Service with valid ClusterIP",
+			endpoints: []*ir.DestinationEndpoint{
+				{Host: "10.0.0.1"},
+			},
+			want: false,
+		},
+		{
+			name:      "empty slice",
+			endpoints: nil,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := &ir.DestinationSetting{Endpoints: tt.endpoints}
+			got := isHeadlessService(ds)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

fix(translator): Early status push for headless Service

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

- When Endpoint routing is disabled (e.g. headless Service), we now reject
  headless Services early by setting RouteConditionResolvedRefs=False with
  reason=UnsupportedSetting, preventing xDS validation failures.
- Extracts headless detection into `isHeadlessService` helper.
- Adds unit tests for `isHeadlessService` and `validateDestinationSettings`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #5708 

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
