### PR TITLE
chore: disable CollectAndDump by default

### DIFF
--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -604,6 +604,7 @@ type LokiQueryResponse struct {
 func CollectAndDump(t *testing.T, rest *rest.Config) {
 	if os.Getenv("ACTIONS_STEP_DEBUG") != "true" {
 		tlog.Logf(t, "Skipping collecting and dumping cluster data, set ACTIONS_STEP_DEBUG=true to enable it")
+		return
 	}
 
 	dumpedNamespaces := []string{"envoy-gateway-system"}


### PR DESCRIPTION
Disable CollectAndDump by default because the output is huge.
You can enable it when rerun the jobs with [enable debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging).

![image](https://github.com/user-attachments/assets/a99b22cd-eb21-4e84-8522-d5f3c80fb38c)
