### PR TITLE
chore: use the latest envoy image for e2e

### DIFF
--- a/test/config/gatewayclass.yaml
+++ b/test/config/gatewayclass.yaml
@@ -22,7 +22,6 @@ spec:
     kubernetes:
       envoyDeployment:
         container:
-          image: envoyproxy/envoy:distroless-v1.34.1   # https://github.com/envoyproxy/gateway/issues/6077
           volumeMounts:
             - mountPath: /var/run/ext-proc
               name: socket-dir


### PR DESCRIPTION
change back to the latest envoy image as https://github.com/envoyproxy/envoy/issues/39479 has been fixed upstream.