### PR TITLE
docs: Clarify unsupported `%PATH%` access log operator in ProxyAccessLogFormat

### DIFF
--- a/site/content/en/v1.4/api/extension_types.md
+++ b/site/content/en/v1.4/api/extension_types.md
@@ -3437,6 +3437,16 @@ _Appears in:_
 | `text` | _string_ |  false  |  | Text defines the text accesslog format, following Envoy accesslog formatting,<br />It's required when the format type is "Text".<br />Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be used in the format.<br />The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings) provides more information. |
 | `json` | _object (keys:string, values:string)_ |  false  |  | JSON is additional attributes that describe the specific event occurrence.<br />Structured format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)<br />can be used as values for fields within the Struct.<br />It's required when the format type is "JSON". |
 
+**Note:**  
+`%PATH%` is **not a supported command operator** in Envoy for access log format strings.  
+To log the request path, use `%REQ(:path)%` instead.  
+See the [Envoy command operator documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) for all valid options.
+
+**Example:**
+```
+%REQ(:method)% %REQ(:path)% %PROTOCOL%
+```
+
 
 #### ProxyAccessLogFormatType
 


### PR DESCRIPTION
…xes #6094)

**What type of PR is this?**
'This PR adds a note to the `ProxyAccessLogFormat` documentation making it clear that `%PATH%` is not a supported Envoy access log operator, and that `%REQ(:path)%` should be used to log the request path.'
<!-- 
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
This PR adds a note to the `ProxyAccessLogFormat` documentation making it clear that `%PATH%` is not a supported Envoy access log operator, and that `%REQ(:path)%` should be used to log the request path.
**Which issue(s) this PR fixes**:
Fixes #6094 <!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes/No
