### PR TITLE
[release/v1.4] chore: publish shouldnt wait for resilience-test (#6053)

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -220,7 +220,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [conformance-test, e2e-test, resilience-test]
+    needs: [conformance-test, e2e-test]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - uses: ./tools/github-actions/setup-deps


### PR DESCRIPTION
resilience-test is skipped in push flows https://github.com/envoyproxy/gateway/actions/runs/15009104216

which

breaks release https://github.com/envoyproxy/gateway/actions/runs/15009937798


(cherry picked from commit 9b22b7ca1818dc22df64b3326c160471484e0769)
