### PR TITLE
chore: disable codecov to generate the latest images and helm charts

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -54,14 +54,16 @@ jobs:
     # test
     - name: Run Coverage Tests
       run: make go.test.coverage
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
-      with:
-        fail_ci_if_error: true
-        files: ./coverage.xml
-        name: codecov-envoy-gateway
-        verbose: true
-        use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+    # TODO: temporary disable it to generate the latest image and helm chart
+    # https://github.com/codecov/codecov-action/issues/1817
+    # - name: Upload coverage to Codecov
+    #   uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
+    #   with:
+    #     fail_ci_if_error: true
+    #     files: ./coverage.xml
+    #     name: codecov-envoy-gateway
+    #     verbose: true
+    #    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Temporarily disable codecov to generate the latest images and helm charts. 

We may switch to the codecov token until the OIDC issue is solved.

https://github.com/codecov/codecov-action/issues/1817
