### PR TITLE
fix: allows offline k8s controller to use non default CRDs

### DIFF
--- a/internal/provider/kubernetes/controller_offline.go
+++ b/internal/provider/kubernetes/controller_offline.go
@@ -75,6 +75,21 @@ func NewOfflineGatewayAPIController(
 		envoyGateway:      cfg.EnvoyGateway,
 		mergeGateways:     sets.New[string](),
 		extServerPolicies: extServerPoliciesGVKs,
+		// We assume all CRDs are available in offline mode.
+		backendCRDExists:       true,
+		bTLSPolicyCRDExists:    true,
+		btpCRDExists:           true,
+		ctpCRDExists:           true,
+		eepCRDExists:           true,
+		epCRDExists:            true,
+		eppCRDExists:           true,
+		hrfCRDExists:           true,
+		grpcRouteCRDExists:     true,
+		serviceImportCRDExists: true,
+		spCRDExists:            true,
+		tcpRouteCRDExists:      true,
+		tlsRouteCRDExists:      true,
+		udpRouteCRDExists:      true,
 	}
 
 	r.log.Info("created offline gatewayapi controller")


### PR DESCRIPTION
This fixes a regression in https://github.com/envoyproxy/gateway/pull/5767