### PR TITLE
e2e: fix BackendUpgrade flaky

### DIFF
--- a/test/e2e/testdata/backendtrafficpolicy-translation-failed.yaml
+++ b/test/e2e/testdata/backendtrafficpolicy-translation-failed.yaml
@@ -39,4 +39,3 @@ spec:
           limit:
             requests: 10
             unit: Hour
-      type: Global

--- a/test/e2e/tests/backend_upgrade.go
+++ b/test/e2e/tests/backend_upgrade.go
@@ -40,6 +40,18 @@ var BackendUpgradeTest = suite.ConformanceTest{
 			routeNN := types.NamespacedName{Name: "http-backend-upgrade", Namespace: ns}
 			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+			// Make sure the backend is healthy before starting the test
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request: http.Request{
+					Path: "/backend-upgrade",
+				},
+				Response: http.Response{
+					StatusCode: 200,
+				},
+				Namespace: ns,
+			})
+
 			reqURL := url.URL{Scheme: "http", Host: http.CalculateHost(t, gwAddr, "http"), Path: "/backend-upgrade"}
 
 			// get deployment to restart


### PR DESCRIPTION
fixes: https://github.com/envoyproxy/gateway/issues/6035

Make sure listener is ready and health before run test.