### PR TITLE
fix: sort virtual hosts in the xDS RouteConfig

### DIFF
--- a/internal/xds/translator/testdata/out/xds-ir/api-key-auth.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/api-key-auth.routes.yaml
@@ -2,45 +2,6 @@
   name: default/gateway-1/http
   virtualHosts:
   - domains:
-    - www.foo.com
-    name: default/gateway-1/http/www_foo_com
-    routes:
-    - match:
-        pathSeparatedPrefix: /foo1
-      name: httproute/default/httproute-1/rule/0/match/0/www_foo_com
-      route:
-        cluster: httproute/default/httproute-1/rule/0
-        upgradeConfigs:
-        - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.api_key_auth:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
-          credentials:
-          - client: client-1
-            key: key1
-          forwarding:
-            header: X-API-KEY-CLIENT-ID
-            hideCredentials: true
-          keySources:
-          - header: X-API-KEY
-          - header: X-API-KEY-2
-    - match:
-        pathSeparatedPrefix: /foo2
-      name: httproute/default/httproute-1/rule/1/match/0/www_foo_com
-      route:
-        cluster: httproute/default/httproute-1/rule/1
-        upgradeConfigs:
-        - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.api_key_auth:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
-          credentials:
-          - client: client-2
-            key: key2
-          keySources:
-          - query: X-API-KEY
-          - query: X-API-KEY-2
-  - domains:
     - www.bar.com
     name: default/gateway-1/http/www_bar_com
     routes:
@@ -78,5 +39,44 @@
           - cookie: X-API-KEY-2
           - header: X-API-KEY
           - header: X-API-KEY-2
+          - query: X-API-KEY
+          - query: X-API-KEY-2
+  - domains:
+    - www.foo.com
+    name: default/gateway-1/http/www_foo_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /foo1
+      name: httproute/default/httproute-1/rule/0/match/0/www_foo_com
+      route:
+        cluster: httproute/default/httproute-1/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.api_key_auth:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
+          credentials:
+          - client: client-1
+            key: key1
+          forwarding:
+            header: X-API-KEY-CLIENT-ID
+            hideCredentials: true
+          keySources:
+          - header: X-API-KEY
+          - header: X-API-KEY-2
+    - match:
+        pathSeparatedPrefix: /foo2
+      name: httproute/default/httproute-1/rule/1/match/0/www_foo_com
+      route:
+        cluster: httproute/default/httproute-1/rule/1
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.api_key_auth:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
+          credentials:
+          - client: client-2
+            key: key2
+          keySources:
           - query: X-API-KEY
           - query: X-API-KEY-2

--- a/internal/xds/translator/testdata/out/xds-ir/backend-priority.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-priority.routes.yaml
@@ -2,6 +2,32 @@
   name: default/gateway-1/http
   virtualHosts:
   - domains:
+    - www.bar.com
+    metadata:
+      filterMetadata:
+        envoy-gateway:
+          resources:
+          - kind: Gateway
+            name: gateway-1
+            namespace: default
+            sectionName: http
+    name: default/gateway-1/http/www_bar_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /bar
+      metadata:
+        filterMetadata:
+          envoy-gateway:
+            resources:
+            - kind: HTTPRoute
+              name: httproute-2
+              namespace: default
+      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
+      route:
+        cluster: httproute/default/httproute-2/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+  - domains:
     - www.foo.com
     metadata:
       filterMetadata:
@@ -31,29 +57,3 @@
         envoy.filters.http.ext_proc/envoyextensionpolicy/default/policy-for-http-route/extproc/0:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}
-  - domains:
-    - www.bar.com
-    metadata:
-      filterMetadata:
-        envoy-gateway:
-          resources:
-          - kind: Gateway
-            name: gateway-1
-            namespace: default
-            sectionName: http
-    name: default/gateway-1/http/www_bar_com
-    routes:
-    - match:
-        pathSeparatedPrefix: /bar
-      metadata:
-        filterMetadata:
-          envoy-gateway:
-            resources:
-            - kind: HTTPRoute
-              name: httproute-2
-              namespace: default
-      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
-      route:
-        cluster: httproute/default/httproute-2/rule/0
-        upgradeConfigs:
-        - upgradeType: websocket

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth-username-header.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth-username-header.routes.yaml
@@ -2,6 +2,22 @@
   name: default/gateway-1/http
   virtualHosts:
   - domains:
+    - www.bar.com
+    name: default/gateway-1/http/www_bar_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /bar
+      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
+      route:
+        cluster: httproute/default/httproute-2/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.basic_auth/securitypolicy/default/policy-for-gateway-1:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
+          users:
+            inlineBytes: Zm9vOntTSEF9WXMyM0FnLzVJT1dxWkN3OVFHYVZEZEh3SDAwPQpmb28xOntTSEF9ZGpaMTFxSFkwS09pamV5bUs3YUt2WXV2aHZNPQo=
+  - domains:
     - www.foo.com
     name: default/gateway-1/http/www_foo_com
     routes:
@@ -29,19 +45,3 @@
           '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
           users:
             inlineBytes: dXNlcjE6e1NIQX10RVNzQm1FL3lOWTNsYjZhMEw2dlZRRVpOcXc9CnVzZXIyOntTSEF9RUo5TFBGRFhzTjl5blNtYnh2anA3NUJtbHg4PQo=
-  - domains:
-    - www.bar.com
-    name: default/gateway-1/http/www_bar_com
-    routes:
-    - match:
-        pathSeparatedPrefix: /bar
-      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
-      route:
-        cluster: httproute/default/httproute-2/rule/0
-        upgradeConfigs:
-        - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.basic_auth/securitypolicy/default/policy-for-gateway-1:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
-          users:
-            inlineBytes: Zm9vOntTSEF9WXMyM0FnLzVJT1dxWkN3OVFHYVZEZEh3SDAwPQpmb28xOntTSEF9ZGpaMTFxSFkwS09pamV5bUs3YUt2WXV2aHZNPQo=

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth.routes.yaml
@@ -2,6 +2,22 @@
   name: default/gateway-1/http
   virtualHosts:
   - domains:
+    - www.bar.com
+    name: default/gateway-1/http/www_bar_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /bar
+      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
+      route:
+        cluster: httproute/default/httproute-2/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.basic_auth/securitypolicy/default/policy-for-gateway-1:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
+          users:
+            inlineBytes: Zm9vOntTSEF9WXMyM0FnLzVJT1dxWkN3OVFHYVZEZEh3SDAwPQpmb28xOntTSEF9ZGpaMTFxSFkwS09pamV5bUs3YUt2WXV2aHZNPQo=
+  - domains:
     - www.foo.com
     name: default/gateway-1/http/www_foo_com
     routes:
@@ -29,19 +45,3 @@
           '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
           users:
             inlineBytes: dXNlcjE6e1NIQX10RVNzQm1FL3lOWTNsYjZhMEw2dlZRRVpOcXc9CnVzZXIyOntTSEF9RUo5TFBGRFhzTjl5blNtYnh2anA3NUJtbHg4PQo=
-  - domains:
-    - www.bar.com
-    name: default/gateway-1/http/www_bar_com
-    routes:
-    - match:
-        pathSeparatedPrefix: /bar
-      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
-      route:
-        cluster: httproute/default/httproute-2/rule/0
-        upgradeConfigs:
-        - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.basic_auth/securitypolicy/default/policy-for-gateway-1:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
-          users:
-            inlineBytes: Zm9vOntTSEF9WXMyM0FnLzVJT1dxWkN3OVFHYVZEZEh3SDAwPQpmb28xOntTSEF9ZGpaMTFxSFkwS09pamV5bUs3YUt2WXV2aHZNPQo=

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.routes.yaml
@@ -2,6 +2,21 @@
   name: default/gateway-1/http
   virtualHosts:
   - domains:
+    - www.bar.com
+    name: default/gateway-1/http/www_bar_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /bar
+      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
+      route:
+        cluster: httproute/default/httproute-2/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ext_authz/securitypolicy/default/policy-for-gateway-1:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}
+  - domains:
     - www.foo.com
     name: default/gateway-1/http/www_foo_com
     routes:
@@ -25,20 +40,5 @@
         - upgradeType: websocket
       typedPerFilterConfig:
         envoy.filters.http.ext_authz/securitypolicy/default/policy-for-http-route-1:
-          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-          config: {}
-  - domains:
-    - www.bar.com
-    name: default/gateway-1/http/www_bar_com
-    routes:
-    - match:
-        pathSeparatedPrefix: /bar
-      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
-      route:
-        cluster: httproute/default/httproute-2/rule/0
-        upgradeConfigs:
-        - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ext_authz/securitypolicy/default/policy-for-gateway-1:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-body.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-body.routes.yaml
@@ -2,6 +2,21 @@
   name: default/gateway-1/http
   virtualHosts:
   - domains:
+    - www.bar.com
+    name: default/gateway-1/http/www_bar_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /bar
+      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
+      route:
+        cluster: httproute/default/httproute-2/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ext_authz/securitypolicy/default/policy-for-gateway-1:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}
+  - domains:
     - www.foo.com
     name: default/gateway-1/http/www_foo_com
     routes:
@@ -25,20 +40,5 @@
         - upgradeType: websocket
       typedPerFilterConfig:
         envoy.filters.http.ext_authz/securitypolicy/default/policy-for-http-route-1:
-          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-          config: {}
-  - domains:
-    - www.bar.com
-    name: default/gateway-1/http/www_bar_com
-    routes:
-    - match:
-        pathSeparatedPrefix: /bar
-      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
-      route:
-        cluster: httproute/default/httproute-2/rule/0
-        upgradeConfigs:
-        - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ext_authz/securitypolicy/default/policy-for-gateway-1:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.routes.yaml
@@ -2,6 +2,21 @@
   name: default/gateway-1/http
   virtualHosts:
   - domains:
+    - www.bar.com
+    name: default/gateway-1/http/www_bar_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /bar
+      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
+      route:
+        cluster: httproute/default/httproute-2/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ext_authz/securitypolicy/default/policy-for-gateway-1:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}
+  - domains:
     - www.foo.com
     name: default/gateway-1/http/www_foo_com
     routes:
@@ -25,20 +40,5 @@
         - upgradeType: websocket
       typedPerFilterConfig:
         envoy.filters.http.ext_authz/securitypolicy/default/policy-for-http-route-1:
-          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-          config: {}
-  - domains:
-    - www.bar.com
-    name: default/gateway-1/http/www_bar_com
-    routes:
-    - match:
-        pathSeparatedPrefix: /bar
-      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
-      route:
-        cluster: httproute/default/httproute-2/rule/0
-        upgradeConfigs:
-        - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ext_authz/securitypolicy/default/policy-for-gateway-1:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.routes.yaml
@@ -2,6 +2,21 @@
   name: default/gateway-1/http
   virtualHosts:
   - domains:
+    - www.bar.com
+    name: default/gateway-1/http/www_bar_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /bar
+      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
+      route:
+        cluster: httproute/default/httproute-2/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ext_authz/securitypolicy/default/policy-for-gateway-1:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}
+  - domains:
     - www.foo.com
     name: default/gateway-1/http/www_foo_com
     routes:
@@ -25,20 +40,5 @@
         - upgradeType: websocket
       typedPerFilterConfig:
         envoy.filters.http.ext_authz/securitypolicy/default/policy-for-http-route-1:
-          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-          config: {}
-  - domains:
-    - www.bar.com
-    name: default/gateway-1/http/www_bar_com
-    routes:
-    - match:
-        pathSeparatedPrefix: /bar
-      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
-      route:
-        cluster: httproute/default/httproute-2/rule/0
-        upgradeConfigs:
-        - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.ext_authz/securitypolicy/default/policy-for-gateway-1:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.routes.yaml
@@ -2,6 +2,32 @@
   name: default/gateway-1/http
   virtualHosts:
   - domains:
+    - www.bar.com
+    metadata:
+      filterMetadata:
+        envoy-gateway:
+          resources:
+          - kind: Gateway
+            name: gateway-1
+            namespace: default
+            sectionName: http
+    name: default/gateway-1/http/www_bar_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /bar
+      metadata:
+        filterMetadata:
+          envoy-gateway:
+            resources:
+            - kind: HTTPRoute
+              name: httproute-2
+              namespace: default
+      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
+      route:
+        cluster: httproute/default/httproute-2/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+  - domains:
     - www.foo.com
     metadata:
       filterMetadata:
@@ -31,29 +57,3 @@
         envoy.filters.http.ext_proc/envoyextensionpolicy/default/policy-for-http-route/extproc/0:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}
-  - domains:
-    - www.bar.com
-    metadata:
-      filterMetadata:
-        envoy-gateway:
-          resources:
-          - kind: Gateway
-            name: gateway-1
-            namespace: default
-            sectionName: http
-    name: default/gateway-1/http/www_bar_com
-    routes:
-    - match:
-        pathSeparatedPrefix: /bar
-      metadata:
-        filterMetadata:
-          envoy-gateway:
-            resources:
-            - kind: HTTPRoute
-              name: httproute-2
-              namespace: default
-      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
-      route:
-        cluster: httproute/default/httproute-2/rule/0
-        upgradeConfigs:
-        - upgradeType: websocket

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.routes.yaml
@@ -2,6 +2,26 @@
   name: default/gateway-1/http
   virtualHosts:
   - domains:
+    - www.bar.com
+    name: default/gateway-2/http/www_bar_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /bar
+      name: httproute/default/httproute-3/rule/0/match/0/www_bar_com
+      responseHeadersToAdd:
+      - append: true
+        header:
+          key: alt-svc
+          value: h3=":443"; ma=86400
+      route:
+        cluster: httproute/default/httproute-3/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.oauth2/securitypolicy/default/policy-for-gateway-2:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}
+  - domains:
     - www.foo.com
     name: default/gateway-1/http/www_foo_com
     routes:
@@ -36,25 +56,5 @@
         - upgradeType: websocket
       typedPerFilterConfig:
         envoy.filters.http.ext_authz/securitypolicy/default/policy-for-http-route-2:
-          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-          config: {}
-  - domains:
-    - www.bar.com
-    name: default/gateway-2/http/www_bar_com
-    routes:
-    - match:
-        pathSeparatedPrefix: /bar
-      name: httproute/default/httproute-3/rule/0/match/0/www_bar_com
-      responseHeadersToAdd:
-      - append: true
-        header:
-          key: alt-svc
-          value: h3=":443"; ma=86400
-      route:
-        cluster: httproute/default/httproute-3/rule/0
-        upgradeConfigs:
-        - upgradeType: websocket
-      typedPerFilterConfig:
-        envoy.filters.http.oauth2/securitypolicy/default/policy-for-gateway-2:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}

--- a/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.routes.yaml
@@ -2,6 +2,30 @@
   name: first-listener
   virtualHosts:
   - domains:
+    - bar
+    name: first-listener/bar
+  - domains:
+    - foo
+    name: first-listener/foo
+    routes:
+    - match:
+        prefix: /
+      name: second-route-defaults
+      route:
+        cluster: first-route-dest
+        retryPolicy:
+          hostSelectionRetryMaxAttempts: "5"
+          numRetries: 2
+          retriableStatusCodes:
+          - 503
+          retryHostPredicate:
+          - name: envoy.retry_host_predicates.previous_hosts
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
+          retryOn: connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes
+        upgradeConfigs:
+        - upgradeType: websocket
+  - domains:
     - '*'
     name: first-listener/*
     routes:
@@ -27,27 +51,3 @@
           retryOn: reset,connect-failure,retriable-status-codes
         upgradeConfigs:
         - upgradeType: websocket
-  - domains:
-    - foo
-    name: first-listener/foo
-    routes:
-    - match:
-        prefix: /
-      name: second-route-defaults
-      route:
-        cluster: first-route-dest
-        retryPolicy:
-          hostSelectionRetryMaxAttempts: "5"
-          numRetries: 2
-          retriableStatusCodes:
-          - 503
-          retryHostPredicate:
-          - name: envoy.retry_host_predicates.previous_hosts
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
-          retryOn: connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes
-        upgradeConfigs:
-        - upgradeType: websocket
-  - domains:
-    - bar
-    name: first-listener/bar

--- a/internal/xds/translator/testdata/out/xds-ir/retry.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry.routes.yaml
@@ -2,29 +2,6 @@
   name: first-listener
   virtualHosts:
   - domains:
-    - '*'
-    name: first-listener/*
-    routes:
-    - match:
-        prefix: /
-      name: first-route
-      route:
-        cluster: first-route-dest
-        retryPolicy:
-          hostSelectionRetryMaxAttempts: "5"
-          numRetries: 3
-          retriableStatusCodes:
-          - 500
-          retryBackOff:
-            baseInterval: 0.200s
-          retryHostPredicate:
-          - name: envoy.retry_host_predicates.previous_hosts
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
-          retryOn: connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes
-        upgradeConfigs:
-        - upgradeType: websocket
-  - domains:
     - foo
     name: first-listener/foo
     routes:
@@ -63,5 +40,28 @@
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.retry.priority.previous_priorities.v3.PreviousPrioritiesConfig
               updateFrequency: 3
+        upgradeConfigs:
+        - upgradeType: websocket
+  - domains:
+    - '*'
+    name: first-listener/*
+    routes:
+    - match:
+        prefix: /
+      name: first-route
+      route:
+        cluster: first-route-dest
+        retryPolicy:
+          hostSelectionRetryMaxAttempts: "5"
+          numRetries: 3
+          retriableStatusCodes:
+          - 500
+          retryBackOff:
+            baseInterval: 0.200s
+          retryHostPredicate:
+          - name: envoy.retry_host_predicates.previous_hosts
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
+          retryOn: connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes
         upgradeConfigs:
         - upgradeType: websocket

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -457,8 +457,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 		}
 	}
 
-	// Sort the virtual hosts in the route configurations to ensure that
-	// the most specific virtual host is matched first and the order is deterministic.
+	// Sort the virtual hosts in the route configurations to ensure the order is deterministic.
 	xdsRouteCfgs := tCtx.XdsResources[resourcev3.RouteType]
 	for _, xdsRouteCfg := range xdsRouteCfgs {
 		sortVirtualHosts(xdsRouteCfg.(*routev3.RouteConfiguration).VirtualHosts)
@@ -645,9 +644,7 @@ func (t *Translator) addRouteToRouteConfig(
 	return errs
 }
 
-// SortVirtualHosts sorts the virtual hosts by domain, so:
-// * the most specific virtual host is matched first.
-// * the order of the virtual hosts is deterministic.
+// SortVirtualHosts sorts the virtual hosts by domain so the order is deterministic.
 func sortVirtualHosts(vHosts []*routev3.VirtualHost) {
 	slices.SortFunc(vHosts, func(a, b *routev3.VirtualHost) int {
 		if a == nil && b == nil {


### PR DESCRIPTION
This PR sorts the virtual hosts in the route configurations to ensure that the most specific virtual host is matched first and the order is deterministic.

Fixes: https://github.com/envoyproxy/gateway/pull/6544#discussion_r2232611171