### PR TITLE
fix: add unix domain socket path length validation

### DIFF
--- a/api/v1alpha1/backend_types.go
+++ b/api/v1alpha1/backend_types.go
@@ -115,6 +115,9 @@ type FQDNEndpoint struct {
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#config-core-v3-pipe
 type UnixSocket struct {
 	// Path defines the unix domain socket path of the backend endpoint.
+	// The path length must not exceed 108 characters.
+	//
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=108
 	Path string `json:"path"`
 }

--- a/api/v1alpha1/backend_types.go
+++ b/api/v1alpha1/backend_types.go
@@ -115,6 +115,8 @@ type FQDNEndpoint struct {
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#config-core-v3-pipe
 type UnixSocket struct {
 	// Path defines the unix domain socket path of the backend endpoint.
+	// +kubebuilder:validation:MaxLength=108
+	// +kubebuilder:validation:XValidation:rule="self.size() <= 108",message="Unix domain socket path length must not exceed 108 characters"
 	Path string `json:"path"`
 }
 

--- a/api/v1alpha1/backend_types.go
+++ b/api/v1alpha1/backend_types.go
@@ -116,7 +116,6 @@ type FQDNEndpoint struct {
 type UnixSocket struct {
 	// Path defines the unix domain socket path of the backend endpoint.
 	// +kubebuilder:validation:MaxLength=108
-	// +kubebuilder:validation:XValidation:rule="self.size() <= 108",message="Unix domain socket path length must not exceed 108 characters"
 	Path string `json:"path"`
 }
 

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backends.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backends.yaml
@@ -119,14 +119,12 @@ spec:
                       description: Unix defines the unix domain socket endpoint
                       properties:
                         path:
-                          description: Path defines the unix domain socket path of
-                            the backend endpoint.
+                          description: |-
+                            Path defines the unix domain socket path of the backend endpoint.
+                            The path length must not exceed 108 characters.
                           maxLength: 108
+                          minLength: 1
                           type: string
-                          x-kubernetes-validations:
-                          - message: Unix domain socket path length must not exceed
-                              108 characters
-                            rule: self.size() <= 108
                       required:
                       - path
                       type: object

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backends.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backends.yaml
@@ -121,7 +121,12 @@ spec:
                         path:
                           description: Path defines the unix domain socket path of
                             the backend endpoint.
+                          maxLength: 108
                           type: string
+                          x-kubernetes-validations:
+                          - message: Unix domain socket path length must not exceed
+                              108 characters
+                            rule: self.size() <= 108
                       required:
                       - path
                       type: object

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_backends.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_backends.yaml
@@ -120,7 +120,12 @@ spec:
                         path:
                           description: Path defines the unix domain socket path of
                             the backend endpoint.
+                          maxLength: 108
                           type: string
+                          x-kubernetes-validations:
+                          - message: Unix domain socket path length must not exceed
+                              108 characters
+                            rule: self.size() <= 108
                       required:
                       - path
                       type: object

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_backends.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_backends.yaml
@@ -118,14 +118,12 @@ spec:
                       description: Unix defines the unix domain socket endpoint
                       properties:
                         path:
-                          description: Path defines the unix domain socket path of
-                            the backend endpoint.
+                          description: |-
+                            Path defines the unix domain socket path of the backend endpoint.
+                            The path length must not exceed 108 characters.
                           maxLength: 108
+                          minLength: 1
                           type: string
-                          x-kubernetes-validations:
-                          - message: Unix domain socket path length must not exceed
-                              108 characters
-                            rule: self.size() <= 108
                       required:
                       - path
                       type: object

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -4757,7 +4757,7 @@ _Appears in:_
 
 | Field | Type | Required | Default | Description |
 | ---   | ---  | ---      | ---     | ---         |
-| `path` | _string_ |  true  |  | Path defines the unix domain socket path of the backend endpoint. |
+| `path` | _string_ |  true  |  | Path defines the unix domain socket path of the backend endpoint.<br />The path length must not exceed 108 characters. |
 
 
 #### Wasm

--- a/test/cel-validation/backend_test.go
+++ b/test/cel-validation/backend_test.go
@@ -16,7 +16,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 )
@@ -276,28 +275,20 @@ func TestBackend(t *testing.T) {
 			wantErrors: []string{"DynamicResolver type cannot have endpoints and appProtocols specified"},
 		},
 		{
-			desc: "tls settings on non-dynamic resolver",
+			desc: "Invalid Unix socket path length",
 			mutate: func(backend *egv1a1.Backend) {
 				backend.Spec = egv1a1.BackendSpec{
 					AppProtocols: []egv1a1.AppProtocolType{egv1a1.AppProtocolTypeH2C},
 					Endpoints: []egv1a1.BackendEndpoint{
 						{
-							FQDN: &egv1a1.FQDNEndpoint{
-								Hostname: "example.com",
-								Port:     443,
-							},
-						},
-					},
-					TLS: &egv1a1.BackendTLSSettings{
-						CACertificateRefs: []gwapiv1.LocalObjectReference{
-							{
-								Name: "ca-certificate",
+							Unix: &egv1a1.UnixSocket{
+								Path: "/path/to/a/very/long/unix/socket/path/that/exceeds/the/maximum/allowed/length/of/108/characters/and/should/fail/validation.sock",
 							},
 						},
 					},
 				}
 			},
-			wantErrors: []string{"TLS settings can only be specified for DynamicResolver backends"},
+			wantErrors: []string{"spec.endpoints[0].unix.path: Too long: may not be more than 108 bytes"},
 		},
 	}
 

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -17431,8 +17431,11 @@ spec:
                       description: Unix defines the unix domain socket endpoint
                       properties:
                         path:
-                          description: Path defines the unix domain socket path of
-                            the backend endpoint.
+                          description: |-
+                            Path defines the unix domain socket path of the backend endpoint.
+                            The path length must not exceed 108 characters.
+                          maxLength: 108
+                          minLength: 1
                           type: string
                       required:
                       - path

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -119,8 +119,11 @@ spec:
                       description: Unix defines the unix domain socket endpoint
                       properties:
                         path:
-                          description: Path defines the unix domain socket path of
-                            the backend endpoint.
+                          description: |-
+                            Path defines the unix domain socket path of the backend endpoint.
+                            The path length must not exceed 108 characters.
+                          maxLength: 108
+                          minLength: 1
                           type: string
                       required:
                       - path


### PR DESCRIPTION
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
This PR adds validation to limit Unix domain socket path length to 108 characters, which is the standard limit across Unix systems. This limitation exists for historical reasons related to the kernel's mbuf (memory buffer) data structure in early BSD implementations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #6145 

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes