### PR TITLE
fix: Do not set backendRequestTimeout when Retries are set

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -327,7 +327,7 @@ func processRouteTimeout(irRoute *ir.HTTPRoute, rule gwapiv1.HTTPRouteRule) {
 
 		// Also set the IR Route Timeout to the backend request timeout
 		// until we introduce retries, then set it to per try timeout
-		if rule.Timeouts.BackendRequest != nil {
+		if rule.Timeouts.BackendRequest != nil && rule.Retry == nil {
 			d, err := time.ParseDuration(string(*rule.Timeouts.BackendRequest))
 			if err != nil {
 				d, _ = time.ParseDuration(HTTPRequestTimeout)

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -325,8 +325,9 @@ func processRouteTimeout(irRoute *ir.HTTPRoute, rule gwapiv1.HTTPRouteRule) {
 			irRoute.Timeout = ptr.To(metav1.Duration{Duration: d})
 		}
 
-		// Also set the IR Route Timeout to the backend request timeout
-		// until we introduce retries, then set it to per try timeout
+		// Only set the IR Route Timeout to the backend request timeout
+		// when retries are not configured. When retries are configured,
+		// the backend request timeout should set for per-retry timeout.
 		if rule.Timeouts.BackendRequest != nil && rule.Retry == nil {
 			d, err := time.ParseDuration(string(*rule.Timeouts.BackendRequest))
 			if err != nil {

--- a/internal/gatewayapi/testdata/httproute-retry.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-retry.out.yaml
@@ -323,7 +323,6 @@ xdsIR:
           retryOn:
             httpStatusCodes:
             - 500
-        timeout: 3s
         traffic:
           retry:
             numAttemptsPerPriority: 1


### PR DESCRIPTION
Fixes #6414 