### PR TITLE
watchable: use Store directly instead of HandleStore wrapper

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -194,11 +194,11 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 						r.Logger.Error(err, "unable to validate infra ir, skipped sending it")
 						errChan <- err
 					} else {
-						message.HandleStore(message.Metadata{
+						r.InfraIR.Store(key, val)
+						message.PublishMetric(message.Metadata{
 							Runner:  r.Name(),
 							Message: message.InfraIRMessageName,
-						},
-							key, val, &r.InfraIR.Map)
+						})
 						newIRKeys = append(newIRKeys, key)
 					}
 				}
@@ -209,67 +209,67 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 						r.Logger.Error(err, "unable to validate xds ir, skipped sending it")
 						errChan <- err
 					} else {
-						message.HandleStore(message.Metadata{
+						r.XdsIR.Store(key, val)
+						message.PublishMetric(message.Metadata{
 							Runner:  r.Name(),
 							Message: message.XDSIRMessageName,
-						},
-							key, val, &r.XdsIR.Map)
+						})
 					}
 				}
 
 				// Update Status
 				for _, gateway := range result.Gateways {
 					key := utils.NamespacedName(gateway)
-					message.HandleStore(message.Metadata{
+					r.ProviderResources.GatewayStatuses.Store(key, &gateway.Status)
+					message.PublishMetric(message.Metadata{
 						Runner:  r.Name(),
 						Message: message.GatewayStatusMessageName,
-					},
-						key, &gateway.Status, &r.ProviderResources.GatewayStatuses)
+					})
 					delete(statusesToDelete.GatewayStatusKeys, key)
 				}
 				for _, httpRoute := range result.HTTPRoutes {
 					key := utils.NamespacedName(httpRoute)
-					message.HandleStore(message.Metadata{
+					r.ProviderResources.HTTPRouteStatuses.Store(key, &httpRoute.Status)
+					message.PublishMetric(message.Metadata{
 						Runner:  r.Name(),
 						Message: message.HTTPRouteStatusMessageName,
-					},
-						key, &httpRoute.Status, &r.ProviderResources.HTTPRouteStatuses)
+					})
 					delete(statusesToDelete.HTTPRouteStatusKeys, key)
 				}
 				for _, grpcRoute := range result.GRPCRoutes {
 					key := utils.NamespacedName(grpcRoute)
-					message.HandleStore(message.Metadata{
+					r.ProviderResources.GRPCRouteStatuses.Store(key, &grpcRoute.Status)
+					message.PublishMetric(message.Metadata{
 						Runner:  r.Name(),
 						Message: message.GRPCRouteStatusMessageName,
-					},
-						key, &grpcRoute.Status, &r.ProviderResources.GRPCRouteStatuses)
+					})
 					delete(statusesToDelete.GRPCRouteStatusKeys, key)
 				}
 				for _, tlsRoute := range result.TLSRoutes {
 					key := utils.NamespacedName(tlsRoute)
-					message.HandleStore(message.Metadata{
+					r.ProviderResources.TLSRouteStatuses.Store(key, &tlsRoute.Status)
+					message.PublishMetric(message.Metadata{
 						Runner:  r.Name(),
 						Message: message.TLSRouteStatusMessageName,
-					},
-						key, &tlsRoute.Status, &r.ProviderResources.TLSRouteStatuses)
+					})
 					delete(statusesToDelete.TLSRouteStatusKeys, key)
 				}
 				for _, tcpRoute := range result.TCPRoutes {
 					key := utils.NamespacedName(tcpRoute)
-					message.HandleStore(message.Metadata{
+					r.ProviderResources.TCPRouteStatuses.Store(key, &tcpRoute.Status)
+					message.PublishMetric(message.Metadata{
 						Runner:  r.Name(),
 						Message: message.TCPRouteStatusMessageName,
-					},
-						key, &tcpRoute.Status, &r.ProviderResources.TCPRouteStatuses)
+					})
 					delete(statusesToDelete.TCPRouteStatusKeys, key)
 				}
 				for _, udpRoute := range result.UDPRoutes {
 					key := utils.NamespacedName(udpRoute)
-					message.HandleStore(message.Metadata{
+					r.ProviderResources.UDPRouteStatuses.Store(key, &udpRoute.Status)
+					message.PublishMetric(message.Metadata{
 						Runner:  r.Name(),
 						Message: message.UDPRouteStatusMessageName,
-					},
-						key, &udpRoute.Status, &r.ProviderResources.UDPRouteStatuses)
+					})
 					delete(statusesToDelete.UDPRouteStatusKeys, key)
 				}
 
@@ -280,11 +280,11 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 				for _, backendTLSPolicy := range result.BackendTLSPolicies {
 					key := utils.NamespacedName(backendTLSPolicy)
 					if !(reflect.ValueOf(backendTLSPolicy.Status).IsZero()) {
-						message.HandleStore(message.Metadata{
+						r.ProviderResources.BackendTLSPolicyStatuses.Store(key, &backendTLSPolicy.Status)
+						message.PublishMetric(message.Metadata{
 							Runner:  r.Name(),
 							Message: message.BackendTLSPolicyStatusMessageName,
-						},
-							key, &backendTLSPolicy.Status, &r.ProviderResources.BackendTLSPolicyStatuses)
+						})
 					}
 					delete(statusesToDelete.BackendTLSPolicyStatusKeys, key)
 				}
@@ -292,55 +292,55 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 				for _, clientTrafficPolicy := range result.ClientTrafficPolicies {
 					key := utils.NamespacedName(clientTrafficPolicy)
 					if !(reflect.ValueOf(clientTrafficPolicy.Status).IsZero()) {
-						message.HandleStore(message.Metadata{
+						r.ProviderResources.ClientTrafficPolicyStatuses.Store(key, &clientTrafficPolicy.Status)
+						message.PublishMetric(message.Metadata{
 							Runner:  r.Name(),
 							Message: message.ClientTrafficPolicyStatusMessageName,
-						},
-							key, &clientTrafficPolicy.Status, &r.ProviderResources.ClientTrafficPolicyStatuses)
+						})
 					}
 					delete(statusesToDelete.ClientTrafficPolicyStatusKeys, key)
 				}
 				for _, backendTrafficPolicy := range result.BackendTrafficPolicies {
 					key := utils.NamespacedName(backendTrafficPolicy)
 					if !(reflect.ValueOf(backendTrafficPolicy.Status).IsZero()) {
-						message.HandleStore(message.Metadata{
+						r.ProviderResources.BackendTrafficPolicyStatuses.Store(key, &backendTrafficPolicy.Status)
+						message.PublishMetric(message.Metadata{
 							Runner:  r.Name(),
 							Message: message.BackendTrafficPolicyStatusMessageName,
-						},
-							key, &backendTrafficPolicy.Status, &r.ProviderResources.BackendTrafficPolicyStatuses)
+						})
 					}
 					delete(statusesToDelete.BackendTrafficPolicyStatusKeys, key)
 				}
 				for _, securityPolicy := range result.SecurityPolicies {
 					key := utils.NamespacedName(securityPolicy)
 					if !(reflect.ValueOf(securityPolicy.Status).IsZero()) {
-						message.HandleStore(message.Metadata{
+						r.ProviderResources.SecurityPolicyStatuses.Store(key, &securityPolicy.Status)
+						message.PublishMetric(message.Metadata{
 							Runner:  r.Name(),
 							Message: message.SecurityPolicyStatusMessageName,
-						},
-							key, &securityPolicy.Status, &r.ProviderResources.SecurityPolicyStatuses)
+						})
 					}
 					delete(statusesToDelete.SecurityPolicyStatusKeys, key)
 				}
 				for _, envoyExtensionPolicy := range result.EnvoyExtensionPolicies {
 					key := utils.NamespacedName(envoyExtensionPolicy)
 					if !(reflect.ValueOf(envoyExtensionPolicy.Status).IsZero()) {
-						message.HandleStore(message.Metadata{
+						r.ProviderResources.EnvoyExtensionPolicyStatuses.Store(key, &envoyExtensionPolicy.Status)
+						message.PublishMetric(message.Metadata{
 							Runner:  r.Name(),
 							Message: message.EnvoyExtensionPolicyStatusMessageName,
-						},
-							key, &envoyExtensionPolicy.Status, &r.ProviderResources.EnvoyExtensionPolicyStatuses)
+						})
 					}
 					delete(statusesToDelete.EnvoyExtensionPolicyStatusKeys, key)
 				}
 				for _, backend := range result.Backends {
 					key := utils.NamespacedName(backend)
 					if !(reflect.ValueOf(backend.Status).IsZero()) {
-						message.HandleStore(message.Metadata{
+						r.ProviderResources.BackendStatuses.Store(key, &backend.Status)
+						message.PublishMetric(message.Metadata{
 							Runner:  r.Name(),
 							Message: message.BackendStatusMessageName,
-						},
-							key, &backend.Status, &r.ProviderResources.BackendStatuses)
+						})
 					}
 					delete(statusesToDelete.BackendStatusKeys, key)
 				}
@@ -351,11 +351,11 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 					}
 					if !(reflect.ValueOf(extServerPolicy.Object["status"]).IsZero()) {
 						policyStatus := unstructuredToPolicyStatus(extServerPolicy.Object["status"].(map[string]any))
-						message.HandleStore(message.Metadata{
+						r.ProviderResources.ExtensionPolicyStatuses.Store(key, &policyStatus)
+						message.PublishMetric(message.Metadata{
 							Runner:  r.Name(),
 							Message: message.ExtensionServerPoliciesStatusMessageName,
-						},
-							key, &policyStatus, &r.ProviderResources.ExtensionPolicyStatuses)
+						})
 					}
 					delete(statusesToDelete.ExtensionServerPolicyStatusKeys, key)
 				}

--- a/internal/message/watchutil.go
+++ b/internal/message/watchutil.go
@@ -28,6 +28,10 @@ type Metadata struct {
 	Message MessageName
 }
 
+func PublishMetric(meta Metadata) {
+	watchablePublishTotal.WithSuccess(meta.LabelValues()...).Increment()
+}
+
 func (m Metadata) LabelValues() []metrics.LabelValue {
 	labels := make([]metrics.LabelValue, 0, 2)
 	if m.Runner != "" {
@@ -99,9 +103,4 @@ func HandleSubscription[K comparable, V any](
 			handleWithCrashRecovery(handle, Update[K, V](update), meta, errChans)
 		}
 	}
-}
-
-func HandleStore[K comparable, V any](meta Metadata, key K, value V, publish *watchable.Map[K, V]) {
-	publish.Store(key, value)
-	watchablePublishTotal.WithSuccess(meta.LabelValues()...).Increment()
 }

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -300,11 +300,11 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 					false,
 					string(gwapiv1.GatewayClassReasonInvalidParameters),
 					msg)
-				message.HandleStore(message.Metadata{
+				r.resources.GatewayClassStatuses.Store(utils.NamespacedName(gc), &gc.Status)
+				message.PublishMetric(message.Metadata{
 					Runner:  string(egv1a1.LogComponentProviderRunner),
 					Message: message.GatewayClassStatusMessageName,
-				},
-					utils.NamespacedName(gc), &gc.Status, &r.resources.GatewayClassStatuses)
+				})
 				failToProcessGCParamsRef = true
 			}
 		}
@@ -322,11 +322,11 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 				false,
 				string(gwapiv1.GatewayClassReasonAccepted),
 				fmt.Sprintf("%s: %v", status.MsgGatewayClassInvalidParams, err))
-			message.HandleStore(message.Metadata{
+			r.resources.GatewayClassStatuses.Store(utils.NamespacedName(gc), &gc.Status)
+			message.PublishMetric(message.Metadata{
 				Runner:  string(egv1a1.LogComponentProviderRunner),
 				Message: message.GatewayClassStatusMessageName,
-			},
-				utils.NamespacedName(gc), &gc.Status, &r.resources.GatewayClassStatuses)
+			})
 			failToProcessGCParamsRef = true
 		}
 
@@ -512,11 +512,11 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 	// The Store is triggered even when there are no Gateways associated to the
 	// GatewayClass. This would happen in case the last Gateway is removed and the
 	// Store will be required to trigger a cleanup of envoy infra resources.
-	message.HandleStore(message.Metadata{
+	r.resources.GatewayAPIResources.Store(string(r.classController), &gwcResources)
+	message.PublishMetric(message.Metadata{
 		Runner:  string(egv1a1.LogComponentProviderRunner),
 		Message: message.ProviderResourcesMessageName,
-	},
-		string(r.classController), &gwcResources, &r.resources.GatewayAPIResources)
+	})
 
 	r.log.Info("reconciled gateways successfully")
 	return reconcile.Result{}, nil

--- a/internal/xds/translator/runner/runner.go
+++ b/internal/xds/translator/runner/runner.go
@@ -131,11 +131,11 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *ir
 
 				// Publish
 				if err == nil {
-					message.HandleStore(message.Metadata{
+					r.Xds.Store(key, result)
+					message.PublishMetric(message.Metadata{
 						Runner:  r.Name(),
 						Message: message.XDSMessageName,
-					},
-						key, result, &r.Xds.Map)
+					})
 				} else {
 					r.Logger.Error(err, "skipped publishing xds resources")
 				}


### PR DESCRIPTION
GC is unable to collect the temporary references created in `HandleStore`

Here is some `pprof` data between `v1.5.0-rc.1` and this PR
* Running with 2000 HTTPRoutes
* Agressive cacheSyncPeriod of `1m`
* T1 data is at 0m and T5 data is at 8m


Comparing T5 across 2 versions, there's a 19.93% decrease
```
$ go tool pprof -top -inuse_space -base v1.5.0-rc-profile/heap_profile_5_20250802_162916.pprof direct-store-profile/heap_profile_5_20250802_155443.pprof | grep Store
  536.37kB  0.26%  5.65%   536.33kB  0.26%  github.com/telepresenceio/watchable.(*Map[go.shape.struct { Namespace string; Name string },go.shape.*uint8]).unlockedStore
  512.19kB  0.25%  6.43%   512.19kB  0.25%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).literalStore
         0     0%  3.90% -40453.66kB 19.93%  github.com/envoyproxy/gateway/internal/message.HandleStore[go.shape.string,go.shape.*uint8]
         0     0%  3.90% -1024.14kB   0.5%  github.com/envoyproxy/gateway/internal/message.HandleStore[go.shape.struct { Namespace string; Name string },go.shape.*uint8]
         0     0%  3.90%  7685.33kB  3.79%  github.com/telepresenceio/watchable.(*Map[go.shape.string,go.shape.*uint8]).Store
         0     0%  3.90%  7685.33kB  3.79%  github.com/telepresenceio/watchable.(*Map[go.shape.string,go.shape.*uint8]).unlockedStore
         0     0%  3.90%   536.33kB  0.26%  github.com/telepresenceio/watchable.(*Map[go.shape.struct { Namespace string; Name string },go.shape.*uint8]).Store
         0     0%  3.90%   512.02kB  0.25%  internal/sync.(*HashTrieMap[go.shape.interface {},go.shape.interface {}]).LoadOrStore
         0     0%  3.90%   512.02kB  0.25%  sync.(*Map).LoadOrStore (inline)

```

Comparing T1 across 2 versions, there's a 18% decrease

```
$ go tool pprof -top -inuse_space -base v1.5.0-rc-profile/heap_profile_1_20250802_162116.pprof direct-store-profile/heap_profile_1_20250802_154643.pprof | grep Store
   549247B  0.25% 15.37%   1598151B  0.73%  github.com/telepresenceio/watchable.(*Map[go.shape.struct { Namespace string; Name string },go.shape.*uint8]).unlockedStore
   524668B  0.24% 16.61%   1048968B  0.48%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).literalStore
         0     0% 17.33% -41424572B 18.91%  github.com/envoyproxy/gateway/internal/message.HandleStore[go.shape.string,go.shape.*uint8]
         0     0% 17.33%  -1572968B  0.72%  github.com/envoyproxy/gateway/internal/message.HandleStore[go.shape.struct { Namespace string; Name string },go.shape.*uint8]
         0     0% 17.33%   9442726B  4.31%  github.com/telepresenceio/watchable.(*Map[go.shape.string,go.shape.*uint8]).Store
         0     0% 17.33%   9442726B  4.31%  github.com/telepresenceio/watchable.(*Map[go.shape.string,go.shape.*uint8]).unlockedStore
         0     0% 17.33%   1598151B  0.73%  github.com/telepresenceio/watchable.(*Map[go.shape.struct { Namespace string; Name string },go.shape.*uint8]).Store
         0     0% 17.33%    524312B  0.24%  internal/sync.(*HashTrieMap[go.shape.interface {},go.shape.interface {}]).LoadOrStore
         0     0% 17.33%    524312B  0.24%  sync.(*Map).LoadOrStore (inline)
```

In v1.5.0-rc.1, between T1 and T5 there's a 1% decrease
```

go tool pprof -top -inuse_space -base v1.5.0-rc-profile/heap_profile_1_20250802_162116.pprof v1.5.0-rc-profile/heap_profile_5_20250802_162916.pprof | grep Store
 1024.03kB  2.21% 11.63%  1024.03kB  2.21%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).literalStore
         0     0% 18.51%  -511.96kB  1.10%  github.com/envoyproxy/gateway/internal/message.HandleStore[go.shape.struct { Namespace string; Name string },go.shape.*uint8]
         0     0% 18.51%  -511.96kB  1.10%  github.com/telepresenceio/watchable.(*Map[go.shape.struct { Namespace string; Name string },go.shape.*uint8]).Store
         0     0% 18.51%  -511.96kB  1.10%  github.com/telepresenceio/watchable.(*Map[go.shape.struct { Namespace string; Name string },go.shape.*uint8]).unlockedStore
```

In current commit, between T1 and T5 there's a 2.92% decrease
```
$ go tool pprof -top -inuse_space -base direct-store-profile/heap_profile_1_20250802_154643.pprof direct-store-profile/heap_profile_5_20250802_155443.pprof | grep Store
       1MB  1.95% 36.86%     0.50MB  0.97%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).literalStore
         0     0% 37.16%    -1.50MB  2.92%  github.com/telepresenceio/watchable.(*Map[go.shape.string,go.shape.*uint8]).Store
         0     0% 37.16%    -1.50MB  2.92%  github.com/telepresenceio/watchable.(*Map[go.shape.string,go.shape.*uint8]).unlockedStore
         0     0% 37.16%    -1.50MB  2.92%  github.com/telepresenceio/watchable.(*Map[go.shape.struct { Namespace string; Name string },go.shape.*uint8]).Store
         0     0% 37.16%    -1.50MB  2.92%  github.com/telepresenceio/watchable.(*Map[go.shape.struct { Namespace string; Name string },go.shape.*uint8]).unlockedStore
```

Relates to https://github.com/envoyproxy/gateway/pull/6406