### PR TITLE
fix: add missing HTTP filters for HTTP3 listener

### DIFF
--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.listeners.yaml
@@ -42,6 +42,49 @@
             '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuth
             users:
               inlineBytes: dXNlcjE6e1NIQX10RVNzQm1FL3lOWTNsYjZhMEw2dlZRRVpOcXc9CnVzZXIyOntTSEF9RUo5TFBGRFhzTjl5blNtYnh2anA3NUJtbHg4PQo=
+        - disabled: true
+          name: envoy.filters.http.oauth2/securitypolicy/default/policy-for-gateway-2
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2
+            config:
+              authScopes:
+              - openid
+              - email
+              - profile
+              authType: BASIC_AUTH
+              authorizationEndpoint: https://oauth.foo.com/oauth2/v2/auth
+              credentials:
+                clientId: client.oauth.foo.com
+                cookieNames:
+                  bearerToken: AccessToken-5F93C2E4
+                  idToken: IdToken-5F93C2E4
+                  oauthExpires: OauthExpires-5F93C2E4
+                  oauthHmac: OauthHMAC-5F93C2E4
+                  oauthNonce: OauthNonce-5F93C2E4
+                  refreshToken: RefreshToken-5F93C2E4
+                hmacSecret:
+                  name: oauth2/hmac_secret/securitypolicy/default/policy-for-gateway-2
+                  sdsConfig:
+                    ads: {}
+                    resourceApiVersion: V3
+                tokenSecret:
+                  name: oauth2/client_secret/securitypolicy/default/policy-for-gateway-2
+                  sdsConfig:
+                    ads: {}
+                    resourceApiVersion: V3
+              preserveAuthorizationHeader: true
+              redirectPathMatcher:
+                path:
+                  exact: /foo/oauth2/callback
+              redirectUri: https://www.example.com/foo/oauth2/callback
+              signoutPath:
+                path:
+                  exact: /foo/logout
+              tokenEndpoint:
+                cluster: oauth_foo_com_443
+                timeout: 10s
+                uri: https://oauth.foo.com/token
+              useRefreshToken: false
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.routes.yaml
@@ -45,6 +45,11 @@
     - match:
         pathSeparatedPrefix: /bar
       name: httproute/default/httproute-3/rule/0/match/0/www_bar_com
+      responseHeadersToAdd:
+      - append: true
+        header:
+          key: alt-svc
+          value: h3=":443"; ma=86400
       route:
         cluster: httproute/default/httproute-3/rule/0
         upgradeConfigs:


### PR DESCRIPTION
HTTP filters are missing in the UDP listener when HTTP3 is enabled and multiple listeners are on the same port.

Fixes https://github.com/envoyproxy/gateway/pull/6544#discussion_r2225548956

