### PR TITLE
Updated the chart by extraVolumeMounts and extraVolumes fields to be mapped on the pods for eternal volumes, one of the cases is the unix volume mapping.

### DIFF
--- a/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
@@ -88,6 +88,9 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
+        {{- with .Values.deployment.pod.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- include "eg.image.pullSecrets" . | nindent 6 }}
       {{- with .Values.deployment.priorityClassName }}
       priorityClassName: {{ . | quote }}
@@ -102,3 +105,6 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
+      {{- with .Values.deployment.pod.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -79,6 +79,18 @@ deployment:
     topologySpreadConstraints: []
     tolerations: []
     nodeSelector: {}
+    # Additional volumeMounts on the deployment definition.
+    extraVolumeMounts: []
+    # - name: example-dir
+    #   mountPath: "/etc/example"
+    #   readOnly: true
+
+    # Additional volumes on the deployment definition.
+    extraVolumes: []
+    # - name: example-dir
+    #   secret:
+    #     secretName: mysecret
+    #     optional: false
 
 service:
   # If set to PreferClose, the Envoy fleet will prioritize connecting to the Envoy Gateway pods that are topologically closest to them.


### PR DESCRIPTION

**What type of PR is this?**
* chart: add support for external volumes and volumeMounts

**What this PR does / why we need it**: 
Whenever wants the gateway to communicate with the extensions over the unix socket, the gateway have to be configured with the right existing socket directory path which should be mounted to the deployment.


Release Notes: No
