### PR TITLE
fix: set order for grpc_web and grpc_stats filters

### DIFF
--- a/api/v1alpha1/envoyproxy_types.go
+++ b/api/v1alpha1/envoyproxy_types.go
@@ -229,6 +229,12 @@ const (
 	// EnvoyFilterHealthCheck defines the Envoy HTTP health check filter.
 	EnvoyFilterHealthCheck EnvoyFilter = "envoy.filters.http.health_check"
 
+	// EnvoyFilterGRPCWeb defines the Envoy HTTP gRPC-web filter.
+	EnvoyFilterGRPCWeb EnvoyFilter = "envoy.filters.http.grpc_web"
+
+	// EnvoyFilterGRPCStats defines the Envoy HTTP gRPC stats filter.
+	EnvoyFilterGRPCStats EnvoyFilter = "envoy.filters.http.grpc_stats"
+
 	// EnvoyFilterFault defines the Envoy HTTP fault filter.
 	EnvoyFilterFault EnvoyFilter = "envoy.filters.http.fault"
 

--- a/api/v1alpha1/envoyproxy_types.go
+++ b/api/v1alpha1/envoyproxy_types.go
@@ -229,12 +229,6 @@ const (
 	// EnvoyFilterHealthCheck defines the Envoy HTTP health check filter.
 	EnvoyFilterHealthCheck EnvoyFilter = "envoy.filters.http.health_check"
 
-	// EnvoyFilterGRPCWeb defines the Envoy HTTP gRPC-web filter.
-	EnvoyFilterGRPCWeb EnvoyFilter = "envoy.filters.http.grpc_web"
-
-	// EnvoyFilterGRPCStats defines the Envoy HTTP gRPC stats filter.
-	EnvoyFilterGRPCStats EnvoyFilter = "envoy.filters.http.grpc_stats"
-
 	// EnvoyFilterFault defines the Envoy HTTP fault filter.
 	EnvoyFilterFault EnvoyFilter = "envoy.filters.http.fault"
 
@@ -277,6 +271,12 @@ const (
 
 	// EnvoyFilterRateLimit defines the Envoy HTTP rate limit filter.
 	EnvoyFilterRateLimit EnvoyFilter = "envoy.filters.http.ratelimit"
+
+	// EnvoyFilterGRPCWeb defines the Envoy HTTP gRPC-web filter.
+	EnvoyFilterGRPCWeb EnvoyFilter = "envoy.filters.http.grpc_web"
+
+	// EnvoyFilterGRPCStats defines the Envoy HTTP gRPC stats filter.
+	EnvoyFilterGRPCStats EnvoyFilter = "envoy.filters.http.grpc_stats"
 
 	// EnvoyFilterCustomResponse defines the Envoy HTTP custom response filter.
 	EnvoyFilterCustomResponse EnvoyFilter = "envoy.filters.http.custom_response"

--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -1214,14 +1214,14 @@ xds:
                     initialStreamWindowSize: 65536
                     maxConcurrentStreams: 100
                   httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
                   - name: envoy.filters.http.grpc_stats
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
                       emitFilterState: true
                       statsForAllMethods: true
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
                   - name: envoy.filters.http.router
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -1090,17 +1090,17 @@
                           },
                           "httpFilters": [
                             {
+                              "name": "envoy.filters.http.grpc_web",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb"
+                              }
+                            },
+                            {
                               "name": "envoy.filters.http.grpc_stats",
                               "typedConfig": {
                                 "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
                                 "emitFilterState": true,
                                 "statsForAllMethods": true
-                              }
-                            },
-                            {
-                              "name": "envoy.filters.http.grpc_web",
-                              "typedConfig": {
-                                "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb"
                               }
                             },
                             {

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -667,14 +667,14 @@ xds:
                     initialStreamWindowSize: 65536
                     maxConcurrentStreams: 100
                   httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
                   - name: envoy.filters.http.grpc_stats
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
                       emitFilterState: true
                       statsForAllMethods: true
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
                   - name: envoy.filters.http.router
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
@@ -230,14 +230,14 @@ xds:
                   initialStreamWindowSize: 65536
                   maxConcurrentStreams: 100
                 httpFilters:
+                - name: envoy.filters.http.grpc_web
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
                 - name: envoy.filters.http.grpc_stats
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
                     emitFilterState: true
                     statsForAllMethods: true
-                - name: envoy.filters.http.grpc_web
-                  typedConfig:
-                    '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
                 - name: envoy.filters.http.router
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/httpfilters.go
+++ b/internal/xds/translator/httpfilters.go
@@ -100,30 +100,26 @@ func newOrderedHTTPFilter(filter *hcmv3.HttpFilter) *OrderedHTTPFilter {
 	switch {
 	case isFilterType(filter, egv1a1.EnvoyFilterHealthCheck):
 		order = 0
-	case isFilterType(filter, egv1a1.EnvoyFilterGRPCWeb):
-		order = 1
-	case isFilterType(filter, egv1a1.EnvoyFilterGRPCStats):
-		order = 2
 	case isFilterType(filter, egv1a1.EnvoyFilterFault):
-		order = 3
+		order = 1
 	case isFilterType(filter, egv1a1.EnvoyFilterCORS):
-		order = 4
+		order = 2
 	case isFilterType(filter, egv1a1.EnvoyFilterExtAuthz):
-		order = 5
+		order = 3
 	case isFilterType(filter, egv1a1.EnvoyFilterAPIKeyAuth):
-		order = 6
+		order = 4
 	case isFilterType(filter, egv1a1.EnvoyFilterBasicAuth):
-		order = 7
+		order = 5
 	case isFilterType(filter, egv1a1.EnvoyFilterOAuth2):
-		order = 8
+		order = 6
 	case isFilterType(filter, egv1a1.EnvoyFilterJWTAuthn):
-		order = 9
+		order = 7
 	case isFilterType(filter, egv1a1.EnvoyFilterSessionPersistence):
-		order = 10
+		order = 8
 	case isFilterType(filter, egv1a1.EnvoyFilterBuffer):
-		order = 11
+		order = 9
 	case isFilterType(filter, egv1a1.EnvoyFilterLua):
-		order = 12 + mustGetFilterIndex(filter.Name)
+		order = 10 + mustGetFilterIndex(filter.Name)
 	case isFilterType(filter, egv1a1.EnvoyFilterExtProc):
 		order = 100 + mustGetFilterIndex(filter.Name)
 	case isFilterType(filter, egv1a1.EnvoyFilterWasm):
@@ -134,14 +130,18 @@ func newOrderedHTTPFilter(filter *hcmv3.HttpFilter) *OrderedHTTPFilter {
 		order = 302
 	case isFilterType(filter, egv1a1.EnvoyFilterRateLimit):
 		order = 303
-	case isFilterType(filter, egv1a1.EnvoyFilterCustomResponse):
+	case isFilterType(filter, egv1a1.EnvoyFilterGRPCWeb):
 		order = 304
-	case isFilterType(filter, egv1a1.EnvoyFilterCredentialInjector):
+	case isFilterType(filter, egv1a1.EnvoyFilterGRPCStats):
 		order = 305
-	case isFilterType(filter, egv1a1.EnvoyFilterCompressor):
+	case isFilterType(filter, egv1a1.EnvoyFilterCustomResponse):
 		order = 306
-	case isFilterType(filter, egv1a1.EnvoyFilterRouter):
+	case isFilterType(filter, egv1a1.EnvoyFilterCredentialInjector):
 		order = 307
+	case isFilterType(filter, egv1a1.EnvoyFilterCompressor):
+		order = 308
+	case isFilterType(filter, egv1a1.EnvoyFilterRouter):
+		order = 309
 	}
 
 	return &OrderedHTTPFilter{

--- a/internal/xds/translator/httpfilters.go
+++ b/internal/xds/translator/httpfilters.go
@@ -100,26 +100,30 @@ func newOrderedHTTPFilter(filter *hcmv3.HttpFilter) *OrderedHTTPFilter {
 	switch {
 	case isFilterType(filter, egv1a1.EnvoyFilterHealthCheck):
 		order = 0
-	case isFilterType(filter, egv1a1.EnvoyFilterFault):
+	case isFilterType(filter, egv1a1.EnvoyFilterGRPCWeb):
 		order = 1
-	case isFilterType(filter, egv1a1.EnvoyFilterCORS):
+	case isFilterType(filter, egv1a1.EnvoyFilterGRPCStats):
 		order = 2
-	case isFilterType(filter, egv1a1.EnvoyFilterExtAuthz):
+	case isFilterType(filter, egv1a1.EnvoyFilterFault):
 		order = 3
-	case isFilterType(filter, egv1a1.EnvoyFilterAPIKeyAuth):
+	case isFilterType(filter, egv1a1.EnvoyFilterCORS):
 		order = 4
-	case isFilterType(filter, egv1a1.EnvoyFilterBasicAuth):
+	case isFilterType(filter, egv1a1.EnvoyFilterExtAuthz):
 		order = 5
-	case isFilterType(filter, egv1a1.EnvoyFilterOAuth2):
+	case isFilterType(filter, egv1a1.EnvoyFilterAPIKeyAuth):
 		order = 6
-	case isFilterType(filter, egv1a1.EnvoyFilterJWTAuthn):
+	case isFilterType(filter, egv1a1.EnvoyFilterBasicAuth):
 		order = 7
-	case isFilterType(filter, egv1a1.EnvoyFilterSessionPersistence):
+	case isFilterType(filter, egv1a1.EnvoyFilterOAuth2):
 		order = 8
-	case isFilterType(filter, egv1a1.EnvoyFilterBuffer):
+	case isFilterType(filter, egv1a1.EnvoyFilterJWTAuthn):
 		order = 9
+	case isFilterType(filter, egv1a1.EnvoyFilterSessionPersistence):
+		order = 10
+	case isFilterType(filter, egv1a1.EnvoyFilterBuffer):
+		order = 11
 	case isFilterType(filter, egv1a1.EnvoyFilterLua):
-		order = 10 + mustGetFilterIndex(filter.Name)
+		order = 12 + mustGetFilterIndex(filter.Name)
 	case isFilterType(filter, egv1a1.EnvoyFilterExtProc):
 		order = 100 + mustGetFilterIndex(filter.Name)
 	case isFilterType(filter, egv1a1.EnvoyFilterWasm):

--- a/internal/xds/translator/testdata/out/xds-ir/dns-lookup-family.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/dns-lookup-family.listeners.yaml
@@ -126,14 +126,6 @@
           initialStreamWindowSize: 65536
           maxConcurrentStreams: 100
         httpFilters:
-        - name: envoy.filters.http.grpc_web
-          typedConfig:
-            '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-        - name: envoy.filters.http.grpc_stats
-          typedConfig:
-            '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-            emitFilterState: true
-            statsForAllMethods: true
         - disabled: true
           name: envoy.filters.http.ext_authz/securitypolicy/envoy-gateway/policy-for-gateway-1
           typedConfig:
@@ -160,6 +152,14 @@
               requestTrailerMode: SKIP
               responseHeaderMode: SKIP
               responseTrailerMode: SKIP
+        - name: envoy.filters.http.grpc_web
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+        - name: envoy.filters.http.grpc_stats
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+            emitFilterState: true
+            statsForAllMethods: true
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/dns-lookup-family.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/dns-lookup-family.listeners.yaml
@@ -126,6 +126,14 @@
           initialStreamWindowSize: 65536
           maxConcurrentStreams: 100
         httpFilters:
+        - name: envoy.filters.http.grpc_web
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+        - name: envoy.filters.http.grpc_stats
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+            emitFilterState: true
+            statsForAllMethods: true
         - disabled: true
           name: envoy.filters.http.ext_authz/securitypolicy/envoy-gateway/policy-for-gateway-1
           typedConfig:
@@ -138,14 +146,6 @@
             transportApiVersion: V3
             withRequestBody:
               maxRequestBytes: 8192
-        - name: envoy.filters.http.grpc_stats
-          typedConfig:
-            '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-            emitFilterState: true
-            statsForAllMethods: true
-        - name: envoy.filters.http.grpc_web
-          typedConfig:
-            '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
         - disabled: true
           name: envoy.filters.http.ext_proc/envoyextensionpolicy/default/policy-for-httproute/extproc/0
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.listeners.yaml
@@ -14,14 +14,14 @@
           initialStreamWindowSize: 65536
           maxConcurrentStreams: 100
         httpFilters:
+        - name: envoy.filters.http.grpc_web
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
         - name: envoy.filters.http.grpc_stats
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
             emitFilterState: true
             statsForAllMethods: true
-        - name: envoy.filters.http.grpc_web
-          typedConfig:
-            '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -1210,6 +1210,8 @@ _Appears in:_
 | Value | Description |
 | ----- | ----------- |
 | `envoy.filters.http.health_check` | EnvoyFilterHealthCheck defines the Envoy HTTP health check filter.<br /> | 
+| `envoy.filters.http.grpc_web` | EnvoyFilterGRPCWeb defines the Envoy HTTP gRPC-web filter.<br /> | 
+| `envoy.filters.http.grpc_stats` | EnvoyFilterGRPCStats defines the Envoy HTTP gRPC stats filter.<br /> | 
 | `envoy.filters.http.fault` | EnvoyFilterFault defines the Envoy HTTP fault filter.<br /> | 
 | `envoy.filters.http.cors` | EnvoyFilterCORS defines the Envoy HTTP CORS filter.<br /> | 
 | `envoy.filters.http.ext_authz` | EnvoyFilterExtAuthz defines the Envoy HTTP external authorization filter.<br /> | 

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -1210,8 +1210,6 @@ _Appears in:_
 | Value | Description |
 | ----- | ----------- |
 | `envoy.filters.http.health_check` | EnvoyFilterHealthCheck defines the Envoy HTTP health check filter.<br /> | 
-| `envoy.filters.http.grpc_web` | EnvoyFilterGRPCWeb defines the Envoy HTTP gRPC-web filter.<br /> | 
-| `envoy.filters.http.grpc_stats` | EnvoyFilterGRPCStats defines the Envoy HTTP gRPC stats filter.<br /> | 
 | `envoy.filters.http.fault` | EnvoyFilterFault defines the Envoy HTTP fault filter.<br /> | 
 | `envoy.filters.http.cors` | EnvoyFilterCORS defines the Envoy HTTP CORS filter.<br /> | 
 | `envoy.filters.http.ext_authz` | EnvoyFilterExtAuthz defines the Envoy HTTP external authorization filter.<br /> | 
@@ -1226,6 +1224,8 @@ _Appears in:_
 | `envoy.filters.http.rbac` | EnvoyFilterRBAC defines the Envoy RBAC filter.<br /> | 
 | `envoy.filters.http.local_ratelimit` | EnvoyFilterLocalRateLimit defines the Envoy HTTP local rate limit filter.<br /> | 
 | `envoy.filters.http.ratelimit` | EnvoyFilterRateLimit defines the Envoy HTTP rate limit filter.<br /> | 
+| `envoy.filters.http.grpc_web` | EnvoyFilterGRPCWeb defines the Envoy HTTP gRPC-web filter.<br /> | 
+| `envoy.filters.http.grpc_stats` | EnvoyFilterGRPCStats defines the Envoy HTTP gRPC stats filter.<br /> | 
 | `envoy.filters.http.custom_response` | EnvoyFilterCustomResponse defines the Envoy HTTP custom response filter.<br /> | 
 | `envoy.filters.http.credential_injector` | EnvoyFilterCredentialInjector defines the Envoy HTTP credential injector filter.<br /> | 
 | `envoy.filters.http.compressor` | EnvoyFilterCompressor defines the Envoy HTTP compressor filter.<br /> | 


### PR DESCRIPTION
The `grpc_web` filter should be put in front of the `grpc_stats` filter,  otherwise `grpc_stats` won’t see the traffic as valid gRPC and may not work correctly.

Fixes: #6620