### PR TITLE
fix: xds name schema v2

### DIFF
--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -490,13 +490,6 @@ func (t *Translator) addHCMToXDSListener(
 	return nil
 }
 
-func routeConfigName(irListener *ir.HTTPListener, nameSchemeV2 bool) string {
-	if irListener.TLS != nil {
-		return httpsListenerRouteConfigName(irListener)
-	}
-	return httpListenerRouteConfigName(irListener, nameSchemeV2)
-}
-
 func hcmStatPrefix(irListener *ir.HTTPListener, nameSchemeV2 bool) string {
 	statPrefix := "http"
 	if irListener.TLS != nil {
@@ -507,6 +500,13 @@ func hcmStatPrefix(irListener *ir.HTTPListener, nameSchemeV2 bool) string {
 		return fmt.Sprintf("%s-%d", statPrefix, irListener.ExternalPort)
 	}
 	return fmt.Sprintf("%s-%d", statPrefix, irListener.Port)
+}
+
+func routeConfigName(irListener *ir.HTTPListener, nameSchemeV2 bool) string {
+	if irListener.TLS != nil {
+		return httpsListenerRouteConfigName(irListener)
+	}
+	return httpListenerRouteConfigName(irListener, nameSchemeV2)
 }
 
 // port value is used for the route config name for HTTP listeners. as multiple HTTP listeners on the same port are

--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -341,7 +341,7 @@ func (t *Translator) addHCMToXDSListener(
 	if originalIPDetectionExtensions != nil {
 		useRemoteAddress = false
 	}
-    statPrefix := hcmStatPrefix(irListener, t.xdsNameSchemeV2())
+	statPrefix := hcmStatPrefix(irListener, t.xdsNameSchemeV2())
 	mgr := &hcmv3.HttpConnectionManager{
 		AccessLog:  al,
 		CodecType:  hcmv3.HttpConnectionManager_AUTO,

--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -502,28 +502,12 @@ func hcmStatPrefix(irListener *ir.HTTPListener, nameSchemeV2 bool) string {
 	return fmt.Sprintf("%s-%d", statPrefix, irListener.Port)
 }
 
+// use the same name for the route config as the filter chain name, as they're 1:1 mapping.
 func routeConfigName(irListener *ir.HTTPListener, nameSchemeV2 bool) string {
 	if irListener.TLS != nil {
-		return httpsListenerRouteConfigName(irListener)
+		return httpsListenerFilterChainName(irListener)
 	}
-	return httpListenerRouteConfigName(irListener, nameSchemeV2)
-}
-
-// port value is used for the route config name for HTTP listeners. as multiple HTTP listeners on the same port are
-// using the same route config.
-func httpListenerRouteConfigName(irListener *ir.HTTPListener, nameSchemeV2 bool) string {
-	if nameSchemeV2 {
-		return fmt.Sprint(irListener.ExternalPort)
-	}
-	// For backward compatibility, we use the listener name as the route config name.
-	return irListener.Name
-}
-
-// irListener name is used as the route config name for HTTPS listener, as HTTPS Listener is 1:1 mapping to the filter chain,
-// and the HCM in each filter chain uses a unique route config.
-// The Gateway API layer ensures that each listener has a unique combination of hostname and port.
-func httpsListenerRouteConfigName(irListener *ir.HTTPListener) string {
-	return irListener.Name
+	return httpListenerDefaultFilterChainName(irListener, nameSchemeV2)
 }
 
 // port value is used for the default filter chain name for HTTP listeners, as multiple HTTP listeners are merged into

--- a/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.listeners.yaml
@@ -25,7 +25,7 @@
           configSource:
             ads: {}
             resourceApiVersion: V3
-          routeConfigName: "80"
+          routeConfigName: http-80
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http-80
         useRemoteAddress: true

--- a/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.listeners.yaml
@@ -25,7 +25,7 @@
           configSource:
             ads: {}
             resourceApiVersion: V3
-          routeConfigName: envoy-gateway/gateway-1/http1
+          routeConfigName: "80"
         serverHeaderTransformation: PASS_THROUGH
         statPrefix: http-10080
         useRemoteAddress: true

--- a/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.listeners.yaml
@@ -27,7 +27,7 @@
             resourceApiVersion: V3
           routeConfigName: "80"
         serverHeaderTransformation: PASS_THROUGH
-        statPrefix: http-10080
+        statPrefix: http-80
         useRemoteAddress: true
     name: http-80
   maxConnectionsToAcceptPerSocketEvent: 1
@@ -65,7 +65,7 @@
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-1/https1
         serverHeaderTransformation: PASS_THROUGH
-        statPrefix: https-10443
+        statPrefix: https-443
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/https1
     transportSocket:
@@ -110,7 +110,7 @@
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-1/https2
         serverHeaderTransformation: PASS_THROUGH
-        statPrefix: https-10443
+        statPrefix: https-443
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/https2
     transportSocket:
@@ -168,7 +168,7 @@
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-2/https-http3
         serverHeaderTransformation: PASS_THROUGH
-        statPrefix: https-11443
+        statPrefix: https-1443
         useRemoteAddress: true
     name: envoy-gateway/gateway-2/https-http3
     transportSocket:
@@ -222,7 +222,7 @@
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-2/https-http3
         serverHeaderTransformation: PASS_THROUGH
-        statPrefix: https-11443
+        statPrefix: https-1443
         useRemoteAddress: true
     name: envoy-gateway/gateway-2/https-http3
     transportSocket:

--- a/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.routes.yaml
@@ -1,5 +1,5 @@
 - ignorePortInHostMatching: true
-  name: "80"
+  name: http-80
   virtualHosts:
   - domains:
     - foo.net

--- a/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.routes.yaml
@@ -3,7 +3,7 @@
   virtualHosts:
   - domains:
     - foo.net
-    name: envoy-gateway/gateway-1/http1/foo_net
+    name: foo_net
     routes:
     - match:
         prefix: /
@@ -14,7 +14,7 @@
         - upgradeType: websocket
   - domains:
     - bar.net
-    name: envoy-gateway/gateway-1/http2/bar_net
+    name: bar_net
     routes:
     - match:
         prefix: /
@@ -28,7 +28,7 @@
   virtualHosts:
   - domains:
     - foo.com
-    name: envoy-gateway/gateway-1/https1/foo_com
+    name: foo_com
     routes:
     - match:
         prefix: /
@@ -42,7 +42,7 @@
   virtualHosts:
   - domains:
     - bar.com
-    name: envoy-gateway/gateway-1/https2/bar_com
+    name: bar_com
     routes:
     - match:
         prefix: /
@@ -56,7 +56,7 @@
   virtualHosts:
   - domains:
     - '*'
-    name: envoy-gateway/gateway-2/https-http3/*
+    name: '*'
     routes:
     - match:
         prefix: /

--- a/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.routes.yaml
@@ -1,5 +1,5 @@
 - ignorePortInHostMatching: true
-  name: envoy-gateway/gateway-1/http1
+  name: "80"
   virtualHosts:
   - domains:
     - foo.net

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -504,7 +504,7 @@ func (t *Translator) addRouteToRouteConfig(
 			underscoredHostname := strings.ReplaceAll(httpRoute.Hostname, ".", "_")
 			// Allocate virtual host for this httpRoute.
 			vHost = &routev3.VirtualHost{
-				Name:     virtualHostName(httpListener, underscoredHostname),
+				Name:     virtualHostName(httpListener, underscoredHostname, t.xdsNameSchemeV2()),
 				Domains:  []string{httpRoute.Hostname},
 				Metadata: buildXdsMetadata(httpListener.Metadata),
 			}
@@ -656,7 +656,10 @@ func (t *Translator) addRouteToRouteConfig(
 	return errs
 }
 
-func virtualHostName(httpListener *ir.HTTPListener, underscoredHostname string) string {
+func virtualHostName(httpListener *ir.HTTPListener, underscoredHostname string, xdsNameSchemeV2 bool) string {
+	if xdsNameSchemeV2 {
+		return underscoredHostname
+	}
 	return fmt.Sprintf("%s/%s", httpListener.Name, underscoredHostname)
 }
 

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -446,7 +446,7 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 		routeCfgName = findXdsHTTPRouteConfigName(tcpXDSListener)
 		// If the route config name is not found, we use the current ir Listener name as the route config name to create a new route config.
 		if routeCfgName == "" {
-			routeCfgName = routeConfigName(httpListener)
+			routeCfgName = routeConfigName(httpListener, t.xdsNameSchemeV2())
 		}
 
 		// Create a route config if we have not found one yet

--- a/test/e2e/tests/connection_limit.go
+++ b/test/e2e/tests/connection_limit.go
@@ -85,7 +85,7 @@ var ConnectionLimitTest = suite.ConformanceTest{
 			}
 
 			prefix := "http-10080"
-			if XDSNameSchemeV2(){
+			if XDSNameSchemeV2() {
 				prefix = "http-80"
 			}
 			gtwName := "connection-limit-gateway"

--- a/test/e2e/tests/connection_limit.go
+++ b/test/e2e/tests/connection_limit.go
@@ -85,6 +85,9 @@ var ConnectionLimitTest = suite.ConformanceTest{
 			}
 
 			prefix := "http-10080"
+			if XDSNameSchemeV2(){
+				prefix = "http-80"
+			}
 			gtwName := "connection-limit-gateway"
 			promQL := fmt.Sprintf(`envoy_connection_limit_limited_connections{envoy_connection_limit_prefix="%s",gateway_envoyproxy_io_owning_gateway_name="%s"}`, prefix, gtwName)
 


### PR DESCRIPTION
Follow-up of https://github.com/envoyproxy/gateway/pull/6544
* RouteConfig:
   * HTTP Listener:  before `envoy-gateway/gateway-1/http` after `http-80`
   * HTTPS Listener: keep the current name `envoy-gateway/gateway-1/https`
* VirtualHost: before `envoy-gateway/gateway-1/https1/www_example_com` after `www_example_com`
* HCM StatPrefix: before `http-10080` after `http-80`   