### PR TITLE
fix: create IPv4 Service with ipFamily IPv4 on dual-stack, IPv6-first cluster

### DIFF
--- a/internal/infrastructure/kubernetes/proxy/resource_provider.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider.go
@@ -251,8 +251,10 @@ func (r *ResourceRender) Service() (*corev1.Service, error) {
 	// Set IP family policy and families based on proxy config request
 	ipFamily := r.infra.GetProxyConfig().Spec.IPFamily
 	if ipFamily != nil {
-		// SingleStack+IPv4 is default behavior from K8s and so is omitted
 		switch *ipFamily {
+		case egv1a1.IPv4:
+			serviceSpec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+			serviceSpec.IPFamilyPolicy = ptr.To(corev1.IPFamilyPolicySingleStack)
 		case egv1a1.IPv6:
 			serviceSpec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol}
 			serviceSpec.IPFamilyPolicy = ptr.To(corev1.IPFamilyPolicySingleStack)

--- a/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
@@ -1864,8 +1864,8 @@ func TestIPFamilyPresentInSpec(t *testing.T) {
 		{
 			"ipv4 specified",
 			ptr.To(egv1a1.IPv4),
-			nil,
-			nil,
+			[]corev1.IPFamily{corev1.IPv4Protocol},
+			ptr.To(corev1.IPFamilyPolicySingleStack),
 		},
 		{
 			"ipv6 specified",

--- a/internal/infrastructure/kubernetes/proxy/testdata/services/ipv4-singlestack.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/services/ipv4-singlestack.yaml
@@ -17,6 +17,9 @@ metadata:
     uid: test-owner-reference-uid-for-gatewayclass
 spec:
   externalTrafficPolicy: Local
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
   ports:
   - name: EnvoyHTTPPort
     port: 0

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -39,6 +39,7 @@ bug fixes: |
   Fixed bug in certificate SANs overlap detection in listeners.
   Fixed issue where EnvoyExtensionPolicy ExtProc body processing mode is set to FullDuplexStreamed, but trailers were not sent.
   Fixed validation issue where EnvoyExtensionPolicy ExtProc failOpen is true, and body processing mode FullDuplexStreamed is not rejected.
+  Fixed bug with IPv6, dual stack clusters and ipFamily IPV4 where the Service was IPv6.
 
 
 # Enhancements that improve performance.


### PR DESCRIPTION
**What type of PR is this?**
fix: create IPv4 Service with ipFamily IPv4 on dual-stack, IPv6-first cluster

**What this PR does / why we need it**:
The deleted comment isn't accurate. From [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services):

> The address family of a Service defaults to the address family of the first service cluster IP range (configured via the --service-cluster-ip-range flag to the kube-apiserver).

**Which issue(s) this PR fixes**:
Fixes #6389

Release Notes: Yes
