### PR TITLE
docs(fault-injection): fix incorrect policy name

### DIFF
--- a/site/content/en/latest/tasks/traffic/fault-injection.md
+++ b/site/content/en/latest/tasks/traffic/fault-injection.md
@@ -290,7 +290,7 @@ Verify the GRPCRoute configuration and status:
 kubectl get grpcroute/yages -o yaml
 ```
 
-Verify the SecurityPolicy configuration:
+Verify the BackendTrafficPolicy configuration:
 
 ```shell
 kubectl get backendtrafficpolicy/fault-injection-abort -o yaml

--- a/site/content/en/v1.4/tasks/traffic/fault-injection.md
+++ b/site/content/en/v1.4/tasks/traffic/fault-injection.md
@@ -290,7 +290,7 @@ Verify the GRPCRoute configuration and status:
 kubectl get grpcroute/yages -o yaml
 ```
 
-Verify the SecurityPolicy configuration:
+Verify the BackendTrafficPolicy configuration:
 
 ```shell
 kubectl get backendtrafficpolicy/fault-injection-abort -o yaml


### PR DESCRIPTION
**What type of PR is this?**
docs: fix incorrect policy name in fault-injection task


**What this PR does / why we need it**:
This PR fixes a documentation error in the Fault Injection task.
The policy name "SecurityPolicy" was incorrectly used and is now replaced with the correct term "BackendTrafficPolicy".

**Which issue(s) this PR fixes**:
Fixes #6167

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
