### PR TITLE
xds: enable udpa.TypeStruct

### DIFF
--- a/internal/xds/extensions/udpa.go
+++ b/internal/xds/extensions/udpa.go
@@ -1,0 +1,10 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package extensions
+
+import udpa "github.com/cncf/xds/go/udpa/type/v1"
+
+var _ = udpa.TypedStruct{}


### PR DESCRIPTION
This patch enable us to use configuration as following:
```yaml
apiVersion: gateway.envoyproxy.io/v1alpha1
kind: EnvoyPatchPolicy
metadata:
  name: envoy-lua-filter
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: eg
  type: JSONPatch
  jsonPatches:
    - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
      # The listener name is of the form <GatewayNamespace>/<GatewayName>/<GatewayListenerName>
      name: default/eg/http
      operation:
        op: add
        path: "/default_filter_chain/filters/0/typed_config/http_filters/0"
        value:
          name: "envoy.lua"
          typedConfig:
            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
            typeUrl: type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
            value:
              inline_code: |
                function envoy_on_request(request_handle)
                  -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
                  val = request_handle:headers():get("key1")
                  request_handle:logWarn("get result: " .. val)
                end
```