### PR TITLE
pin envoy image in e2e tests to avoid ext proc test failure

### DIFF
--- a/test/config/gatewayclass.yaml
+++ b/test/config/gatewayclass.yaml
@@ -22,6 +22,7 @@ spec:
     kubernetes:
       envoyDeployment:
         container:
+          image: envoyproxy/envoy:distroless-v1.34.1   # https://github.com/envoyproxy/gateway/issues/6077
           volumeMounts:
             - mountPath: /var/run/ext-proc
               name: socket-dir
@@ -137,4 +138,3 @@ spec:
     name: proxy-config
     namespace: envoy-gateway-system
 ---
-


### PR DESCRIPTION
A temporary workaround for https://github.com/envoyproxy/gateway/issues/6077 before it's fixed upstream.