### PR TITLE
move ordering gateway-api resources to provider

### DIFF
--- a/internal/cmd/egctl/translate_test.go
+++ b/internal/cmd/egctl/translate_test.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/envoyproxy/gateway/internal/gatewayapi/resource"
 	"github.com/envoyproxy/gateway/internal/utils/field"
 	"github.com/envoyproxy/gateway/internal/utils/file"
 	"github.com/envoyproxy/gateway/internal/utils/test"
@@ -377,7 +376,6 @@ func TestTranslate(t *testing.T) {
 
 			opts := []cmp.Option{
 				cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
-				cmpopts.IgnoreFields(resource.Resources{}, "serviceMap"),
 			}
 
 			require.Empty(t, cmp.Diff(want, got, opts...))

--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -42,19 +42,7 @@ func (t *Translator) ProcessBackendTrafficPolicies(resources *resource.Resources
 	res := make([]*egv1a1.BackendTrafficPolicy, 0, len(resources.BackendTrafficPolicies))
 
 	backendTrafficPolicies := resources.BackendTrafficPolicies
-
-	// Initially, backendTrafficPolicies sort by creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple policies share same timestamp.
-	sort.Slice(backendTrafficPolicies, func(i, j int) bool {
-		if backendTrafficPolicies[i].CreationTimestamp.Equal(&(backendTrafficPolicies[j].CreationTimestamp)) {
-			policyKeyI := fmt.Sprintf("%s/%s", backendTrafficPolicies[i].Namespace, backendTrafficPolicies[i].Name)
-			policyKeyJ := fmt.Sprintf("%s/%s", backendTrafficPolicies[j].Namespace, backendTrafficPolicies[j].Name)
-			return policyKeyI < policyKeyJ
-		}
-		// Not identical CreationTimestamps
-
-		return backendTrafficPolicies[i].CreationTimestamp.Before(&(backendTrafficPolicies[j].CreationTimestamp))
-	})
+	// BackendTrafficPolicies are already sorted by the provider layer
 
 	// First build a map out of the routes and gateways for faster lookup since users might have thousands of routes or more.
 	routeMap := map[policyTargetRouteKey]*policyRouteTargetContext{}

--- a/internal/gatewayapi/clienttrafficpolicy.go
+++ b/internal/gatewayapi/clienttrafficpolicy.go
@@ -45,19 +45,7 @@ func (t *Translator) ProcessClientTrafficPolicies(
 	var res []*egv1a1.ClientTrafficPolicy
 
 	clientTrafficPolicies := resources.ClientTrafficPolicies
-
-	// Initially, clientTrafficPolicies sort by creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple policies share same timestamp.
-	sort.Slice(clientTrafficPolicies, func(i, j int) bool {
-		if clientTrafficPolicies[i].CreationTimestamp.Equal(&(clientTrafficPolicies[j].CreationTimestamp)) {
-			policyKeyI := fmt.Sprintf("%s/%s", clientTrafficPolicies[i].Namespace, clientTrafficPolicies[i].Name)
-			policyKeyJ := fmt.Sprintf("%s/%s", clientTrafficPolicies[j].Namespace, clientTrafficPolicies[j].Name)
-			return policyKeyI < policyKeyJ
-		}
-		// Not identical CreationTimestamps
-
-		return clientTrafficPolicies[i].CreationTimestamp.Before(&(clientTrafficPolicies[j].CreationTimestamp))
-	})
+	// ClientTrafficPolicies are already sorted by the provider layer
 
 	policyMap := make(map[types.NamespacedName]sets.Set[string])
 

--- a/internal/gatewayapi/envoyextensionpolicy.go
+++ b/internal/gatewayapi/envoyextensionpolicy.go
@@ -42,19 +42,7 @@ func (t *Translator) ProcessEnvoyExtensionPolicies(envoyExtensionPolicies []*egv
 	xdsIR resource.XdsIRMap,
 ) []*egv1a1.EnvoyExtensionPolicy {
 	var res []*egv1a1.EnvoyExtensionPolicy
-
-	// Initially, policies sort by creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple gateways share same timestamp.
-	sort.Slice(envoyExtensionPolicies, func(i, j int) bool {
-		if envoyExtensionPolicies[i].CreationTimestamp.Equal(&(envoyExtensionPolicies[j].CreationTimestamp)) {
-			policyKeyI := fmt.Sprintf("%s/%s", envoyExtensionPolicies[i].Namespace, envoyExtensionPolicies[i].Name)
-			policyKeyJ := fmt.Sprintf("%s/%s", envoyExtensionPolicies[j].Namespace, envoyExtensionPolicies[j].Name)
-			return policyKeyI < policyKeyJ
-		}
-		// Not identical CreationTimestamps
-
-		return envoyExtensionPolicies[i].CreationTimestamp.Before(&(envoyExtensionPolicies[j].CreationTimestamp))
-	})
+	// EnvoyExtensionPolicies are already sorted by the provider layer
 
 	// First build a map out of the routes and gateways for faster lookup since users might have thousands of routes or more.
 	routeMap := map[policyTargetRouteKey]*policyRouteTargetContext{}

--- a/internal/gatewayapi/envoypatchpolicy.go
+++ b/internal/gatewayapi/envoypatchpolicy.go
@@ -7,7 +7,6 @@ package gatewayapi
 
 import (
 	"fmt"
-	"sort"
 
 	"k8s.io/apimachinery/pkg/types"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -20,22 +19,7 @@ import (
 )
 
 func (t *Translator) ProcessEnvoyPatchPolicies(envoyPatchPolicies []*egv1a1.EnvoyPatchPolicy, xdsIR resource.XdsIRMap) {
-	// Initially, envoyPatchPolicies sort by priority
-	// if the priority is equal, they sort based on creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple policies share same timestamp.
-	sort.Slice(envoyPatchPolicies, func(i, j int) bool {
-		if envoyPatchPolicies[i].Spec.Priority == envoyPatchPolicies[j].Spec.Priority {
-			if envoyPatchPolicies[i].CreationTimestamp.Equal(&(envoyPatchPolicies[j].CreationTimestamp)) {
-				policyKeyI := fmt.Sprintf("%s/%s", envoyPatchPolicies[i].Namespace, envoyPatchPolicies[i].Name)
-				policyKeyJ := fmt.Sprintf("%s/%s", envoyPatchPolicies[j].Namespace, envoyPatchPolicies[j].Name)
-				return policyKeyI < policyKeyJ
-			}
-			// Not identical CreationTimestamps
-			return envoyPatchPolicies[i].CreationTimestamp.Before(&(envoyPatchPolicies[j].CreationTimestamp))
-		}
-		// Not identical Priorities
-		return envoyPatchPolicies[i].Spec.Priority < envoyPatchPolicies[j].Spec.Priority
-	})
+	// EnvoyPatchPolicies are already sorted by the provider layer (priority, then timestamp, then name)
 
 	for _, policy := range envoyPatchPolicies {
 		var (

--- a/internal/gatewayapi/extensionserverpolicy.go
+++ b/internal/gatewayapi/extensionserverpolicy.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -28,21 +27,7 @@ func (t *Translator) ProcessExtensionServerPolicies(policies []unstructured.Unst
 	xdsIR resource.XdsIRMap,
 ) ([]unstructured.Unstructured, error) {
 	res := []unstructured.Unstructured{}
-
-	// Initially, policies sort by creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple gateways share same timestamp.
-	sort.Slice(policies, func(i, j int) bool {
-		tsI := policies[i].GetCreationTimestamp()
-		tsJ := policies[j].GetCreationTimestamp()
-		if tsI.Equal(&tsJ) {
-			policyKeyI := fmt.Sprintf("%s/%s", policies[i].GetNamespace(), policies[i].GetName())
-			policyKeyJ := fmt.Sprintf("%s/%s", policies[j].GetNamespace(), policies[j].GetName())
-			return policyKeyI < policyKeyJ
-		}
-		// Not identical CreationTimestamps
-
-		return tsI.Before(&tsJ)
-	})
+	// ExtensionServerPolicies are already sorted by the provider layer
 
 	// First build a map out of the gateways for faster lookup
 	gatewayMap := map[types.NamespacedName]*policyGatewayTargetContext{}

--- a/internal/gatewayapi/resource/load.go
+++ b/internal/gatewayapi/resource/load.go
@@ -42,6 +42,13 @@ func LoadResourcesFromYAMLBytes(yamlBytes []byte, addMissingResources bool) (*Re
 		return nil, err
 	}
 
+	// Sort to:
+	// 1. ensure identical resources are not retranslated
+	//    and updates are avoided by the watchable layer
+	// 2. ensure gateway-api layer receives resources in order
+	//    which impacts translation output
+	r.Sort()
+
 	return r, nil
 }
 

--- a/internal/gatewayapi/resource/load_test.go
+++ b/internal/gatewayapi/resource/load_test.go
@@ -62,7 +62,6 @@ func TestLoadAllSupportedResourcesFromYAMLBytes(t *testing.T) {
 	mustUnmarshal(t, outFile, want)
 
 	opts := []cmp.Option{
-		cmpopts.IgnoreFields(Resources{}, "serviceMap"),
 		cmpopts.EquateEmpty(),
 	}
 	require.Empty(t, cmp.Diff(want, got, opts...))

--- a/internal/gatewayapi/resource/resource.go
+++ b/internal/gatewayapi/resource/resource.go
@@ -240,251 +240,255 @@ func (c ControllerResources) Sort() {
 
 	// Then, run Sort for each item
 	for idx := range c {
-		// Sort gateways based on timestamp.
-		// Initially, gateways sort by creation timestamp
-		// or sort alphabetically by “{namespace}/{name}” if multiple gateways share same timestamp.
-		sort.Slice(c[idx].Gateways, func(i, j int) bool {
-			if c[idx].Gateways[i].CreationTimestamp.Equal(&(c[idx].Gateways[j].CreationTimestamp)) {
-				gatewayKeyI := fmt.Sprintf("%s/%s", c[idx].Gateways[i].Namespace, c[idx].Gateways[i].Name)
-				gatewayKeyJ := fmt.Sprintf("%s/%s", c[idx].Gateways[j].Namespace, c[idx].Gateways[j].Name)
-				return gatewayKeyI < gatewayKeyJ
-			}
-			// Not identical CreationTimestamps
-
-			return c[idx].Gateways[i].CreationTimestamp.Before(&(c[idx].Gateways[j].CreationTimestamp))
-		})
-
-		// Sort HTTPRoutes by creation timestamp, then namespace/name
-		sort.Slice(c[idx].HTTPRoutes, func(i, j int) bool {
-			if c[idx].HTTPRoutes[i].CreationTimestamp.Equal(&(c[idx].HTTPRoutes[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].HTTPRoutes[i].Namespace, c[idx].HTTPRoutes[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].HTTPRoutes[j].Namespace, c[idx].HTTPRoutes[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].HTTPRoutes[i].CreationTimestamp.Before(&(c[idx].HTTPRoutes[j].CreationTimestamp))
-		})
-
-		// Sort GRPCRoutes by creation timestamp, then namespace/name
-		sort.Slice(c[idx].GRPCRoutes, func(i, j int) bool {
-			if c[idx].GRPCRoutes[i].CreationTimestamp.Equal(&(c[idx].GRPCRoutes[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].GRPCRoutes[i].Namespace, c[idx].GRPCRoutes[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].GRPCRoutes[j].Namespace, c[idx].GRPCRoutes[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].GRPCRoutes[i].CreationTimestamp.Before(&(c[idx].GRPCRoutes[j].CreationTimestamp))
-		})
-
-		// Sort TLSRoutes by creation timestamp, then namespace/name
-		sort.Slice(c[idx].TLSRoutes, func(i, j int) bool {
-			if c[idx].TLSRoutes[i].CreationTimestamp.Equal(&(c[idx].TLSRoutes[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].TLSRoutes[i].Namespace, c[idx].TLSRoutes[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].TLSRoutes[j].Namespace, c[idx].TLSRoutes[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].TLSRoutes[i].CreationTimestamp.Before(&(c[idx].TLSRoutes[j].CreationTimestamp))
-		})
-
-		// Sort TCPRoutes by creation timestamp, then namespace/name
-		sort.Slice(c[idx].TCPRoutes, func(i, j int) bool {
-			if c[idx].TCPRoutes[i].CreationTimestamp.Equal(&(c[idx].TCPRoutes[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].TCPRoutes[i].Namespace, c[idx].TCPRoutes[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].TCPRoutes[j].Namespace, c[idx].TCPRoutes[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].TCPRoutes[i].CreationTimestamp.Before(&(c[idx].TCPRoutes[j].CreationTimestamp))
-		})
-
-		// Sort UDPRoutes by creation timestamp, then namespace/name
-		sort.Slice(c[idx].UDPRoutes, func(i, j int) bool {
-			if c[idx].UDPRoutes[i].CreationTimestamp.Equal(&(c[idx].UDPRoutes[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].UDPRoutes[i].Namespace, c[idx].UDPRoutes[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].UDPRoutes[j].Namespace, c[idx].UDPRoutes[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].UDPRoutes[i].CreationTimestamp.Before(&(c[idx].UDPRoutes[j].CreationTimestamp))
-		})
-
-		// Sort ReferenceGrants by creation timestamp, then namespace/name
-		sort.Slice(c[idx].ReferenceGrants, func(i, j int) bool {
-			if c[idx].ReferenceGrants[i].CreationTimestamp.Equal(&(c[idx].ReferenceGrants[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].ReferenceGrants[i].Namespace, c[idx].ReferenceGrants[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].ReferenceGrants[j].Namespace, c[idx].ReferenceGrants[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].ReferenceGrants[i].CreationTimestamp.Before(&(c[idx].ReferenceGrants[j].CreationTimestamp))
-		})
-
-		// Sort Namespaces by creation timestamp, then name
-		sort.Slice(c[idx].Namespaces, func(i, j int) bool {
-			if c[idx].Namespaces[i].CreationTimestamp.Equal(&(c[idx].Namespaces[j].CreationTimestamp)) {
-				return c[idx].Namespaces[i].Name < c[idx].Namespaces[j].Name
-			}
-			return c[idx].Namespaces[i].CreationTimestamp.Before(&(c[idx].Namespaces[j].CreationTimestamp))
-		})
-
-		// Sort Services by creation timestamp, then namespace/name
-		sort.Slice(c[idx].Services, func(i, j int) bool {
-			if c[idx].Services[i].CreationTimestamp.Equal(&(c[idx].Services[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].Services[i].Namespace, c[idx].Services[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].Services[j].Namespace, c[idx].Services[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].Services[i].CreationTimestamp.Before(&(c[idx].Services[j].CreationTimestamp))
-		})
-
-		// Sort ServiceImports by creation timestamp, then namespace/name
-		sort.Slice(c[idx].ServiceImports, func(i, j int) bool {
-			if c[idx].ServiceImports[i].CreationTimestamp.Equal(&(c[idx].ServiceImports[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].ServiceImports[i].Namespace, c[idx].ServiceImports[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].ServiceImports[j].Namespace, c[idx].ServiceImports[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].ServiceImports[i].CreationTimestamp.Before(&(c[idx].ServiceImports[j].CreationTimestamp))
-		})
-
-		// Sort EndpointSlices by creation timestamp, then namespace/name
-		sort.Slice(c[idx].EndpointSlices, func(i, j int) bool {
-			if c[idx].EndpointSlices[i].CreationTimestamp.Equal(&(c[idx].EndpointSlices[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].EndpointSlices[i].Namespace, c[idx].EndpointSlices[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].EndpointSlices[j].Namespace, c[idx].EndpointSlices[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].EndpointSlices[i].CreationTimestamp.Before(&(c[idx].EndpointSlices[j].CreationTimestamp))
-		})
-
-		// Sort Secrets by creation timestamp, then namespace/name
-		sort.Slice(c[idx].Secrets, func(i, j int) bool {
-			if c[idx].Secrets[i].CreationTimestamp.Equal(&(c[idx].Secrets[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].Secrets[i].Namespace, c[idx].Secrets[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].Secrets[j].Namespace, c[idx].Secrets[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].Secrets[i].CreationTimestamp.Before(&(c[idx].Secrets[j].CreationTimestamp))
-		})
-
-		// Sort ConfigMaps by creation timestamp, then namespace/name
-		sort.Slice(c[idx].ConfigMaps, func(i, j int) bool {
-			if c[idx].ConfigMaps[i].CreationTimestamp.Equal(&(c[idx].ConfigMaps[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].ConfigMaps[i].Namespace, c[idx].ConfigMaps[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].ConfigMaps[j].Namespace, c[idx].ConfigMaps[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].ConfigMaps[i].CreationTimestamp.Before(&(c[idx].ConfigMaps[j].CreationTimestamp))
-		})
-
-		// Sort EnvoyPatchPolicies by priority first, then creation timestamp, then namespace/name
-		sort.Slice(c[idx].EnvoyPatchPolicies, func(i, j int) bool {
-			if c[idx].EnvoyPatchPolicies[i].Spec.Priority == c[idx].EnvoyPatchPolicies[j].Spec.Priority {
-				if c[idx].EnvoyPatchPolicies[i].CreationTimestamp.Equal(&(c[idx].EnvoyPatchPolicies[j].CreationTimestamp)) {
-					keyI := fmt.Sprintf("%s/%s", c[idx].EnvoyPatchPolicies[i].Namespace, c[idx].EnvoyPatchPolicies[i].Name)
-					keyJ := fmt.Sprintf("%s/%s", c[idx].EnvoyPatchPolicies[j].Namespace, c[idx].EnvoyPatchPolicies[j].Name)
-					return keyI < keyJ
-				}
-				return c[idx].EnvoyPatchPolicies[i].CreationTimestamp.Before(&(c[idx].EnvoyPatchPolicies[j].CreationTimestamp))
-			}
-			return c[idx].EnvoyPatchPolicies[i].Spec.Priority < c[idx].EnvoyPatchPolicies[j].Spec.Priority
-		})
-
-		// Sort ClientTrafficPolicies by creation timestamp, then namespace/name
-		sort.Slice(c[idx].ClientTrafficPolicies, func(i, j int) bool {
-			if c[idx].ClientTrafficPolicies[i].CreationTimestamp.Equal(&(c[idx].ClientTrafficPolicies[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].ClientTrafficPolicies[i].Namespace, c[idx].ClientTrafficPolicies[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].ClientTrafficPolicies[j].Namespace, c[idx].ClientTrafficPolicies[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].ClientTrafficPolicies[i].CreationTimestamp.Before(&(c[idx].ClientTrafficPolicies[j].CreationTimestamp))
-		})
-
-		// Sort BackendTrafficPolicies by creation timestamp, then namespace/name
-		sort.Slice(c[idx].BackendTrafficPolicies, func(i, j int) bool {
-			if c[idx].BackendTrafficPolicies[i].CreationTimestamp.Equal(&(c[idx].BackendTrafficPolicies[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].BackendTrafficPolicies[i].Namespace, c[idx].BackendTrafficPolicies[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].BackendTrafficPolicies[j].Namespace, c[idx].BackendTrafficPolicies[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].BackendTrafficPolicies[i].CreationTimestamp.Before(&(c[idx].BackendTrafficPolicies[j].CreationTimestamp))
-		})
-
-		// Sort SecurityPolicies by creation timestamp, then namespace/name
-		sort.Slice(c[idx].SecurityPolicies, func(i, j int) bool {
-			if c[idx].SecurityPolicies[i].CreationTimestamp.Equal(&(c[idx].SecurityPolicies[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].SecurityPolicies[i].Namespace, c[idx].SecurityPolicies[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].SecurityPolicies[j].Namespace, c[idx].SecurityPolicies[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].SecurityPolicies[i].CreationTimestamp.Before(&(c[idx].SecurityPolicies[j].CreationTimestamp))
-		})
-
-		// Sort BackendTLSPolicies by creation timestamp, then namespace/name
-		sort.Slice(c[idx].BackendTLSPolicies, func(i, j int) bool {
-			if c[idx].BackendTLSPolicies[i].CreationTimestamp.Equal(&(c[idx].BackendTLSPolicies[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].BackendTLSPolicies[i].Namespace, c[idx].BackendTLSPolicies[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].BackendTLSPolicies[j].Namespace, c[idx].BackendTLSPolicies[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].BackendTLSPolicies[i].CreationTimestamp.Before(&(c[idx].BackendTLSPolicies[j].CreationTimestamp))
-		})
-
-		// Sort EnvoyExtensionPolicies by creation timestamp, then namespace/name
-		sort.Slice(c[idx].EnvoyExtensionPolicies, func(i, j int) bool {
-			if c[idx].EnvoyExtensionPolicies[i].CreationTimestamp.Equal(&(c[idx].EnvoyExtensionPolicies[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].EnvoyExtensionPolicies[i].Namespace, c[idx].EnvoyExtensionPolicies[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].EnvoyExtensionPolicies[j].Namespace, c[idx].EnvoyExtensionPolicies[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].EnvoyExtensionPolicies[i].CreationTimestamp.Before(&(c[idx].EnvoyExtensionPolicies[j].CreationTimestamp))
-		})
-
-		// Sort Backends by creation timestamp, then namespace/name
-		sort.Slice(c[idx].Backends, func(i, j int) bool {
-			if c[idx].Backends[i].CreationTimestamp.Equal(&(c[idx].Backends[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].Backends[i].Namespace, c[idx].Backends[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].Backends[j].Namespace, c[idx].Backends[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].Backends[i].CreationTimestamp.Before(&(c[idx].Backends[j].CreationTimestamp))
-		})
-
-		// Sort HTTPRouteFilters by creation timestamp, then namespace/name
-		sort.Slice(c[idx].HTTPRouteFilters, func(i, j int) bool {
-			if c[idx].HTTPRouteFilters[i].CreationTimestamp.Equal(&(c[idx].HTTPRouteFilters[j].CreationTimestamp)) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].HTTPRouteFilters[i].Namespace, c[idx].HTTPRouteFilters[i].Name)
-				keyJ := fmt.Sprintf("%s/%s", c[idx].HTTPRouteFilters[j].Namespace, c[idx].HTTPRouteFilters[j].Name)
-				return keyI < keyJ
-			}
-			return c[idx].HTTPRouteFilters[i].CreationTimestamp.Before(&(c[idx].HTTPRouteFilters[j].CreationTimestamp))
-		})
-
-		// Sort ClusterTrustBundles by creation timestamp, then name (cluster-scoped)
-		sort.Slice(c[idx].ClusterTrustBundles, func(i, j int) bool {
-			if c[idx].ClusterTrustBundles[i].CreationTimestamp.Equal(&(c[idx].ClusterTrustBundles[j].CreationTimestamp)) {
-				return c[idx].ClusterTrustBundles[i].Name < c[idx].ClusterTrustBundles[j].Name
-			}
-			return c[idx].ClusterTrustBundles[i].CreationTimestamp.Before(&(c[idx].ClusterTrustBundles[j].CreationTimestamp))
-		})
-
-		// Sort ExtensionRefFilters by creation timestamp, then namespace/name (unstructured resources)
-		sort.Slice(c[idx].ExtensionRefFilters, func(i, j int) bool {
-			tsI := c[idx].ExtensionRefFilters[i].GetCreationTimestamp()
-			tsJ := c[idx].ExtensionRefFilters[j].GetCreationTimestamp()
-			if tsI.Equal(&tsJ) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].ExtensionRefFilters[i].GetNamespace(), c[idx].ExtensionRefFilters[i].GetName())
-				keyJ := fmt.Sprintf("%s/%s", c[idx].ExtensionRefFilters[j].GetNamespace(), c[idx].ExtensionRefFilters[j].GetName())
-				return keyI < keyJ
-			}
-			return tsI.Before(&tsJ)
-		})
-
-		// Sort ExtensionServerPolicies by creation timestamp, then namespace/name (unstructured resources)
-		sort.Slice(c[idx].ExtensionServerPolicies, func(i, j int) bool {
-			tsI := c[idx].ExtensionServerPolicies[i].GetCreationTimestamp()
-			tsJ := c[idx].ExtensionServerPolicies[j].GetCreationTimestamp()
-			if tsI.Equal(&tsJ) {
-				keyI := fmt.Sprintf("%s/%s", c[idx].ExtensionServerPolicies[i].GetNamespace(), c[idx].ExtensionServerPolicies[i].GetName())
-				keyJ := fmt.Sprintf("%s/%s", c[idx].ExtensionServerPolicies[j].GetNamespace(), c[idx].ExtensionServerPolicies[j].GetName())
-				return keyI < keyJ
-			}
-			return tsI.Before(&tsJ)
-		})
+		c[idx].Sort()
 	}
+}
+
+func (r *Resources) Sort() {
+	// Sort gateways based on timestamp.
+	// Initially, gateways sort by creation timestamp
+	// or sort alphabetically by “{namespace}/{name}” if multiple gateways share same timestamp.
+	sort.Slice(r.Gateways, func(i, j int) bool {
+		if r.Gateways[i].CreationTimestamp.Equal(&(r.Gateways[j].CreationTimestamp)) {
+			gatewayKeyI := fmt.Sprintf("%s/%s", r.Gateways[i].Namespace, r.Gateways[i].Name)
+			gatewayKeyJ := fmt.Sprintf("%s/%s", r.Gateways[j].Namespace, r.Gateways[j].Name)
+			return gatewayKeyI < gatewayKeyJ
+		}
+		// Not identical CreationTimestamps
+
+		return r.Gateways[i].CreationTimestamp.Before(&(r.Gateways[j].CreationTimestamp))
+	})
+
+	// Sort HTTPRoutes by creation timestamp, then namespace/name
+	sort.Slice(r.HTTPRoutes, func(i, j int) bool {
+		if r.HTTPRoutes[i].CreationTimestamp.Equal(&(r.HTTPRoutes[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.HTTPRoutes[i].Namespace, r.HTTPRoutes[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.HTTPRoutes[j].Namespace, r.HTTPRoutes[j].Name)
+			return keyI < keyJ
+		}
+		return r.HTTPRoutes[i].CreationTimestamp.Before(&(r.HTTPRoutes[j].CreationTimestamp))
+	})
+
+	// Sort GRPCRoutes by creation timestamp, then namespace/name
+	sort.Slice(r.GRPCRoutes, func(i, j int) bool {
+		if r.GRPCRoutes[i].CreationTimestamp.Equal(&(r.GRPCRoutes[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.GRPCRoutes[i].Namespace, r.GRPCRoutes[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.GRPCRoutes[j].Namespace, r.GRPCRoutes[j].Name)
+			return keyI < keyJ
+		}
+		return r.GRPCRoutes[i].CreationTimestamp.Before(&(r.GRPCRoutes[j].CreationTimestamp))
+	})
+
+	// Sort TLSRoutes by creation timestamp, then namespace/name
+	sort.Slice(r.TLSRoutes, func(i, j int) bool {
+		if r.TLSRoutes[i].CreationTimestamp.Equal(&(r.TLSRoutes[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.TLSRoutes[i].Namespace, r.TLSRoutes[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.TLSRoutes[j].Namespace, r.TLSRoutes[j].Name)
+			return keyI < keyJ
+		}
+		return r.TLSRoutes[i].CreationTimestamp.Before(&(r.TLSRoutes[j].CreationTimestamp))
+	})
+
+	// Sort TCPRoutes by creation timestamp, then namespace/name
+	sort.Slice(r.TCPRoutes, func(i, j int) bool {
+		if r.TCPRoutes[i].CreationTimestamp.Equal(&(r.TCPRoutes[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.TCPRoutes[i].Namespace, r.TCPRoutes[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.TCPRoutes[j].Namespace, r.TCPRoutes[j].Name)
+			return keyI < keyJ
+		}
+		return r.TCPRoutes[i].CreationTimestamp.Before(&(r.TCPRoutes[j].CreationTimestamp))
+	})
+
+	// Sort UDPRoutes by creation timestamp, then namespace/name
+	sort.Slice(r.UDPRoutes, func(i, j int) bool {
+		if r.UDPRoutes[i].CreationTimestamp.Equal(&(r.UDPRoutes[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.UDPRoutes[i].Namespace, r.UDPRoutes[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.UDPRoutes[j].Namespace, r.UDPRoutes[j].Name)
+			return keyI < keyJ
+		}
+		return r.UDPRoutes[i].CreationTimestamp.Before(&(r.UDPRoutes[j].CreationTimestamp))
+	})
+
+	// Sort ReferenceGrants by creation timestamp, then namespace/name
+	sort.Slice(r.ReferenceGrants, func(i, j int) bool {
+		if r.ReferenceGrants[i].CreationTimestamp.Equal(&(r.ReferenceGrants[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.ReferenceGrants[i].Namespace, r.ReferenceGrants[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.ReferenceGrants[j].Namespace, r.ReferenceGrants[j].Name)
+			return keyI < keyJ
+		}
+		return r.ReferenceGrants[i].CreationTimestamp.Before(&(r.ReferenceGrants[j].CreationTimestamp))
+	})
+
+	// Sort Namespaces by creation timestamp, then name
+	sort.Slice(r.Namespaces, func(i, j int) bool {
+		if r.Namespaces[i].CreationTimestamp.Equal(&(r.Namespaces[j].CreationTimestamp)) {
+			return r.Namespaces[i].Name < r.Namespaces[j].Name
+		}
+		return r.Namespaces[i].CreationTimestamp.Before(&(r.Namespaces[j].CreationTimestamp))
+	})
+
+	// Sort Services by creation timestamp, then namespace/name
+	sort.Slice(r.Services, func(i, j int) bool {
+		if r.Services[i].CreationTimestamp.Equal(&(r.Services[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.Services[i].Namespace, r.Services[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.Services[j].Namespace, r.Services[j].Name)
+			return keyI < keyJ
+		}
+		return r.Services[i].CreationTimestamp.Before(&(r.Services[j].CreationTimestamp))
+	})
+
+	// Sort ServiceImports by creation timestamp, then namespace/name
+	sort.Slice(r.ServiceImports, func(i, j int) bool {
+		if r.ServiceImports[i].CreationTimestamp.Equal(&(r.ServiceImports[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.ServiceImports[i].Namespace, r.ServiceImports[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.ServiceImports[j].Namespace, r.ServiceImports[j].Name)
+			return keyI < keyJ
+		}
+		return r.ServiceImports[i].CreationTimestamp.Before(&(r.ServiceImports[j].CreationTimestamp))
+	})
+
+	// Sort EndpointSlices by creation timestamp, then namespace/name
+	sort.Slice(r.EndpointSlices, func(i, j int) bool {
+		if r.EndpointSlices[i].CreationTimestamp.Equal(&(r.EndpointSlices[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.EndpointSlices[i].Namespace, r.EndpointSlices[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.EndpointSlices[j].Namespace, r.EndpointSlices[j].Name)
+			return keyI < keyJ
+		}
+		return r.EndpointSlices[i].CreationTimestamp.Before(&(r.EndpointSlices[j].CreationTimestamp))
+	})
+
+	// Sort Secrets by creation timestamp, then namespace/name
+	sort.Slice(r.Secrets, func(i, j int) bool {
+		if r.Secrets[i].CreationTimestamp.Equal(&(r.Secrets[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.Secrets[i].Namespace, r.Secrets[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.Secrets[j].Namespace, r.Secrets[j].Name)
+			return keyI < keyJ
+		}
+		return r.Secrets[i].CreationTimestamp.Before(&(r.Secrets[j].CreationTimestamp))
+	})
+
+	// Sort ConfigMaps by creation timestamp, then namespace/name
+	sort.Slice(r.ConfigMaps, func(i, j int) bool {
+		if r.ConfigMaps[i].CreationTimestamp.Equal(&(r.ConfigMaps[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.ConfigMaps[i].Namespace, r.ConfigMaps[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.ConfigMaps[j].Namespace, r.ConfigMaps[j].Name)
+			return keyI < keyJ
+		}
+		return r.ConfigMaps[i].CreationTimestamp.Before(&(r.ConfigMaps[j].CreationTimestamp))
+	})
+
+	// Sort EnvoyPatchPolicies by priority first, then creation timestamp, then namespace/name
+	sort.Slice(r.EnvoyPatchPolicies, func(i, j int) bool {
+		if r.EnvoyPatchPolicies[i].Spec.Priority == r.EnvoyPatchPolicies[j].Spec.Priority {
+			if r.EnvoyPatchPolicies[i].CreationTimestamp.Equal(&(r.EnvoyPatchPolicies[j].CreationTimestamp)) {
+				keyI := fmt.Sprintf("%s/%s", r.EnvoyPatchPolicies[i].Namespace, r.EnvoyPatchPolicies[i].Name)
+				keyJ := fmt.Sprintf("%s/%s", r.EnvoyPatchPolicies[j].Namespace, r.EnvoyPatchPolicies[j].Name)
+				return keyI < keyJ
+			}
+			return r.EnvoyPatchPolicies[i].CreationTimestamp.Before(&(r.EnvoyPatchPolicies[j].CreationTimestamp))
+		}
+		return r.EnvoyPatchPolicies[i].Spec.Priority < r.EnvoyPatchPolicies[j].Spec.Priority
+	})
+
+	// Sort ClientTrafficPolicies by creation timestamp, then namespace/name
+	sort.Slice(r.ClientTrafficPolicies, func(i, j int) bool {
+		if r.ClientTrafficPolicies[i].CreationTimestamp.Equal(&(r.ClientTrafficPolicies[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.ClientTrafficPolicies[i].Namespace, r.ClientTrafficPolicies[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.ClientTrafficPolicies[j].Namespace, r.ClientTrafficPolicies[j].Name)
+			return keyI < keyJ
+		}
+		return r.ClientTrafficPolicies[i].CreationTimestamp.Before(&(r.ClientTrafficPolicies[j].CreationTimestamp))
+	})
+
+	// Sort BackendTrafficPolicies by creation timestamp, then namespace/name
+	sort.Slice(r.BackendTrafficPolicies, func(i, j int) bool {
+		if r.BackendTrafficPolicies[i].CreationTimestamp.Equal(&(r.BackendTrafficPolicies[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.BackendTrafficPolicies[i].Namespace, r.BackendTrafficPolicies[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.BackendTrafficPolicies[j].Namespace, r.BackendTrafficPolicies[j].Name)
+			return keyI < keyJ
+		}
+		return r.BackendTrafficPolicies[i].CreationTimestamp.Before(&(r.BackendTrafficPolicies[j].CreationTimestamp))
+	})
+
+	// Sort SecurityPolicies by creation timestamp, then namespace/name
+	sort.Slice(r.SecurityPolicies, func(i, j int) bool {
+		if r.SecurityPolicies[i].CreationTimestamp.Equal(&(r.SecurityPolicies[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.SecurityPolicies[i].Namespace, r.SecurityPolicies[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.SecurityPolicies[j].Namespace, r.SecurityPolicies[j].Name)
+			return keyI < keyJ
+		}
+		return r.SecurityPolicies[i].CreationTimestamp.Before(&(r.SecurityPolicies[j].CreationTimestamp))
+	})
+
+	// Sort BackendTLSPolicies by creation timestamp, then namespace/name
+	sort.Slice(r.BackendTLSPolicies, func(i, j int) bool {
+		if r.BackendTLSPolicies[i].CreationTimestamp.Equal(&(r.BackendTLSPolicies[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.BackendTLSPolicies[i].Namespace, r.BackendTLSPolicies[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.BackendTLSPolicies[j].Namespace, r.BackendTLSPolicies[j].Name)
+			return keyI < keyJ
+		}
+		return r.BackendTLSPolicies[i].CreationTimestamp.Before(&(r.BackendTLSPolicies[j].CreationTimestamp))
+	})
+
+	// Sort EnvoyExtensionPolicies by creation timestamp, then namespace/name
+	sort.Slice(r.EnvoyExtensionPolicies, func(i, j int) bool {
+		if r.EnvoyExtensionPolicies[i].CreationTimestamp.Equal(&(r.EnvoyExtensionPolicies[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.EnvoyExtensionPolicies[i].Namespace, r.EnvoyExtensionPolicies[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.EnvoyExtensionPolicies[j].Namespace, r.EnvoyExtensionPolicies[j].Name)
+			return keyI < keyJ
+		}
+		return r.EnvoyExtensionPolicies[i].CreationTimestamp.Before(&(r.EnvoyExtensionPolicies[j].CreationTimestamp))
+	})
+
+	// Sort Backends by creation timestamp, then namespace/name
+	sort.Slice(r.Backends, func(i, j int) bool {
+		if r.Backends[i].CreationTimestamp.Equal(&(r.Backends[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.Backends[i].Namespace, r.Backends[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.Backends[j].Namespace, r.Backends[j].Name)
+			return keyI < keyJ
+		}
+		return r.Backends[i].CreationTimestamp.Before(&(r.Backends[j].CreationTimestamp))
+	})
+
+	// Sort HTTPRouteFilters by creation timestamp, then namespace/name
+	sort.Slice(r.HTTPRouteFilters, func(i, j int) bool {
+		if r.HTTPRouteFilters[i].CreationTimestamp.Equal(&(r.HTTPRouteFilters[j].CreationTimestamp)) {
+			keyI := fmt.Sprintf("%s/%s", r.HTTPRouteFilters[i].Namespace, r.HTTPRouteFilters[i].Name)
+			keyJ := fmt.Sprintf("%s/%s", r.HTTPRouteFilters[j].Namespace, r.HTTPRouteFilters[j].Name)
+			return keyI < keyJ
+		}
+		return r.HTTPRouteFilters[i].CreationTimestamp.Before(&(r.HTTPRouteFilters[j].CreationTimestamp))
+	})
+
+	// Sort ClusterTrustBundles by creation timestamp, then name (cluster-scoped)
+	sort.Slice(r.ClusterTrustBundles, func(i, j int) bool {
+		if r.ClusterTrustBundles[i].CreationTimestamp.Equal(&(r.ClusterTrustBundles[j].CreationTimestamp)) {
+			return r.ClusterTrustBundles[i].Name < r.ClusterTrustBundles[j].Name
+		}
+		return r.ClusterTrustBundles[i].CreationTimestamp.Before(&(r.ClusterTrustBundles[j].CreationTimestamp))
+	})
+
+	// Sort ExtensionRefFilters by creation timestamp, then namespace/name (unstructured resources)
+	sort.Slice(r.ExtensionRefFilters, func(i, j int) bool {
+		tsI := r.ExtensionRefFilters[i].GetCreationTimestamp()
+		tsJ := r.ExtensionRefFilters[j].GetCreationTimestamp()
+		if tsI.Equal(&tsJ) {
+			keyI := fmt.Sprintf("%s/%s", r.ExtensionRefFilters[i].GetNamespace(), r.ExtensionRefFilters[i].GetName())
+			keyJ := fmt.Sprintf("%s/%s", r.ExtensionRefFilters[j].GetNamespace(), r.ExtensionRefFilters[j].GetName())
+			return keyI < keyJ
+		}
+		return tsI.Before(&tsJ)
+	})
+
+	// Sort ExtensionServerPolicies by creation timestamp, then namespace/name (unstructured resources)
+	sort.Slice(r.ExtensionServerPolicies, func(i, j int) bool {
+		tsI := r.ExtensionServerPolicies[i].GetCreationTimestamp()
+		tsJ := r.ExtensionServerPolicies[j].GetCreationTimestamp()
+		if tsI.Equal(&tsJ) {
+			keyI := fmt.Sprintf("%s/%s", r.ExtensionServerPolicies[i].GetNamespace(), r.ExtensionServerPolicies[i].GetName())
+			keyJ := fmt.Sprintf("%s/%s", r.ExtensionServerPolicies[j].GetNamespace(), r.ExtensionServerPolicies[j].GetName())
+			return keyI < keyJ
+		}
+		return tsI.Before(&tsJ)
+	})
 }

--- a/internal/gatewayapi/resource/resource_test.go
+++ b/internal/gatewayapi/resource/resource_test.go
@@ -121,7 +121,11 @@ func TestEqualXds(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			require.Equal(t, tc.equal, cmp.Equal(tc.a, tc.b))
+			tc.a.Sort()
+			tc.b.Sort()
+			diff := cmp.Diff(tc.a, tc.b)
+			got := diff == ""
+			require.Equal(t, tc.equal, got)
 		})
 	}
 }

--- a/internal/gatewayapi/resource/testdata/all-resources.out.yaml
+++ b/internal/gatewayapi/resource/testdata/all-resources.out.yaml
@@ -286,14 +286,14 @@ namespaces:
   kind: Namespace
   metadata:
     creationTimestamp: null
-    name: envoy-gateway-system
+    name: default
   spec: {}
   status: {}
 - apiVersion: v1
   kind: Namespace
   metadata:
     creationTimestamp: null
-    name: default
+    name: envoy-gateway-system
   spec: {}
   status: {}
 - apiVersion: v1
@@ -334,18 +334,18 @@ secrets:
   kind: Secret
   metadata:
     creationTimestamp: null
-    name: secret-with-data-and-string-data
+    name: secret-with-data
     namespace: default
-  stringData:
-    secret: literal value
 - apiVersion: v1
   data:
     .secret-file: dmFsdWUtMg0KDQo=
   kind: Secret
   metadata:
     creationTimestamp: null
-    name: secret-with-data
+    name: secret-with-data-and-string-data
     namespace: default
+  stringData:
+    secret: literal value
 - apiVersion: v1
   kind: Secret
   metadata:

--- a/internal/gatewayapi/resource/zz_generated.deepcopy.go
+++ b/internal/gatewayapi/resource/zz_generated.deepcopy.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1alpha3"
@@ -301,22 +300,6 @@ func (in *Resources) DeepCopyInto(out *Resources) {
 				*out = new(certificatesv1beta1.ClusterTrustBundle)
 				(*in).DeepCopyInto(*out)
 			}
-		}
-	}
-	if in.serviceMap != nil {
-		in, out := &in.serviceMap, &out.serviceMap
-		*out = make(map[types.NamespacedName]*corev1.Service, len(*in))
-		for key, val := range *in {
-			var outVal *corev1.Service
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				inVal := (*in)[key]
-				in, out := &inVal, &outVal
-				*out = new(corev1.Service)
-				(*in).DeepCopyInto(*out)
-			}
-			(*out)[key] = outVal
 		}
 	}
 }

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -8,7 +8,6 @@ package gatewayapi
 import (
 	"fmt"
 	"net"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -55,19 +54,7 @@ type RoutesTranslator interface {
 func (t *Translator) ProcessHTTPRoutes(httpRoutes []*gwapiv1.HTTPRoute, gateways []*GatewayContext, resources *resource.Resources, xdsIR resource.XdsIRMap) []*HTTPRouteContext {
 	var relevantHTTPRoutes []*HTTPRouteContext
 
-	// Initially, httpRoutes sort by creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple routes share same timestamp.
-	// Later on, additional sorting based on matcher type and match length may occur.
-	sort.Slice(httpRoutes, func(i, j int) bool {
-		if httpRoutes[i].CreationTimestamp.Equal(&(httpRoutes[j].CreationTimestamp)) {
-			routeKeyI := fmt.Sprintf("%s/%s", httpRoutes[i].Namespace, httpRoutes[i].Name)
-			routeKeyJ := fmt.Sprintf("%s/%s", httpRoutes[j].Namespace, httpRoutes[j].Name)
-			return routeKeyI < routeKeyJ
-		}
-		// Not identical CreationTimestamps
-
-		return httpRoutes[i].CreationTimestamp.Before(&(httpRoutes[j].CreationTimestamp))
-	})
+	// HTTPRoutes are already sorted by the provider layer
 
 	for _, h := range httpRoutes {
 		if h == nil {
@@ -97,19 +84,7 @@ func (t *Translator) ProcessHTTPRoutes(httpRoutes []*gwapiv1.HTTPRoute, gateways
 func (t *Translator) ProcessGRPCRoutes(grpcRoutes []*gwapiv1.GRPCRoute, gateways []*GatewayContext, resources *resource.Resources, xdsIR resource.XdsIRMap) []*GRPCRouteContext {
 	var relevantGRPCRoutes []*GRPCRouteContext
 
-	// Initially, grpcRoutes sort by creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple routes share same timestamp.
-	// Later on, additional sorting based on matcher type and match length may occur.
-	sort.Slice(grpcRoutes, func(i, j int) bool {
-		if grpcRoutes[i].CreationTimestamp.Equal(&(grpcRoutes[j].CreationTimestamp)) {
-			routeKeyI := fmt.Sprintf("%s/%s", grpcRoutes[i].Namespace, grpcRoutes[i].Name)
-			routeKeyJ := fmt.Sprintf("%s/%s", grpcRoutes[j].Namespace, grpcRoutes[j].Name)
-			return routeKeyI < routeKeyJ
-		}
-		// Not identical CreationTimestamps
-
-		return grpcRoutes[i].CreationTimestamp.Before(&(grpcRoutes[j].CreationTimestamp))
-	})
+	// GRPCRoutes are already sorted by the provider layer
 
 	for _, g := range grpcRoutes {
 		if g == nil {
@@ -941,19 +916,7 @@ func filterEGPrefix(in map[string]string) map[string]string {
 
 func (t *Translator) ProcessTLSRoutes(tlsRoutes []*gwapiv1a2.TLSRoute, gateways []*GatewayContext, resources *resource.Resources, xdsIR resource.XdsIRMap) []*TLSRouteContext {
 	var relevantTLSRoutes []*TLSRouteContext
-
-	// Initially, tlsRoutes sort by creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple routes share same timestamp.
-	sort.Slice(tlsRoutes, func(i, j int) bool {
-		if tlsRoutes[i].CreationTimestamp.Equal(&(tlsRoutes[j].CreationTimestamp)) {
-			routeKeyI := fmt.Sprintf("%s/%s", tlsRoutes[i].Namespace, tlsRoutes[i].Name)
-			routeKeyJ := fmt.Sprintf("%s/%s", tlsRoutes[j].Namespace, tlsRoutes[j].Name)
-			return routeKeyI < routeKeyJ
-		}
-		// Not identical CreationTimestamps
-
-		return tlsRoutes[i].CreationTimestamp.Before(&(tlsRoutes[j].CreationTimestamp))
-	})
+	// TLSRoutes are already sorted by the provider layer
 
 	for _, tls := range tlsRoutes {
 		if tls == nil {
@@ -1100,19 +1063,7 @@ func (t *Translator) ProcessUDPRoutes(udpRoutes []*gwapiv1a2.UDPRoute, gateways 
 	xdsIR resource.XdsIRMap,
 ) []*UDPRouteContext {
 	var relevantUDPRoutes []*UDPRouteContext
-
-	// Initially, udpRoutes sort by creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple routes share same timestamp.
-	sort.Slice(udpRoutes, func(i, j int) bool {
-		if udpRoutes[i].CreationTimestamp.Equal(&(udpRoutes[j].CreationTimestamp)) {
-			routeKeyI := fmt.Sprintf("%s/%s", udpRoutes[i].Namespace, udpRoutes[i].Name)
-			routeKeyJ := fmt.Sprintf("%s/%s", udpRoutes[j].Namespace, udpRoutes[j].Name)
-			return routeKeyI < routeKeyJ
-		}
-		// Not identical CreationTimestamps
-
-		return udpRoutes[i].CreationTimestamp.Before(&(udpRoutes[j].CreationTimestamp))
-	})
+	// UDPRoutes are already sorted by the provider layer
 
 	for _, u := range udpRoutes {
 		if u == nil {
@@ -1263,19 +1214,7 @@ func (t *Translator) ProcessTCPRoutes(tcpRoutes []*gwapiv1a2.TCPRoute, gateways 
 	xdsIR resource.XdsIRMap,
 ) []*TCPRouteContext {
 	var relevantTCPRoutes []*TCPRouteContext
-
-	// Initially, tcpRoutes sort by creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple routes share same timestamp.
-	sort.Slice(tcpRoutes, func(i, j int) bool {
-		if tcpRoutes[i].CreationTimestamp.Equal(&(tcpRoutes[j].CreationTimestamp)) {
-			routeKeyI := fmt.Sprintf("%s/%s", tcpRoutes[i].Namespace, tcpRoutes[i].Name)
-			routeKeyJ := fmt.Sprintf("%s/%s", tcpRoutes[j].Namespace, tcpRoutes[j].Name)
-			return routeKeyI < routeKeyJ
-		}
-		// Not identical CreationTimestamps
-
-		return tcpRoutes[i].CreationTimestamp.Before(&(tcpRoutes[j].CreationTimestamp))
-	})
+	// TCPRoutes are already sorted by the provider layer
 
 	for _, tcp := range tcpRoutes {
 		if tcp == nil {

--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -58,19 +58,7 @@ func (t *Translator) ProcessSecurityPolicies(securityPolicies []*egv1a1.Security
 	xdsIR resource.XdsIRMap,
 ) []*egv1a1.SecurityPolicy {
 	var res []*egv1a1.SecurityPolicy
-
-	// Initially, policies sort by creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple policies share same timestamp.
-	sort.Slice(securityPolicies, func(i, j int) bool {
-		if securityPolicies[i].CreationTimestamp.Equal(&(securityPolicies[j].CreationTimestamp)) {
-			policyKeyI := fmt.Sprintf("%s/%s", securityPolicies[i].Namespace, securityPolicies[i].Name)
-			policyKeyJ := fmt.Sprintf("%s/%s", securityPolicies[j].Namespace, securityPolicies[j].Name)
-			return policyKeyI < policyKeyJ
-		}
-		// Not identical CreationTimestamps
-
-		return securityPolicies[i].CreationTimestamp.Before(&(securityPolicies[j].CreationTimestamp))
-	})
+	// SecurityPolicies are already sorted by the provider layer
 
 	// First build a map out of the routes and gateways for faster lookup since users might have thousands of routes or more.
 	// For gateways this probably isn't quite as necessary.

--- a/internal/gatewayapi/testdata/backendtlspolicy-default-ns-targetrefs.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-default-ns-targetrefs.out.yaml
@@ -68,7 +68,7 @@ gateways:
   kind: Gateway
   metadata:
     creationTimestamp: null
-    name: gateway-btls
+    name: gateway-btls2
     namespace: envoy-gateway
   spec:
     gatewayClassName: envoy-gateway-class
@@ -77,7 +77,7 @@ gateways:
         namespaces:
           from: All
       name: http
-      port: 80
+      port: 81
       protocol: HTTP
   status:
     listeners:
@@ -108,7 +108,7 @@ gateways:
   kind: Gateway
   metadata:
     creationTimestamp: null
-    name: gateway-btls2
+    name: gateway-btls
     namespace: envoy-gateway
   spec:
     gatewayClassName: envoy-gateway-class
@@ -117,7 +117,7 @@ gateways:
         namespaces:
           from: All
       name: http
-      port: 81
+      port: 80
       protocol: HTTP
   status:
     listeners:

--- a/internal/gatewayapi/testdata/backendtlspolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-status-conditions-truncated.out.yaml
@@ -416,6 +416,326 @@ gateways:
   kind: Gateway
   metadata:
     creationTimestamp: null
+    name: gateway-2
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-3
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-4
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-5
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-6
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-7
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-8
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-9
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
     name: gateway-10
     namespace: envoy-gateway
   spec:
@@ -737,326 +1057,6 @@ gateways:
   metadata:
     creationTimestamp: null
     name: gateway-18
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-2
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-3
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-4
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-5
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-6
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-7
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-8
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-9
     namespace: envoy-gateway
   spec:
     gatewayClassName: envoy-gateway-class

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions-truncated.out.yaml
@@ -223,217 +223,6 @@ backendTrafficPolicies:
   kind: BackendTrafficPolicy
   metadata:
     creationTimestamp: null
-    name: target-httproute-with-accepted-truncated-ancestors
-    namespace: envoy-gateway
-  spec:
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: httproute-1
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-1
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-10
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-11
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-12
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-13
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-14
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-15
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-16
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-17
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-18
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-2
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-3
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-4
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-5
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-6
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-7
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
-        reason: Aggregated
-        status: "True"
-        type: Aggregated
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: BackendTrafficPolicy
-  metadata:
-    creationTimestamp: null
     name: target-httproute-with-attachment-conflict-truncated-ancestors
     namespace: envoy-gateway
   spec:
@@ -657,12 +446,543 @@ backendTrafficPolicies:
         status: "True"
         type: Aggregated
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    creationTimestamp: null
+    name: target-httproute-with-accepted-truncated-ancestors
+    namespace: envoy-gateway
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httproute-1
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-10
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-11
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-12
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-13
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-14
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-15
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-16
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-17
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-18
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-3
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-4
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-5
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-6
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-7
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: 'Ancestors have been aggregated because the number of policy ancestors
+          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        reason: Aggregated
+        status: "True"
+        type: Aggregated
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
 gateways:
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: Gateway
   metadata:
     creationTimestamp: null
     name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-2
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-3
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-4
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-5
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-6
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-7
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-8
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-9
     namespace: envoy-gateway
   spec:
     gatewayClassName: envoy-gateway-class
@@ -1023,326 +1343,6 @@ gateways:
   metadata:
     creationTimestamp: null
     name: gateway-18
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-2
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-3
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-4
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-5
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-6
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-7
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-8
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-9
     namespace: envoy-gateway
   spec:
     gatewayClassName: envoy-gateway-class

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions.out.yaml
@@ -3,7 +3,7 @@ backendTrafficPolicies:
   kind: BackendTrafficPolicy
   metadata:
     creationTimestamp: null
-    name: also-target-httproute-in-gateway-1
+    name: target-httproute-in-gateway-1
     namespace: envoy-gateway
   spec:
     targetRef:
@@ -28,15 +28,28 @@ backendTrafficPolicies:
   kind: BackendTrafficPolicy
   metadata:
     creationTimestamp: null
-    name: not-same-namespace-httproute
+    name: also-target-httproute-in-gateway-1
     namespace: envoy-gateway
   spec:
     targetRef:
       group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: not-same-namespace-httproute
+      name: httproute-1
   status:
-    ancestors: null
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Unable to target HTTPRoute httproute-1, another BackendTrafficPolicy
+          has already attached to it
+        reason: Conflicted
+        status: "False"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: BackendTrafficPolicy
   metadata:
@@ -66,32 +79,6 @@ backendTrafficPolicies:
   kind: BackendTrafficPolicy
   metadata:
     creationTimestamp: null
-    name: target-httproute-in-gateway-1
-    namespace: envoy-gateway
-  spec:
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: httproute-1
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-1
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Unable to target HTTPRoute httproute-1, another BackendTrafficPolicy
-          has already attached to it
-        reason: Conflicted
-        status: "False"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: BackendTrafficPolicy
-  metadata:
-    creationTimestamp: null
     name: target-unknown-httproute
     namespace: envoy-gateway
   spec:
@@ -105,13 +92,13 @@ backendTrafficPolicies:
   kind: BackendTrafficPolicy
   metadata:
     creationTimestamp: null
-    name: not-same-namespace-gateway
+    name: not-same-namespace-httproute
     namespace: envoy-gateway
   spec:
     targetRef:
       group: gateway.networking.k8s.io
-      kind: Gateway
-      name: not-same-namespace-gateway
+      kind: HTTPRoute
+      name: not-same-namespace-httproute
   status:
     ancestors: null
 - apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -184,47 +171,20 @@ backendTrafficPolicies:
       name: unknown-gateway
   status:
     ancestors: null
-gateways:
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
   metadata:
     creationTimestamp: null
     name: not-same-namespace-gateway
-    namespace: another-namespace
+    namespace: envoy-gateway
   spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: not-same-namespace-gateway
   status:
-    listeners:
-    - attachedRoutes: 0
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
+    ancestors: null
+gateways:
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: Gateway
   metadata:
@@ -356,6 +316,46 @@ gateways:
       supportedKinds:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: not-same-namespace-gateway
+    namespace: another-namespace
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
 grpcRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: GRPCRoute
@@ -398,40 +398,6 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     creationTimestamp: null
-    name: not-same-namespace-httproute
-    namespace: another-namespace
-  spec:
-    parentRefs:
-    - name: not-same-namespace-gateway
-      namespace: another-namespace
-    rules:
-    - backendRefs:
-      - name: service-1
-        port: 8080
-      matches:
-      - path:
-          value: /
-  status:
-    parents:
-    - conditions:
-      - lastTransitionTime: null
-        message: No listeners included by this parent ref allowed this attachment.
-        reason: NotAllowedByListeners
-        status: "False"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Resolved all the Object references for the Route
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-      parentRef:
-        name: not-same-namespace-gateway
-        namespace: another-namespace
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: HTTPRoute
-  metadata:
-    creationTimestamp: null
     name: httproute-1
     namespace: envoy-gateway
   spec:
@@ -462,6 +428,40 @@ httpRoutes:
       parentRef:
         name: gateway-1
         namespace: envoy-gateway
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    creationTimestamp: null
+    name: not-same-namespace-httproute
+    namespace: another-namespace
+  spec:
+    parentRefs:
+    - name: not-same-namespace-gateway
+      namespace: another-namespace
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          value: /
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: No listeners included by this parent ref allowed this attachment.
+        reason: NotAllowedByListeners
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: not-same-namespace-gateway
+        namespace: another-namespace
 infraIR:
   another-namespace/not-same-namespace-gateway:
     proxy:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-status-fault-injection.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-status-fault-injection.out.yaml
@@ -3,39 +3,6 @@ backendTrafficPolicies:
   kind: BackendTrafficPolicy
   metadata:
     creationTimestamp: null
-    name: policy-for-grpcroute
-    namespace: default
-  spec:
-    faultInjection:
-      abort:
-        grpcStatus: 14
-        percentage: 100
-      delay:
-        fixedDelay: 5.4s
-        percentage: 80
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: GRPCRoute
-      name: grpcroute-1
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-1
-        namespace: envoy-gateway
-        sectionName: http
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: BackendTrafficPolicy
-  metadata:
-    creationTimestamp: null
     name: policy-for-route
     namespace: default
   spec:
@@ -56,6 +23,39 @@ backendTrafficPolicies:
         group: gateway.networking.k8s.io
         kind: Gateway
         name: gateway-2
+        namespace: envoy-gateway
+        sectionName: http
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    creationTimestamp: null
+    name: policy-for-grpcroute
+    namespace: default
+  spec:
+    faultInjection:
+      abort:
+        grpcStatus: 14
+        percentage: 100
+      delay:
+        fixedDelay: 5.4s
+        percentage: 80
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: GRPCRoute
+      name: grpcroute-1
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
         namespace: envoy-gateway
         sectionName: http
       conditions:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer-multiple-mixed.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer-multiple-mixed.out.yaml
@@ -181,6 +181,7 @@ xdsIR:
             - host: 7.7.7.7
               port: 8080
             metadata:
+              kind: Service
               name: service-1
               namespace: default
               sectionName: "8080"

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer-single-header.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer-single-header.out.yaml
@@ -181,6 +181,7 @@ xdsIR:
             - host: 7.7.7.7
               port: 8080
             metadata:
+              kind: Service
               name: service-1
               namespace: default
               sectionName: "8080"

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer.out.yaml
@@ -219,6 +219,7 @@ xdsIR:
             - host: 7.7.7.7
               port: 8080
             metadata:
+              kind: Service
               name: service-2
               namespace: default
               sectionName: "8080"
@@ -250,6 +251,7 @@ xdsIR:
             - host: 7.7.7.7
               port: 8080
             metadata:
+              kind: Service
               name: service-1
               namespace: default
               sectionName: "8080"

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-healthcheck.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-healthcheck.out.yaml
@@ -3,74 +3,6 @@ backendTrafficPolicies:
   kind: BackendTrafficPolicy
   metadata:
     creationTimestamp: null
-    name: policy-for-grpc-route
-    namespace: default
-  spec:
-    healthCheck:
-      active:
-        healthyThreshold: 1
-        interval: 3s
-        timeout: 1s
-        type: GRPC
-        unhealthyThreshold: 3
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: GRPCRoute
-      name: grpcroute-2
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-1
-        namespace: envoy-gateway
-        sectionName: http
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: BackendTrafficPolicy
-  metadata:
-    creationTimestamp: null
-    name: policy-for-grpc-route-3
-    namespace: default
-  spec:
-    healthCheck:
-      active:
-        grpc:
-          service: foo-service
-        healthyThreshold: 1
-        interval: 3s
-        timeout: 1s
-        type: GRPC
-        unhealthyThreshold: 3
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: GRPCRoute
-      name: grpcroute-3
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-1
-        namespace: envoy-gateway
-        sectionName: http
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: BackendTrafficPolicy
-  metadata:
-    creationTimestamp: null
     name: policy-for-route-1
     namespace: default
   spec:
@@ -103,6 +35,45 @@ backendTrafficPolicies:
       group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: httproute-1
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+        sectionName: http
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    creationTimestamp: null
+    name: policy-for-route-4
+    namespace: default
+  spec:
+    healthCheck:
+      active:
+        healthyThreshold: 3
+        http:
+          expectedResponse:
+            text: pong
+            type: Text
+          method: GET
+          path: /healthz
+        interval: 5s
+        timeout: 1s
+        type: HTTP
+        unhealthyThreshold: 3
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httproute-4
   status:
     ancestors:
     - ancestorRef:
@@ -218,45 +189,6 @@ backendTrafficPolicies:
   kind: BackendTrafficPolicy
   metadata:
     creationTimestamp: null
-    name: policy-for-route-4
-    namespace: default
-  spec:
-    healthCheck:
-      active:
-        healthyThreshold: 3
-        http:
-          expectedResponse:
-            text: pong
-            type: Text
-          method: GET
-          path: /healthz
-        interval: 5s
-        timeout: 1s
-        type: HTTP
-        unhealthyThreshold: 3
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: httproute-4
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-2
-        namespace: envoy-gateway
-        sectionName: http
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: BackendTrafficPolicy
-  metadata:
-    creationTimestamp: null
     name: policy-for-route-5
     namespace: default
   spec:
@@ -279,6 +211,74 @@ backendTrafficPolicies:
         group: gateway.networking.k8s.io
         kind: Gateway
         name: gateway-2
+        namespace: envoy-gateway
+        sectionName: http
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    creationTimestamp: null
+    name: policy-for-grpc-route
+    namespace: default
+  spec:
+    healthCheck:
+      active:
+        healthyThreshold: 1
+        interval: 3s
+        timeout: 1s
+        type: GRPC
+        unhealthyThreshold: 3
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: GRPCRoute
+      name: grpcroute-2
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    creationTimestamp: null
+    name: policy-for-grpc-route-3
+    namespace: default
+  spec:
+    healthCheck:
+      active:
+        grpc:
+          service: foo-service
+        healthyThreshold: 1
+        interval: 3s
+        timeout: 1s
+        type: GRPC
+        unhealthyThreshold: 3
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: GRPCRoute
+      name: grpcroute-3
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
         namespace: envoy-gateway
         sectionName: http
       conditions:
@@ -462,7 +462,7 @@ grpcRoutes:
   kind: GRPCRoute
   metadata:
     creationTimestamp: null
-    name: grpcroute-2
+    name: grpcroute-3
     namespace: default
   spec:
     parentRefs:
@@ -471,7 +471,7 @@ grpcRoutes:
       sectionName: http
     rules:
     - backendRefs:
-      - name: service-2
+      - name: service-3
         port: 8080
   status:
     parents:
@@ -495,7 +495,7 @@ grpcRoutes:
   kind: GRPCRoute
   metadata:
     creationTimestamp: null
-    name: grpcroute-3
+    name: grpcroute-2
     namespace: default
   spec:
     parentRefs:
@@ -504,7 +504,7 @@ grpcRoutes:
       sectionName: http
     rules:
     - backendRefs:
-      - name: service-3
+      - name: service-2
         port: 8080
   status:
     parents:
@@ -828,39 +828,6 @@ xdsIR:
       - destination:
           metadata:
             kind: GRPCRoute
-            name: grpcroute-2
-            namespace: default
-          name: grpcroute/default/grpcroute-2/rule/0
-          settings:
-          - addressType: IP
-            endpoints:
-            - host: 7.7.7.7
-              port: 8080
-            metadata:
-              name: service-2
-              namespace: default
-              sectionName: "8080"
-            name: grpcroute/default/grpcroute-2/rule/0/backend/0
-            protocol: GRPC
-            weight: 1
-        hostname: '*'
-        isHTTP2: true
-        metadata:
-          kind: GRPCRoute
-          name: grpcroute-2
-          namespace: default
-        name: grpcroute/default/grpcroute-2/rule/0/match/-1/*
-        traffic:
-          healthCheck:
-            active:
-              grpc: {}
-              healthyThreshold: 1
-              interval: 3s
-              timeout: 1s
-              unhealthyThreshold: 3
-      - destination:
-          metadata:
-            kind: GRPCRoute
             name: grpcroute-3
             namespace: default
           name: grpcroute/default/grpcroute-3/rule/0
@@ -888,6 +855,39 @@ xdsIR:
             active:
               grpc:
                 service: foo-service
+              healthyThreshold: 1
+              interval: 3s
+              timeout: 1s
+              unhealthyThreshold: 3
+      - destination:
+          metadata:
+            kind: GRPCRoute
+            name: grpcroute-2
+            namespace: default
+          name: grpcroute/default/grpcroute-2/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              name: service-2
+              namespace: default
+              sectionName: "8080"
+            name: grpcroute/default/grpcroute-2/rule/0/backend/0
+            protocol: GRPC
+            weight: 1
+        hostname: '*'
+        isHTTP2: true
+        metadata:
+          kind: GRPCRoute
+          name: grpcroute-2
+          namespace: default
+        name: grpcroute/default/grpcroute-2/rule/0/match/-1/*
+        traffic:
+          healthCheck:
+            active:
+              grpc: {}
               healthyThreshold: 1
               interval: 3s
               timeout: 1s

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-proxyprotocol-legacy-mixed.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-proxyprotocol-legacy-mixed.out.yaml
@@ -3,6 +3,34 @@ clientTrafficPolicies:
   kind: ClientTrafficPolicy
   metadata:
     creationTimestamp: null
+    name: target-gateway-precedence-test
+    namespace: envoy-gateway
+  spec:
+    enableProxyProtocol: false
+    proxyProtocol:
+      optional: true
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-precedence-test
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-precedence-test
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: ClientTrafficPolicy
+  metadata:
+    creationTimestamp: null
     name: target-gateway-legacy-only
     namespace: envoy-gateway
   spec:
@@ -52,35 +80,47 @@ clientTrafficPolicies:
         status: "True"
         type: Accepted
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: ClientTrafficPolicy
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
   metadata:
     creationTimestamp: null
-    name: target-gateway-precedence-test
+    name: gateway-precedence-test
     namespace: envoy-gateway
   spec:
-    enableProxyProtocol: false
-    proxyProtocol:
-      optional: true
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: Gateway
-      name: gateway-precedence-test
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http-1
+      port: 80
+      protocol: HTTP
   status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-precedence-test
-        namespace: envoy-gateway
+    listeners:
+    - attachedRoutes: 0
       conditions:
       - lastTransitionTime: null
-        message: Policy has been accepted.
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
         reason: Accepted
         status: "True"
         type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-gateways:
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http-1
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
 - apiVersion: gateway.networking.k8s.io/v1
   kind: Gateway
   metadata:
@@ -154,46 +194,6 @@ gateways:
         status: "True"
         type: ResolvedRefs
       name: http-2
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-precedence-test
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http-1
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 0
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
         kind: HTTPRoute

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions-truncated.out.yaml
@@ -584,6 +584,326 @@ gateways:
   kind: Gateway
   metadata:
     creationTimestamp: null
+    name: gateway-2
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-3
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-4
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-5
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-6
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-7
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-8
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-9
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
     name: gateway-10
     namespace: envoy-gateway
   spec:
@@ -905,326 +1225,6 @@ gateways:
   metadata:
     creationTimestamp: null
     name: gateway-18
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 0
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-2
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 0
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-3
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 0
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-4
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 0
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-5
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 0
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-6
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 0
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-7
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 0
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-8
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 0
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-9
     namespace: envoy-gateway
   spec:
     gatewayClassName: envoy-gateway-class

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions.out.yaml
@@ -3,33 +3,6 @@ clientTrafficPolicies:
   kind: ClientTrafficPolicy
   metadata:
     creationTimestamp: null
-    name: not-found-section-name
-    namespace: envoy-gateway
-  spec:
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: Gateway
-      name: gateway-3
-      sectionName: foo-bar
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-3
-        namespace: envoy-gateway
-        sectionName: foo-bar
-      conditions:
-      - lastTransitionTime: null
-        message: No section name foo-bar found for Gateway envoy-gateway/gateway-3
-        reason: TargetNotFound
-        status: "False"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: ClientTrafficPolicy
-  metadata:
-    creationTimestamp: null
     name: target-gateway-2-http
     namespace: envoy-gateway
   spec:
@@ -112,15 +85,29 @@ clientTrafficPolicies:
   kind: ClientTrafficPolicy
   metadata:
     creationTimestamp: null
-    name: not-same-namespace-with-gateway
+    name: not-found-section-name
     namespace: envoy-gateway
   spec:
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway
-      name: not-same-namespace-gateway
+      name: gateway-3
+      sectionName: foo-bar
   status:
-    ancestors: null
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-3
+        namespace: envoy-gateway
+        sectionName: foo-bar
+      conditions:
+      - lastTransitionTime: null
+        message: No section name foo-bar found for Gateway envoy-gateway/gateway-3
+        reason: TargetNotFound
+        status: "False"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: ClientTrafficPolicy
   metadata:
@@ -214,6 +201,19 @@ clientTrafficPolicies:
       group: gateway.networking.k8s.io
       kind: Gateway
       name: unknown-gateway
+  status:
+    ancestors: null
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: ClientTrafficPolicy
+  metadata:
+    creationTimestamp: null
+    name: not-same-namespace-with-gateway
+    namespace: envoy-gateway
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: not-same-namespace-gateway
   status:
     ancestors: null
 gateways:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions-truncated.out.yaml
@@ -223,217 +223,6 @@ envoyExtensionPolicies:
   kind: EnvoyExtensionPolicy
   metadata:
     creationTimestamp: null
-    name: target-httproute-with-accepted-truncated-ancestors
-    namespace: envoy-gateway
-  spec:
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: httproute-1
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-1
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-10
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-11
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-12
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-13
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-14
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-15
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-16
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-17
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-18
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-2
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-3
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-4
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-5
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-6
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-7
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
-        reason: Aggregated
-        status: "True"
-        type: Aggregated
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: EnvoyExtensionPolicy
-  metadata:
-    creationTimestamp: null
     name: target-httproute-with-attachment-conflict-truncated-ancestors
     namespace: envoy-gateway
   spec:
@@ -657,12 +446,543 @@ envoyExtensionPolicies:
         status: "True"
         type: Aggregated
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: EnvoyExtensionPolicy
+  metadata:
+    creationTimestamp: null
+    name: target-httproute-with-accepted-truncated-ancestors
+    namespace: envoy-gateway
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httproute-1
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-10
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-11
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-12
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-13
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-14
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-15
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-16
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-17
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-18
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-3
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-4
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-5
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-6
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-7
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: 'Ancestors have been aggregated because the number of policy ancestors
+          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        reason: Aggregated
+        status: "True"
+        type: Aggregated
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
 gateways:
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: Gateway
   metadata:
     creationTimestamp: null
     name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-2
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-3
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-4
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-5
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-6
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-7
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-8
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-9
     namespace: envoy-gateway
   spec:
     gatewayClassName: envoy-gateway-class
@@ -1023,326 +1343,6 @@ gateways:
   metadata:
     creationTimestamp: null
     name: gateway-18
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-2
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-3
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-4
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-5
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-6
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-7
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-8
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-9
     namespace: envoy-gateway
   spec:
     gatewayClassName: envoy-gateway-class

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions.out.yaml
@@ -3,7 +3,7 @@ envoyExtensionPolicies:
   kind: EnvoyExtensionPolicy
   metadata:
     creationTimestamp: null
-    name: also-target-httproute-in-gateway-1
+    name: target-httproute-in-gateway-1
     namespace: envoy-gateway
   spec:
     targetRef:
@@ -28,15 +28,28 @@ envoyExtensionPolicies:
   kind: EnvoyExtensionPolicy
   metadata:
     creationTimestamp: null
-    name: not-same-namespace-httproute
+    name: also-target-httproute-in-gateway-1
     namespace: envoy-gateway
   spec:
     targetRef:
       group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: not-same-namespace-httproute
+      name: httproute-1
   status:
-    ancestors: null
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Unable to target HTTPRoute httproute-1, another EnvoyExtensionPolicy
+          has already attached to it
+        reason: Conflicted
+        status: "False"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: EnvoyExtensionPolicy
   metadata:
@@ -66,32 +79,6 @@ envoyExtensionPolicies:
   kind: EnvoyExtensionPolicy
   metadata:
     creationTimestamp: null
-    name: target-httproute-in-gateway-1
-    namespace: envoy-gateway
-  spec:
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: httproute-1
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-1
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Unable to target HTTPRoute httproute-1, another EnvoyExtensionPolicy
-          has already attached to it
-        reason: Conflicted
-        status: "False"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: EnvoyExtensionPolicy
-  metadata:
-    creationTimestamp: null
     name: target-unknown-httproute
     namespace: envoy-gateway
   spec:
@@ -105,13 +92,13 @@ envoyExtensionPolicies:
   kind: EnvoyExtensionPolicy
   metadata:
     creationTimestamp: null
-    name: not-same-namespace-gateway
+    name: not-same-namespace-httproute
     namespace: envoy-gateway
   spec:
     targetRef:
       group: gateway.networking.k8s.io
-      kind: Gateway
-      name: not-same-namespace-gateway
+      kind: HTTPRoute
+      name: not-same-namespace-httproute
   status:
     ancestors: null
 - apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -184,47 +171,20 @@ envoyExtensionPolicies:
       name: unknown-gateway
   status:
     ancestors: null
-gateways:
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: EnvoyExtensionPolicy
   metadata:
     creationTimestamp: null
     name: not-same-namespace-gateway
-    namespace: another-namespace
+    namespace: envoy-gateway
   spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: not-same-namespace-gateway
   status:
-    listeners:
-    - attachedRoutes: 0
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
+    ancestors: null
+gateways:
 - apiVersion: gateway.networking.k8s.io/v1beta1
   kind: Gateway
   metadata:
@@ -356,6 +316,46 @@ gateways:
       supportedKinds:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: not-same-namespace-gateway
+    namespace: another-namespace
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
 grpcRoutes:
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: GRPCRoute
@@ -398,40 +398,6 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     creationTimestamp: null
-    name: not-same-namespace-httproute
-    namespace: another-namespace
-  spec:
-    parentRefs:
-    - name: not-same-namespace-gateway
-      namespace: another-namespace
-    rules:
-    - backendRefs:
-      - name: service-1
-        port: 8080
-      matches:
-      - path:
-          value: /
-  status:
-    parents:
-    - conditions:
-      - lastTransitionTime: null
-        message: No listeners included by this parent ref allowed this attachment.
-        reason: NotAllowedByListeners
-        status: "False"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Resolved all the Object references for the Route
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-      parentRef:
-        name: not-same-namespace-gateway
-        namespace: another-namespace
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: HTTPRoute
-  metadata:
-    creationTimestamp: null
     name: httproute-1
     namespace: envoy-gateway
   spec:
@@ -462,6 +428,40 @@ httpRoutes:
       parentRef:
         name: gateway-1
         namespace: envoy-gateway
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: HTTPRoute
+  metadata:
+    creationTimestamp: null
+    name: not-same-namespace-httproute
+    namespace: another-namespace
+  spec:
+    parentRefs:
+    - name: not-same-namespace-gateway
+      namespace: another-namespace
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          value: /
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: No listeners included by this parent ref allowed this attachment.
+        reason: NotAllowedByListeners
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: not-same-namespace-gateway
+        namespace: another-namespace
 infraIR:
   another-namespace/not-same-namespace-gateway:
     proxy:

--- a/internal/gatewayapi/testdata/envoypatchpolicy-valid-merge-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-valid-merge-gateways.out.yaml
@@ -79,10 +79,10 @@ xdsIR:
       - name: envoy-gateway-gateway-1-http
         operation:
           op: replace
-          path: /ignore_global_conn_limit
-          value: "true"
+          path: /per_connection_buffer_limit_bytes
+          value: "1024"
         type: type.googleapis.com/envoy.config.listener.v3.Listener
-      name: edit-ignore-global-limit
+      name: edit-conn-buffer-bytes
       namespace: envoy-gateway
       status:
         ancestors:
@@ -101,10 +101,10 @@ xdsIR:
       - name: envoy-gateway-gateway-1-http
         operation:
           op: replace
-          path: /per_connection_buffer_limit_bytes
-          value: "1024"
+          path: /ignore_global_conn_limit
+          value: "true"
         type: type.googleapis.com/envoy.config.listener.v3.Listener
-      name: edit-conn-buffer-bytes
+      name: edit-ignore-global-limit
       namespace: envoy-gateway
       status:
         ancestors:

--- a/internal/gatewayapi/testdata/envoypatchpolicy-valid.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-valid.out.yaml
@@ -69,10 +69,10 @@ xdsIR:
       - name: envoy-gateway-gateway-1-http
         operation:
           op: replace
-          path: /ignore_global_conn_limit
-          value: "true"
+          path: /per_connection_buffer_limit_bytes
+          value: "1024"
         type: type.googleapis.com/envoy.config.listener.v3.Listener
-      name: edit-ignore-global-limit
+      name: edit-conn-buffer-bytes
       namespace: envoy-gateway
       status:
         ancestors:
@@ -93,10 +93,10 @@ xdsIR:
       - name: envoy-gateway-gateway-1-http
         operation:
           op: replace
-          path: /per_connection_buffer_limit_bytes
-          value: "1024"
+          path: /ignore_global_conn_limit
+          value: "true"
         type: type.googleapis.com/envoy.config.listener.v3.Listener
-      name: edit-conn-buffer-bytes
+      name: edit-ignore-global-limit
       namespace: envoy-gateway
       status:
         ancestors:

--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-mixed-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-mixed-multiple.out.yaml
@@ -169,6 +169,7 @@ xdsIR:
             - host: 7.7.7.7
               port: 8080
             metadata:
+              kind: Service
               name: service-1
               namespace: default
               sectionName: "8080"
@@ -231,6 +232,7 @@ xdsIR:
             - host: 7.7.7.7
               port: 8080
             metadata:
+              kind: Service
               name: service-2
               namespace: default
               sectionName: "8080"

--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-mixed.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-mixed.out.yaml
@@ -161,6 +161,7 @@ xdsIR:
             - host: 7.7.7.7
               port: 8080
             metadata:
+              kind: Service
               name: service-1
               namespace: default
               sectionName: "8080"
@@ -207,6 +208,7 @@ xdsIR:
             - host: 7.7.7.7
               port: 8080
             metadata:
+              kind: Service
               name: service-2
               namespace: default
               sectionName: "8080"

--- a/internal/gatewayapi/testdata/gateway-namespace-mode-infra-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-namespace-mode-infra-httproute.out.yaml
@@ -317,6 +317,7 @@ xdsIR:
             - host: 7.7.7.7
               port: 8080
             metadata:
+              kind: Service
               name: service-1
               namespace: default
               sectionName: "8080"
@@ -372,6 +373,7 @@ xdsIR:
             - host: 7.7.7.7
               port: 8080
             metadata:
+              kind: Service
               name: service-2
               namespace: default
               sectionName: "8080"

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-and-core-backendrefs.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-and-core-backendrefs.out.yaml
@@ -98,7 +98,7 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     creationTimestamp: null
-    name: httproute-fqdn
+    name: httproute-static
     namespace: default
   spec:
     parentRefs:
@@ -109,16 +109,16 @@ httpRoutes:
     - backendRefs:
       - group: gateway.envoyproxy.io
         kind: Backend
-        name: backend-fqdn
-      - name: service-fqdn
+        name: backend-ip
+      - name: service-ip
         port: 8080
       - group: multicluster.x-k8s.io
         kind: ServiceImport
-        name: service-import-fqdn
+        name: service-import-ip
         port: 8081
       matches:
       - path:
-          value: /2
+          value: /1
   status:
     parents:
     - conditions:
@@ -141,7 +141,7 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     creationTimestamp: null
-    name: httproute-static
+    name: httproute-fqdn
     namespace: default
   spec:
     parentRefs:
@@ -152,16 +152,16 @@ httpRoutes:
     - backendRefs:
       - group: gateway.envoyproxy.io
         kind: Backend
-        name: backend-ip
-      - name: service-ip
+        name: backend-fqdn
+      - name: service-fqdn
         port: 8080
       - group: multicluster.x-k8s.io
         kind: ServiceImport
-        name: service-import-ip
+        name: service-import-fqdn
         port: 8081
       matches:
       - path:
-          value: /1
+          value: /2
   status:
     parents:
     - conditions:
@@ -240,59 +240,6 @@ xdsIR:
       - destination:
           metadata:
             kind: HTTPRoute
-            name: httproute-fqdn
-            namespace: default
-          name: httproute/default/httproute-fqdn/rule/0
-          settings:
-          - addressType: FQDN
-            endpoints:
-            - host: primary.foo.com
-              port: 3000
-            metadata:
-              kind: Backend
-              name: backend-fqdn
-              namespace: default
-            name: httproute/default/httproute-fqdn/rule/0/backend/0
-            protocol: HTTP
-            weight: 1
-          - addressType: FQDN
-            endpoints:
-            - host: bar.foo
-              port: 8080
-            metadata:
-              kind: Service
-              name: service-fqdn
-              namespace: default
-              sectionName: "8080"
-            name: httproute/default/httproute-fqdn/rule/0/backend/1
-            protocol: HTTP
-            weight: 1
-          - addressType: FQDN
-            endpoints:
-            - host: foo.bar
-              port: 8080
-            metadata:
-              kind: ServiceImport
-              name: service-import-fqdn
-              namespace: default
-              sectionName: "8081"
-            name: httproute/default/httproute-fqdn/rule/0/backend/2
-            protocol: HTTP
-            weight: 1
-        hostname: '*'
-        isHTTP2: false
-        metadata:
-          kind: HTTPRoute
-          name: httproute-fqdn
-          namespace: default
-        name: httproute/default/httproute-fqdn/rule/0/match/0/*
-        pathMatch:
-          distinct: false
-          name: ""
-          prefix: /2
-      - destination:
-          metadata:
-            kind: HTTPRoute
             name: httproute-static
             namespace: default
           name: httproute/default/httproute-static/rule/0
@@ -343,6 +290,59 @@ xdsIR:
           distinct: false
           name: ""
           prefix: /1
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-fqdn
+            namespace: default
+          name: httproute/default/httproute-fqdn/rule/0
+          settings:
+          - addressType: FQDN
+            endpoints:
+            - host: primary.foo.com
+              port: 3000
+            metadata:
+              kind: Backend
+              name: backend-fqdn
+              namespace: default
+            name: httproute/default/httproute-fqdn/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+          - addressType: FQDN
+            endpoints:
+            - host: bar.foo
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-fqdn
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-fqdn/rule/0/backend/1
+            protocol: HTTP
+            weight: 1
+          - addressType: FQDN
+            endpoints:
+            - host: foo.bar
+              port: 8080
+            metadata:
+              kind: ServiceImport
+              name: service-import-fqdn
+              namespace: default
+              sectionName: "8081"
+            name: httproute/default/httproute-fqdn/rule/0/backend/2
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-fqdn
+          namespace: default
+        name: httproute/default/httproute-fqdn/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /2
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref-mixed-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref-mixed-address-type.out.yaml
@@ -165,7 +165,7 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     creationTimestamp: null
-    name: httproute-2
+    name: httproute-3
     namespace: default
   spec:
     parentRefs:
@@ -176,10 +176,10 @@ httpRoutes:
     - backendRefs:
       - group: gateway.envoyproxy.io
         kind: Backend
-        name: backend-mixed-uds-fqdn
+        name: backend-mixed-ip-fqdn
       matches:
       - path:
-          value: /2
+          value: /3
   status:
     parents:
     - conditions:
@@ -203,7 +203,7 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     creationTimestamp: null
-    name: httproute-3
+    name: httproute-2
     namespace: default
   spec:
     parentRefs:
@@ -214,10 +214,10 @@ httpRoutes:
     - backendRefs:
       - group: gateway.envoyproxy.io
         kind: Backend
-        name: backend-mixed-ip-fqdn
+        name: backend-mixed-uds-fqdn
       matches:
       - path:
-          value: /3
+          value: /2
   status:
     parents:
     - conditions:
@@ -313,19 +313,6 @@ xdsIR:
         isHTTP2: false
         metadata:
           kind: HTTPRoute
-          name: httproute-2
-          namespace: default
-        name: httproute/default/httproute-2/rule/0/match/0/*
-        pathMatch:
-          distinct: false
-          name: ""
-          prefix: /2
-      - directResponse:
-          statusCode: 500
-        hostname: '*'
-        isHTTP2: false
-        metadata:
-          kind: HTTPRoute
           name: httproute-3
           namespace: default
         name: httproute/default/httproute-3/rule/0/match/0/*
@@ -333,6 +320,19 @@ xdsIR:
           distinct: false
           name: ""
           prefix: /3
+      - directResponse:
+          statusCode: 500
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-2
+          namespace: default
+        name: httproute/default/httproute-2/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /2
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref.out.yaml
@@ -174,7 +174,7 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     creationTimestamp: null
-    name: httproute-2
+    name: httproute-3
     namespace: default
   spec:
     parentRefs:
@@ -185,10 +185,10 @@ httpRoutes:
     - backendRefs:
       - group: gateway.envoyproxy.io
         kind: Backend
-        name: backend-ip
+        name: backend-fqdn
       matches:
       - path:
-          value: /2
+          value: /3
   status:
     parents:
     - conditions:
@@ -211,7 +211,7 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     creationTimestamp: null
-    name: httproute-3
+    name: httproute-2
     namespace: default
   spec:
     parentRefs:
@@ -222,10 +222,10 @@ httpRoutes:
     - backendRefs:
       - group: gateway.envoyproxy.io
         kind: Backend
-        name: backend-fqdn
+        name: backend-ip
       matches:
       - path:
-          value: /3
+          value: /2
   status:
     parents:
     - conditions:
@@ -393,35 +393,6 @@ xdsIR:
       - destination:
           metadata:
             kind: HTTPRoute
-            name: httproute-2
-            namespace: default
-          name: httproute/default/httproute-2/rule/0
-          settings:
-          - addressType: IP
-            endpoints:
-            - host: 1.1.1.1
-              port: 3001
-            metadata:
-              kind: Backend
-              name: backend-ip
-              namespace: default
-            name: httproute/default/httproute-2/rule/0/backend/0
-            protocol: HTTP
-            weight: 1
-        hostname: '*'
-        isHTTP2: false
-        metadata:
-          kind: HTTPRoute
-          name: httproute-2
-          namespace: default
-        name: httproute/default/httproute-2/rule/0/match/0/*
-        pathMatch:
-          distinct: false
-          name: ""
-          prefix: /2
-      - destination:
-          metadata:
-            kind: HTTPRoute
             name: httproute-3
             namespace: default
           name: httproute/default/httproute-3/rule/0
@@ -448,6 +419,35 @@ xdsIR:
           distinct: false
           name: ""
           prefix: /3
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-2
+            namespace: default
+          name: httproute/default/httproute-2/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 1.1.1.1
+              port: 3001
+            metadata:
+              kind: Backend
+              name: backend-ip
+              namespace: default
+            name: httproute/default/httproute-2/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-2
+          namespace: default
+        name: httproute/default/httproute-2/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /2
       - directResponse:
           statusCode: 500
         hostname: '*'

--- a/internal/gatewayapi/testdata/httproute-default-order-by-creation-date-and-route-name.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-default-order-by-creation-date-and-route-name.out.yaml
@@ -44,8 +44,8 @@ httpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: HTTPRoute
   metadata:
-    creationTimestamp: "2025-07-10T20:43:53Z"
-    name: httproute-5
+    creationTimestamp: "2025-07-12T20:47:53Z"
+    name: httproute-default
     namespace: default
   spec:
     hostnames:
@@ -61,14 +61,46 @@ httpRoutes:
       matches:
       - path:
           type: PathPrefix
-          value: /route5
+          value: /
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    creationTimestamp: "2025-07-12T20:47:53Z"
+    name: httproute-3
+    namespace: default
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+      sectionName: http
+    rules:
     - backendRefs:
-      - name: service-2
+      - name: service-1
         port: 8080
       matches:
       - path:
           type: PathPrefix
-          value: /123
+          value: /route3
   status:
     parents:
     - conditions:
@@ -143,8 +175,8 @@ httpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: HTTPRoute
   metadata:
-    creationTimestamp: "2025-07-12T20:47:53Z"
-    name: httproute-3
+    creationTimestamp: "2025-07-10T20:43:53Z"
+    name: httproute-5
     namespace: default
   spec:
     hostnames:
@@ -160,46 +192,14 @@ httpRoutes:
       matches:
       - path:
           type: PathPrefix
-          value: /route3
-  status:
-    parents:
-    - conditions:
-      - lastTransitionTime: null
-        message: Route is accepted
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Resolved all the Object references for the Route
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-      parentRef:
-        name: gateway-1
-        namespace: envoy-gateway
-        sectionName: http
-- apiVersion: gateway.networking.k8s.io/v1
-  kind: HTTPRoute
-  metadata:
-    creationTimestamp: "2025-07-12T20:47:53Z"
-    name: httproute-default
-    namespace: default
-  spec:
-    hostnames:
-    - gateway.envoyproxy.io
-    parentRefs:
-    - name: gateway-1
-      namespace: envoy-gateway
-      sectionName: http
-    rules:
+          value: /route5
     - backendRefs:
-      - name: service-1
+      - name: service-2
         port: 8080
       matches:
       - path:
           type: PathPrefix
-          value: /
+          value: /123
   status:
     parents:
     - conditions:
@@ -370,9 +370,9 @@ xdsIR:
       - destination:
           metadata:
             kind: HTTPRoute
-            name: httproute-5
+            name: httproute-3
             namespace: default
-          name: httproute/default/httproute-5/rule/0
+          name: httproute/default/httproute-3/rule/0
           settings:
           - addressType: IP
             endpoints:
@@ -382,20 +382,20 @@ xdsIR:
               name: service-1
               namespace: default
               sectionName: "8080"
-            name: httproute/default/httproute-5/rule/0/backend/0
+            name: httproute/default/httproute-3/rule/0/backend/0
             protocol: HTTP
             weight: 1
         hostname: gateway.envoyproxy.io
         isHTTP2: false
         metadata:
           kind: HTTPRoute
-          name: httproute-5
+          name: httproute-3
           namespace: default
-        name: httproute/default/httproute-5/rule/0/match/0/gateway_envoyproxy_io
+        name: httproute/default/httproute-3/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""
-          prefix: /route5
+          prefix: /route3
       - destination:
           metadata:
             kind: HTTPRoute
@@ -457,9 +457,9 @@ xdsIR:
       - destination:
           metadata:
             kind: HTTPRoute
-            name: httproute-3
+            name: httproute-5
             namespace: default
-          name: httproute/default/httproute-3/rule/0
+          name: httproute/default/httproute-5/rule/0
           settings:
           - addressType: IP
             endpoints:
@@ -469,20 +469,20 @@ xdsIR:
               name: service-1
               namespace: default
               sectionName: "8080"
-            name: httproute/default/httproute-3/rule/0/backend/0
+            name: httproute/default/httproute-5/rule/0/backend/0
             protocol: HTTP
             weight: 1
         hostname: gateway.envoyproxy.io
         isHTTP2: false
         metadata:
           kind: HTTPRoute
-          name: httproute-3
+          name: httproute-5
           namespace: default
-        name: httproute/default/httproute-3/rule/0/match/0/gateway_envoyproxy_io
+        name: httproute/default/httproute-5/rule/0/match/0/gateway_envoyproxy_io
         pathMatch:
           distinct: false
           name: ""
-          prefix: /route3
+          prefix: /route5
       - destination:
           metadata:
             kind: HTTPRoute
@@ -546,35 +546,6 @@ xdsIR:
       - destination:
           metadata:
             kind: HTTPRoute
-            name: httproute-5
-            namespace: default
-          name: httproute/default/httproute-5/rule/1
-          settings:
-          - addressType: IP
-            endpoints:
-            - host: 7.7.7.7
-              port: 8080
-            metadata:
-              name: service-2
-              namespace: default
-              sectionName: "8080"
-            name: httproute/default/httproute-5/rule/1/backend/0
-            protocol: HTTP
-            weight: 1
-        hostname: gateway.envoyproxy.io
-        isHTTP2: false
-        metadata:
-          kind: HTTPRoute
-          name: httproute-5
-          namespace: default
-        name: httproute/default/httproute-5/rule/1/match/0/gateway_envoyproxy_io
-        pathMatch:
-          distinct: false
-          name: ""
-          prefix: /123
-      - destination:
-          metadata:
-            kind: HTTPRoute
             name: httproute-1
             namespace: default
           name: httproute/default/httproute-1/rule/2
@@ -601,6 +572,35 @@ xdsIR:
           distinct: false
           name: ""
           prefix: /bar
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-5
+            namespace: default
+          name: httproute/default/httproute-5/rule/1
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              name: service-2
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-5/rule/1/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: gateway.envoyproxy.io
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-5
+          namespace: default
+        name: httproute/default/httproute-5/rule/1/match/0/gateway_envoyproxy_io
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /123
       - destination:
           metadata:
             kind: HTTPRoute

--- a/internal/gatewayapi/testdata/httproute-order-by-creation-date.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-order-by-creation-date.out.yaml
@@ -44,45 +44,6 @@ httpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: HTTPRoute
   metadata:
-    creationTimestamp: "2025-04-04T20:47:53Z"
-    name: httproute-4
-    namespace: test-ns2
-  spec:
-    hostnames:
-    - gateway.envoyproxy.io
-    parentRefs:
-    - name: gateway-1
-      namespace: envoy-gateway
-      sectionName: http
-    rules:
-    - backendRefs:
-      - name: test-service
-        port: 8080
-      matches:
-      - path:
-          type: PathPrefix
-          value: /route4
-  status:
-    parents:
-    - conditions:
-      - lastTransitionTime: null
-        message: Route is accepted
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Resolved all the Object references for the Route
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-      parentRef:
-        name: gateway-1
-        namespace: envoy-gateway
-        sectionName: http
-- apiVersion: gateway.networking.k8s.io/v1
-  kind: HTTPRoute
-  metadata:
     creationTimestamp: "2025-07-01T20:47:53Z"
     name: httproute-3
     namespace: default
@@ -204,6 +165,45 @@ httpRoutes:
         name: gateway-1
         namespace: envoy-gateway
         sectionName: http
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    creationTimestamp: "2025-04-04T20:47:53Z"
+    name: httproute-4
+    namespace: test-ns2
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+      sectionName: http
+    rules:
+    - backendRefs:
+      - name: test-service
+        port: 8080
+      matches:
+      - path:
+          type: PathPrefix
+          value: /route4
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
@@ -261,36 +261,6 @@ xdsIR:
         mergeSlashes: true
       port: 10080
       routes:
-      - destination:
-          metadata:
-            kind: HTTPRoute
-            name: httproute-4
-            namespace: test-ns2
-          name: httproute/test-ns2/httproute-4/rule/0
-          settings:
-          - addressType: IP
-            endpoints:
-            - host: 8.8.8.8
-              port: 8080
-            metadata:
-              kind: Service
-              name: test-service
-              namespace: test-ns2
-              sectionName: "8080"
-            name: httproute/test-ns2/httproute-4/rule/0/backend/0
-            protocol: HTTP
-            weight: 1
-        hostname: gateway.envoyproxy.io
-        isHTTP2: false
-        metadata:
-          kind: HTTPRoute
-          name: httproute-4
-          namespace: test-ns2
-        name: httproute/test-ns2/httproute-4/rule/0/match/0/gateway_envoyproxy_io
-        pathMatch:
-          distinct: false
-          name: ""
-          prefix: /route4
       - destination:
           metadata:
             kind: HTTPRoute
@@ -408,6 +378,36 @@ xdsIR:
           distinct: false
           name: ""
           prefix: /route2
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-4
+            namespace: test-ns2
+          name: httproute/test-ns2/httproute-4/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 8.8.8.8
+              port: 8080
+            metadata:
+              kind: Service
+              name: test-service
+              namespace: test-ns2
+              sectionName: "8080"
+            name: httproute/test-ns2/httproute-4/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: gateway.envoyproxy.io
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-4
+          namespace: test-ns2
+        name: httproute/test-ns2/httproute-4/rule/0/match/0/gateway_envoyproxy_io
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /route4
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/httproute-with-direct-response.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-direct-response.out.yaml
@@ -95,6 +95,46 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     creationTimestamp: null
+    name: direct-response-with-value-not-found
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+      sectionName: http
+    rules:
+    - filters:
+      - extensionRef:
+          group: gateway.envoyproxy.io
+          kind: HTTPRouteFilter
+          name: direct-response-value-ref-not-found
+        type: ExtensionRef
+      matches:
+      - path:
+          type: PathPrefix
+          value: /value-ref-not-found
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: 'Unable to translate HTTPRouteFilter: default/direct-response-value-ref-not-found'
+        reason: UnsupportedValue
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: 'Unable to translate HTTPRouteFilter: default/direct-response-value-ref-not-found'
+        reason: BackendNotFound
+        status: "False"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    creationTimestamp: null
     name: direct-response-too-long
     namespace: default
   spec:
@@ -126,46 +166,6 @@ httpRoutes:
         message: Resolved all the Object references for the Route
         reason: ResolvedRefs
         status: "True"
-        type: ResolvedRefs
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-      parentRef:
-        name: gateway-1
-        namespace: envoy-gateway
-        sectionName: http
-- apiVersion: gateway.networking.k8s.io/v1
-  kind: HTTPRoute
-  metadata:
-    creationTimestamp: null
-    name: direct-response-with-value-not-found
-    namespace: default
-  spec:
-    parentRefs:
-    - name: gateway-1
-      namespace: envoy-gateway
-      sectionName: http
-    rules:
-    - filters:
-      - extensionRef:
-          group: gateway.envoyproxy.io
-          kind: HTTPRouteFilter
-          name: direct-response-value-ref-not-found
-        type: ExtensionRef
-      matches:
-      - path:
-          type: PathPrefix
-          value: /value-ref-not-found
-  status:
-    parents:
-    - conditions:
-      - lastTransitionTime: null
-        message: 'Unable to translate HTTPRouteFilter: default/direct-response-value-ref-not-found'
-        reason: UnsupportedValue
-        status: "False"
-        type: Accepted
-      - lastTransitionTime: null
-        message: 'Unable to translate HTTPRouteFilter: default/direct-response-value-ref-not-found'
-        reason: BackendNotFound
-        status: "False"
         type: ResolvedRefs
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       parentRef:

--- a/internal/gatewayapi/testdata/httproute-with-multi-gateways-with-same-name.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-multi-gateways-with-same-name.out.yaml
@@ -4,7 +4,7 @@ gateways:
   metadata:
     creationTimestamp: null
     name: gateway-1
-    namespace: default
+    namespace: envoy-gateway
   spec:
     gatewayClassName: envoy-gateway-class
     listeners:
@@ -16,7 +16,7 @@ gateways:
       protocol: HTTP
   status:
     listeners:
-    - attachedRoutes: 1
+    - attachedRoutes: 0
       conditions:
       - lastTransitionTime: null
         message: Sending translated listener configuration to the data plane
@@ -44,7 +44,7 @@ gateways:
   metadata:
     creationTimestamp: null
     name: gateway-1
-    namespace: envoy-gateway
+    namespace: default
   spec:
     gatewayClassName: envoy-gateway-class
     listeners:
@@ -56,7 +56,7 @@ gateways:
       protocol: HTTP
   status:
     listeners:
-    - attachedRoutes: 0
+    - attachedRoutes: 1
       conditions:
       - lastTransitionTime: null
         message: Sending translated listener configuration to the data plane

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-hostname-filter-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-hostname-filter-invalid.out.yaml
@@ -45,55 +45,6 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     creationTimestamp: null
-    name: httproute-header-and-backend-host-rewrites
-    namespace: default
-  spec:
-    hostnames:
-    - gateway.envoyproxy.io
-    parentRefs:
-    - name: gateway-1
-      namespace: envoy-gateway
-      sectionName: http
-    rules:
-    - backendRefs:
-      - name: service-1
-        port: 8080
-      filters:
-      - extensionRef:
-          group: gateway.envoyproxy.io
-          kind: HTTPRouteFilter
-          name: valid-header
-        type: ExtensionRef
-      - extensionRef:
-          group: gateway.envoyproxy.io
-          kind: HTTPRouteFilter
-          name: valid-header
-        type: ExtensionRef
-      matches:
-      - path:
-          value: /header-and-backend
-  status:
-    parents:
-    - conditions:
-      - lastTransitionTime: null
-        message: Cannot configure multiple urlRewrite filters for a single HTTPRouteRule
-        reason: UnsupportedValue
-        status: "False"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Resolved all the Object references for the Route
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-      parentRef:
-        name: gateway-1
-        namespace: envoy-gateway
-        sectionName: http
-- apiVersion: gateway.networking.k8s.io/v1
-  kind: HTTPRoute
-  metadata:
-    creationTimestamp: null
     name: httproute-invalid-header
     namespace: default
   spec:
@@ -121,6 +72,100 @@ httpRoutes:
     - conditions:
       - lastTransitionTime: null
         message: Header must be set when rewrite path type is "Header"
+        reason: UnsupportedValue
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    creationTimestamp: null
+    name: httproute-multiple-host-rewrites-1
+    namespace: default
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+      sectionName: http
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - extensionRef:
+          group: gateway.envoyproxy.io
+          kind: HTTPRouteFilter
+          name: valid-header
+        type: ExtensionRef
+      - type: URLRewrite
+        urlRewrite:
+          hostname: rewrite.com
+      matches:
+      - path:
+          value: /ext-first
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Cannot configure multiple urlRewrite filters for a single HTTPRouteRule
+        reason: UnsupportedValue
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    creationTimestamp: null
+    name: httproute-multiple-path-rewrites-2
+    namespace: default
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+      sectionName: http
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          hostname: rewrite.com
+      - extensionRef:
+          group: gateway.envoyproxy.io
+          kind: HTTPRouteFilter
+          name: valid-header
+        type: ExtensionRef
+      matches:
+      - path:
+          value: /inline-first
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Cannot configure multiple urlRewrite filters for a single HTTPRouteRule
         reason: UnsupportedValue
         status: "False"
         type: Accepted
@@ -236,7 +281,7 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     creationTimestamp: null
-    name: httproute-multiple-host-rewrites-1
+    name: httproute-header-and-backend-host-rewrites
     namespace: default
   spec:
     hostnames:
@@ -255,51 +300,6 @@ httpRoutes:
           kind: HTTPRouteFilter
           name: valid-header
         type: ExtensionRef
-      - type: URLRewrite
-        urlRewrite:
-          hostname: rewrite.com
-      matches:
-      - path:
-          value: /ext-first
-  status:
-    parents:
-    - conditions:
-      - lastTransitionTime: null
-        message: Cannot configure multiple urlRewrite filters for a single HTTPRouteRule
-        reason: UnsupportedValue
-        status: "False"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Resolved all the Object references for the Route
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-      parentRef:
-        name: gateway-1
-        namespace: envoy-gateway
-        sectionName: http
-- apiVersion: gateway.networking.k8s.io/v1
-  kind: HTTPRoute
-  metadata:
-    creationTimestamp: null
-    name: httproute-multiple-path-rewrites-2
-    namespace: default
-  spec:
-    hostnames:
-    - gateway.envoyproxy.io
-    parentRefs:
-    - name: gateway-1
-      namespace: envoy-gateway
-      sectionName: http
-    rules:
-    - backendRefs:
-      - name: service-1
-        port: 8080
-      filters:
-      - type: URLRewrite
-        urlRewrite:
-          hostname: rewrite.com
       - extensionRef:
           group: gateway.envoyproxy.io
           kind: HTTPRouteFilter
@@ -307,7 +307,7 @@ httpRoutes:
         type: ExtensionRef
       matches:
       - path:
-          value: /inline-first
+          value: /header-and-backend
   status:
     parents:
     - conditions:

--- a/internal/gatewayapi/testdata/securitypolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-status-conditions-truncated.out.yaml
@@ -43,6 +43,326 @@ gateways:
   kind: Gateway
   metadata:
     creationTimestamp: null
+    name: gateway-2
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-3
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-4
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-5
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-6
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-7
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-8
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-9
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
     name: gateway-10
     namespace: envoy-gateway
   spec:
@@ -364,326 +684,6 @@ gateways:
   metadata:
     creationTimestamp: null
     name: gateway-18
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-2
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-3
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-4
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-5
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-6
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-7
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-8
-    namespace: envoy-gateway
-  spec:
-    gatewayClassName: envoy-gateway-class
-    listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: http
-      port: 80
-      protocol: HTTP
-  status:
-    listeners:
-    - attachedRoutes: 2
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: http
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-- apiVersion: gateway.networking.k8s.io/v1beta1
-  kind: Gateway
-  metadata:
-    creationTimestamp: null
-    name: gateway-9
     namespace: envoy-gateway
   spec:
     gatewayClassName: envoy-gateway-class
@@ -1970,217 +1970,6 @@ securityPolicies:
   kind: SecurityPolicy
   metadata:
     creationTimestamp: null
-    name: target-httproute-with-accepted-truncated-ancestors
-    namespace: envoy-gateway
-  spec:
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: httproute-1
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-1
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-10
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-11
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-12
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-13
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-14
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-15
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-16
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-17
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-18
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-2
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-3
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-4
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-5
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-6
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-7
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Policy has been accepted.
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
-        reason: Aggregated
-        status: "True"
-        type: Aggregated
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: SecurityPolicy
-  metadata:
-    creationTimestamp: null
     name: target-httproute-with-attachment-conflict-truncated-ancestors
     namespace: envoy-gateway
   spec:
@@ -2396,6 +2185,217 @@ securityPolicies:
           already attached to it
         reason: Conflicted
         status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: 'Ancestors have been aggregated because the number of policy ancestors
+          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        reason: Aggregated
+        status: "True"
+        type: Aggregated
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: SecurityPolicy
+  metadata:
+    creationTimestamp: null
+    name: target-httproute-with-accepted-truncated-ancestors
+    namespace: envoy-gateway
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httproute-1
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-10
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-11
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-12
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-13
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-14
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-15
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-16
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-17
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-18
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-3
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-4
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-5
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-6
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-7
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: 'Ancestors have been aggregated because the number of policy ancestors

--- a/internal/gatewayapi/testdata/securitypolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-status-conditions.out.yaml
@@ -255,9 +255,13 @@ securityPolicies:
   kind: SecurityPolicy
   metadata:
     creationTimestamp: null
-    name: also-target-httproute-in-gateway-1
+    name: target-httproute-in-gateway-1
     namespace: envoy-gateway
   spec:
+    cors:
+      allowOrigins:
+      - http://*.example.com
+      maxAge: 1000s
     targetRef:
       group: gateway.networking.k8s.io
       kind: HTTPRoute
@@ -274,6 +278,32 @@ securityPolicies:
         message: Policy has been accepted.
         reason: Accepted
         status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: SecurityPolicy
+  metadata:
+    creationTimestamp: null
+    name: also-target-httproute-in-gateway-1
+    namespace: envoy-gateway
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httproute-1
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Unable to target HTTPRoute httproute-1, another SecurityPolicy has
+          already attached to it
+        reason: Conflicted
+        status: "False"
         type: Accepted
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
 - apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -303,36 +333,6 @@ securityPolicies:
         message: Policy has been accepted.
         reason: Accepted
         status: "True"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: SecurityPolicy
-  metadata:
-    creationTimestamp: null
-    name: target-httproute-in-gateway-1
-    namespace: envoy-gateway
-  spec:
-    cors:
-      allowOrigins:
-      - http://*.example.com
-      maxAge: 1000s
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: httproute-1
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-1
-        namespace: envoy-gateway
-      conditions:
-      - lastTransitionTime: null
-        message: Unable to target HTTPRoute httproute-1, another SecurityPolicy has
-          already attached to it
-        reason: Conflicted
-        status: "False"
         type: Accepted
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
 - apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -453,7 +453,13 @@ xdsIR:
           distinct: false
           name: ""
           prefix: /
-        security: {}
+        security:
+          cors:
+            allowOrigins:
+            - distinct: false
+              name: ""
+              safeRegex: http://.*\.example\.com
+            maxAge: 16m40s
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-local-jwks.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-local-jwks.out.yaml
@@ -296,42 +296,6 @@ securityPolicies:
   kind: SecurityPolicy
   metadata:
     creationTimestamp: null
-    name: securitypolicy-with-jwt-local-jwks-valueref-missing-configmap
-    namespace: default
-  spec:
-    jwt:
-      providers:
-      - issuer: https://one.example.com
-        localJWKS:
-          type: ValueRef
-          valueRef:
-            group: ""
-            kind: ConfigMap
-            name: example3-jwks
-        name: example2
-    targetRef:
-      group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: httproute-4
-  status:
-    ancestors:
-    - ancestorRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: gateway-1
-        namespace: envoy-gateway
-        sectionName: http
-      conditions:
-      - lastTransitionTime: null
-        message: 'JWT: local JWKS ConfigMap default/example3-jwks not found.'
-        reason: Invalid
-        status: "False"
-        type: Accepted
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: SecurityPolicy
-  metadata:
-    creationTimestamp: null
     name: securitypolicy-with-jwt-local-jwks-valueref-missing-key
     namespace: default
   spec:
@@ -362,6 +326,42 @@ securityPolicies:
         message: Policy has been accepted.
         reason: Accepted
         status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: SecurityPolicy
+  metadata:
+    creationTimestamp: null
+    name: securitypolicy-with-jwt-local-jwks-valueref-missing-configmap
+    namespace: default
+  spec:
+    jwt:
+      providers:
+      - issuer: https://one.example.com
+        localJWKS:
+          type: ValueRef
+          valueRef:
+            group: ""
+            kind: ConfigMap
+            name: example3-jwks
+        name: example2
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httproute-4
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      conditions:
+      - lastTransitionTime: null
+        message: 'JWT: local JWKS ConfigMap default/example3-jwks not found.'
+        reason: Invalid
+        status: "False"
         type: Accepted
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
 xdsIR:

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-secretref.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-secretref.out.yaml
@@ -182,16 +182,16 @@ securityPolicies:
   kind: SecurityPolicy
   metadata:
     creationTimestamp: null
-    name: policy-no-client-secret-key
+    name: policy-non-exist-secretRef
     namespace: default
+    uid: b8284d0f-de82-4c65-b204-96a0d3f258a1
   spec:
     oidc:
       clientID: client1.apps.googleusercontent.com
       clientSecret:
         group: null
         kind: null
-        name: client3-secret
-        namespace: default
+        name: client1-secret
       provider:
         authorizationEndpoint: https://accounts.google.com/o/oauth2/v2/auth
         issuer: https://accounts.google.com
@@ -199,17 +199,17 @@ securityPolicies:
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway
-      name: gateway-3
+      name: gateway-1
   status:
     ancestors:
     - ancestorRef:
         group: gateway.networking.k8s.io
         kind: Gateway
-        name: gateway-3
+        name: gateway-1
         namespace: default
       conditions:
       - lastTransitionTime: null
-        message: 'OIDC: client secret not found in secret default/client3-secret.'
+        message: 'OIDC: secret default/client1-secret does not exist.'
         reason: Invalid
         status: "False"
         type: Accepted
@@ -255,16 +255,16 @@ securityPolicies:
   kind: SecurityPolicy
   metadata:
     creationTimestamp: null
-    name: policy-non-exist-secretRef
+    name: policy-no-client-secret-key
     namespace: default
-    uid: b8284d0f-de82-4c65-b204-96a0d3f258a1
   spec:
     oidc:
       clientID: client1.apps.googleusercontent.com
       clientSecret:
         group: null
         kind: null
-        name: client1-secret
+        name: client3-secret
+        namespace: default
       provider:
         authorizationEndpoint: https://accounts.google.com/o/oauth2/v2/auth
         issuer: https://accounts.google.com
@@ -272,17 +272,17 @@ securityPolicies:
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway
-      name: gateway-1
+      name: gateway-3
   status:
     ancestors:
     - ancestorRef:
         group: gateway.networking.k8s.io
         kind: Gateway
-        name: gateway-1
+        name: gateway-3
         namespace: default
       conditions:
       - lastTransitionTime: null
-        message: 'OIDC: secret default/client1-secret does not exist.'
+        message: 'OIDC: client secret not found in secret default/client3-secret.'
         reason: Invalid
         status: "False"
         type: Accepted

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -7,8 +7,6 @@ package gatewayapi
 
 import (
 	"errors"
-	"fmt"
-	"sort"
 
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -169,19 +167,7 @@ func (t *Translator) Translate(resources *resource.Resources) (*TranslateResult,
 	// Get Gateways belonging to our GatewayClass.
 	acceptedGateways, failedGateways := t.GetRelevantGateways(resources)
 
-	// Sort gateways based on timestamp.
-	// Initially, acceptedGateways sort by creation timestamp
-	// or sort alphabetically by “{namespace}/{name}” if multiple gateways share same timestamp.
-	sort.Slice(acceptedGateways, func(i, j int) bool {
-		if acceptedGateways[i].CreationTimestamp.Equal(&(acceptedGateways[j].CreationTimestamp)) {
-			gatewayKeyI := fmt.Sprintf("%s/%s", acceptedGateways[i].Namespace, acceptedGateways[i].Name)
-			gatewayKeyJ := fmt.Sprintf("%s/%s", acceptedGateways[j].Namespace, acceptedGateways[j].Name)
-			return gatewayKeyI < gatewayKeyJ
-		}
-		// Not identical CreationTimestamps
-
-		return acceptedGateways[i].CreationTimestamp.Before(&(acceptedGateways[j].CreationTimestamp))
-	})
+	// Gateways are already sorted by the provider layer
 
 	// Build IR maps.
 	xdsIR, infraIR := t.InitIRs(acceptedGateways)

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -423,7 +423,6 @@ func TestTranslate(t *testing.T) {
 
 			opts := []cmp.Option{
 				cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
-				cmpopts.IgnoreFields(resource.Resources{}, "serviceMap"),
 				cmp.Transformer("ClearXdsEqual", xdsWithoutEqual),
 				cmpopts.IgnoreTypes(ir.PrivateBytes{}),
 				cmpopts.EquateEmpty(),
@@ -702,7 +701,6 @@ func TestTranslateWithExtensionKinds(t *testing.T) {
 
 			opts := []cmp.Option{
 				cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
-				cmpopts.IgnoreFields(resource.Resources{}, "serviceMap"),
 			}
 			require.Empty(t, cmp.Diff(want, got, opts...))
 		})

--- a/internal/ir/infra.go
+++ b/internal/ir/infra.go
@@ -6,13 +6,10 @@
 package ir
 
 import (
-	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 
-	"golang.org/x/exp/slices"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/yaml"
 
@@ -248,21 +245,4 @@ func (p *ProxyInfra) ObjectName() string {
 		return fmt.Sprintf("envoy-%s", DefaultProxyName)
 	}
 	return "envoy-" + p.Name
-}
-
-// Equal implements the Comparable interface used by watchable.DeepEqual to skip unnecessary updates.
-func (p *ProxyInfra) Equal(y *ProxyInfra) bool {
-	// Deep copy to avoid modifying the original ordering.
-	p = p.DeepCopy()
-	p.sort()
-	y = y.DeepCopy()
-	y.sort()
-	return reflect.DeepEqual(p, y)
-}
-
-// sort ensures the listeners are in a consistent order.
-func (p *ProxyInfra) sort() {
-	slices.SortFunc(p.Listeners, func(l1, l2 *ProxyListener) int {
-		return cmp.Compare(l1.Name, l2.Name)
-	})
 }

--- a/internal/ir/infra_test.go
+++ b/internal/ir/infra_test.go
@@ -8,7 +8,6 @@ package ir
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -205,38 +204,6 @@ func TestObjectName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := tc.infra.Proxy.ObjectName()
 			require.Equal(t, tc.expected, actual)
-		})
-	}
-}
-
-func TestEqualInfra(t *testing.T) {
-	tests := []struct {
-		desc  string
-		a     *ProxyInfra
-		b     *ProxyInfra
-		equal bool
-	}{
-		{
-			desc: "out of order proxy listeners are equal",
-			a: &ProxyInfra{
-				Listeners: []*ProxyListener{
-					{Name: "listener-1"},
-					{Name: "listener-2"},
-				},
-			},
-			b: &ProxyInfra{
-				Listeners: []*ProxyListener{
-					{Name: "listener-2"},
-					{Name: "listener-1"},
-				},
-			},
-			equal: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			require.Equal(t, tc.equal, cmp.Equal(tc.a, tc.b))
 		})
 	}
 }

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -6,7 +6,6 @@
 package ir
 
 import (
-	"cmp"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding"
@@ -15,10 +14,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
-	"reflect"
 	"time"
 
-	"golang.org/x/exp/slices"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -163,34 +160,6 @@ type Xds struct {
 	GlobalResources *GlobalResources `json:"globalResources,omitempty" yaml:"globalResources,omitempty"`
 	// ExtensionServerPolicies is the intermediate representation of the ExtensionServerPolicy resource
 	ExtensionServerPolicies []*UnstructuredRef `json:"extensionServerPolicies,omitempty" yaml:"extensionServerPolicies,omitempty"`
-}
-
-// Equal implements the Comparable interface used by watchable.DeepEqual to skip unnecessary updates.
-func (x *Xds) Equal(y *Xds) bool {
-	// Deep copy to avoid modifying the original ordering.
-	x = x.DeepCopy()
-	x.sort()
-	y = y.DeepCopy()
-	y.sort()
-	return reflect.DeepEqual(x, y)
-}
-
-// sort ensures the listeners are in a consistent order.
-func (x *Xds) sort() {
-	slices.SortFunc(x.HTTP, func(l1, l2 *HTTPListener) int {
-		return cmp.Compare(l1.Name, l2.Name)
-	})
-	for _, l := range x.HTTP {
-		slices.SortFunc(l.Routes, func(r1, r2 *HTTPRoute) int {
-			return cmp.Compare(r1.Name, r2.Name)
-		})
-	}
-	slices.SortFunc(x.TCP, func(l1, l2 *TCPListener) int {
-		return cmp.Compare(l1.Name, l2.Name)
-	})
-	slices.SortFunc(x.UDP, func(l1, l2 *UDPListener) int {
-		return cmp.Compare(l1.Name, l2.Name)
-	})
 }
 
 // Validate the fields within the Xds structure.

--- a/internal/ir/xds_test.go
+++ b/internal/ir/xds_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -751,80 +750,6 @@ func TestValidateTLSListenerConfig(t *testing.T) {
 			} else {
 				require.EqualError(t, test.input.Validate(), test.want.Error())
 			}
-		})
-	}
-}
-
-func TestEqualXds(t *testing.T) {
-	tests := []struct {
-		desc  string
-		a     *Xds
-		b     *Xds
-		equal bool
-	}{
-		{
-			desc: "out of order tcp listeners are equal",
-			a: &Xds{
-				TCP: []*TCPListener{
-					{CoreListenerDetails: CoreListenerDetails{Name: "listener-1"}},
-					{CoreListenerDetails: CoreListenerDetails{Name: "listener-2"}},
-				},
-			},
-			b: &Xds{
-				TCP: []*TCPListener{
-					{CoreListenerDetails: CoreListenerDetails{Name: "listener-2"}},
-					{CoreListenerDetails: CoreListenerDetails{Name: "listener-1"}},
-				},
-			},
-			equal: true,
-		},
-		{
-			desc: "out of order http routes are equal",
-			a: &Xds{
-				HTTP: []*HTTPListener{
-					{
-						CoreListenerDetails: CoreListenerDetails{Name: "listener-1"},
-						Routes: []*HTTPRoute{
-							{Name: "route-1"},
-							{Name: "route-2"},
-						},
-					},
-				},
-			},
-			b: &Xds{
-				HTTP: []*HTTPListener{
-					{
-						CoreListenerDetails: CoreListenerDetails{Name: "listener-1"},
-						Routes: []*HTTPRoute{
-							{Name: "route-2"},
-							{Name: "route-1"},
-						},
-					},
-				},
-			},
-			equal: true,
-		},
-		{
-			desc: "out of order udp listeners are equal",
-			a: &Xds{
-				UDP: []*UDPListener{
-					{CoreListenerDetails: CoreListenerDetails{Name: "listener-1"}},
-					{CoreListenerDetails: CoreListenerDetails{Name: "listener-2"}},
-				},
-			},
-			b: &Xds{
-				UDP: []*UDPListener{
-					{CoreListenerDetails: CoreListenerDetails{Name: "listener-2"}},
-					{CoreListenerDetails: CoreListenerDetails{Name: "listener-1"}},
-				},
-			},
-			equal: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			require.Equal(t, tc.equal, cmp.Equal(tc.a, tc.b))
 		})
 	}
 }

--- a/internal/provider/file/file_test.go
+++ b/internal/provider/file/file_test.go
@@ -290,7 +290,6 @@ func mustUnmarshal(t *testing.T, path string, out interface{}) {
 
 func cmpResources(t *testing.T, x, y interface{}) {
 	opts := []cmp.Option{
-		cmpopts.IgnoreFields(resource.Resources{}, "serviceMap"),
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
 		cmpopts.EquateEmpty(),
 	}

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -508,6 +508,13 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 		}
 	}
 
+	// Sort before storing to:
+	// 1. ensure identical resources are not retranslated
+	//    and updates are avoided by the watchable layer
+	// 2. ensure gateway-api layer receives resources in order
+	//    which impacts translation output
+	gwcResources.Sort()
+
 	// Store the Gateway Resources for the GatewayClass.
 	// The Store is triggered even when there are no Gateways associated to the
 	// GatewayClass. This would happen in case the last Gateway is removed and the


### PR DESCRIPTION
* sorts a collection of resources on gatewayClass - creationTimestamp then name
* moves all per resource sort function to provider layer

This ensures all resources will be sorted, and duplicate updates wont result into watchable subscribe calls to runners. It also means per XDS IR is also ordered

This allows us to delete `Equal()` functions added for `ProviderResources` and `XDS IR` which called expensive `DeepCopy` and `sort` functions, and rely on the top level

* the internal `svcMap` field is removed, because it was affecting caching and equality performance, it can be introduced back in the gateway-api layer as part of Translator context to improve config convergence time once we start accurately tracking it

Tested with 2000 HTTPRoutes and a aggressive cache sync period of 1m

Observations

* Watchable subscriber counts go down to 0
* CPU usage drops by 80%
* Memory drops by 20%


Before

<img width="1376" height="814" alt="Screenshot 2025-08-04 at 9 08 02 PM" src="https://github.com/user-attachments/assets/52271b29-7dfb-48e8-bf76-0c19cad00e3f" />

<img width="1366" height="775" alt="Screenshot 2025-08-04 at 9 07 58 PM" src="https://github.com/user-attachments/assets/7643f0dd-ea3b-46a3-8215-8a4f1862708b" />



<img width="1371" height="689" alt="Screenshot 2025-08-04 at 9 07 54 PM" src="https://github.com/user-attachments/assets/c8fdd231-988d-425f-8033-e515e1f0c5ee" />
-0f7e-4495-9fdb-9e44cbdf1f81" />

<img width="1372" height="830" alt="Screenshot 2025-08-04 at 9 07 48 PM" src="https://github.com/user-attachments/assets/3348c4ee-bc74-4af5-af51-12ce6745f69b" />


After


<img width="1371" height="786" alt="Screenshot 2025-08-04 at 9 39 50 PM" src="https://github.com/user-attachments/assets/995c80e1-5f44-4be9-af5a-b932b4b04322" />

<img width="1370" height="704" alt="Screenshot 2025-08-04 at 9 39 19 PM" src="https://github.com/user-attachments/assets/db680f66-417d-4a82-808d-e4c4565672b6" />

<img width="1383" height="741" alt="Screenshot 2025-08-04 at 9 39 01 PM" src="https://github.com/user-attachments/assets/21bb49f1-3a5f-48d2-bd76-224286c195b0" />

<img width="1373" height="801" alt="Screenshot 2025-08-04 at 9 38 22 PM" src="https://github.com/user-attachments/assets/6707f111-a6ae-4e5b-8d62-5bbe60799934" />



Fixes: https://github.com/envoyproxy/gateway/issues/6690