### PR TITLE
gatewayapi: don't append gwcResource if there's invalid GatewayClass

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -177,7 +177,7 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 				result, err := t.Translate(resources)
 				if err != nil {
 					// Currently all errors that Translate returns should just be logged
-					r.Logger.Error(err, "errors detected during translation")
+					r.Logger.Error(err, "errors detected during translation", "gateway-class", resources.GatewayClass.Name)
 				}
 
 				// Publish the IRs.

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -242,11 +242,9 @@ func (t *Translator) Translate(resources *resource.Resources) (*TranslateResult,
 		errs = errors.Join(errs, err)
 	}
 
-	if len(acceptedGateways) > 0 {
-		// Process global resources that are not tied to a specific listener or route
-		if err := t.ProcessGlobalResources(resources, xdsIR); err != nil {
-			errs = errors.Join(errs, err)
-		}
+	// Process global resources that are not tied to a specific listener or route
+	if err := t.ProcessGlobalResources(resources, xdsIR); err != nil {
+		errs = errors.Join(errs, err)
 	}
 
 	// Sort xdsIR based on the Gateway API spec

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -242,9 +242,11 @@ func (t *Translator) Translate(resources *resource.Resources) (*TranslateResult,
 		errs = errors.Join(errs, err)
 	}
 
-	// Process global resources that are not tied to a specific listener or route
-	if err := t.ProcessGlobalResources(resources, xdsIR); err != nil {
-		errs = errors.Join(errs, err)
+	if len(acceptedGateways) > 0 {
+		// Process global resources that are not tied to a specific listener or route
+		if err := t.ProcessGlobalResources(resources, xdsIR); err != nil {
+			errs = errors.Join(errs, err)
+		}
 	}
 
 	// Sort xdsIR based on the Gateway API spec

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -7,6 +7,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -214,13 +215,14 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 		// Initialize resource types.
 		gwcResource := resource.NewResources()
 		gwcResource.GatewayClass = managedGC
-		gwcResources = append(gwcResources, gwcResource)
-		resourceMappings := newResourceMapping()
+
+		gwcResourceMapping := newResourceMapping()
 
 		// Process the parametersRef of the accepted GatewayClass.
 		// This should run before processGateways and processBackendRefs
 		if managedGC.Spec.ParametersRef != nil && managedGC.DeletionTimestamp == nil {
-			if err := r.processGatewayClassParamsRef(ctx, managedGC, resourceMappings, gwcResource); err != nil {
+			if err := r.processGatewayClassParamsRef(ctx, managedGC, gwcResourceMapping, gwcResource); err != nil {
+				r.log.Error(err, fmt.Sprintf("failed processGatewayClassParamsRef for gatewayClass %s, skipping it", managedGC.Name))
 				msg := fmt.Sprintf("%s: %v", status.MsgGatewayClassInvalidParams, err)
 				gc := status.SetGatewayClassAccepted(
 					managedGC.DeepCopy(),
@@ -233,21 +235,31 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 		}
 
 		// Add all Gateways, their associated Routes, and referenced resources to the resourceTree
-		if err = r.processGateways(ctx, managedGC, resourceMappings, gwcResource); err != nil {
+		if err = r.processGateways(ctx, managedGC, gwcResourceMapping, gwcResource); err != nil {
 			r.log.Error(err, fmt.Sprintf("failed processGateways for gatewayClass %s, skipping it", managedGC.Name))
 			continue
 		}
 
+		// it's safe here to append gwcResource to gwcResources
+		gwcResources = append(gwcResources, gwcResource)
+
+		// process global resources
+		// add the OIDC HMAC Secret to the resourceTree
+		r.processOIDCHMACSecret(ctx, gwcResource, gwcResourceMapping)
+		// add the Envoy TLS Secret to the resourceTree
+		r.processEnvoyTLSSecret(ctx, gwcResource, gwcResourceMapping)
+
 		if r.eppCRDExists {
 			// Add all EnvoyPatchPolicies to the resourceTree
-			if err = r.processEnvoyPatchPolicies(ctx, gwcResource, resourceMappings); err != nil {
+			if err = r.processEnvoyPatchPolicies(ctx, gwcResource, gwcResourceMapping); err != nil {
 				r.log.Error(err, fmt.Sprintf("failed processEnvoyPatchPolicies for gatewayClass %s, skipping it", managedGC.Name))
 				continue
 			}
 		}
+
 		if r.ctpCRDExists {
 			// Add all ClientTrafficPolicies and their referenced resources to the resourceTree
-			if err = r.processClientTrafficPolicies(ctx, gwcResource, resourceMappings); err != nil {
+			if err = r.processClientTrafficPolicies(ctx, gwcResource, gwcResourceMapping); err != nil {
 				r.log.Error(err, fmt.Sprintf("failed processClientTrafficPolicies for gatewayClass %s, skipping it", managedGC.Name))
 				continue
 			}
@@ -255,7 +267,7 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 
 		if r.btpCRDExists {
 			// Add all BackendTrafficPolicies to the resourceTree
-			if err = r.processBackendTrafficPolicies(ctx, gwcResource, resourceMappings); err != nil {
+			if err = r.processBackendTrafficPolicies(ctx, gwcResource, gwcResourceMapping); err != nil {
 				r.log.Error(err, fmt.Sprintf("failed processBackendTrafficPolicies for gatewayClass %s, skipping it", managedGC.Name))
 				continue
 			}
@@ -263,7 +275,7 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 
 		if r.spCRDExists {
 			// Add all SecurityPolicies and their referenced resources to the resourceTree
-			if err = r.processSecurityPolicies(ctx, gwcResource, resourceMappings); err != nil {
+			if err = r.processSecurityPolicies(ctx, gwcResource, gwcResourceMapping); err != nil {
 				r.log.Error(err, fmt.Sprintf("failed processSecurityPolicies for gatewayClass %s, skipping it", managedGC.Name))
 				continue
 			}
@@ -271,7 +283,7 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 
 		if r.bTLSPolicyCRDExists {
 			// Add all BackendTLSPolies to the resourceTree
-			if err = r.processBackendTLSPolicies(ctx, gwcResource, resourceMappings); err != nil {
+			if err = r.processBackendTLSPolicies(ctx, gwcResource, gwcResourceMapping); err != nil {
 				r.log.Error(err, fmt.Sprintf("failed processBackendTLSPolicies for gatewayClass %s, skipping it", managedGC.Name))
 				continue
 			}
@@ -279,7 +291,7 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 
 		if r.eepCRDExists {
 			// Add all EnvoyExtensionPolicies and their referenced resources to the resourceTree
-			if err = r.processEnvoyExtensionPolicies(ctx, gwcResource, resourceMappings); err != nil {
+			if err = r.processEnvoyExtensionPolicies(ctx, gwcResource, gwcResourceMapping); err != nil {
 				r.log.Error(err, fmt.Sprintf("failed processEnvoyExtensionPolicies for gatewayClass %s, skipping it", managedGC.Name))
 				continue
 			}
@@ -300,11 +312,11 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 		// Add the referenced services, ServiceImports, and EndpointSlices in
 		// the collected BackendRefs to the resourceTree.
 		// BackendRefs are referred by various Route objects and the ExtAuth in SecurityPolicies.
-		r.processBackendRefs(ctx, gwcResource, resourceMappings)
+		r.processBackendRefs(ctx, gwcResource, gwcResourceMapping)
 
 		// For this particular Gateway, and all associated objects, check whether the
 		// namespace exists. Add to the resourceTree.
-		for ns := range resourceMappings.allAssociatedNamespaces {
+		for ns := range gwcResourceMapping.allAssociatedNamespaces {
 			namespace, err := r.getNamespace(ctx, ns)
 			if err != nil {
 				r.log.Error(err, "unable to find the namespace")
@@ -1271,11 +1283,6 @@ func (r *gatewayAPIReconciler) processSecurityPolicies(
 	// Add the referenced Resources in SecurityPolicies to the resourceTree
 	r.processSecurityPolicyObjectRefs(ctx, resourceTree, resourceMap)
 
-	// Add the OIDC HMAC Secret to the resourceTree
-	r.processOIDCHMACSecret(ctx, resourceTree, resourceMap)
-
-	// Add the Envoy TLS Secret to the resourceTree
-	r.processEnvoyTLSSecret(ctx, resourceTree, resourceMap)
 	return nil
 }
 
@@ -2045,7 +2052,7 @@ func (r *gatewayAPIReconciler) processGatewayClassParamsRef(ctx context.Context,
 
 	// Check for incompatible configuration: both MergeGateways and GatewayNamespaceMode enabled
 	if r.gatewayNamespaceMode && ep.Spec.MergeGateways != nil && *ep.Spec.MergeGateways {
-		return fmt.Errorf("using Merged Gateways with Gateway Namespace Mode is not supported.")
+		return errors.New("using Merged Gateways with Gateway Namespace Mode is not supported")
 	}
 
 	if err := r.processEnvoyProxy(ep, resourceMap); err != nil {

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -233,21 +233,19 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 				continue
 			}
 		}
+		// it's safe here to append gwcResource to gwcResources
+		gwcResources = append(gwcResources, gwcResource)
+		// process global resources
+		// add the OIDC HMAC Secret to the resourceTree
+		r.processOIDCHMACSecret(ctx, gwcResource, gwcResourceMapping)
+		// add the Envoy TLS Secret to the resourceTree
+		r.processEnvoyTLSSecret(ctx, gwcResource, gwcResourceMapping)
 
 		// Add all Gateways, their associated Routes, and referenced resources to the resourceTree
 		if err = r.processGateways(ctx, managedGC, gwcResourceMapping, gwcResource); err != nil {
 			r.log.Error(err, fmt.Sprintf("failed processGateways for gatewayClass %s, skipping it", managedGC.Name))
 			continue
 		}
-
-		// it's safe here to append gwcResource to gwcResources
-		gwcResources = append(gwcResources, gwcResource)
-
-		// process global resources
-		// add the OIDC HMAC Secret to the resourceTree
-		r.processOIDCHMACSecret(ctx, gwcResource, gwcResourceMapping)
-		// add the Envoy TLS Secret to the resourceTree
-		r.processEnvoyTLSSecret(ctx, gwcResource, gwcResourceMapping)
 
 		if r.eppCRDExists {
 			// Add all EnvoyPatchPolicies to the resourceTree

--- a/internal/provider/kubernetes/controller_test.go
+++ b/internal/provider/kubernetes/controller_test.go
@@ -281,7 +281,7 @@ func TestProcessGatewayClassParamsRef(t *testing.T) {
 			},
 			gatewayNamespaceMode: true,
 			expected:             false,
-			expectedError:        "using Merged Gateways with Gateway Namespace Mode is not supported.",
+			expectedError:        "using Merged Gateways with Gateway Namespace Mode is not supported",
 		},
 		{
 			name: "valid merged gateways enabled configuration",


### PR DESCRIPTION
this fix a error log when there more than one unaccepted gatewayclass like following:
```console
2025-06-23T04:32:40.628Z	INFO	provider	kubernetes/controller.go:361	secret	{"runner": "provider", "count": 2, "gwc": "eg"}
2025-06-23T04:32:40.629Z	INFO	provider	kubernetes/controller.go:361	secret	{"runner": "provider", "count": 2, "gwc": "eg"}
2025-06-23T04:33:08.944Z	INFO	provider	kubernetes/controller.go:361	secret	{"runner": "provider", "count": 2, "gwc": "eg"}
2025-06-23T04:34:07.884Z	INFO	provider	kubernetes/controller.go:361	secret	{"runner": "provider", "count": 2, "gwc": "envoy-gateway"}
2025-06-23T04:34:07.884Z	INFO	provider	kubernetes/controller.go:361	secret	{"runner": "provider", "count": 2, "gwc": "eg"}
2025-06-23T04:36:06.505Z	INFO	provider	kubernetes/controller.go:361	secret	{"runner": "provider", "count": 0, "gwc": "envoy-gateway"}
2025-06-23T04:36:06.505Z	INFO	provider	kubernetes/controller.go:361	secret	{"runner": "provider", "count": 2, "gwc": "eg"}
2025-06-23T04:36:06.506Z	ERROR	gateway-api	runner/runner.go:180	errors detected during translation	{"runner": "gateway-api", "error": "envoy TLS secret envoy-gateway-system/envoy not found"}
```

it's easy to reproduce with following configuration:
```
kind: GatewayClass
apiVersion: gateway.networking.k8s.io/v1
metadata:
  name: envoy-gateway
spec:
  controllerName: gateway.envoyproxy.io/gatewayclass-controller
  parametersRef:
    group: gateway.envoyproxy.io
    kind: EnvoyProxy
    name: proxy-config
    namespace: envoy-gateway-system
---
apiVersion: gateway.networking.k8s.io/v1
kind: GatewayClass
metadata:
  name: eg
spec:
  controllerName: gateway.envoyproxy.io/gatewayclass-controller
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: eg
  namespace: ingress
spec:
  gatewayClassName: eg
  listeners:
    - name: http
      protocol: HTTP
      port: 80
      allowedRoutes:
        namespaces:
          from: All
```
