### PR TITLE
Revert "feat: add listener metadata (#6639)"

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -1127,14 +1127,6 @@ xds:
                   useRemoteAddress: true
               name: default/eg/http
             maxConnectionsToAcceptPerSocketEvent: 1
-            metadata:
-              filterMetadata:
-                envoy-gateway:
-                  resources:
-                  - kind: Gateway
-                    name: eg
-                    namespace: default
-                    sectionName: http
             name: default/eg/http
             perConnectionBufferLimitBytes: 32768
       - activeState:
@@ -1247,14 +1239,6 @@ xds:
                   useRemoteAddress: true
               name: default/eg/grpc
             maxConnectionsToAcceptPerSocketEvent: 1
-            metadata:
-              filterMetadata:
-                envoy-gateway:
-                  resources:
-                  - kind: Gateway
-                    name: eg
-                    namespace: default
-                    sectionName: grpc
             name: default/eg/grpc
             perConnectionBufferLimitBytes: 32768
       - activeState:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -978,20 +978,6 @@
                     "name": "default/eg/http"
                   },
                   "maxConnectionsToAcceptPerSocketEvent": 1,
-                  "metadata": {
-                    "filterMetadata": {
-                      "envoy-gateway": {
-                        "resources": [
-                          {
-                            "kind": "Gateway",
-                            "name": "eg",
-                            "namespace": "default",
-                            "sectionName": "http"
-                          }
-                        ]
-                      }
-                    }
-                  },
                   "name": "default/eg/http",
                   "perConnectionBufferLimitBytes": 32768
                 }
@@ -1144,20 +1130,6 @@
                     "name": "default/eg/grpc"
                   },
                   "maxConnectionsToAcceptPerSocketEvent": 1,
-                  "metadata": {
-                    "filterMetadata": {
-                      "envoy-gateway": {
-                        "resources": [
-                          {
-                            "kind": "Gateway",
-                            "name": "eg",
-                            "namespace": "default",
-                            "sectionName": "grpc"
-                          }
-                        ]
-                      }
-                    }
-                  },
                   "name": "default/eg/grpc",
                   "perConnectionBufferLimitBytes": 32768
                 }

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -580,14 +580,6 @@ xds:
                   useRemoteAddress: true
               name: default/eg/http
             maxConnectionsToAcceptPerSocketEvent: 1
-            metadata:
-              filterMetadata:
-                envoy-gateway:
-                  resources:
-                  - kind: Gateway
-                    name: eg
-                    namespace: default
-                    sectionName: http
             name: default/eg/http
             perConnectionBufferLimitBytes: 32768
       - activeState:
@@ -700,14 +692,6 @@ xds:
                   useRemoteAddress: true
               name: default/eg/grpc
             maxConnectionsToAcceptPerSocketEvent: 1
-            metadata:
-              filterMetadata:
-                envoy-gateway:
-                  resources:
-                  - kind: Gateway
-                    name: eg
-                    namespace: default
-                    sectionName: grpc
             name: default/eg/grpc
             perConnectionBufferLimitBytes: 32768
       - activeState:

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.listener.yaml
@@ -143,14 +143,6 @@ xds:
                 useRemoteAddress: true
             name: default/eg/http
           maxConnectionsToAcceptPerSocketEvent: 1
-          metadata:
-            filterMetadata:
-              envoy-gateway:
-                resources:
-                - kind: Gateway
-                  name: eg
-                  namespace: default
-                  sectionName: http
           name: default/eg/http
           perConnectionBufferLimitBytes: 32768
     - activeState:
@@ -263,14 +255,6 @@ xds:
                 useRemoteAddress: true
             name: default/eg/grpc
           maxConnectionsToAcceptPerSocketEvent: 1
-          metadata:
-            filterMetadata:
-              envoy-gateway:
-                resources:
-                - kind: Gateway
-                  name: eg
-                  namespace: default
-                  sectionName: grpc
           name: default/eg/grpc
           perConnectionBufferLimitBytes: 32768
     - activeState:

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -689,20 +689,6 @@
                     "name": "envoy-gateway-system/eg/http"
                   },
                   "maxConnectionsToAcceptPerSocketEvent": 1,
-                  "metadata": {
-                    "filterMetadata": {
-                      "envoy-gateway": {
-                        "resources": [
-                          {
-                            "kind": "Gateway",
-                            "name": "eg",
-                            "namespace": "envoy-gateway-system",
-                            "sectionName": "http"
-                          }
-                        ]
-                      }
-                    }
-                  },
                   "name": "envoy-gateway-system/eg/http",
                   "perConnectionBufferLimitBytes": 32768
                 }

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -418,14 +418,6 @@ xds:
                   useRemoteAddress: true
               name: envoy-gateway-system/eg/http
             maxConnectionsToAcceptPerSocketEvent: 1
-            metadata:
-              filterMetadata:
-                envoy-gateway:
-                  resources:
-                  - kind: Gateway
-                    name: eg
-                    namespace: envoy-gateway-system
-                    sectionName: http
             name: envoy-gateway-system/eg/http
             perConnectionBufferLimitBytes: 32768
     - '@type': type.googleapis.com/envoy.admin.v3.RoutesConfigDump

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
@@ -163,13 +163,5 @@ xds:
                 useRemoteAddress: true
             name: envoy-gateway-system/eg/http
           maxConnectionsToAcceptPerSocketEvent: 1
-          metadata:
-            filterMetadata:
-              envoy-gateway:
-                resources:
-                - kind: Gateway
-                  name: eg
-                  namespace: envoy-gateway-system
-                  sectionName: http
           name: envoy-gateway-system/eg/http
           perConnectionBufferLimitBytes: 32768

--- a/internal/cmd/egctl/testdata/translate/out/no-service-cluster-ip.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/no-service-cluster-ip.all.yaml
@@ -353,14 +353,6 @@ xds:
                   useRemoteAddress: true
               name: envoy-gateway-system/eg/http
             maxConnectionsToAcceptPerSocketEvent: 1
-            metadata:
-              filterMetadata:
-                envoy-gateway:
-                  resources:
-                  - kind: Gateway
-                    name: eg
-                    namespace: envoy-gateway-system
-                    sectionName: http
             name: envoy-gateway-system/eg/http
             perConnectionBufferLimitBytes: 32768
     - '@type': type.googleapis.com/envoy.admin.v3.RoutesConfigDump

--- a/internal/xds/translator/metadata.go
+++ b/internal/xds/translator/metadata.go
@@ -27,23 +27,8 @@ func buildXdsMetadata(metadata *ir.ResourceMetadata) *corev3.Metadata {
 		return nil
 	}
 
-	return buildXdsMetadataFromMultiple([]*ir.ResourceMetadata{metadata})
-}
-
-func buildXdsMetadataFromMultiple(metadata []*ir.ResourceMetadata) *corev3.Metadata {
-	if metadata == nil {
-		return nil
-	}
-
 	resourcesList := &structpb.ListValue{}
-	for _, md := range metadata {
-		if md != nil {
-			resourcesList.Values = append(resourcesList.Values, buildResourceMetadata(md))
-		}
-	}
-	if len(resourcesList.Values) == 0 {
-		return nil
-	}
+	resourcesList.Values = append(resourcesList.Values, buildResourceMetadata(metadata))
 
 	return &corev3.Metadata{
 		FilterMetadata: map[string]*structpb.Struct{

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-types.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-types.listeners.yaml
@@ -345,13 +345,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.listeners.yaml
@@ -75,13 +75,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.listeners.yaml
@@ -75,13 +75,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/backend-priority.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-priority.listeners.yaml
@@ -45,13 +45,5 @@
         useRemoteAddress: true
     name: default/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: default
-          sectionName: http
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/btp-telemetry.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/btp-telemetry.listeners.yaml
@@ -31,13 +31,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/compression.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/compression.listeners.yaml
@@ -47,13 +47,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/credential-injection-backend-filter.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/credential-injection-backend-filter.listeners.yaml
@@ -31,13 +31,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/credential-injection.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/credential-injection.listeners.yaml
@@ -59,13 +59,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/custom-response.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-response.listeners.yaml
@@ -167,13 +167,5 @@
         useRemoteAddress: true
     name: default/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: default
-          sectionName: http
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/dns-lookup-family.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/dns-lookup-family.listeners.yaml
@@ -177,13 +177,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.listeners.yaml
@@ -45,13 +45,5 @@
         useRemoteAddress: true
     name: default/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: default
-          sectionName: http
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-connect-proxy.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-connect-proxy.listeners.yaml
@@ -31,13 +31,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-connect-terminate.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-connect-terminate.listeners.yaml
@@ -31,13 +31,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-dynamic-resolver.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-dynamic-resolver.listeners.yaml
@@ -67,13 +67,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-metadata.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-metadata.listeners.yaml
@@ -31,15 +31,5 @@
         useRemoteAddress: true
     name: first-listener
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - annotations:
-            foo: bar
-          kind: Gateway
-          name: first-gateway
-          namespace: first-gateway
-          sectionName: first-listener
   name: first-listener
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-upgrade-spdy.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-upgrade-spdy.listeners.yaml
@@ -31,13 +31,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-upgrade-websocket-spdy.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-upgrade-websocket-spdy.listeners.yaml
@@ -31,13 +31,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.listeners.yaml
@@ -63,13 +63,5 @@
         useRemoteAddress: true
     name: default/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: default
-          sectionName: http
   name: default/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/listener-overlapping-tls-config.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-overlapping-tls-config.listeners.yaml
@@ -96,18 +96,6 @@
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: https-1
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: https-2
   name: envoy-gateway/gateway-1/https-1
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -164,13 +152,5 @@
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: https-3
   name: envoy-gateway/gateway-1/https-3
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/request-buffer.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/request-buffer.listeners.yaml
@@ -36,14 +36,6 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768
 - address:
@@ -84,13 +76,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-2/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-2
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-2/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.listeners.yaml
@@ -103,13 +103,5 @@
         useRemoteAddress: true
     name: envoy-gateway/gateway-1/http
   maxConnectionsToAcceptPerSocketEvent: 1
-  metadata:
-    filterMetadata:
-      envoy-gateway:
-        resources:
-        - kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
   name: envoy-gateway/gateway-1/http
   perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -276,7 +276,6 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 	// The XDS translation is done in a best-effort manner, so we collect all
 	// errors and return them at the end.
 	var (
-		ownerGatewayListeners = make(map[string][]*ir.ResourceMetadata) // The set of Gateway HTTPListeners that own the xDS Listener
 		http3EnabledListeners = make(map[listenerKey]*ir.HTTP3Settings) // Map to track HTTP3 settings for listeners by address and port
 		errs                  error
 	)
@@ -402,12 +401,6 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 			}
 		}
 
-		// Collect the metadata for the HTTPListener.
-		ownerGatewayListeners[tcpXDSListener.Name] = append(ownerGatewayListeners[tcpXDSListener.Name], httpListener.Metadata)
-		if http3Enabled {
-			ownerGatewayListeners[quicXDSListener.Name] = append(ownerGatewayListeners[quicXDSListener.Name], httpListener.Metadata)
-		}
-
 		// Add the secrets referenced by the listener's TLS configuration to the
 		// resource version table.
 		// 1:1 between IR TLSListenerConfig and xDS Secret
@@ -479,14 +472,6 @@ func (t *Translator) processHTTPListenerXdsTranslation(
 		// resource version table.
 		if err = patchResources(tCtx, httpListener.Routes); err != nil {
 			errs = errors.Join(errs, err)
-		}
-	}
-
-	// Add the owner Gateway Listeners to the xDS listeners' metadata.
-	for listenerName, ownerGatewayListeners := range ownerGatewayListeners {
-		xdsListener := findXdsListener(tCtx, listenerName)
-		if xdsListener != nil {
-			xdsListener.Metadata = buildXdsMetadataFromMultiple(ownerGatewayListeners)
 		}
 	}
 


### PR DESCRIPTION
This reverts commit 20cb68b819c24a4205939f6c99b4abb0950961ef.

Updating the xds listener thats common across multiple Gateway API listeners targeting the same port, could cause listener drains, so its safer to avoid updating the metadata field for now

Relates to https://github.com/envoyproxy/gateway/issues/6716