### PR TITLE
fix: Node objects should not be subject to namespace label checks

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -1807,11 +1807,6 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 			return r.handleNode(node)
 		}),
 	}
-	if r.namespaceLabel != nil {
-		nPredicates = append(nPredicates, predicate.NewTypedPredicateFuncs(func(node *corev1.Node) bool {
-			return r.hasMatchingNamespaceLabels(node)
-		}))
-	}
 	// resource address.
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), &corev1.Node{},


### PR DESCRIPTION
**What type of PR is this?**

bugfix

**What this PR does / why we need it**:

`corev1.Node` objects in Kubernetes are cluster-level resources that don't have a namespace, then `r.hasMatchingNamespaceLabels` function will always return `false, nil`.