### PR TITLE
fix: ResourceVersionTable deep copy implementation

### DIFF
--- a/internal/xds/types/resourceversiontable.go
+++ b/internal/xds/types/resourceversiontable.go
@@ -53,6 +53,15 @@ func (t *ResourceVersionTable) DeepCopyInto(out *ResourceVersionTable) {
 			(*out)[key] = outVal
 		}
 	}
+	if t.EnvoyPatchPolicyStatuses != nil {
+		in, out := &t.EnvoyPatchPolicyStatuses, &out.EnvoyPatchPolicyStatuses
+		*out = make([]*ir.EnvoyPatchPolicyStatus, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				(*out)[i] = (*in)[i].DeepCopy()
+			}
+		}
+	}
 }
 
 // DeepCopy generates a deep copy of the ResourceVersionTable object.

--- a/release-notes/v1.5.0-rc.1.yaml
+++ b/release-notes/v1.5.0-rc.1.yaml
@@ -67,6 +67,7 @@ bug fixes: |
   Fixed issue that failed to update policy status when there are more than 16 ancestors.
   Fixed race condition in watchable.Map Snapshot subscription.
   Fixed issue where HTTPRoutes with sessionPersistence caused the Envoy listeners to drain.
+  Fixed shared references in ResourceVersionTable deep copy implementation.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->
fix: ResourceVersionTable deep copy implementation
<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

Fixes the ResourceVersionTable deep copy implementation to prevent shared data between copies. This can lead to race conditions when watchable map copies values for thread safe comparison in the `Store()` method. Check [code pointer](https://github.com/telepresenceio/watchable/blob/main/map.go#L162).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #6251 

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes
