### PR TITLE
chore: clean up BTP status

### DIFF
--- a/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid-ns.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid-ns.out.yaml
@@ -20,11 +20,9 @@ backendTLSPolicies:
         namespace: envoy-gateway
       conditions:
       - lastTransitionTime: null
-        message: 'ClientCertificateRef Secret is not located in the same namespace
-          as Envoyproxy. Secret namespace: envoy-gateway-user-ns does not match Envoyproxy
-          namespace: envoy-gateway-system.'
-        reason: Invalid
-        status: "False"
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
         type: Accepted
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
 gateways:

--- a/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid.out.yaml
@@ -20,10 +20,9 @@ backendTLSPolicies:
         namespace: envoy-gateway
       conditions:
       - lastTransitionTime: null
-        message: 'Failed to locate TLS secret for client auth: envoy-gateway-system/client-auth-not-found
-          specified in EnvoyProxy envoy-gateway-system/test.'
-        reason: Invalid
-        status: "False"
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
         type: Accepted
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
 gateways:


### PR DESCRIPTION
fixes: #5931

Errors from the EnvoyProxy TLS settings should not be reflected in the BackendTLSPolicy status.

Instead, the BackendTLSPolicy should be accepted, since its configuration is valid.

The EnvoyProxy TLS error is already reported in the HTTPRoute status, as shown in the following yaml snippet:

```
  status:
    parents:
    - conditions:
      - lastTransitionTime: null
        message: Route is accepted
        reason: Accepted
        status: "True"
        type: Accepted
      - lastTransitionTime: null
        message: 'Failed to process route rule 0 backendRef 0: failed to locate TLS
          secret for client auth: envoy-gateway-system/client-auth-not-found specified
          in EnvoyProxy envoy-gateway-system/test.'
        reason: InvalidBackendTLS
        status: "False"
        type: ResolvedRefs
      controllerName: gateway.envoyproxy.io/gatewayclass-controller
```