### PR TITLE
docs: Change Subtitle of Concept Template

### DIFF
--- a/site/archetypes/concept.md
+++ b/site/archetypes/concept.md
@@ -22,9 +22,11 @@ Describe common use cases. When would someone need this concept?
 List scenarios where understanding this will help the user make better architectural or operational decisions.
 -->
 
-## Configuration in Envoy Gateway
+## {Title} in Envoy Gateway
 
 <!-- 
+Replace Title with the name of the concept. 
+
 Explain the inner workings of the concept. 
 Use diagrams, code snippets, or flow explanations as needed.
 Example: Describe how Envoy Gateway interacts with Kubernetes Gateway API resources.


### PR DESCRIPTION
**What type of PR is this?**
Changes subtitle in Concept Template from "Configuration in Envoy Gateway" to "{Title} in Envoy Gateway", where the writer replaces Title with the name of the concept.

**What this PR does / why we need it**:
New title makes the intention of the section clearer.

**Which issue(s) this PR fixes**:
Fixes #5892

Release Notes: No
