### PR TITLE
fix: prevent port shifting for TLS passthrough on port 443

### DIFF
--- a/internal/gatewayapi/testdata/tlsroute-invalid-reference-grant.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-invalid-reference-grant.out.yaml
@@ -48,7 +48,7 @@ infraIR:
       - address: null
         name: gateway-conformance-infra/gateway-tlsroute-referencegrant/https
         ports:
-        - containerPort: 10443
+        - containerPort: 443
           name: tls-443
           protocol: TLS
           servicePort: 443
@@ -108,4 +108,4 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       name: gateway-conformance-infra/gateway-tlsroute-referencegrant/https
-      port: 10443
+      port: 443

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -790,6 +790,7 @@ func TestServicePortToContainerPort(t *testing.T) {
 		servicePort               int32
 		containerPort             int32
 		envoyProxy                *egv1a1.EnvoyProxy
+		isTLSPassthrough          bool
 		listenerPortShiftDisabled bool
 	}{
 		{
@@ -856,10 +857,15 @@ func TestServicePortToContainerPort(t *testing.T) {
 			containerPort:             99,
 			listenerPortShiftDisabled: true,
 		},
+		{
+			servicePort:      443,
+			containerPort:    443,
+			isTLSPassthrough: true,
+		},
 	}
 	for _, tc := range testCases {
 		translator := &Translator{ListenerPortShiftDisabled: tc.listenerPortShiftDisabled}
-		got := translator.servicePortToContainerPort(tc.servicePort, tc.envoyProxy)
+		got := translator.servicePortToContainerPort(tc.servicePort, tc.envoyProxy, tc.isTLSPassthrough)
 		assert.Equal(t, tc.containerPort, got)
 	}
 }


### PR DESCRIPTION
PROXY protocol headers were showing incorrect destination ports for TLS passthrough listeners configured on port 443. The port shifting mechanism was converting port 443 to 10443, causing PROXY protocol to capture and send the internal container port (10443) instead of the logical service port (443).


-->Cause 
The `servicePortToContainerPort` function was shifting all well-known ports (< 1024) to ephemeral ports without considering TLS passthrough scenarios where PROXY protocol is commonly used.

what i did :
Modified the port shifting logic to skip port conversion for TLS passthrough listeners specifically on port 443, ensuring PROXY protocol headers contain the correct destination port.

what r ur views on it ?



