### PR TITLE
fix(xds-server): clear snapshot on stream close

### DIFF
--- a/internal/xds/cache/snapshotcache.go
+++ b/internal/xds/cache/snapshotcache.go
@@ -173,6 +173,10 @@ func (s *snapshotCache) OnStreamClosed(streamID int64, node *corev3.Node) {
 
 	delete(s.streamIDNodeInfo, streamID)
 	delete(s.streamDuration, streamID)
+
+	// Only snapshots for nodes with active connections are updated, we need to clear
+	// the snapshot for this node so it doesn't get stale data when it reconnects.
+	s.ClearSnapshot(node.Id)
 }
 
 func (s *snapshotCache) OnStreamRequest(streamID int64, req *discoveryv3.DiscoveryRequest) error {
@@ -280,6 +284,10 @@ func (s *snapshotCache) OnDeltaStreamClosed(streamID int64, node *corev3.Node) {
 
 	delete(s.streamIDNodeInfo, streamID)
 	delete(s.deltaStreamDuration, streamID)
+
+	// Only snapshots for nodes with active connections are updated, we need to clear
+	// the snapshot for this node so it doesn't get stale data when it reconnects.
+	s.ClearSnapshot(node.Id)
 }
 
 func (s *snapshotCache) OnStreamDeltaRequest(streamID int64, req *discoveryv3.DeltaDiscoveryRequest) error {

--- a/internal/xds/cache/snapshotcache.go
+++ b/internal/xds/cache/snapshotcache.go
@@ -55,11 +55,14 @@ type snapshotMap map[string]*cachev3.Snapshot
 
 type nodeInfoMap map[int64]*corev3.Node
 
+type nodeFrequencyMap map[string]int
+
 type streamDurationMap map[int64]time.Time
 
 type snapshotCache struct {
 	cachev3.SnapshotCache
 	streamIDNodeInfo    nodeInfoMap
+	nodeFrequency       nodeFrequencyMap
 	streamDuration      streamDurationMap
 	deltaStreamDuration streamDurationMap
 	snapshotVersion     int64
@@ -127,6 +130,7 @@ func NewSnapshotCache(ads bool, logger logging.Logger) SnapshotCacheWithCallback
 		log:                 wrappedLogger,
 		lastSnapshot:        make(snapshotMap),
 		streamIDNodeInfo:    make(nodeInfoMap),
+		nodeFrequency:       make(nodeFrequencyMap),
 		streamDuration:      make(streamDurationMap),
 		deltaStreamDuration: make(streamDurationMap),
 	}
@@ -174,9 +178,14 @@ func (s *snapshotCache) OnStreamClosed(streamID int64, node *corev3.Node) {
 	delete(s.streamIDNodeInfo, streamID)
 	delete(s.streamDuration, streamID)
 
-	// Only snapshots for nodes with active connections are updated, we need to clear
-	// the snapshot for this node so it doesn't get stale data when it reconnects.
-	s.ClearSnapshot(node.Id)
+	s.nodeFrequency[node.Id] -= 1
+	if s.nodeFrequency[node.Id] <= 0 {
+		delete(s.nodeFrequency, node.Id)
+
+		// Only snapshots for nodes with active connections are updated, we need to clear
+		// the snapshot for this node so it doesn't get stale data when it reconnects.
+		s.ClearSnapshot(node.Id)
+	}
 }
 
 func (s *snapshotCache) OnStreamRequest(streamID int64, req *discoveryv3.DiscoveryRequest) error {
@@ -194,6 +203,7 @@ func (s *snapshotCache) OnStreamRequest(streamID int64, req *discoveryv3.Discove
 		}
 		s.log.Debugf("First discovery request on stream %d, got nodeID %s", streamID, req.Node.Id)
 		s.streamIDNodeInfo[streamID] = req.Node
+		s.nodeFrequency[req.Node.Id] += 1
 	}
 	nodeID := s.streamIDNodeInfo[streamID].Id
 	cluster := s.streamIDNodeInfo[streamID].Cluster
@@ -285,9 +295,14 @@ func (s *snapshotCache) OnDeltaStreamClosed(streamID int64, node *corev3.Node) {
 	delete(s.streamIDNodeInfo, streamID)
 	delete(s.deltaStreamDuration, streamID)
 
-	// Only snapshots for nodes with active connections are updated, we need to clear
-	// the snapshot for this node so it doesn't get stale data when it reconnects.
-	s.ClearSnapshot(node.Id)
+	s.nodeFrequency[node.Id] -= 1
+	if s.nodeFrequency[node.Id] <= 0 {
+		delete(s.nodeFrequency, node.Id)
+
+		// Only snapshots for nodes with active connections are updated, we need to clear
+		// the snapshot for this node so it doesn't get stale data when it reconnects.
+		s.ClearSnapshot(node.Id)
+	}
 }
 
 func (s *snapshotCache) OnStreamDeltaRequest(streamID int64, req *discoveryv3.DeltaDiscoveryRequest) error {
@@ -310,6 +325,7 @@ func (s *snapshotCache) OnStreamDeltaRequest(streamID int64, req *discoveryv3.De
 		}
 		s.log.Debugf("First incremental discovery request on stream %d, got nodeID %s", streamID, req.Node.Id)
 		s.streamIDNodeInfo[streamID] = req.Node
+		s.nodeFrequency[req.Node.Id] += 1
 	}
 	nodeID := s.streamIDNodeInfo[streamID].Id
 	cluster := s.streamIDNodeInfo[streamID].Cluster


### PR DESCRIPTION
In the snapshotcache, only snapshots for nodes with active connections are updated.
https://github.com/envoyproxy/gateway/blob/ceec66655765bea49635f951fa075796ca47796d/internal/xds/cache/snapshotcache.go#L92-L95

As far as I can tell, these snapshots are never deleted. When a node disconnects and then reconnects it will receive the configuration from the time it disconnected. It will only get the latest configuration when there is an update while it is still connected.

This is a big problem when you are running multiple replicas of envoy-gateway, if a proxy flips between which instance it is connected to it can receive data that is several days out of date. We have seen proxy instances suddenly start using certificates that are expired and have already been rotated, and use pod IPs that do not exist anymore.

If we clear the snapshot for a node when it disconnects, it will get the latest snapshot when it reconnects (this does _not_ happen if a node already has a cached snapshot).
https://github.com/envoyproxy/gateway/blob/ceec66655765bea49635f951fa075796ca47796d/internal/xds/cache/snapshotcache.go#L208-L210