### PR TITLE
docs: Added prereq boilerplate to Response Compression doc in latest and v1.4

### DIFF
--- a/site/content/en/latest/tasks/traffic/response-compression.md
+++ b/site/content/en/latest/tasks/traffic/response-compression.md
@@ -4,10 +4,9 @@ title: "Response Compression"
 
 Response Compression allows you to compress the response from the backend before sending it to the client. This can be useful for scenarios where the backend sends large responses that can be compressed to reduce the network bandwidth. However, this comes with a trade-off of increased CPU usage on the Envoy side to compress the response.
 
-## Installation
+## Prerequisites
 
-Follow the steps from the [Quickstart](../../quickstart) to install Envoy Gateway and the example manifest.
-Before proceeding, you should be able to query the example backend using HTTP.
+{{< boilerplate prerequisites >}}
 
 ## Testing Response Compression
 

--- a/site/content/en/v1.4/tasks/traffic/response-compression.md
+++ b/site/content/en/v1.4/tasks/traffic/response-compression.md
@@ -4,10 +4,9 @@ title: "Response Compression"
 
 Response Compression allows you to compress the response from the backend before sending it to the client. This can be useful for scenarios where the backend sends large responses that can be compressed to reduce the network bandwidth. However, this comes with a trade-off of increased CPU usage on the Envoy side to compress the response.
 
-## Installation
+## Prerequisites
 
-Follow the steps from the [Quickstart](../../quickstart) to install Envoy Gateway and the example manifest.
-Before proceeding, you should be able to query the example backend using HTTP.
+{{< boilerplate prerequisites >}}
 
 ## Testing Response Compression
 


### PR DESCRIPTION
**What type of PR is this?**
Replaced links to Quickstart in the "Response Compression" doc with the prereq boilerplate for latest and v1.4.

**What this PR does / why we need it**:
The user can stay on the same page to install EG.

**Which issue(s) this PR fixes**:
Fixes #6164

Release Notes: No
