### PR TITLE
Fuzzing: Fail on xds translation error

### DIFF
--- a/test/fuzz/xds_fuzz_test.go
+++ b/test/fuzz/xds_fuzz_test.go
@@ -6,6 +6,7 @@
 package fuzz
 
 import (
+	"strings"
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
@@ -25,6 +26,9 @@ func FuzzGatewayAPIToXDS(f *testing.F) {
 		dnsDomain, _ := fc.GetString()
 		resourceType, _ := fc.GetString()
 
-		_, _ = egctl.TranslateGatewayAPIToXds(namespace, dnsDomain, resourceType, rs)
+		_, err = egctl.TranslateGatewayAPIToXds(namespace, dnsDomain, resourceType, rs)
+		if err != nil && strings.Contains(err.Error(), "failed to translate xds") {
+			t.Fatalf("%v", err)
+		}
 	})
 }


### PR DESCRIPTION
[This](https://github.com/envoyproxy/gateway/blob/756d2ef625b74563a894c0592395686599a62fdb/internal/cmd/egctl/translate.go#L372) error should never reach to XDS translator. We fail the fuzzer for any input that causes above error so that we can handle those cases in either of

- API / CEL validation / kubebuilder CRD layer
- Gateway API layer
- IR layer