### PR TITLE
[releae/v1.4] ci: remove windows_arm64 uploads (#5884)

### DIFF
--- a/.github/workflows/latest_release.yaml
+++ b/.github/workflows/latest_release.yaml
@@ -81,7 +81,6 @@ jobs:
         tar -zcvf egctl_latest_darwin_amd64.tar.gz bin/darwin/amd64/egctl
         tar -zcvf egctl_latest_darwin_arm64.tar.gz bin/darwin/arm64/egctl
         zip -r egctl_latest_windows_amd64.zip bin/windows/amd64/egctl
-        zip -r egctl_latest_windows_arm64.zip bin/windows/arm64/egctl
 
     # Ignore the error when we delete the latest release, it might not exist.
 
@@ -127,7 +126,6 @@ jobs:
           egctl_latest_darwin_amd64.tar.gz
           egctl_latest_darwin_arm64.tar.gz
           egctl_latest_windows_amd64.zip
-          egctl_latest_windows_arm64.zip
         body: |
           This is the "latest" release of **Envoy Gateway**, which contains the most recent commits from the main branch.
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,6 @@ jobs:
           tar -zcvf egctl_${{ env.release_tag }}_darwin_amd64.tar.gz bin/darwin/amd64/egctl
           tar -zcvf egctl_${{ env.release_tag }}_darwin_arm64.tar.gz bin/darwin/arm64/egctl
           zip -r egctl_${{ env.release_tag }}_windows_amd64.zip bin/windows/amd64/egctl
-          zip -r egctl_${{ env.release_tag }}_windows_arm64.zip bin/windows/arm64/egctl
 
       - name: Upload Release Manifests
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631  # v2.2.2
@@ -115,4 +114,3 @@ jobs:
             egctl_${{ env.release_tag }}_darwin_amd64.tar.gz
             egctl_${{ env.release_tag }}_darwin_arm64.tar.gz
             egctl_${{ env.release_tag }}_windows_amd64.zip
-            egctl_${{ env.release_tag }}_windows_arm64.zip


### PR DESCRIPTION
Relates to https://github.com/envoyproxy/gateway/pull/5878


(cherry picked from commit 19b7af3a45cf2fae134e0597e846d8cdc7b7679b)
