### PR TITLE
chore: retry when failing to check doc links

### DIFF
--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -174,7 +174,7 @@ docs-release-gen:
 .PHONY: docs-check-links
 docs-check-links: # Check for broken links in the docs
 	@$(LOG_TARGET)
-	linkinator site/public/ -r --concurrency 25 --retry-errors --retry --retry-errors-jitter --skip $(LINKINATOR_IGNORE) --verbosity error
+	linkinator site/public/ -r --concurrency 25 --retry-errors --retry --retry-errors-jitter --retry-errors-count 5 --skip $(LINKINATOR_IGNORE) --verbosity error
 
 docs-markdown-lint:
 	markdownlint -c .github/markdown_lint_config.json site/content/*

--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -174,7 +174,7 @@ docs-release-gen:
 .PHONY: docs-check-links
 docs-check-links: # Check for broken links in the docs
 	@$(LOG_TARGET)
-	linkinator site/public/ -r --concurrency 25 --skip $(LINKINATOR_IGNORE) --verbosity error
+	linkinator site/public/ -r --concurrency 25 --retry-errors --retry --retry-errors-jitter --skip $(LINKINATOR_IGNORE) --verbosity error
 
 docs-markdown-lint:
 	markdownlint -c .github/markdown_lint_config.json site/content/*


### PR DESCRIPTION
Hope this can mitigate the flaky docs-link check.

```bash
hugo: collected modules in 11695 ms🏊‍♂️ crawling site/public/
[0] https://www.envoyproxy.io/docs/envoy/latest/operations/cli
site/public/docs/api/extension_types/
  [0] https://www.envoyproxy.io/docs/envoy/latest/operations/cli
ERROR: Detected 1 broken links. Scanned 1411 links in 115.907 seconds.
```

https://github.com/envoyproxy/gateway/actions/runs/16335732136/job/46147426798?pr=6533