### PR TITLE
feat(api): allow pinning custom image repository for Envoy Proxy.

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -208,7 +208,7 @@ type KubernetesPodSpec struct {
 }
 
 // KubernetesContainerSpec defines the desired state of the Kubernetes container resource.
-// +kubebuilder:validation:XValidation:rule="!has(self.image) || !has(self.imageRepository)",message="image and imageRepository are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!has(self.image) || !has(self.imageRepository)",message="Either image or imageRepository can be set."
 type KubernetesContainerSpec struct {
 	// List of environment variables to set in the container.
 	//

--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -208,6 +208,7 @@ type KubernetesPodSpec struct {
 }
 
 // KubernetesContainerSpec defines the desired state of the Kubernetes container resource.
+// +kubebuilder:validation:XValidation:rule="!has(self.image) || !has(self.imageRepository)",message="image and imageRepository are mutually exclusive"
 type KubernetesContainerSpec struct {
 	// List of environment variables to set in the container.
 	//
@@ -227,10 +228,18 @@ type KubernetesContainerSpec struct {
 	// +optional
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 
-	// Image specifies the EnvoyProxy container image to be used, instead of the default image.
+	// Image specifies the EnvoyProxy container image to be used including a tag, instead of the default image.
+	// This field is mutually exclusive with ImageRepository.
 	//
 	// +optional
 	Image *string `json:"image,omitempty"`
+
+	// ImageRepository specifies the container image repository to be used without specifying a tag.
+	// The default tag will be used.
+	// This field is mutually exclusive with Image.
+	//
+	// +optional
+	ImageRepository *string `json:"imageRepository,omitempty"`
 
 	// VolumeMounts are volumes to mount into the container's filesystem.
 	// Cannot be updated.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -3882,6 +3882,11 @@ func (in *KubernetesContainerSpec) DeepCopyInto(out *KubernetesContainerSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ImageRepository != nil {
+		in, out := &in.ImageRepository, &out.ImageRepository
+		*out = new(string)
+		**out = **in
+	}
 	if in.VolumeMounts != nil {
 		in, out := &in.VolumeMounts, &out.VolumeMounts
 		*out = make([]corev1.VolumeMount, len(*in))

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_envoyproxies.yaml
@@ -939,7 +939,7 @@ spec:
                                 type: array
                             type: object
                             x-kubernetes-validations:
-                            - message: image and imageRepository are mutually exclusive
+                            - message: Either image or imageRepository can be set.
                               rule: '!has(self.image) || !has(self.imageRepository)'
                           name:
                             description: |-
@@ -4776,7 +4776,7 @@ spec:
                                 type: array
                             type: object
                             x-kubernetes-validations:
-                            - message: image and imageRepository are mutually exclusive
+                            - message: Either image or imageRepository can be set.
                               rule: '!has(self.image) || !has(self.imageRepository)'
                           initContainers:
                             description: |-

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_envoyproxies.yaml
@@ -604,8 +604,15 @@ spec:
                                   type: object
                                 type: array
                               image:
-                                description: Image specifies the EnvoyProxy container
-                                  image to be used, instead of the default image.
+                                description: |-
+                                  Image specifies the EnvoyProxy container image to be used including a tag, instead of the default image.
+                                  This field is mutually exclusive with ImageRepository.
+                                type: string
+                              imageRepository:
+                                description: |-
+                                  ImageRepository specifies the container image repository to be used without specifying a tag.
+                                  The default tag will be used.
+                                  This field is mutually exclusive with Image.
                                 type: string
                               resources:
                                 description: |-
@@ -931,6 +938,9 @@ spec:
                                   type: object
                                 type: array
                             type: object
+                            x-kubernetes-validations:
+                            - message: image and imageRepository are mutually exclusive
+                              rule: '!has(self.image) || !has(self.imageRepository)'
                           name:
                             description: |-
                               Name of the daemonSet.
@@ -4431,8 +4441,15 @@ spec:
                                   type: object
                                 type: array
                               image:
-                                description: Image specifies the EnvoyProxy container
-                                  image to be used, instead of the default image.
+                                description: |-
+                                  Image specifies the EnvoyProxy container image to be used including a tag, instead of the default image.
+                                  This field is mutually exclusive with ImageRepository.
+                                type: string
+                              imageRepository:
+                                description: |-
+                                  ImageRepository specifies the container image repository to be used without specifying a tag.
+                                  The default tag will be used.
+                                  This field is mutually exclusive with Image.
                                 type: string
                               resources:
                                 description: |-
@@ -4758,6 +4775,9 @@ spec:
                                   type: object
                                 type: array
                             type: object
+                            x-kubernetes-validations:
+                            - message: image and imageRepository are mutually exclusive
+                              rule: '!has(self.image) || !has(self.imageRepository)'
                           initContainers:
                             description: |-
                               List of initialization containers belonging to the pod.

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
@@ -603,8 +603,15 @@ spec:
                                   type: object
                                 type: array
                               image:
-                                description: Image specifies the EnvoyProxy container
-                                  image to be used, instead of the default image.
+                                description: |-
+                                  Image specifies the EnvoyProxy container image to be used including a tag, instead of the default image.
+                                  This field is mutually exclusive with ImageRepository.
+                                type: string
+                              imageRepository:
+                                description: |-
+                                  ImageRepository specifies the container image repository to be used without specifying a tag.
+                                  The default tag will be used.
+                                  This field is mutually exclusive with Image.
                                 type: string
                               resources:
                                 description: |-
@@ -930,6 +937,9 @@ spec:
                                   type: object
                                 type: array
                             type: object
+                            x-kubernetes-validations:
+                            - message: image and imageRepository are mutually exclusive
+                              rule: '!has(self.image) || !has(self.imageRepository)'
                           name:
                             description: |-
                               Name of the daemonSet.
@@ -4430,8 +4440,15 @@ spec:
                                   type: object
                                 type: array
                               image:
-                                description: Image specifies the EnvoyProxy container
-                                  image to be used, instead of the default image.
+                                description: |-
+                                  Image specifies the EnvoyProxy container image to be used including a tag, instead of the default image.
+                                  This field is mutually exclusive with ImageRepository.
+                                type: string
+                              imageRepository:
+                                description: |-
+                                  ImageRepository specifies the container image repository to be used without specifying a tag.
+                                  The default tag will be used.
+                                  This field is mutually exclusive with Image.
                                 type: string
                               resources:
                                 description: |-
@@ -4757,6 +4774,9 @@ spec:
                                   type: object
                                 type: array
                             type: object
+                            x-kubernetes-validations:
+                            - message: image and imageRepository are mutually exclusive
+                              rule: '!has(self.image) || !has(self.imageRepository)'
                           initContainers:
                             description: |-
                               List of initialization containers belonging to the pod.

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
@@ -938,7 +938,7 @@ spec:
                                 type: array
                             type: object
                             x-kubernetes-validations:
-                            - message: image and imageRepository are mutually exclusive
+                            - message: Either image or imageRepository can be set.
                               rule: '!has(self.image) || !has(self.imageRepository)'
                           name:
                             description: |-
@@ -4775,7 +4775,7 @@ spec:
                                 type: array
                             type: object
                             x-kubernetes-validations:
-                            - message: image and imageRepository are mutually exclusive
+                            - message: Either image or imageRepository can be set.
                               rule: '!has(self.image) || !has(self.imageRepository)'
                           initContainers:
                             description: |-

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f
+	github.com/containers/image/v5 v5.34.3
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/cli v28.2.2+incompatible
 	github.com/docker/docker v27.5.1+incompatible
@@ -180,7 +181,6 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
-	github.com/containers/image/v5 v5.34.3 // indirect
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
 	github.com/containers/ocicrypt v1.2.1 // indirect
 	github.com/containers/storage v1.57.2 // indirect

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -2751,7 +2751,8 @@ _Appears in:_
 | `env` | _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#envvar-v1-core) array_ |  false  |  | List of environment variables to set in the container. |
 | `resources` | _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#resourcerequirements-v1-core)_ |  false  |  | Resources required by this container.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | `securityContext` | _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#securitycontext-v1-core)_ |  false  |  | SecurityContext defines the security options the container should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
-| `image` | _string_ |  false  |  | Image specifies the EnvoyProxy container image to be used, instead of the default image. |
+| `image` | _string_ |  false  |  | Image specifies the EnvoyProxy container image to be used including a tag, instead of the default image.<br />This field is mutually exclusive with ImageRepository. |
+| `imageRepository` | _string_ |  false  |  | ImageRepository specifies the container image repository to be used without specifying a tag.<br />The default tag will be used.<br />This field is mutually exclusive with Image. |
 | `volumeMounts` | _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#volumemount-v1-core) array_ |  false  |  | VolumeMounts are volumes to mount into the container's filesystem.<br />Cannot be updated. |
 
 

--- a/test/cel-validation/envoyproxy_test.go
+++ b/test/cel-validation/envoyproxy_test.go
@@ -1544,6 +1544,61 @@ func TestEnvoyProxyProvider(t *testing.T) {
 				}
 			},
 		},
+		{
+			desc: "valid: image set, imageRepository not set",
+			mutate: func(envoy *egv1a1.EnvoyProxy) {
+				envoy.Spec = egv1a1.EnvoyProxySpec{
+					Provider: &egv1a1.EnvoyProxyProvider{
+						Type: egv1a1.ProviderTypeKubernetes,
+						Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
+							EnvoyDeployment: &egv1a1.KubernetesDeploymentSpec{
+								Container: &egv1a1.KubernetesContainerSpec{
+									Image: ptr.To("envoyproxy/envoy:v1.2.3"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{},
+		},
+		{
+			desc: "valid: imageRepository set, image not set",
+			mutate: func(envoy *egv1a1.EnvoyProxy) {
+				envoy.Spec = egv1a1.EnvoyProxySpec{
+					Provider: &egv1a1.EnvoyProxyProvider{
+						Type: egv1a1.ProviderTypeKubernetes,
+						Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
+							EnvoyDeployment: &egv1a1.KubernetesDeploymentSpec{
+								Container: &egv1a1.KubernetesContainerSpec{
+									ImageRepository: ptr.To("envoyproxy/envoy"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{},
+		},
+		{
+			desc: "invalid: both image and imageRepository set",
+			mutate: func(envoy *egv1a1.EnvoyProxy) {
+				envoy.Spec = egv1a1.EnvoyProxySpec{
+					Provider: &egv1a1.EnvoyProxyProvider{
+						Type: egv1a1.ProviderTypeKubernetes,
+						Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
+							EnvoyDeployment: &egv1a1.KubernetesDeploymentSpec{
+								Container: &egv1a1.KubernetesContainerSpec{
+									Image:           ptr.To("envoyproxy/envoy:v1.2.3"),
+									ImageRepository: ptr.To("envoyproxy/envoy"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{"Either image or imageRepository can be set."},
+		},
 	}
 
 	for _, tc := range cases {

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -24486,7 +24486,7 @@ spec:
                                 type: array
                             type: object
                             x-kubernetes-validations:
-                            - message: image and imageRepository are mutually exclusive
+                            - message: Either image or imageRepository can be set.
                               rule: '!has(self.image) || !has(self.imageRepository)'
                           name:
                             description: |-
@@ -28323,7 +28323,7 @@ spec:
                                 type: array
                             type: object
                             x-kubernetes-validations:
-                            - message: image and imageRepository are mutually exclusive
+                            - message: Either image or imageRepository can be set.
                               rule: '!has(self.image) || !has(self.imageRepository)'
                           initContainers:
                             description: |-

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -24151,8 +24151,15 @@ spec:
                                   type: object
                                 type: array
                               image:
-                                description: Image specifies the EnvoyProxy container
-                                  image to be used, instead of the default image.
+                                description: |-
+                                  Image specifies the EnvoyProxy container image to be used including a tag, instead of the default image.
+                                  This field is mutually exclusive with ImageRepository.
+                                type: string
+                              imageRepository:
+                                description: |-
+                                  ImageRepository specifies the container image repository to be used without specifying a tag.
+                                  The default tag will be used.
+                                  This field is mutually exclusive with Image.
                                 type: string
                               resources:
                                 description: |-
@@ -24478,6 +24485,9 @@ spec:
                                   type: object
                                 type: array
                             type: object
+                            x-kubernetes-validations:
+                            - message: image and imageRepository are mutually exclusive
+                              rule: '!has(self.image) || !has(self.imageRepository)'
                           name:
                             description: |-
                               Name of the daemonSet.
@@ -27978,8 +27988,15 @@ spec:
                                   type: object
                                 type: array
                               image:
-                                description: Image specifies the EnvoyProxy container
-                                  image to be used, instead of the default image.
+                                description: |-
+                                  Image specifies the EnvoyProxy container image to be used including a tag, instead of the default image.
+                                  This field is mutually exclusive with ImageRepository.
+                                type: string
+                              imageRepository:
+                                description: |-
+                                  ImageRepository specifies the container image repository to be used without specifying a tag.
+                                  The default tag will be used.
+                                  This field is mutually exclusive with Image.
                                 type: string
                               resources:
                                 description: |-
@@ -28305,6 +28322,9 @@ spec:
                                   type: object
                                 type: array
                             type: object
+                            x-kubernetes-validations:
+                            - message: image and imageRepository are mutually exclusive
+                              rule: '!has(self.image) || !has(self.imageRepository)'
                           initContainers:
                             description: |-
                               List of initialization containers belonging to the pod.

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -6839,8 +6839,15 @@ spec:
                                   type: object
                                 type: array
                               image:
-                                description: Image specifies the EnvoyProxy container
-                                  image to be used, instead of the default image.
+                                description: |-
+                                  Image specifies the EnvoyProxy container image to be used including a tag, instead of the default image.
+                                  This field is mutually exclusive with ImageRepository.
+                                type: string
+                              imageRepository:
+                                description: |-
+                                  ImageRepository specifies the container image repository to be used without specifying a tag.
+                                  The default tag will be used.
+                                  This field is mutually exclusive with Image.
                                 type: string
                               resources:
                                 description: |-
@@ -7166,6 +7173,9 @@ spec:
                                   type: object
                                 type: array
                             type: object
+                            x-kubernetes-validations:
+                            - message: image and imageRepository are mutually exclusive
+                              rule: '!has(self.image) || !has(self.imageRepository)'
                           name:
                             description: |-
                               Name of the daemonSet.
@@ -10666,8 +10676,15 @@ spec:
                                   type: object
                                 type: array
                               image:
-                                description: Image specifies the EnvoyProxy container
-                                  image to be used, instead of the default image.
+                                description: |-
+                                  Image specifies the EnvoyProxy container image to be used including a tag, instead of the default image.
+                                  This field is mutually exclusive with ImageRepository.
+                                type: string
+                              imageRepository:
+                                description: |-
+                                  ImageRepository specifies the container image repository to be used without specifying a tag.
+                                  The default tag will be used.
+                                  This field is mutually exclusive with Image.
                                 type: string
                               resources:
                                 description: |-
@@ -10993,6 +11010,9 @@ spec:
                                   type: object
                                 type: array
                             type: object
+                            x-kubernetes-validations:
+                            - message: image and imageRepository are mutually exclusive
+                              rule: '!has(self.image) || !has(self.imageRepository)'
                           initContainers:
                             description: |-
                               List of initialization containers belonging to the pod.

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -7174,7 +7174,7 @@ spec:
                                 type: array
                             type: object
                             x-kubernetes-validations:
-                            - message: image and imageRepository are mutually exclusive
+                            - message: Either image or imageRepository can be set.
                               rule: '!has(self.image) || !has(self.imageRepository)'
                           name:
                             description: |-
@@ -11011,7 +11011,7 @@ spec:
                                 type: array
                             type: object
                             x-kubernetes-validations:
-                            - message: image and imageRepository are mutually exclusive
+                            - message: Either image or imageRepository can be set.
                               rule: '!has(self.image) || !has(self.imageRepository)'
                           initContainers:
                             description: |-


### PR DESCRIPTION
This PR allows users to specify a custom image repository for **EnvoyProxy** without needing to provide a tag.

Fixes #6066

Release Notes: No
