### PR TITLE
e2e: bump upgrade test version to v1.3.2

### DIFF
--- a/test/e2e/tests/eg_upgrade.go
+++ b/test/e2e/tests/eg_upgrade.go
@@ -52,7 +52,7 @@ var EGUpgradeTest = suite.ConformanceTest{
 			chartPath := "../../../charts/gateway-helm"
 			relName := "eg"
 			depNS := "envoy-gateway-system"
-			lastVersionTag := "v1.2.3" //  the latest prior release
+			lastVersionTag := "v1.3.2" //  the latest prior release
 
 			t.Logf("Upgrading from version: %s", lastVersionTag)
 


### PR DESCRIPTION
this was missed for a while.