### PR TITLE
feat(site): add community CTAs for Slack, GitHub, LinkedIn and Twitter on landing page

### DIFF
--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -32,3 +32,4 @@ deprecations: |
 
 # Other notable changes not covered by the above sections.
 Other changes: |
+  Enhanced landing page with prominent community CTAs for Slack, GitHub, LinkedIn, and Twitter to improve community engagement and discoverability.

--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -1627,3 +1627,136 @@ footer {
     margin-right: auto;
   }
 }
+
+// Announcement Banner
+.announcement-banner {
+  background: linear-gradient(135deg, $gradient-start 0%, $gradient-end 100%);
+  color: $white;
+  padding: 0.75rem 0;
+  position: relative;
+  z-index: 1000;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+
+  .announcement-content {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem 0;
+    
+    @media (max-width: 768px) {
+      flex-direction: column;
+      text-align: center;
+      gap: 0.5rem;
+    }
+  }
+
+  .announcement-icon {
+    font-size: 1.25rem;
+    color: rgba(255, 255, 255, 0.9);
+    flex-shrink: 0;
+    
+    @media (max-width: 768px) {
+      display: none;
+    }
+  }
+
+  .announcement-text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    
+    @media (max-width: 768px) {
+      text-align: center;
+    }
+  }
+
+  .announcement-title {
+    font-weight: 600;
+    font-size: 1rem;
+    display: block;
+    
+    @media (max-width: 768px) {
+      font-size: 0.9rem;
+    }
+  }
+
+  .announcement-message {
+    font-size: 0.9rem;
+    opacity: 0.95;
+    
+    @media (max-width: 768px) {
+      font-size: 0.8rem;
+    }
+  }
+
+  .announcement-link {
+    color: $white;
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 255, 255, 0.5);
+    font-weight: 500;
+    transition: all 0.2s ease;
+    margin-left: 0.5rem;
+    
+    &:hover {
+      color: $white;
+      text-decoration-color: $white;
+      text-shadow: 0 0 8px rgba(255, 255, 255, 0.3);
+    }
+    
+    i {
+      font-size: 0.8em;
+      margin-left: 0.25rem;
+    }
+    
+    @media (max-width: 768px) {
+      margin-left: 0;
+      margin-top: 0.25rem;
+      display: inline-block;
+    }
+  }
+
+  .announcement-close {
+    background: rgba(255, 255, 255, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    color: $white;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+    backdrop-filter: blur(4px);
+    
+    &:hover {
+      background: rgba(255, 255, 255, 0.25);
+      border-color: rgba(255, 255, 255, 0.5);
+      transform: scale(1.05);
+    }
+    
+    &:active {
+      transform: scale(0.95);
+    }
+    
+    i {
+      font-size: 0.75rem;
+    }
+    
+    @media (max-width: 768px) {
+      position: absolute;
+      top: 0.5rem;
+      right: 1rem;
+      width: 1.5rem;
+      height: 1.5rem;
+      
+      i {
+        font-size: 0.6rem;
+      }
+    }
+  }
+}

--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -1760,3 +1760,312 @@ footer {
     }
   }
 }
+
+// Community CTA Section Styling
+.community-cta-section {
+  background: linear-gradient(135deg, rgba($gradient-start, 0.05) 0%, rgba($gradient-end, 0.05) 100%);
+  padding: 4rem 0;
+  position: relative;
+  
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23f3f0ff' fill-opacity='0.3'%3E%3Ccircle cx='30' cy='30' r='2'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+    opacity: 0.3;
+  }
+
+  .container {
+    position: relative;
+    z-index: 1;
+  }
+
+  .community-cta-content {
+    text-align: center;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+
+  .community-cta-title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: $dark;
+    margin-bottom: 1.5rem;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+
+    @media (max-width: 768px) {
+      font-size: 2rem;
+    }
+  }
+
+  .community-cta-subtitle {
+    font-size: 1.2rem;
+    color: rgba($dark, 0.8);
+    margin-bottom: 3rem;
+    line-height: 1.6;
+    max-width: 600px;
+    margin-left: auto;
+    margin-right: auto;
+
+    @media (max-width: 768px) {
+      font-size: 1.1rem;
+      margin-bottom: 2.5rem;
+    }
+  }
+
+  .community-cta-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    flex-wrap: wrap;
+
+    @media (max-width: 768px) {
+      gap: 1.5rem;
+      flex-direction: column;
+      align-items: center;
+    }
+  }
+}
+
+// Community CTA Button Base Styles
+.btn-community {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.25rem 2rem;
+  border-radius: 16px;
+  text-decoration: none;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  border: 2px solid transparent;
+  background: $white;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  position: relative;
+  overflow: hidden;
+  min-width: 240px;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.4), transparent);
+    transition: left 0.5s ease;
+  }
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    text-decoration: none;
+
+    &::before {
+      left: 100%;
+    }
+  }
+
+  &:active {
+    transform: translateY(-2px);
+  }
+
+  @media (max-width: 768px) {
+    min-width: 280px;
+    padding: 1rem 1.5rem;
+  }
+
+  .btn-community-icon {
+    font-size: 1.5rem;
+    flex-shrink: 0;
+    width: 24px;
+    text-align: center;
+  }
+
+  .btn-community-text {
+    flex: 1;
+    text-align: left;
+  }
+
+  .btn-community-title {
+    display: block;
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    line-height: 1.2;
+  }
+
+  .btn-community-subtitle {
+    display: block;
+    font-size: 0.9rem;
+    opacity: 0.8;
+    line-height: 1.3;
+  }
+}
+
+// Slack Button
+.btn-slack {
+  border-color: rgba(#4A154B, 0.2);
+
+  .btn-community-icon {
+    color: #4A154B;
+  }
+
+  .btn-community-title {
+    color: #4A154B;
+  }
+
+  .btn-community-subtitle {
+    color: rgba(#4A154B, 0.7);
+  }
+
+  &:hover {
+    border-color: #4A154B;
+    background: linear-gradient(135deg, rgba(#4A154B, 0.05) 0%, rgba(#4A154B, 0.1) 100%);
+
+    .btn-community-icon,
+    .btn-community-title {
+      color: #4A154B;
+    }
+
+    .btn-community-subtitle {
+      color: rgba(#4A154B, 0.8);
+    }
+  }
+}
+
+// GitHub Button
+.btn-github {
+  border-color: rgba(#24292e, 0.2);
+
+  .btn-community-icon {
+    color: #24292e;
+  }
+
+  .btn-community-title {
+    color: #24292e;
+  }
+
+  .btn-community-subtitle {
+    color: rgba(#24292e, 0.7);
+  }
+
+  &:hover {
+    border-color: #24292e;
+    background: linear-gradient(135deg, rgba(#24292e, 0.05) 0%, rgba(#24292e, 0.1) 100%);
+
+    .btn-community-icon,
+    .btn-community-title {
+      color: #24292e;
+    }
+
+    .btn-community-subtitle {
+      color: rgba(#24292e, 0.8);
+    }
+  }
+}
+
+// LinkedIn Button
+.btn-linkedin {
+  border-color: rgba(#0A66C2, 0.2);
+
+  .btn-community-icon {
+    color: #0A66C2;
+  }
+
+  .btn-community-title {
+    color: #0A66C2;
+  }
+
+  .btn-community-subtitle {
+    color: rgba(#0A66C2, 0.7);
+  }
+
+  &:hover {
+    border-color: #0A66C2;
+    background: linear-gradient(135deg, rgba(#0A66C2, 0.05) 0%, rgba(#0A66C2, 0.1) 100%);
+
+    .btn-community-icon,
+    .btn-community-title {
+      color: #0A66C2;
+    }
+
+    .btn-community-subtitle {
+      color: rgba(#0A66C2, 0.8);
+    }
+  }
+}
+
+// Twitter Button (keeping for backwards compatibility)
+.btn-twitter {
+  border-color: rgba(#1DA1F2, 0.2);
+
+  .btn-community-icon {
+    color: #1DA1F2;
+  }
+
+  .btn-community-title {
+    color: #1DA1F2;
+  }
+
+  .btn-community-subtitle {
+    color: rgba(#1DA1F2, 0.7);
+  }
+
+  &:hover {
+    border-color: #1DA1F2;
+    background: linear-gradient(135deg, rgba(#1DA1F2, 0.05) 0%, rgba(#1DA1F2, 0.1) 100%);
+
+    .btn-community-icon,
+    .btn-community-title {
+      color: #1DA1F2;
+    }
+
+    .btn-community-subtitle {
+      color: rgba(#1DA1F2, 0.8);
+    }
+  }
+}
+
+// Community links in hero section
+.btn-outline-light {
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(8px);
+  border-radius: 20px;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.3s ease;
+  text-decoration: none;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.2);
+    color: $white;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    text-decoration: none;
+  }
+
+  &:focus,
+  &:active {
+    color: $white;
+    background: rgba(255, 255, 255, 0.25);
+    border-color: rgba(255, 255, 255, 0.6);
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.3);
+  }
+
+  i {
+    font-size: 0.8rem;
+  }
+}
+
+.text-white-50 {
+  color: rgba(255, 255, 255, 0.7) !important;
+  font-size: 0.9rem;
+  font-weight: 400;
+}

--- a/site/content/en/_index.md
+++ b/site/content/en/_index.md
@@ -22,13 +22,39 @@ no_list: true
         <i class="fab fa-github me-2"></i>GitHub
       </a>
     </div>
-    <!-- <div class="mt-4">
-      <a href="/docs/tasks/quickstart/" class="btn btn-primary btn-lg me-3">Get Started →</a>
-    </div> -->
+    <div class="mt-4">
+      <p class="text-white-50 mb-3">Join our community:</p>
+      <div class="d-flex justify-content-center gap-3 flex-wrap">
+        <a href="https://envoyproxy.slack.com/archives/C03E6NHLESV" 
+           target="_blank" 
+           rel="noopener noreferrer"
+           class="btn btn-outline-light btn-sm">
+          <i class="fab fa-slack me-1"></i>Slack
+        </a>
+        <a href="https://www.linkedin.com/company/envoyproxy" 
+           target="_blank" 
+           rel="noopener noreferrer"
+           class="btn btn-outline-light btn-sm">
+          <i class="fab fa-linkedin me-1"></i>LinkedIn
+        </a>
+        <a href="https://twitter.com/EnvoyProxy" 
+           target="_blank" 
+           rel="noopener noreferrer"
+           class="btn btn-outline-light btn-sm">
+          <i class="fab fa-twitter me-1"></i>Twitter
+        </a>
+        <a href="https://github.com/envoyproxy/gateway" 
+           target="_blank" 
+           rel="noopener noreferrer"
+           class="btn btn-outline-light btn-sm">
+          <i class="fab fa-github me-1"></i>Follow
+        </a>
+      </div>
+    </div>
   </div>
 </div>
 
-{{ partial "community-cta.html" . }}
+{{- partial "community-cta.html" . -}}
 
 <section class="feature-section">
   <div class="container">

--- a/site/content/en/_index.md
+++ b/site/content/en/_index.md
@@ -31,13 +31,13 @@ no_list: true
            class="btn btn-outline-light btn-sm">
           <i class="fab fa-slack me-1"></i>Slack
         </a>
-        <a href="https://www.linkedin.com/company/envoyproxy" 
+        <a href="https://www.linkedin.com/company/envoy-cloud-native/" 
            target="_blank" 
            rel="noopener noreferrer"
            class="btn btn-outline-light btn-sm">
           <i class="fab fa-linkedin me-1"></i>LinkedIn
         </a>
-        <a href="https://twitter.com/EnvoyProxy" 
+        <a href="https://x.com/EnvoyProxy" 
            target="_blank" 
            rel="noopener noreferrer"
            class="btn btn-outline-light btn-sm">

--- a/site/content/en/_index.md
+++ b/site/content/en/_index.md
@@ -28,6 +28,8 @@ no_list: true
   </div>
 </div>
 
+{{ partial "community-cta.html" . }}
+
 <section class="feature-section">
   <div class="container">
     <div class="row justify-content-center">

--- a/site/layouts/partials/community-cta.html
+++ b/site/layouts/partials/community-cta.html
@@ -1,0 +1,50 @@
+<!-- Community CTA Section -->
+<section class="community-cta-section">
+  <div class="container">
+    <div class="community-cta-content">
+      <h2 class="community-cta-title">Join Our Community</h2>
+      <p class="community-cta-subtitle">
+        Connect with developers, contributors, and users building the future of API gateways. 
+        Get help, share ideas, and stay updated with the latest developments.
+      </p>
+      
+      <div class="community-cta-buttons">
+        <!-- Slack CTA -->
+        <a href="https://envoyproxy.slack.com/archives/C03E6NHLESV" 
+           target="_blank" 
+           rel="noopener noreferrer"
+           class="btn-community btn-slack">
+          <i class="fab fa-slack btn-community-icon"></i>
+          <div class="btn-community-text">
+            <span class="btn-community-title">Join Slack</span>
+            <span class="btn-community-subtitle">Chat with developers</span>
+          </div>
+        </a>
+        
+        <!-- GitHub CTA -->
+        <a href="{{ .Site.Params.github_repo }}" 
+           target="_blank" 
+           rel="noopener noreferrer"
+           class="btn-community btn-github">
+          <i class="fab fa-github btn-community-icon"></i>
+          <div class="btn-community-text">
+            <span class="btn-community-title">Star on GitHub</span>
+            <span class="btn-community-subtitle">Contribute & follow updates</span>
+          </div>
+        </a>
+        
+        <!-- Twitter CTA -->
+        <a href="https://twitter.com/EnvoyProxy" 
+           target="_blank" 
+           rel="noopener noreferrer"
+           class="btn-community btn-twitter">
+          <i class="fab fa-twitter btn-community-icon"></i>
+          <div class="btn-community-text">
+            <span class="btn-community-title">Follow on Twitter</span>
+            <span class="btn-community-subtitle">Latest news & updates</span>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/site/layouts/partials/community-cta.html
+++ b/site/layouts/partials/community-cta.html
@@ -34,7 +34,7 @@
         </a>
         
         <!-- LinkedIn CTA -->
-        <a href="https://www.linkedin.com/company/envoyproxy" 
+        <a href="https://www.linkedin.com/company/envoy-cloud-native/" 
            target="_blank" 
            rel="noopener noreferrer"
            class="btn-community btn-linkedin">
@@ -46,7 +46,7 @@
         </a>
         
         <!-- Twitter CTA -->
-        <a href="https://twitter.com/EnvoyProxy" 
+        <a href="https://x.com/EnvoyProxy"
            target="_blank" 
            rel="noopener noreferrer"
            class="btn-community btn-twitter">

--- a/site/layouts/partials/community-cta.html
+++ b/site/layouts/partials/community-cta.html
@@ -33,6 +33,18 @@
           </div>
         </a>
         
+        <!-- LinkedIn CTA -->
+        <a href="https://www.linkedin.com/company/envoyproxy" 
+           target="_blank" 
+           rel="noopener noreferrer"
+           class="btn-community btn-linkedin">
+          <i class="fab fa-linkedin btn-community-icon"></i>
+          <div class="btn-community-text">
+            <span class="btn-community-title">Follow on LinkedIn</span>
+            <span class="btn-community-subtitle">Professional updates</span>
+          </div>
+        </a>
+        
         <!-- Twitter CTA -->
         <a href="https://twitter.com/EnvoyProxy" 
            target="_blank" 


### PR DESCRIPTION
**What type of PR is this?**

feat(site): add community CTAs for Slack, GitHub, and LinkedIn & Twitter on landing page

**What this PR does / why we need it**:

This PR adds prominent community Call-to-Action (CTA) buttons to the Envoy Gateway landing page to encourage community involvement. The CTAs are strategically placed higher up on the page for maximum visibility and include:
-**LinkedIn CTA**: "Follow on LinkedIn" with "Professional updates" subtitle
- **Slack CTA**: "Join Slack" with "Chat with developers" subtitle
- **GitHub CTA**: "Star on GitHub" with "Contribute & follow updates" subtitle  
- **Twitter CTA**: "Follow on Twitter" with "Latest news & updates" subtitle

The implementation features:
- Modern glassmorphism design with gradient borders matching the site's theme
- Responsive layout that adapts from desktop to mobile
- Platform-specific hover effects (Slack purple, GitHub dark, Twitter blue, LinkedIn sky blue)
- Smooth animations and accessibility features
- Strategic placement after the hero section for optimal user engagement

This improves community growth by providing clear, visually appealing entry points for users to connect with the Envoy Gateway community across multiple platforms.

**Which issue(s) this PR fixes**:

Fixes #6224 

Release Notes: Yes