### PR TITLE
docs: show table of content in Gateway API Extensions page

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -81,6 +81,11 @@ id = "G-DXJEH1ZRXX"
     style = "tango"
     # Uncomment if you want your chosen highlight style used for code blocks without a specified language
     # guessSyntax = "true"
+  [markup.tableOfContents]
+    # Need this for Gateway API Extensions page.
+    endLevel = 4
+    ordered = false
+    startLevel = 2
 
 # Everything below this are Site Params
 


### PR DESCRIPTION
fixes: https://github.com/envoyproxy/gateway/issues/6428