### PR TITLE
fix: don't render .spec.replicas if HPA is enabled

### DIFF
--- a/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
@@ -7,7 +7,9 @@ metadata:
     control-plane: envoy-gateway
   {{- include "eg.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.hpa.enabled }}
   replicas: {{ .Values.deployment.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       control-plane: envoy-gateway

--- a/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
+++ b/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
@@ -383,7 +383,6 @@ metadata:
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
 spec:
-  replicas: 1
   selector:
     matchLabels:
       control-plane: envoy-gateway


### PR DESCRIPTION
**What type of PR is this?**
fix: don't render .spec.replicas if HPA is enabled

**What this PR does / why we need it**:

The current chart template will render `.spec.replicas` even if autoscaling is enabled. This causes a conflict in ownership of the `.spec.replicas` field between the HPA and whoever is installing/reconciling the manifests.

The effect of this depends on the tool used to install the manifests:

Helm CLI -> the `.spec.replicas` is reset to the `.Values.deployment.replicas` value everytime Helm Install/Update is invoked.

AgroCD (or any GitOps tool) -> `.spec.replicas` is reset on each Sync... which can result into a constant back and forth between ArgoCD and the HPA that technically eliminate the benefits of the HPA.
