### PR TITLE
fix: handle multi-value response headers as comma-separated per RFC 7230

### DIFF
--- a/internal/gatewayapi/filters.go
+++ b/internal/gatewayapi/filters.go
@@ -617,7 +617,7 @@ func (t *Translator) processResponseHeaderModifierFilter(
 			newHeader := ir.AddHeader{
 				Name:   headerKey,
 				Append: true,
-				Value:  strings.Split(addHeader.Value, ","),
+				Value:  []string{addHeader.Value},
 			}
 
 			filterContext.AddResponseHeaders = append(filterContext.AddResponseHeaders, newHeader)
@@ -672,7 +672,7 @@ func (t *Translator) processResponseHeaderModifierFilter(
 			newHeader := ir.AddHeader{
 				Name:   string(setHeader.Name),
 				Append: false,
-				Value:  strings.Split(setHeader.Value, ","),
+				Value:  []string{setHeader.Value},
 			}
 
 			filterContext.AddResponseHeaders = append(filterContext.AddResponseHeaders, newHeader)

--- a/internal/gatewayapi/filters_test.go
+++ b/internal/gatewayapi/filters_test.go
@@ -1,0 +1,100 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package gatewayapi
+
+import (
+	"reflect"
+	"testing"
+
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/envoyproxy/gateway/internal/ir"
+)
+
+func TestProcessResponseHeaderModifierFilter(t *testing.T) {
+	tests := []struct {
+		name           string
+		filter         *gwapiv1.HTTPHeaderFilter
+		expectedAdd    []ir.AddHeader
+		expectedRemove []string
+	}{
+		{
+			name: "Add headers",
+			filter: &gwapiv1.HTTPHeaderFilter{
+				Add: []gwapiv1.HTTPHeader{
+					{Name: "X-Test-Add", Value: "foo,bar"},
+				},
+			},
+			expectedAdd: []ir.AddHeader{
+				{Name: "X-Test-Add", Append: true, Value: []string{"foo,bar"}},
+			},
+			expectedRemove: nil,
+		},
+		{
+			name: "Set headers",
+			filter: &gwapiv1.HTTPHeaderFilter{
+				Set: []gwapiv1.HTTPHeader{
+					{Name: "X-Test-Set", Value: "baz,qux"},
+				},
+			},
+			expectedAdd: []ir.AddHeader{
+				{Name: "X-Test-Set", Append: false, Value: []string{"baz,qux"}},
+			},
+			expectedRemove: nil,
+		},
+		{
+			name: "Remove headers",
+			filter: &gwapiv1.HTTPHeaderFilter{
+				Remove: []string{"X-Test-Remove", "X-Test-Remove2"},
+			},
+			expectedAdd: nil,
+			expectedRemove: []string{
+				"X-Test-Remove", "X-Test-Remove2",
+			},
+		},
+		{
+			name: "Combined Add, Set, Remove",
+			filter: &gwapiv1.HTTPHeaderFilter{
+				Add: []gwapiv1.HTTPHeader{
+					{Name: "X-Add", Value: "val1,val2"},
+				},
+				Set: []gwapiv1.HTTPHeader{
+					{Name: "X-Set", Value: "val3"},
+				},
+				Remove: []string{"X-Remove"},
+			},
+			expectedAdd: []ir.AddHeader{
+				{Name: "X-Add", Append: true, Value: []string{"val1,val2"}},
+				{Name: "X-Set", Append: false, Value: []string{"val3"}},
+			},
+			expectedRemove: []string{"X-Remove"},
+		},
+		{
+			name:           "Empty config",
+			filter:         &gwapiv1.HTTPHeaderFilter{},
+			expectedAdd:    nil,
+			expectedRemove: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filterCtx := &HTTPFiltersContext{
+				HTTPFilterIR: &HTTPFilterIR{},
+			}
+
+			translator := &Translator{}
+			translator.processResponseHeaderModifierFilter(tt.filter, filterCtx)
+
+			if !reflect.DeepEqual(filterCtx.AddResponseHeaders, tt.expectedAdd) {
+				t.Errorf("unexpected AddResponseHeaders: got=%v, want=%v", filterCtx.AddResponseHeaders, tt.expectedAdd)
+			}
+			if !reflect.DeepEqual(filterCtx.RemoveResponseHeaders, tt.expectedRemove) {
+				t.Errorf("unexpected RemoveResponseHeaders: got=%v, want=%v", filterCtx.RemoveResponseHeaders, tt.expectedRemove)
+			}
+		})
+	}
+}

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -522,6 +522,10 @@ func mirrorPercentByPolicy(mirror *ir.MirrorPolicy) *corev3.RuntimeFractionalPer
 }
 
 func buildXdsAddedHeaders(headersToAdd []ir.AddHeader) []*corev3.HeaderValueOption {
+	if len(headersToAdd) == 0 {
+		return nil
+	}
+
 	headerValueOptions := []*corev3.HeaderValueOption{}
 
 	for _, header := range headersToAdd {


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->
fix

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

This change updates the translation logic of ResponseHeaderModifier so that when multiple values are specified for a header, they are joined into a single, comma-separated value as required by RFC 7230. As a result, the generated Envoy config now emits one HeaderValueOption per header, with all values joined by commas.

Tested using following config:

```
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: backend
  namespace: default
spec:
  hostnames:
  - www.example.com
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: eg
  rules:
  - backendRefs:
    - group: ""
      kind: Service
      name: backend
      port: 3000
      weight: 1
    filters:
    - responseHeaderModifier:
        set:
        - name: Cache-Control
          value: private, no-store
      type: ResponseHeaderModifier
    matches:
    - path:
        type: PathPrefix
        value: /
```

```bash
# curl latest image
root@ubuntu:/$ curl -i http://10.96.20.98/ -H 'Host: www.example.com' -H 'X-Echo-Set-Header: Cache-control: value1' | grep ^cache-control
cache-control:  no-store

# curl e4c8f89 image
root@ubuntu:/$ curl -i http://10.96.20.98/ -H 'Host: www.example.com' -H 'X-Echo-Set-Header: Cache-control: value1' | grep ^cache-control
cache-control: private, no-store
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/envoyproxy/gateway/issues/5733

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes/No
