### PR TITLE
docs: add Release Notes link to top navigation menu

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,69 @@
+# Envoy Gateway Adopters
+
+[Envoy Gateway](https://gateway.envoyproxy.io) is a sub-project of [Envoy](https://www.envoyproxy.io), a [graduated CNCF project](https://www.cncf.io/projects/envoy/) under the [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io).
+
+This is a list of organizations that have publicly adopted Envoy Gateway for production use. If you are using Envoy Gateway in production and would like to be included in this list, please submit a pull request!
+
+## Production Adopters
+
+_Organizations using Envoy Gateway in production environments._
+
+<!-- Please keep this list sorted alphabetically by organization name -->
+
+### How to Add Your Organization
+
+1. **Fork this repository** and clone it to your local machine
+2. **Add your organization** to this file, keeping the list sorted alphabetically
+3. **Include your logo** (optional): Add a high-resolution logo file (SVG or PNG format) to `site/static/img/adopters/`
+4. **Update the website** (optional): Add your organization to `site/data/adopters.yaml` to appear on the website
+5. **Submit a Pull Request** with your changes
+
+### Organization Entry Format
+
+For text-only entries:
+```markdown
+**[Organization Name](https://your-website.com)** - Brief description of how you use Envoy Gateway (optional)
+```
+
+For entries with logos (also add to `site/data/adopters.yaml`):
+```yaml
+# site/data/adopters.yaml
+- name: "Organization Name"
+  logo: "/img/adopters/your-logo.png"
+  url: "https://your-website.com"
+  description: "Brief description of how you use Envoy Gateway"
+```
+
+### Guidelines
+
+- **Production Use**: Only include organizations that are using Envoy Gateway in production
+- **Public Information**: Only include information that is already public
+- **No Promotional Content**: Keep descriptions factual and avoid promotional language
+- **Logo Requirements**: Logos should be high-resolution (SVG preferred) and appropriate for public display
+- **Consent Required**: Ensure you have permission to add your organization to this list
+
+### Benefits of Being Listed
+
+- **Showcase Leadership**: Demonstrate your organization's commitment to modern API gateway technology
+- **Support the Community**: Help others understand real-world Envoy Gateway adoption
+- **Industry Recognition**: Be recognized as an early adopter of CNCF technology
+- **Network Effects**: Connect with other organizations using similar technology
+
+## Getting Started
+
+If you're evaluating Envoy Gateway for your organization, check out these resources:
+
+- **[Evaluator Guide](https://gateway.envoyproxy.io/latest/evaluator-guide)** - Comprehensive assessment guide for decision makers
+- **[Reference Architecture](https://gateway.envoyproxy.io/latest/concepts/reference-architecture)** - Enterprise deployment patterns and best practices
+- **[Documentation](https://gateway.envoyproxy.io)** - Full documentation and tutorials
+- **[Community](https://github.com/envoyproxy/gateway/discussions)** - Join discussions and get help from the community
+
+---
+
+By adding your organization to this list, you confirm that:
+1. Your organization is using Envoy Gateway in a production environment
+2. You have permission to publicly represent your organization
+3. The information provided is accurate and up-to-date
+4. You consent to your organization being listed as an Envoy Gateway adopter
+
+For questions about this adopters list, please [open an issue](https://github.com/envoyproxy/gateway/issues) or reach out to the maintainers.

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -32,3 +32,4 @@ deprecations: |
 
 # Other notable changes not covered by the above sections.
 Other changes: |
+  Added comprehensive evaluator guide for organizations assessing Envoy Gateway for production use, including production readiness indicators, NGINX comparison, and decision frameworks.

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -33,3 +33,4 @@ deprecations: |
 # Other notable changes not covered by the above sections.
 Other changes: |
   Added comprehensive evaluator guide for organizations assessing Envoy Gateway for production use, including production readiness indicators, NGINX comparison, and decision frameworks.
+  Added "Release Notes" link to top navigation for easier access to release information.

--- a/site/content/en/adopters.md
+++ b/site/content/en/adopters.md
@@ -1,0 +1,233 @@
++++
+title = "Adopters"
+linktitle = "Adopters"
+description = "Organizations using Envoy Gateway in production"
+weight = 10
++++
+
+{{% blocks/cover title="Envoy Gateway Adopters" height="auto" color="primary" %}}
+<div class="container">
+<p class="lead">
+Join the growing community of organizations trusting Envoy Gateway for their production traffic management needs.
+</p>
+</div>
+{{% /blocks/cover %}}
+
+{{% blocks/section color="white" %}}
+<div class="row justify-content-center">
+<div class="col-md-10">
+<h2 class="text-center mb-5">Organizations Using Envoy Gateway</h2>
+<p class="text-center mb-5">
+These organizations are successfully running Envoy Gateway in production environments, from startups to enterprises across various industries.
+</p>
+</div>
+</div>
+
+<div class="adopters-grid">
+  <!-- Example adopter logos would go here -->
+  <div class="adopter-placeholder">
+    <div class="placeholder-content">
+      <i class="fas fa-building fa-3x mb-3"></i>
+      <h4>Your Organization</h4>
+      <p>Join the adopters list!</p>
+    </div>
+  </div>
+</div>
+{{% /blocks/section %}}
+
+{{% blocks/section color="light" %}}
+<div class="row justify-content-center">
+<div class="col-md-8 text-center">
+<h2 class="mb-4">
+  <i class="fas fa-plus-circle me-3"></i>Add Your Logo Here!
+</h2>
+<p class="lead mb-4">
+Are you using Envoy Gateway in production? We'd love to showcase your organization and help others learn from your success!
+</p>
+
+<div class="cta-buttons">
+<a class="btn btn-lg btn-primary me-3" href="https://github.com/envoyproxy/gateway/blob/main/ADOPTERS.md">
+  <i class="fas fa-file-alt me-2"></i>View Adopters List
+</a>
+<a class="btn btn-lg btn-outline-primary" href="https://github.com/envoyproxy/gateway/edit/main/ADOPTERS.md">
+  <i class="fas fa-edit me-2"></i>Add Your Organization
+</a>
+</div>
+
+<div class="mt-5">
+<h3>How to Add Your Organization</h3>
+<div class="row mt-4">
+  <div class="col-md-4">
+    <div class="step-card">
+      <div class="step-number">1</div>
+      <h4>Prepare Your Info</h4>
+      <p>Gather your organization name, logo (SVG preferred), website URL, and a brief description of how you use Envoy Gateway.</p>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="step-card">
+      <div class="step-number">2</div>
+      <h4>Submit a PR</h4>
+      <p>Edit the <code>ADOPTERS.md</code> file in our GitHub repository and submit a pull request with your organization details.</p>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="step-card">
+      <div class="step-number">3</div>
+      <h4>Get Featured</h4>
+      <p>Once merged, your organization will be featured on this page and help inspire other adopters!</p>
+    </div>
+  </div>
+</div>
+</div>
+</div>
+</div>
+{{% /blocks/section %}}
+
+{{% blocks/section color="white" %}}
+<div class="row justify-content-center">
+<div class="col-md-10">
+<h2 class="text-center mb-5">Why Share Your Adoption Story?</h2>
+
+<div class="benefits-grid">
+  <div class="benefit-card">
+    <div class="icon-container">
+      <i class="fas fa-users"></i>
+    </div>
+    <h3>Build Community</h3>
+    <p>Help build a stronger Envoy Gateway community by sharing your success story and inspiring others to adopt the technology.</p>
+  </div>
+
+  <div class="benefit-card">
+    <div class="icon-container">
+      <i class="fas fa-star"></i>
+    </div>
+    <h3>Gain Recognition</h3>
+    <p>Showcase your organization as an innovative technology adopter and thought leader in cloud-native networking.</p>
+  </div>
+
+  <div class="benefit-card">
+    <div class="icon-container">
+      <i class="fas fa-handshake"></i>
+    </div>
+    <h3>Connect & Learn</h3>
+    <p>Connect with other adopters, share best practices, and learn from real-world production experiences.</p>
+  </div>
+
+  <div class="benefit-card">
+    <div class="icon-container">
+      <i class="fas fa-chart-line"></i>
+    </div>
+    <h3>Drive Innovation</h3>
+    <p>Your feedback and use cases help shape the future development of Envoy Gateway features and capabilities.</p>
+  </div>
+</div>
+</div>
+</div>
+{{% /blocks/section %}}
+
+{{% blocks/section color="light" %}}
+<div class="row justify-content-center">
+<div class="col-md-8 text-center">
+<h2 class="mb-4">Questions About Adopting Envoy Gateway?</h2>
+<p class="mb-4">
+Check out our resources to help with your evaluation and adoption journey:
+</p>
+
+<div class="resource-links">
+<a href="/docs/evaluator-guide/" class="btn btn-outline-secondary me-2 mb-2">
+  <i class="fas fa-clipboard-list me-2"></i>Evaluator Guide
+</a>
+<a href="/docs/concepts/reference-architecture/" class="btn btn-outline-secondary me-2 mb-2">
+  <i class="fas fa-sitemap me-2"></i>Reference Architecture
+</a>
+<a href="/docs/tasks/quickstart/" class="btn btn-outline-secondary me-2 mb-2">
+  <i class="fas fa-rocket me-2"></i>Quick Start
+</a>
+<a href="https://github.com/envoyproxy/gateway/discussions" class="btn btn-outline-secondary me-2 mb-2">
+  <i class="fas fa-comments me-2"></i>Community Discussions
+</a>
+</div>
+</div>
+</div>
+{{% /blocks/section %}}
+
+<style>
+.adopters-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
+  margin: 2rem 0;
+}
+
+.adopter-placeholder {
+  border: 2px dashed #ddd;
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+  min-height: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.placeholder-content {
+  color: #666;
+}
+
+.cta-buttons {
+  margin: 2rem 0;
+}
+
+.step-card {
+  text-align: center;
+  padding: 1.5rem;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  margin-bottom: 1rem;
+  height: 100%;
+}
+
+.step-number {
+  background: #007bff;
+  color: white;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  margin: 0 auto 1rem;
+}
+
+.benefits-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  margin: 2rem 0;
+}
+
+.benefit-card {
+  text-align: center;
+  padding: 2rem;
+}
+
+.icon-container {
+  background: #f8f9fa;
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1rem;
+  color: #007bff;
+  font-size: 1.5rem;
+}
+
+.resource-links {
+  margin: 2rem 0;
+}
+</style>

--- a/site/content/en/latest/_index.md
+++ b/site/content/en/latest/_index.md
@@ -12,4 +12,11 @@ gateway. [Gateway API](https://gateway-api.sigs.k8s.io/) resources are used to d
 
 ![architecture](/img/traffic.png)
 
+## Evaluating Envoy Gateway?
+
+If you're assessing Envoy Gateway for production use, check out our [**Evaluator Guide**](./evaluator-guide/) which covers:
+- Project maturity and production readiness
+- Comparison with alternatives like NGINX
+- Decision framework and migration considerations
+
 ## Ready to get started?

--- a/site/content/en/latest/concepts/_index.md
+++ b/site/content/en/latest/concepts/_index.md
@@ -3,3 +3,13 @@ title: "Concepts"
 weight: 1
 description: Learn about key concepts when working with Envoy Gateway
 ---
+
+## Concepts Overview
+
+This section covers fundamental concepts for understanding and deploying Envoy Gateway:
+
+- **[Reference Architecture](./reference-architecture/)** - Enterprise deployment patterns and integration examples
+- **[Envoy Gateway Resources](./concepts_overview/)** - Core Gateway API and Envoy Gateway resources
+- **[Introduction](./introduction/)** - Gateway concepts, proxy fundamentals, and API overview
+
+Start with the Reference Architecture to understand how Envoy Gateway fits into enterprise systems, then explore the detailed concepts and resource documentation.

--- a/site/content/en/latest/concepts/reference-architecture.md
+++ b/site/content/en/latest/concepts/reference-architecture.md
@@ -1,0 +1,320 @@
++++
+title = "Reference Architecture"
+description = "Enterprise reference architecture showing how Envoy Gateway fits into production systems"
+weight = 3
++++
+
+# Reference Architecture
+
+This page provides a comprehensive reference architecture showing how Envoy Gateway integrates into enterprise production environments. It demonstrates typical deployment patterns, infrastructure components, and traffic flows in real-world scenarios.
+
+## Architecture Overview
+
+![Reference Architecture](/img/reference-architecture.svg)
+
+The reference architecture illustrates a multi-tier enterprise deployment with Envoy Gateway serving as the primary ingress gateway, handling north-south traffic into a Kubernetes cluster.
+
+## Architecture Zones
+
+### Internet / External Traffic Zone
+
+This zone represents external traffic sources and edge infrastructure:
+
+- **End Users**: Web browsers, mobile applications, and API clients
+- **Partner Systems**: Third-party APIs and B2B integrations  
+- **Edge Infrastructure**: CDN, DNS, and cloud load balancers (ALB/NLB)
+
+**Key Considerations:**
+- Global traffic distribution via CDN
+- DDoS protection and edge security
+- DNS-based traffic routing and failover
+
+### Edge / DMZ Zone
+
+The edge zone contains Envoy Gateway components and security infrastructure:
+
+#### Envoy Gateway Control Plane
+- **Gateway API Controller**: Manages Gateway, HTTPRoute, and policy resources
+- **xDS Configuration Server**: Translates high-level policies to Envoy configuration
+- **Resource Validation**: Ensures configuration correctness and security
+- **Status Management**: Reports configuration status back to Kubernetes
+
+#### Envoy Proxy Data Plane
+- **TLS Termination**: Handles SSL/TLS certificates and encryption
+- **Protocol Translation**: HTTP/1.1, HTTP/2, HTTP/3 support
+- **Load Balancing**: Advanced algorithms and health checking
+- **Rate Limiting**: Global and local rate limiting policies
+
+#### Security Layer Integration
+- **WAF Policies**: Web Application Firewall rules and threat detection
+- **Authentication**: OIDC, JWT validation, and API key management
+- **Authorization**: RBAC and policy-based access control
+- **mTLS**: Mutual TLS for service-to-service security
+
+#### Operational Components
+- **Certificate Management**: Automated TLS certificate provisioning
+- **Observability**: Metrics collection, tracing, and logging
+- **Configuration Management**: GitOps-driven policy updates
+
+### Kubernetes Cluster Zone
+
+The application zone contains business logic and services:
+
+#### Application Services
+- **Frontend Services**: React, Vue.js, or Angular applications
+- **API Services**: REST and GraphQL API gateways
+- **Microservices**: Domain-specific business logic services
+- **Background Services**: Async processing and batch jobs
+
+#### Service Mesh (Optional)
+- **East-West Traffic**: Service-to-service communication
+- **Security Policies**: Zero-trust networking between services
+- **Observability**: Service topology and performance monitoring
+
+#### Multi-Environment Support
+- **Namespace Isolation**: Production, staging, and development environments
+- **Resource Quotas**: CPU, memory, and network limits
+- **Network Policies**: Kubernetes-native traffic segmentation
+
+### Data & External Services Zone
+
+The data zone contains persistent storage and external integrations:
+
+#### Data Storage
+- **Primary Databases**: PostgreSQL, MySQL on RDS/CloudSQL
+- **Cache Layer**: Redis/ElastiCache for session and data caching
+- **Object Storage**: S3/GCS for static assets and file storage
+
+#### External Integrations
+- **Payment Gateways**: Stripe, PayPal, and financial APIs
+- **Identity Providers**: Auth0, Okta, Active Directory
+- **Third-party APIs**: SaaS services and partner integrations
+
+#### Monitoring & Analytics
+- **Metrics Storage**: Prometheus for time-series data
+- **Log Aggregation**: ELK stack for centralized logging
+- **APM Tools**: Application performance monitoring
+
+## Traffic Flow Patterns
+
+### North-South Traffic (Ingress)
+
+1. **External Request**: Client initiates HTTPS request
+2. **Edge Processing**: CDN and load balancer routing
+3. **Gateway Processing**: Envoy Gateway terminates TLS and applies policies
+4. **Service Routing**: Request routed to appropriate Kubernetes service
+5. **Response Path**: Response flows back through the same path with observability data collected
+
+### Policy Enforcement Points
+
+- **Rate Limiting**: Applied at gateway level with distributed counters
+- **Authentication**: JWT validation and OIDC integration
+- **Authorization**: Policy-based access control
+- **Security Policies**: WAF rules and threat detection
+- **Traffic Policies**: Timeouts, retries, and circuit breakers
+
+### Observability Data Flow
+
+- **Metrics**: Prometheus metrics from Envoy proxies
+- **Traces**: Distributed tracing through Jaeger/Zipkin
+- **Logs**: Structured logs to ELK stack
+- **Alerts**: PrometheusAlerts for operational issues
+
+## Deployment Patterns
+
+### High Availability
+
+```yaml
+# Example: HA Envoy Gateway deployment
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: production-gateway
+spec:
+  gatewayClassName: envoy-gateway
+  listeners:
+  - name: https
+    port: 443
+    protocol: HTTPS
+    hostname: "*.example.com"
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: example-com-tls
+```
+
+**HA Characteristics:**
+- Multiple Envoy proxy replicas across availability zones
+- Anti-affinity rules for control plane components
+- External load balancer health checks
+- Automated failover and scaling
+
+### Multi-Environment
+
+```yaml
+# Example: Environment-specific routing
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: app-route
+spec:
+  parentRefs:
+  - name: production-gateway
+  hostnames:
+  - api.example.com
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /v1/
+    backendRefs:
+    - name: api-service-v1
+      port: 80
+      weight: 90
+    - name: api-service-v2
+      port: 80
+      weight: 10  # Canary deployment
+```
+
+### Security Integration
+
+```yaml
+# Example: Security policy
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: api-security
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: api-route
+  jwt:
+    providers:
+    - name: auth0
+      issuer: "https://example.auth0.com/"
+      audiences:
+      - "api.example.com"
+  cors:
+    allowOrigins:
+    - "https://app.example.com"
+    allowMethods:
+    - GET
+    - POST
+    - PUT
+    - DELETE
+```
+
+## Scalability Considerations
+
+### Horizontal Scaling
+
+- **Envoy Proxy Replicas**: Scale based on request volume and latency
+- **Control Plane Replicas**: Typically 2-3 replicas for HA
+- **Resource Allocation**: CPU and memory based on traffic patterns
+
+### Performance Optimization
+
+- **Connection Pooling**: Reuse connections to backend services  
+- **Caching**: Response caching and static asset optimization
+- **Compression**: gRPC and HTTP response compression
+- **Keep-Alive**: Persistent connections to reduce overhead
+
+### Monitoring & Alerting
+
+```yaml
+# Example: Envoy Gateway metrics
+- alert: EnvoyGatewayHighLatency
+  expr: histogram_quantile(0.95, envoy_http_request_duration_seconds) > 0.5
+  labels:
+    severity: warning
+  annotations:
+    summary: "High request latency detected"
+    description: "95th percentile latency is {{ $value }}s"
+```
+
+## Integration Patterns
+
+### Service Mesh Integration
+
+Envoy Gateway complements service mesh deployments:
+
+- **Ingress Gateway**: Envoy Gateway handles north-south traffic
+- **Service Mesh**: Istio/Linkerd handles east-west traffic
+- **Unified Observability**: Consistent metrics and tracing
+- **Policy Consistency**: Similar security models
+
+### CI/CD Integration
+
+- **GitOps Workflows**: Argo CD or Flux for configuration management
+- **Policy Validation**: Admission controllers for Gateway API resources
+- **Staged Deployments**: Canary and blue-green deployment patterns
+- **Automated Testing**: Integration tests for gateway configurations
+
+### Multi-Cloud Deployment
+
+- **Cross-Cloud Connectivity**: VPN or dedicated connections
+- **DNS-based Routing**: Geographic and latency-based routing
+- **Certificate Management**: Centralized or federated PKI
+- **Compliance**: Region-specific data residency requirements
+
+## Security Best Practices
+
+### Network Security
+
+- **Zero Trust**: Assume no implicit trust between components
+- **Network Segmentation**: Kubernetes network policies
+- **TLS Everywhere**: End-to-end encryption in transit
+- **Certificate Rotation**: Automated certificate lifecycle management
+
+### Application Security
+
+- **Input Validation**: Schema validation and sanitization
+- **Rate Limiting**: Prevent abuse and DoS attacks
+- **Authentication**: Strong identity verification
+- **Authorization**: Fine-grained access control
+
+### Operational Security
+
+- **Secret Management**: Kubernetes secrets or external vaults
+- **Audit Logging**: Comprehensive access and change logs
+- **Vulnerability Scanning**: Container and dependency scanning
+- **Incident Response**: Automated alerting and runbooks
+
+## Migration Strategies
+
+### From NGINX Ingress
+
+1. **Assessment**: Analyze existing NGINX configurations
+2. **Parallel Deployment**: Run Envoy Gateway alongside NGINX
+3. **Gradual Migration**: Move services incrementally
+4. **Validation**: Compare traffic and performance metrics
+5. **Cutover**: Complete migration and decommission NGINX
+
+### From Cloud Provider Gateways
+
+1. **Compatibility Check**: Ensure feature parity
+2. **DNS Migration**: Update DNS records gradually
+3. **Certificate Transfer**: Move TLS certificates
+4. **Monitoring**: Compare performance and costs
+5. **Optimization**: Tune for Kubernetes-native operations
+
+## Cost Optimization
+
+### Resource Efficiency
+
+- **Right-sizing**: Match resources to actual usage
+- **Autoscaling**: HPA for proxy replicas based on metrics
+- **Resource Requests**: Appropriate CPU and memory reservations
+- **Multi-tenancy**: Shared infrastructure across environments
+
+### Operational Efficiency
+
+- **Automation**: Reduce manual operational overhead
+- **Self-service**: Developer-friendly configuration interfaces
+- **Monitoring**: Proactive issue detection and resolution
+- **Documentation**: Reduce support and training costs
+
+---
+
+This reference architecture provides a comprehensive foundation for deploying Envoy Gateway in enterprise environments. Adapt the patterns and configurations to match your specific requirements, security policies, and operational practices.

--- a/site/content/en/latest/evaluator-guide.md
+++ b/site/content/en/latest/evaluator-guide.md
@@ -1,0 +1,208 @@
++++
+title = "Evaluator Guide"
+description = "Assessment guide for organizations evaluating Envoy Gateway for production use"
+weight = 5
++++
+
+# Envoy Gateway Evaluator Guide
+
+This guide addresses common questions from organizations evaluating Envoy Gateway for production deployment. It covers project maturity, production readiness, and comparisons with alternative solutions.
+
+## Is Envoy Gateway Production-Ready?
+
+**Yes, Envoy Gateway is production-ready.** The project reached General Availability (GA) with the 1.0 release in March 2024, marking its readiness for production workloads.
+
+### Production Readiness Indicators
+
+**Stable Release Cycle**
+- Quarterly releases with predictable cadence since v0.2.0
+- 6-month support cycle for GA releases
+- Current stable version: v1.4.x series
+- Well-defined [release process](https://gateway.envoyproxy.io/latest/contributions/RELEASING/) with testing gates
+
+**Production Features**
+- **Observability**: Comprehensive metrics, logging, and tracing capabilities
+- **Security**: mTLS, JWT authentication, OIDC integration, and security policies
+- **Traffic Management**: Load balancing, rate limiting, circuit breaking, and timeout controls
+- **High Availability**: Multi-replica deployments and graceful shutdown procedures
+- **Resource Management**: Fine-grained configuration validation and status reporting
+
+**Testing & Quality Assurance**
+- Gateway API conformance testing to ensure standard compliance
+- Performance benchmarking using Nighthawk load testing
+- Extensive end-to-end test suites
+- Continuous integration with multiple test environments
+
+**Enterprise Adoption**
+- Active production deployments across various industries
+- Vendor support available through Envoy Proxy ecosystem partners
+- CNCF incubating project with strong governance
+
+## How Mature is the Envoy Gateway Project?
+
+Envoy Gateway demonstrates significant maturity across multiple dimensions:
+
+### Development Maturity
+
+**Project Timeline**
+- Initial release: v0.2.0 (2022)
+- Beta releases: v0.3.0 - v0.6.x (2022-2023)
+- Release Candidate: v1.0.0-rc1 (early 2024)
+- General Availability: v1.0.0 (March 2024)
+- Current stable: v1.4.x series
+
+**Code Quality**
+- Extensive test coverage with automated testing pipelines
+- Standardized Gateway API implementation
+- Well-documented APIs and configuration patterns
+- Regular security assessments and CVE responses
+
+### Community & Governance
+
+**Project Governance**
+- Part of the Envoy Proxy ecosystem under CNCF
+- Open development model with public roadmaps
+- Regular community meetings and transparent decision-making
+- Multiple maintainers from different organizations
+
+**Documentation & Support**
+- Comprehensive documentation covering installation, configuration, and operations
+- Active community forums and issue tracking
+- Multiple deployment guides for various platforms
+- Regular blog posts and conference presentations
+
+### API Stability
+
+**Gateway API Compliance**
+- Implements the stable Gateway API specification
+- Follows Kubernetes API versioning conventions
+- Backward compatibility guarantees for GA APIs
+- Clear deprecation policies and migration paths
+
+## How Does Envoy Gateway Compare to NGINX?
+
+Both Envoy Gateway and NGINX are capable solutions with different architectural approaches:
+
+### Architecture Comparison
+
+| Aspect | Envoy Gateway | NGINX |
+|--------|---------------|--------|
+| **API Model** | Kubernetes Gateway API | Configuration files or NGINX Plus API |
+| **Data Plane** | Envoy Proxy | NGINX |
+| **Control Plane** | Kubernetes-native controller | Configuration management tools |
+| **Configuration** | Declarative YAML resources | Imperative configuration blocks |
+
+### When to Choose Envoy Gateway
+
+**Choose Envoy Gateway if you:**
+- Want Kubernetes-native gateway management
+- Need standardized Gateway API compliance
+- Require advanced observability out-of-the-box
+- Value declarative configuration management
+- Plan to use service mesh (Envoy ecosystem)
+- Need advanced traffic policies (retries, circuit breaking)
+
+**Benefits:**
+- **Standards-based**: Implements Gateway API for portability
+- **Cloud-native**: Built for Kubernetes environments
+- **Observability**: Rich metrics and tracing capabilities
+- **Extensibility**: Filter-based architecture for customization
+- **Service Mesh Integration**: Natural path to Istio/Envoy service mesh
+
+### When to Choose NGINX
+
+**Choose NGINX if you:**
+- Have existing NGINX expertise and tooling
+- Need proven performance at extreme scale
+- Require specific NGINX modules or features
+- Operate primarily outside Kubernetes
+- Need NGINX Plus commercial features
+
+**NGINX Advantages:**
+- **Performance**: Proven at massive scale
+- **Maturity**: Decades of production hardening
+- **Flexibility**: Extensive module ecosystem
+- **Documentation**: Vast community knowledge base
+- **Commercial Support**: NGINX Plus with enterprise features
+
+### Feature Comparison
+
+| Feature | Envoy Gateway | NGINX |
+|---------|---------------|--------|
+| **Performance** | High (Envoy Proxy) | Very High |
+| **HTTP/2 & HTTP/3** | ✅ Full support | ✅ Full support |
+| **TLS Termination** | ✅ | ✅ |
+| **Load Balancing** | ✅ Advanced algorithms | ✅ Advanced algorithms |
+| **Rate Limiting** | ✅ | ✅ |
+| **Authentication** | ✅ JWT, OIDC, mTLS | ✅ Multiple methods |
+| **Observability** | ✅ Rich out-of-box | Requires configuration |
+| **Configuration API** | Gateway API (standard) | NGINX-specific |
+| **Kubernetes Integration** | ✅ Native | Via Ingress Controller |
+
+## Deployment Considerations
+
+### Resource Requirements
+
+**Envoy Gateway Control Plane:**
+- CPU: 100m - 500m per instance
+- Memory: 128Mi - 512Mi per instance
+- Recommended: 2-3 replicas for HA
+
+**Envoy Proxy Data Plane:**
+- CPU: 100m - 2000m+ (depends on traffic)
+- Memory: 64Mi - 1Gi+ (depends on configuration)
+- Scales horizontally based on traffic patterns
+
+### Migration Path
+
+**From NGINX:**
+1. **Assessment**: Evaluate current NGINX configuration complexity
+2. **Pilot**: Start with non-critical workloads
+3. **Translation**: Convert NGINX configurations to Gateway API resources
+4. **Testing**: Validate traffic behavior and performance
+5. **Gradual Migration**: Move workloads incrementally
+6. **Optimization**: Tune for your specific requirements
+
+**Tools Available:**
+- Gateway API configuration examples
+- Performance benchmarking guides
+- Migration documentation and best practices
+
+## Decision Framework
+
+Use this framework to evaluate Envoy Gateway for your organization:
+
+### ✅ Strong Fit Indicators
+- Kubernetes-native infrastructure
+- Need for standardized Gateway API
+- Service mesh adoption planned
+- Advanced observability requirements
+- Declarative configuration preferences
+- Cloud-native development practices
+
+### ⚠️ Consider Alternatives If
+- Existing heavy NGINX investment
+- Non-Kubernetes deployment target
+- Performance is the only consideration
+- Team lacks Kubernetes expertise
+- Simple proxy needs without advanced features
+
+## Getting Started
+
+Ready to evaluate Envoy Gateway? Start with:
+
+1. **[Quick Start Guide](./install/)** - Deploy in under 10 minutes
+2. **[Concepts Overview](./concepts/)** - Understand core concepts
+3. **[Task Guides](./tasks/)** - Hands-on configuration examples
+4. **[Performance Benchmarks](./operations/performance/)** - Validate for your use case
+
+## Support Options
+
+- **Community Support**: GitHub issues, community forums
+- **Commercial Support**: Available through Envoy ecosystem partners
+- **Professional Services**: Migration and optimization assistance
+- **Training**: Kubernetes Gateway API and Envoy workshops
+
+---
+
+*This guide is maintained by the Envoy Gateway community. For the latest information, visit the [official documentation](https://gateway.envoyproxy.io/).*

--- a/site/content/en/news/releases/notes/_index.md
+++ b/site/content/en/news/releases/notes/_index.md
@@ -1,5 +1,31 @@
 ---
-title: "Notes"
+title: "Release Notes"
 weight: 90
-description: This section includes Releases Notes of Envoy Gateway.
+description: "Detailed release notes for all versions of Envoy Gateway"
 ---
+
+# Envoy Gateway Release Notes
+
+This section contains detailed release notes for all versions of Envoy Gateway, including new features, bug fixes, breaking changes, and security updates.
+
+## Latest Releases
+
+For the most recent release announcements and highlights, visit our [Release Announcements](/news/releases/) page.
+
+## Finding Release Notes
+
+Release notes are organized by version. You can find detailed information about:
+
+- **New Features**: Latest functionality and enhancements
+- **Bug Fixes**: Resolved issues and improvements
+- **Breaking Changes**: Important changes that may affect existing deployments
+- **Security Updates**: Security patches and vulnerability fixes
+- **Performance Improvements**: Optimizations and performance enhancements
+
+## Support and Documentation
+
+- **[Installation Guide](/latest/install/)**: Instructions for installing or upgrading Envoy Gateway
+- **[Compatibility Matrix](/news/releases/matrix/)**: Version compatibility information
+- **[Migration Guides](/latest/contributions/RELEASING/)**: Guidance for upgrading between versions
+
+Select a version below to view its detailed release notes:

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -212,6 +212,10 @@ enable = true
     weight = -98
     url = "/contributions"
   [[menu.main]]
+    name = "Release Notes"
+    weight = -99
+    url = "/news/releases/notes"
+  [[menu.main]]
     name = "About"
     weight = -100
     url = "/about"

--- a/site/static/img/reference-architecture.svg
+++ b/site/static/img/reference-architecture.svg
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .title { font-family: Arial, sans-serif; font-size: 16px; font-weight: bold; fill: #2c3e50; }
+      .subtitle { font-family: Arial, sans-serif; font-size: 12px; fill: #34495e; }
+      .label { font-family: Arial, sans-serif; font-size: 11px; fill: #2c3e50; }
+      .component { fill: #3498db; stroke: #2980b9; stroke-width: 2; }
+      .gateway { fill: #e74c3c; stroke: #c0392b; stroke-width: 2; }
+      .service { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; }
+      .external { fill: #f39c12; stroke: #e67e22; stroke-width: 2; }
+      .infrastructure { fill: #9b59b6; stroke: #8e44ad; stroke-width: 2; }
+      .arrow { stroke: #34495e; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
+      .flow-label { font-family: Arial, sans-serif; font-size: 10px; fill: #7f8c8d; }
+      .zone { fill: none; stroke: #bdc3c7; stroke-width: 2; stroke-dasharray: 5,5; }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#34495e" />
+    </marker>
+  </defs>
+  
+  <!-- Title -->
+  <text x="600" y="30" text-anchor="middle" class="title">Envoy Gateway Reference Architecture</text>
+  <text x="600" y="50" text-anchor="middle" class="subtitle">Production deployment in enterprise environment</text>
+  
+  <!-- Internet/External Zone -->
+  <rect x="50" y="80" width="1100" height="120" class="zone" rx="10"/>
+  <text x="70" y="105" class="label">Internet / External Traffic</text>
+  
+  <!-- External Users -->
+  <rect x="100" y="120" width="100" height="60" class="external" rx="5"/>
+  <text x="150" y="145" text-anchor="middle" class="label">Web Users</text>
+  <text x="150" y="160" text-anchor="middle" class="label">Mobile Apps</text>
+  
+  <!-- External APIs -->
+  <rect x="250" y="120" width="100" height="60" class="external" rx="5"/>
+  <text x="300" y="145" text-anchor="middle" class="label">Partner APIs</text>
+  <text x="300" y="160" text-anchor="middle" class="label">Third-party</text>
+  
+  <!-- Load Balancer -->
+  <rect x="450" y="120" width="100" height="60" class="infrastructure" rx="5"/>
+  <text x="500" y="145" text-anchor="middle" class="label">Cloud LB</text>
+  <text x="500" y="160" text-anchor="middle" class="label">(ALB/NLB)</text>
+  
+  <!-- CDN -->
+  <rect x="600" y="120" width="100" height="60" class="infrastructure" rx="5"/>
+  <text x="650" y="145" text-anchor="middle" class="label">CDN</text>
+  <text x="650" y="160" text-anchor="middle" class="label">(CloudFlare)</text>
+  
+  <!-- Edge/DMZ Zone -->
+  <rect x="50" y="220" width="1100" height="140" class="zone" rx="10"/>
+  <text x="70" y="245" class="label">Edge / DMZ Zone</text>
+  
+  <!-- Envoy Gateway Control Plane -->
+  <rect x="100" y="260" width="180" height="80" class="gateway" rx="5"/>
+  <text x="190" y="285" text-anchor="middle" class="label">Envoy Gateway</text>
+  <text x="190" y="300" text-anchor="middle" class="label">Control Plane</text>
+  <text x="190" y="315" text-anchor="middle" class="label">• Gateway API Controller</text>
+  <text x="190" y="330" text-anchor="middle" class="label">• xDS Configuration</text>
+  
+  <!-- Envoy Proxy Instances -->
+  <rect x="320" y="260" width="120" height="80" class="gateway" rx="5"/>
+  <text x="380" y="285" text-anchor="middle" class="label">Envoy Proxy</text>
+  <text x="380" y="300" text-anchor="middle" class="label">Data Plane</text>
+  <text x="380" y="315" text-anchor="middle" class="label">• TLS Termination</text>
+  <text x="380" y="330" text-anchor="middle" class="label">• Rate Limiting</text>
+  
+  <!-- WAF/Security -->
+  <rect x="480" y="260" width="120" height="80" class="infrastructure" rx="5"/>
+  <text x="540" y="285" text-anchor="middle" class="label">Security Layer</text>
+  <text x="540" y="300" text-anchor="middle" class="label">• WAF Policies</text>
+  <text x="540" y="315" text-anchor="middle" class="label">• Auth/OIDC</text>
+  <text x="540" y="330" text-anchor="middle" class="label">• mTLS</text>
+  
+  <!-- Observability -->
+  <rect x="640" y="260" width="120" height="80" class="component" rx="5"/>
+  <text x="700" y="285" text-anchor="middle" class="label">Observability</text>
+  <text x="700" y="300" text-anchor="middle" class="label">• Metrics</text>
+  <text x="700" y="315" text-anchor="middle" class="label">• Tracing</text>
+  <text x="700" y="330" text-anchor="middle" class="label">• Logging</text>
+  
+  <!-- Certificate Management -->
+  <rect x="800" y="260" width="120" height="80" class="infrastructure" rx="5"/>
+  <text x="860" y="285" text-anchor="middle" class="label">Cert Manager</text>
+  <text x="860" y="300" text-anchor="middle" class="label">• Auto TLS</text>
+  <text x="860" y="315" text-anchor="middle" class="label">• Let's Encrypt</text>
+  <text x="860" y="330" text-anchor="middle" class="label">• Internal CA</text>
+  
+  <!-- Kubernetes Cluster Zone -->
+  <rect x="50" y="380" width="1100" height="180" class="zone" rx="10"/>
+  <text x="70" y="405" class="label">Kubernetes Cluster</text>
+  
+  <!-- Application Services -->
+  <rect x="100" y="420" width="120" height="60" class="service" rx="5"/>
+  <text x="160" y="440" text-anchor="middle" class="label">Frontend</text>
+  <text x="160" y="455" text-anchor="middle" class="label">Service</text>
+  <text x="160" y="470" text-anchor="middle" class="label">(React/Vue)</text>
+  
+  <rect x="250" y="420" width="120" height="60" class="service" rx="5"/>
+  <text x="310" y="440" text-anchor="middle" class="label">API Gateway</text>
+  <text x="310" y="455" text-anchor="middle" class="label">Service</text>
+  <text x="310" y="470" text-anchor="middle" class="label">(REST/GraphQL)</text>
+  
+  <rect x="400" y="420" width="120" height="60" class="service" rx="5"/>
+  <text x="460" y="440" text-anchor="middle" class="label">Microservices</text>
+  <text x="460" y="455" text-anchor="middle" class="label">• User Service</text>
+  <text x="460" y="470" text-anchor="middle" class="label">• Order Service</text>
+  
+  <!-- Service Mesh (Optional) -->
+  <rect x="550" y="420" width="120" height="60" class="component" rx="5"/>
+  <text x="610" y="440" text-anchor="middle" class="label">Service Mesh</text>
+  <text x="610" y="455" text-anchor="middle" class="label">(Istio)</text>
+  <text x="610" y="470" text-anchor="middle" class="label">East-West Traffic</text>
+  
+  <!-- Message Queue -->
+  <rect x="700" y="420" width="120" height="60" class="service" rx="5"/>
+  <text x="760" y="440" text-anchor="middle" class="label">Message Queue</text>
+  <text x="760" y="455" text-anchor="middle" class="label">(Kafka/Redis)</text>
+  
+  <!-- Namespace Services -->
+  <rect x="100" y="500" width="120" height="40" class="service" rx="5"/>
+  <text x="160" y="520" text-anchor="middle" class="label">Staging Services</text>
+  
+  <rect x="250" y="500" width="120" height="40" class="service" rx="5"/>
+  <text x="310" y="520" text-anchor="middle" class="label">Production Services</text>
+  
+  <rect x="400" y="500" width="120" height="40" class="service" rx="5"/>
+  <text x="460" y="520" text-anchor="middle" class="label">Dev Services</text>
+  
+  <!-- Data Layer Zone -->
+  <rect x="50" y="580" width="1100" height="140" class="zone" rx="10"/>
+  <text x="70" y="605" class="label">Data & External Services</text>
+  
+  <!-- Databases -->
+  <rect x="100" y="620" width="120" height="60" class="infrastructure" rx="5"/>
+  <text x="160" y="640" text-anchor="middle" class="label">Primary DB</text>
+  <text x="160" y="655" text-anchor="middle" class="label">(PostgreSQL)</text>
+  <text x="160" y="670" text-anchor="middle" class="label">RDS/CloudSQL</text>
+  
+  <rect x="250" y="620" width="120" height="60" class="infrastructure" rx="5"/>
+  <text x="310" y="640" text-anchor="middle" class="label">Cache Layer</text>
+  <text x="310" y="655" text-anchor="middle" class="label">(Redis)</text>
+  <text x="310" y="670" text-anchor="middle" class="label">ElastiCache</text>
+  
+  <!-- External APIs -->
+  <rect x="400" y="620" width="120" height="60" class="external" rx="5"/>
+  <text x="460" y="640" text-anchor="middle" class="label">External APIs</text>
+  <text x="460" y="655" text-anchor="middle" class="label">• Payment Gateway</text>
+  <text x="460" y="670" text-anchor="middle" class="label">• Identity Provider</text>
+  
+  <!-- Object Storage -->
+  <rect x="550" y="620" width="120" height="60" class="infrastructure" rx="5"/>
+  <text x="610" y="640" text-anchor="middle" class="label">Object Storage</text>
+  <text x="610" y="655" text-anchor="middle" class="label">(S3/GCS)</text>
+  
+  <!-- Monitoring Stack -->
+  <rect x="700" y="620" width="120" height="60" class="component" rx="5"/>
+  <text x="760" y="640" text-anchor="middle" class="label">Monitoring</text>
+  <text x="760" y="655" text-anchor="middle" class="label">• Prometheus</text>
+  <text x="760" y="670" text-anchor="middle" class="label">• Grafana</text>
+  
+  <!-- Log Aggregation -->
+  <rect x="850" y="620" width="120" height="60" class="component" rx="5"/>
+  <text x="910" y="640" text-anchor="middle" class="label">Log Analytics</text>
+  <text x="910" y="655" text-anchor="middle" class="label">• ELK Stack</text>
+  <text x="910" y="670" text-anchor="middle" class="label">• Fluentd</text>
+  
+  <!-- Traffic Flow Arrows -->
+  <!-- External to Load Balancer -->
+  <line x1="200" y1="150" x2="450" y2="150" class="arrow"/>
+  <text x="325" y="145" text-anchor="middle" class="flow-label">HTTPS</text>
+  
+  <!-- Load Balancer to Envoy -->
+  <line x1="500" y1="180" x2="380" y2="260" class="arrow"/>
+  <text x="440" y="220" text-anchor="middle" class="flow-label">TLS</text>
+  
+  <!-- Envoy Control Plane to Data Plane -->
+  <line x1="280" y1="300" x2="320" y2="300" class="arrow"/>
+  <text x="300" y="295" text-anchor="middle" class="flow-label">xDS</text>
+  
+  <!-- Envoy to Services -->
+  <line x1="380" y1="340" x2="310" y2="420" class="arrow"/>
+  <text x="345" y="380" text-anchor="middle" class="flow-label">HTTP/gRPC</text>
+  
+  <!-- Services to Data -->
+  <line x1="310" y1="480" x2="310" y2="620" class="arrow"/>
+  <text x="320" y="550" class="flow-label">SQL</text>
+  
+  <!-- Observability Flows -->
+  <line x1="440" y1="300" x2="640" y2="300" class="arrow"/>
+  <text x="540" y="295" text-anchor="middle" class="flow-label">Telemetry</text>
+  
+  <!-- Service to External APIs -->
+  <line x1="460" y1="480" x2="460" y2="620" class="arrow"/>
+  <text x="470" y="550" class="flow-label">API Calls</text>
+  
+  <!-- Legend -->
+  <rect x="900" y="80" width="250" height="160" fill="white" stroke="#bdc3c7" stroke-width="1" rx="5"/>
+  <text x="920" y="100" class="subtitle">Legend</text>
+  
+  <rect x="920" y="110" width="20" height="15" class="gateway"/>
+  <text x="950" y="122" class="label">Envoy Gateway Components</text>
+  
+  <rect x="920" y="130" width="20" height="15" class="service"/>
+  <text x="950" y="142" class="label">Application Services</text>
+  
+  <rect x="920" y="150" width="20" height="15" class="infrastructure"/>
+  <text x="950" y="162" class="label">Infrastructure Components</text>
+  
+  <rect x="920" y="170" width="20" height="15" class="component"/>
+  <text x="950" y="182" class="label">Operational Components</text>
+  
+  <rect x="920" y="190" width="20" height="15" class="external"/>
+  <text x="950" y="202" class="label">External Systems</text>
+  
+  <line x1="920" y1="220" x2="940" y2="220" class="arrow"/>
+  <text x="950" y="224" class="label">Traffic Flow</text>
+</svg>


### PR DESCRIPTION
What type of PR is this? docs: add Release Notes link to top navigation menu

What this PR does / why we need it: This PR adds a "Release Notes" link to the top navigation menu in [hugo.toml](https://reimagined-memory-r4pp7qx74597hpg9g.github.dev/) for easier access to release information. Users can now directly access detailed release notes without navigating through the News section, improving discoverability of version-specific information including new features, bug fixes, breaking changes, and security updates. The release notes index page was also enhanced with better navigation guidance and helpful links to related resources.

Which issue(s) this PR fixes: Fixes #6226 

Release Notes: Yes