### PR TITLE
docs: remove unused import in ext grpc auth example

### DIFF
--- a/examples/kubernetes/ext-auth-grpc-service.yaml
+++ b/examples/kubernetes/ext-auth-grpc-service.yaml
@@ -64,7 +64,6 @@ data:
 
          	envoy_api_v3_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
          	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
-         	"github.com/golang/protobuf/ptypes/wrappers"
          	"google.golang.org/genproto/googleapis/rpc/code"
          	"google.golang.org/genproto/googleapis/rpc/status"
          	"google.golang.org/grpc"


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->
Fixes grpc ext auth example used in: https://gateway.envoyproxy.io/docs/tasks/security/ext-auth/#grpc-external-authorization-service
  * Remove unused import. Follow up work from https://github.com/envoyproxy/gateway/pull/5771

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
Without this change I was experiencing this issue:
```
$ kubectl get pods
NAME                             READY   STATUS             RESTARTS      AGE
backend-869c8646c5-8pppr         1/1     Running            0             40m
grpc-ext-auth-75f48c58cc-jsrq7   0/1     CrashLoopBackOff   5 (18s ago)   9m43s


$ kubectl logs grpc-ext-auth-75f48c58cc-p54kw -f
go: downloading github.com/envoyproxy/go-control-plane v0.12.0
go: downloading github.com/golang/protobuf v1.5.4
go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20240304212257-790db918fca8
go: downloading google.golang.org/grpc v1.62.1
go: downloading github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa
go: downloading github.com/envoyproxy/protoc-gen-validate v1.0.4
go: downloading google.golang.org/protobuf v1.33.0
go: downloading golang.org/x/net v0.20.0
go: downloading golang.org/x/sys v0.16.0
go: downloading golang.org/x/text v0.14.0
# github.com/envoyproxy/gateway
./main.go:17:2: "github.com/golang/protobuf/ptypes/wrappers" imported and not used
```

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
