### PR TITLE
docs: unhide zoneaware api for docs

### DIFF
--- a/api/v1alpha1/loadbalancer_types.go
+++ b/api/v1alpha1/loadbalancer_types.go
@@ -47,7 +47,6 @@ type LoadBalancer struct {
 	// ZoneAware defines the configuration related to the distribution of requests between locality zones.
 	//
 	// +optional
-	// +notImplementedHide
 	ZoneAware *ZoneAware `json:"zoneAware,omitempty"`
 }
 
@@ -156,7 +155,6 @@ type ZoneAware struct {
 	// PreferLocalZone configures zone-aware routing to prefer sending traffic to the local locality zone.
 	//
 	// +optional
-	// +notImplementedHide
 	PreferLocal *PreferLocalZone `json:"preferLocal,omitempty"`
 }
 
@@ -166,13 +164,11 @@ type PreferLocalZone struct {
 	// which maintains equal distribution among upstream endpoints while sending as much traffic as possible locally.
 	//
 	// +optional
-	// +notImplementedHide
 	Force *ForceLocalZone `json:"force,omitempty"`
 
 	// MinEndpointsThreshold is the minimum number of total upstream endpoints across all zones required to enable zone-aware routing.
 	//
 	// +optional
-	// +notImplementedHide
 	MinEndpointsThreshold *uint64 `json:"minEndpointsThreshold,omitempty"`
 }
 

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -3146,6 +3146,7 @@ _Appears in:_
 | `consistentHash` | _[ConsistentHash](#consistenthash)_ |  false  |  | ConsistentHash defines the configuration when the load balancer type is<br />set to ConsistentHash |
 | `endpointOverride` | _[EndpointOverride](#endpointoverride)_ |  false  |  | EndpointOverride defines the configuration for endpoint override.<br />When specified, the load balancer will attempt to route requests to endpoints<br />based on the override information extracted from request headers or metadata.<br /> If the override endpoints are not available, the configured load balancer policy will be used as fallback. |
 | `slowStart` | _[SlowStart](#slowstart)_ |  false  |  | SlowStart defines the configuration related to the slow start load balancer policy.<br />If set, during slow start window, traffic sent to the newly added hosts will gradually increase.<br />Currently this is only supported for RoundRobin and LeastRequest load balancers |
+| `zoneAware` | _[ZoneAware](#zoneaware)_ |  false  |  | ZoneAware defines the configuration related to the distribution of requests between locality zones. |
 
 
 #### LoadBalancerType
@@ -3602,6 +3603,8 @@ _Appears in:_
 
 | Field | Type | Required | Default | Description |
 | ---   | ---  | ---      | ---     | ---         |
+| `force` | _[ForceLocalZone](#forcelocalzone)_ |  false  |  | ForceLocalZone defines override configuration for forcing all traffic to stay within the local zone instead of the default behavior<br />which maintains equal distribution among upstream endpoints while sending as much traffic as possible locally. |
+| `minEndpointsThreshold` | _integer_ |  false  |  | MinEndpointsThreshold is the minimum number of total upstream endpoints across all zones required to enable zone-aware routing. |
 
 
 #### Principal
@@ -5345,5 +5348,6 @@ _Appears in:_
 
 | Field | Type | Required | Default | Description |
 | ---   | ---  | ---      | ---     | ---         |
+| `preferLocal` | _[PreferLocalZone](#preferlocalzone)_ |  false  |  | PreferLocalZone configures zone-aware routing to prefer sending traffic to the local locality zone. |
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes `notImplementedHide` for generated site docs

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
