### PR TITLE
feat: allow config default envoyproxy image from chart values

### DIFF
--- a/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
@@ -57,6 +57,10 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ .Values.kubernetesClusterDomain }}
+        {{- if .Values.deployment.envoyProxy.image }}
+        - name: CUSTOM_DEFAULT_PROXY_IMAGE
+          value: {{ .Values.deployment.envoyProxy.image }}
+        {{- end }}
         image: {{ include "eg.image" . }}
         imagePullPolicy: {{ include "eg.image.pullPolicy" . }}
         livenessProbe:

--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -7,6 +7,7 @@ package proxy
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/containers/image/v5/docker/reference"
@@ -486,6 +487,8 @@ func expectedShutdownManagerSecurityContext(containerSpec *egv1a1.KubernetesCont
 	return sc
 }
 
+var CustomDefaultProxyImage = os.Getenv("CUSTOM_DEFAULT_PROXY_IMAGE")
+
 func resolveProxyImage(containerSpec *egv1a1.KubernetesContainerSpec) (string, error) {
 	if containerSpec == nil {
 		return "", fmt.Errorf("containerSpec is nil")
@@ -503,6 +506,10 @@ func resolveProxyImage(containerSpec *egv1a1.KubernetesContainerSpec) (string, e
 	image := ptr.Deref(containerSpec.Image, "")
 	if image != "" {
 		return image, nil
+	}
+
+	if CustomDefaultProxyImage != "" {
+		return CustomDefaultProxyImage, nil
 	}
 
 	return egv1a1.DefaultEnvoyProxyImage, nil


### PR DESCRIPTION
## What this PR does / why we need it

As an infrastructure developer, we want to provide flexibility for users to configure their EnvoyProxy deployments (e.g., resource limits, node selectors) while abstracting away the implementation details like the container image source.

This change allows administrators to set a default EnvoyProxy image at the Gateway level, eliminating the need for users to specify the image in individual EnvoyProxy CRs. This approach:

- Simplifies the user experience by hiding infrastructure-level details
- Maintains consistent EnvoyProxy image usage across deployments
- Enables centralized image management by infrastructure teams

This PR demonstrates the implementation approach. Test cases will be added once the design direction is confirmed.

## Implementation Notes
- Adds `CUSTOM_DEFAULT_PROXY_IMAGE` environment variable to Gateway deployment
- Introduces image override logic in proxy resource controller
- Updates Helm chart to support custom image configuration