### PR TITLE
fix wrong enum on SubjectAltNameType

### DIFF
--- a/internal/gatewayapi/backendtlspolicy.go
+++ b/internal/gatewayapi/backendtlspolicy.go
@@ -249,9 +249,9 @@ func getBackendTLSBundle(backendTLSPolicy *gwapiv1a3.BackendTLSPolicy, resources
 	for _, san := range backendTLSPolicy.Spec.Validation.SubjectAltNames {
 		var subjectAltName ir.SubjectAltName
 		switch san.Type {
-		case "DNS":
+		case gwapiv1a3.HostnameSubjectAltNameType:
 			subjectAltName.Hostname = ptr.To(string(san.Hostname))
-		case "URI":
+		case gwapiv1a3.URISubjectAltNameType:
 			subjectAltName.URI = ptr.To(string(san.URI))
 		default:
 			continue // skip unknown types

--- a/internal/gatewayapi/testdata/backendtlspolicy-subjectaltnames.in.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-subjectaltnames.in.yaml
@@ -133,5 +133,5 @@ backendTLSPolicies:
         subjectAltNames:
           - type: URI
             uri: spiffe://cluster.local/ns/istio-demo/sa/echo-v1
-          - type: DNS
+          - type: Hostname
             hostname: subdomain.secondexample.com

--- a/internal/gatewayapi/testdata/backendtlspolicy-subjectaltnames.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-subjectaltnames.out.yaml
@@ -21,7 +21,7 @@ backendTLSPolicies:
       - type: URI
         uri: spiffe://cluster.local/ns/istio-demo/sa/echo-v1
       - hostname: subdomain.secondexample.com
-        type: DNS
+        type: Hostname
   status:
     ancestors:
     - ancestorRef:

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -27,6 +27,7 @@ bug fixes: |
   Fixed issue where WASM cache init failure caused routes with WASM-less EnvoyExtensionPolicies to have 500 direct responses.
   Fixed issue which UDP listeners were not created in the Envoy proxy config when Gateway was created.
   Keep ALPN configuration for listeners with overlapping certificates when ALPN is explicitly set in ClientTrafficPolicy.
+  Fixed issue that switch on wrong SubjectAltNameType enum value in BackendTLSPolicy.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
Valid values for `SubjectAltNameType` as following:

```golang
// SubjectAltNameType is the type of the Subject Alternative Name.
// +kubebuilder:validation:Enum=Hostname;URI
type SubjectAltNameType string
```