### PR TITLE
Fix/apiserver connection refused error

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -1590,6 +1590,14 @@ func (t *Translator) processServiceDestinationSetting(
 		endpoints = append(endpoints, ep)
 	}
 
+	// Log if Zone-Aware Routing is configured for a Service but no active endpoints are found.
+	if processZoneAwareRouting(service) != nil && len(endpoints) == 0 {
+		t.Log.Info("Zone-aware routing configured for Service but no active endpoints found.",
+			"serviceNamespace", service.Namespace,
+			"serviceName", service.Name,
+		)
+	}
+
 	return &ir.DestinationSetting{
 		Name:             name,
 		Protocol:         protocol,

--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -162,6 +162,7 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 					MergeGateways:             gatewayapi.IsMergeGatewaysEnabled(resources),
 					WasmCache:                 r.wasmCache,
 					ListenerPortShiftDisabled: r.EnvoyGateway.Provider != nil && r.EnvoyGateway.Provider.IsRunningOnHost(),
+					Log:                       r.Logger.Logger,
 				}
 
 				// If an extension is loaded, pass its supported groups/kinds to the translator

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"sort"
 
+	"github.com/go-logr/logr"
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -104,6 +105,9 @@ type Translator struct {
 	// gateway listener port into a non privileged port
 	// and reuses the specified value.
 	ListenerPortShiftDisabled bool
+
+	// Logger logs messages.
+	Log logr.Logger
 }
 
 type TranslateResult struct {


### PR DESCRIPTION
**What type of PR is this?**
This PR addresses excessive and noisy error logging in scenarios where the Envoy Gateway controller experienced transient connection issues with the Kubernetes API server. Previously, errors such as "connection refused" or "TLS handshake timeout," often originating from controller-runtime/pkg/cache/internal/informers.go, would flood the logs, making it challenging to identify more critical issues.

issue being fixed #4631

what r ur views does it seem correct to u ?

