### PR TITLE
chore: make log output consistent

### DIFF
--- a/internal/provider/kubernetes/status_updater.go
+++ b/internal/provider/kubernetes/status_updater.go
@@ -104,9 +104,8 @@ func (u *UpdateHandler) apply(update Update) {
 		newObj := update.Mutator.Mutate(obj)
 
 		if isStatusEqual(obj, newObj) {
-			u.log.WithName(update.NamespacedName.Name).
-				WithName(update.NamespacedName.Namespace).
-				Info("status unchanged, bypassing update")
+			u.log.Info("status unchanged, bypassing update", "name", update.NamespacedName.Name,
+				"namespace", update.NamespacedName.Namespace)
 
 			statusUpdateTotal.WithStatus(statusNoAction, kindLabel.Value(objKind)).Increment()
 			return nil


### PR DESCRIPTION
before:
```
2025-06-15T12:45:17.988Z	INFO	provider.httpbin.sidecar	kubernetes/status_updater.go:109	status unchanged, bypassing update	{"runner": "provider"}
2025-06-15T12:45:17.989Z	INFO	provider	kubernetes/status_updater.go:145	received a status update	{"runner": "provider", "namespace": "default", "name": "connect"}
2025-06-15T12:45:17.989Z	INFO	provider.connect.default	kubernetes/status_updater.go:109	status unchanged, bypassing update	{"runner": "provider"}
2025-06-15T12:45:17.989Z	INFO	provider	kubernetes/status_updater.go:145	received a status update	{"runner": "provider", "namespace": "default", "name": "envoy-lua-filter"}
2025-06-15T12:45:17.989Z	INFO	xds-server	runner/runner.go:196	received an update	{"runner": "xds-server"}
2025-06-15T12:45:17.989Z	INFO	provider.envoy-lua-filter.default	kubernetes/status_updater.go:109	status unchanged, bypassing update	{"runner": "provider"}
```


after:

```
2025-06-15T13:00:20.921Z	INFO	provider	kubernetes/status_updater.go:143	received a status update	{"runner": "provider", "namespace": "default", "name": "eg", "kind": "Gateway"}
2025-06-15T13:00:20.921Z	INFO	provider	kubernetes/status_updater.go:108	status unchanged, bypassing update	{"runner": "provider", "name": "eg", "namespace": "default", "kind": "Gateway"}
2025-06-15T13:00:20.937Z	INFO	provider	kubernetes/status_updater.go:143	received a status update	{"runner": "provider", "namespace": "default", "name": "eg", "kind": "Gateway"}
2025-06-15T13:00:20.937Z	INFO	provider	kubernetes/status_updater.go:108	status unchanged, bypassing update	{"runner": "provider", "name": "eg", "namespace": "default", "kind": "Gateway"}
2025-06-15T13:00:20.966Z	INFO	provider	kubernetes/status_updater.go:143	received a status update	{"runner": "provider", "namespace": "default", "name": "eg", "kind": "Gateway"}
2025-06-15T13:00:20.967Z	INFO	provider	kubernetes/status_updater.go:108	status unchanged, bypassing update	{"runner": "provider", "name": "eg", "namespace": "default", "kind": "Gateway"}
2025-06-15T13:00:20.998Z	INFO	provider	kubernetes/status_updater.go:143	received a status update	{"runner": "provider", "namespace": "default", "name": "eg", "kind": "Gateway"}
2025-06-15T13:00:20.998Z	INFO	provider	kubernetes/status_updater.go:108	status unchanged, bypassing update	{"runner": "provider", "name": "eg", "namespace": "default", "kind": "Gateway"}

```