### PR TITLE
Revert "increase liveness probe failureThreshold for shutdown manager…

### DIFF
--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -238,7 +238,7 @@ func expectedProxyContainers(infra *ir.ProxyInfra,
 				TimeoutSeconds:   1,
 				PeriodSeconds:    10,
 				SuccessThreshold: 1,
-				FailureThreshold: 10,
+				FailureThreshold: 3,
 			},
 			Lifecycle: &corev1.Lifecycle{
 				PreStop: &corev1.LifecycleHandler{

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
@@ -158,7 +158,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
@@ -355,7 +355,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
@@ -354,7 +354,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
@@ -345,7 +345,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
@@ -291,7 +291,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
@@ -358,7 +358,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
@@ -354,7 +354,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
@@ -345,7 +345,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
@@ -352,7 +352,7 @@ spec:
               - --drain-timeout=30s
               - --min-drain-duration=15s
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
@@ -358,7 +358,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
@@ -350,7 +350,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
@@ -158,7 +158,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
@@ -347,7 +347,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
@@ -345,7 +345,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
@@ -345,7 +345,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
@@ -345,7 +345,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
@@ -345,7 +345,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -161,7 +161,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -162,7 +162,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -360,7 +360,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -362,7 +362,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -359,7 +359,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -349,7 +349,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -295,7 +295,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
@@ -350,7 +350,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -363,7 +363,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
@@ -364,7 +364,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
@@ -350,7 +350,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -358,7 +358,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -349,7 +349,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -356,7 +356,7 @@ spec:
               - --drain-timeout=30s
               - --min-drain-duration=15s
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -363,7 +363,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -354,7 +354,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -162,7 +162,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -348,7 +348,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -351,7 +351,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -349,7 +349,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
@@ -349,7 +349,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -349,7 +349,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -349,7 +349,7 @@ spec:
               - envoy
               - shutdown
         livenessProbe:
-          failureThreshold: 10
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 19002


### PR DESCRIPTION
… (#5877)"

This reverts commit 93f3d1c2d60f6c3536c1d632f83d9e7a305e20ce.

This commit may introduce other subtle issues where the licenses probes for envoy kicks in but not shutdown manager which will block envoy from restarting, so prefer to not make this change atm.
