### PR TITLE
Enable http2 by default for ALS access-loggers 

### DIFF
--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -619,6 +619,10 @@ func (t *Translator) processAccessLog(envoyproxy *egv1a1.EnvoyProxy, resources *
 				if err != nil {
 					return nil, err
 				}
+				// ALS should always use GRPC protocol. Setting this adds http2 by default to the cluster.
+				for _, setting := range ds {
+					setting.Protocol = ir.GRPC
+				}
 
 				al := &ir.ALSAccessLog{
 					LogName: logName,

--- a/internal/gatewayapi/testdata/accesslog-als-grpc.in.yaml
+++ b/internal/gatewayapi/testdata/accesslog-als-grpc.in.yaml
@@ -1,0 +1,46 @@
+envoyProxyForGatewayClass:
+  apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: EnvoyProxy
+  metadata:
+    namespace: envoy-gateway-system
+    name: als-backend
+  spec:
+    telemetry:
+      accessLog:
+        settings:
+          - sinks:
+              - type: ALS
+                als:
+                  backendRefs:
+                    - name: access-logger
+                      namespace: default
+                      port: 50051
+                  type: HTTP
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: Same
+services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: access-logger
+      namespace: default
+    spec:
+      clusterIP: 10.11.12.13
+      ports:
+        - port: 50051
+          name: grpc
+          protocol: TCP
+          targetPort: 50051

--- a/internal/gatewayapi/testdata/accesslog-als-grpc.out.yaml
+++ b/internal/gatewayapi/testdata/accesslog-als-grpc.out.yaml
@@ -1,0 +1,123 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      config:
+        apiVersion: gateway.envoyproxy.io/v1alpha1
+        kind: EnvoyProxy
+        metadata:
+          creationTimestamp: null
+          name: als-backend
+          namespace: envoy-gateway-system
+        spec:
+          logging: {}
+          telemetry:
+            accessLog:
+              settings:
+              - sinks:
+                  - type: ALS
+                    als:
+                      backendRefs:
+                        - name: access-logger
+                          namespace: default
+                          port: 50051
+                      type: HTTP
+        status: {}
+      listeners:
+      - address: null
+        name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-1
+      namespace: envoy-gateway-system
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      als: 
+        - name: envoy-gateway-system/als-backend
+          destination: 
+            name: accesslog_als_0_0
+            settings:
+              - name: accesslog_als_0_0/backend/-1
+                protocol: GRPC
+                metadata:
+                  kind: Service
+                  name: access-logger
+                  namespace: default
+                  sectionName: "50051"
+            metadata:
+              kind: EnvoyProxy
+              name: als-backend
+              namespace: envoy-gateway-system
+          type: HTTP
+    http:
+    - address: 0.0.0.0
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -36,7 +36,7 @@ new features: |
   Added support for SecurityPolicy and EnvoyExtensionPolicy to target ServiceImport via BackendRefs.
   Introduce validation strictness levels for Lua scripts in EnvoyExtensionPolicies.
   Added metric `watchable_publish_total` counting store events in watchable message queues.
-
+  Accessloggers of type ALS now have http2 enabled on the cluster by default.
 
 bug fixes: |
   Handle integer zone annotation values


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/gateway/issues/6450

Release Notes: Yes