### PR TITLE
skip building egctl for windows_arm64

### DIFF
--- a/tools/make/common.mk
+++ b/tools/make/common.mk
@@ -38,7 +38,8 @@ endif
 REV=$(shell git rev-parse --short HEAD)
 
 # Supported Platforms for building multiarch binaries.
-PLATFORMS ?= darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64 windows_arm64
+# Disabled windows_arm64 due to lack of space while building on the GH Runner
+PLATFORMS ?= darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64
 
 # Set a specific PLATFORM
 ifeq ($(origin PLATFORM), undefined)


### PR DESCRIPTION
Not enough space on the GHA runner, blocking the release can be triaged later

Relates to https://github.com/envoyproxy/gateway/actions/runs/14765129938/job/41457946081

