### PR TITLE
fix: envoy service cluster name for zone-aware routing

### DIFF
--- a/internal/provider/kubernetes/controller_test.go
+++ b/internal/provider/kubernetes/controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/gatewayapi"
 	"github.com/envoyproxy/gateway/internal/gatewayapi/resource"
+	"github.com/envoyproxy/gateway/internal/infrastructure/kubernetes/proxy"
 	"github.com/envoyproxy/gateway/internal/logging"
 	"github.com/envoyproxy/gateway/internal/provider/kubernetes/test"
 	"github.com/envoyproxy/gateway/internal/utils"
@@ -1243,6 +1244,191 @@ func TestProcessSecurityPolicyObjectRefs(t *testing.T) {
 			} else {
 				require.NotContains(t, resourceTree.ReferenceGrants, tc.referenceGrant)
 			}
+		})
+	}
+}
+
+func TestProcessServiceClusterForGatewayClass(t *testing.T) {
+	testCases := []struct {
+		name            string
+		gatewayClass    *gwapiv1.GatewayClass
+		envoyProxy      *egv1a1.EnvoyProxy
+		expectedSvcName string
+	}{
+		{
+			name: "when merged gateways and no hardcoded svc name is used",
+			gatewayClass: &gwapiv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "merged-gc",
+				},
+			},
+			envoyProxy:      nil,
+			expectedSvcName: proxy.ExpectedResourceHashedName("merged-gc"),
+		},
+		{
+			name: "when merged gateways and a hardcoded svc name is used",
+			gatewayClass: &gwapiv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "merged-gc",
+				},
+			},
+			envoyProxy: &egv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "merged-gc",
+				},
+				Spec: egv1a1.EnvoyProxySpec{
+					Provider: &egv1a1.EnvoyProxyProvider{
+						Type: egv1a1.ProviderTypeKubernetes,
+						Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
+							EnvoyService: &egv1a1.KubernetesServiceSpec{
+								Name: ptr.To("merged-gc-svc"),
+							},
+						},
+					},
+				},
+			},
+			expectedSvcName: "merged-gc-svc",
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		// Run the test cases.
+		t.Run(tc.name, func(t *testing.T) {
+			logger := logging.DefaultLogger(os.Stdout, egv1a1.LogLevelInfo)
+			resourceMap := newResourceMapping()
+
+			r := newGatewayAPIReconciler(logger)
+			r.namespace = "envoy-gateway-system"
+
+			r.processServiceClusterForGatewayClass(tc.envoyProxy, tc.gatewayClass, resourceMap)
+
+			require.Contains(t, resourceMap.allAssociatedBackendRefs, gwapiv1.BackendObjectReference{
+				Kind:      ptr.To(gwapiv1.Kind("Service")),
+				Namespace: gatewayapi.NamespacePtr(r.namespace),
+				Name:      gwapiv1.ObjectName(tc.expectedSvcName),
+			})
+		})
+	}
+}
+
+func TestProcessServiceClusterForGateway(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		gateway               *gwapiv1.Gateway
+		envoyProxy            *egv1a1.EnvoyProxy
+		gatewayNamespacedMode bool
+		expectedSvcName       string
+		expectedSvcNamespace  string
+	}{
+		{
+			name: "no gateway namespaced mode with no hardcoded service name",
+			gateway: &gwapiv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gateway",
+					Namespace: "app-namespace",
+				},
+			},
+			envoyProxy:            nil,
+			gatewayNamespacedMode: false,
+			expectedSvcName:       "",
+			expectedSvcNamespace:  "",
+		},
+		{
+			name: "no gateway namespaced mode with hardcoded service name",
+			gateway: &gwapiv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gateway",
+					Namespace: "app-namespace",
+				},
+			},
+			envoyProxy: &egv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-gateway",
+				},
+				Spec: egv1a1.EnvoyProxySpec{
+					Provider: &egv1a1.EnvoyProxyProvider{
+						Type: egv1a1.ProviderTypeKubernetes,
+						Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
+							EnvoyService: &egv1a1.KubernetesServiceSpec{
+								Name: ptr.To("my-gateway-svc"),
+							},
+						},
+					},
+				},
+			},
+			gatewayNamespacedMode: false,
+			expectedSvcName:       "my-gateway-svc",
+			expectedSvcNamespace:  "",
+		},
+		{
+			name: "gateway namespaced mode with no hardcoded service name",
+			gateway: &gwapiv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gateway",
+					Namespace: "app-namespace",
+				},
+			},
+			envoyProxy:            nil,
+			gatewayNamespacedMode: true,
+			expectedSvcName:       "my-gateway",
+			expectedSvcNamespace:  "app-namespace",
+		},
+		{
+			name: "gateway namespaced mode with hardcoded service name",
+			gateway: &gwapiv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gateway",
+					Namespace: "app-namespace",
+				},
+			},
+			envoyProxy: &egv1a1.EnvoyProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-gateway",
+				},
+				Spec: egv1a1.EnvoyProxySpec{
+					Provider: &egv1a1.EnvoyProxyProvider{
+						Type: egv1a1.ProviderTypeKubernetes,
+						Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
+							EnvoyService: &egv1a1.KubernetesServiceSpec{
+								Name: ptr.To("my-gateway-svc"),
+							},
+						},
+					},
+				},
+			},
+			gatewayNamespacedMode: true,
+			expectedSvcName:       "my-gateway-svc",
+			expectedSvcNamespace:  "app-namespace",
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		// Run the test cases.
+		t.Run(tc.name, func(t *testing.T) {
+			logger := logging.DefaultLogger(os.Stdout, egv1a1.LogLevelInfo)
+			resourceMap := newResourceMapping()
+
+			r := newGatewayAPIReconciler(logger)
+			r.namespace = "envoy-gateway-system"
+			r.gatewayNamespaceMode = tc.gatewayNamespacedMode
+
+			if tc.expectedSvcNamespace == "" {
+				tc.expectedSvcNamespace = r.namespace
+			}
+
+			if tc.expectedSvcName == "" {
+				tc.expectedSvcName = proxy.ExpectedResourceHashedName(utils.NamespacedName(tc.gateway).String())
+			}
+
+			r.processServiceClusterForGateway(tc.envoyProxy, tc.gateway, resourceMap)
+
+			require.Contains(t, resourceMap.allAssociatedBackendRefs, gwapiv1.BackendObjectReference{
+				Kind:      ptr.To(gwapiv1.Kind("Service")),
+				Namespace: gatewayapi.NamespacePtr(tc.expectedSvcNamespace),
+				Name:      gwapiv1.ObjectName(tc.expectedSvcName),
+			})
 		})
 	}
 }

--- a/test/e2e/testdata/zone-aware-routing-btp-force-local-zone.yaml
+++ b/test/e2e/testdata/zone-aware-routing-btp-force-local-zone.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: btp-force-local-zone
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: zone-aware-backend
+  ports:
+    - protocol: TCP
+      port: 8080
+      name: http11
+      targetPort: 3000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: btp-force-local-zone
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /btp-force-local-zone
+      backendRefs:
+        - name: btp-force-local-zone
+          port: 8080
+          weight: 1
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: btp-force-local-zone
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: btp-force-local-zone
+  loadBalancer:
+    type: RoundRobin
+    zoneAware:
+      preferLocal:
+        minEndpointsThreshold: 1
+        force:
+          minEndpointsInZoneThreshold: 1

--- a/test/e2e/testdata/zone-aware-routing-btp-no-force-local-zone.yaml
+++ b/test/e2e/testdata/zone-aware-routing-btp-no-force-local-zone.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: btp-zone-aware
+  name: btp-no-force-local-zone
   namespace: gateway-conformance-infra
 spec:
   selector:
@@ -15,7 +15,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: btp-zone-aware
+  name: btp-no-force-local-zone
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
@@ -24,26 +24,24 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: /btp-zone-aware
+            value: /btp-no-force-local-zone
       backendRefs:
-        - name: btp-zone-aware
+        - name: btp-no-force-local-zone
           port: 8080
           weight: 1
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
-  name: btp-zone-aware
+  name: btp-no-force-local-zone
   namespace: gateway-conformance-infra
 spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: btp-zone-aware
+      name: btp-no-force-local-zone
   loadBalancer:
     type: RoundRobin
     zoneAware:
       preferLocal:
         minEndpointsThreshold: 1
-        force:
-          minEndpointsInZoneThreshold: 1

--- a/test/e2e/testdata/zone-aware-routing-gateways.yaml
+++ b/test/e2e/testdata/zone-aware-routing-gateways.yaml
@@ -1,0 +1,91 @@
+# zone-aware-routing-gtw should be similar to `same-namespace` gateway, only difference
+# is having a hard-coded service name in the EnvoyProxy attached, to test zone-aware-routing
+# in that case when no ForceLocal is specified.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: zone-aware-routing-gtw
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: tls
+      protocol: TLS
+      port: 443
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: zone-aware-routing
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: zone-aware-routing
+  namespace: gateway-conformance-infra
+spec:
+  ipFamily: IPv4
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        name: zone-aware-routing-gtw
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: btp-no-force-local-zone-hardcoded-svc-name
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: zone-aware-backend
+  ports:
+    - protocol: TCP
+      port: 8080
+      name: http11
+      targetPort: 3000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: btp-no-force-local-zone-hardcoded-svc-name
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: zone-aware-routing-gtw
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /btp-no-force-local-zone-hardcoded-svc-name
+      backendRefs:
+        - name: btp-no-force-local-zone-hardcoded-svc-name
+          port: 8080
+          weight: 1
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: btp-no-force-local-zone-hardcoded-svc-name
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: btp-no-force-local-zone-hardcoded-svc-name
+  loadBalancer:
+    type: RoundRobin
+    zoneAware:
+      preferLocal:
+        minEndpointsThreshold: 1

--- a/test/e2e/tests/zone_aware_routing.go
+++ b/test/e2e/tests/zone_aware_routing.go
@@ -8,6 +8,7 @@
 package tests
 
 import (
+	"math"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -28,8 +29,10 @@ var ZoneAwareRoutingTest = suite.ConformanceTest{
 	Description: "Test Zone Aware Routing is working",
 	Manifests: []string{
 		"testdata/zone-aware-routing-backendref-enabled.yaml",
-		"testdata/zone-aware-routing-btp-enabled.yaml",
+		"testdata/zone-aware-routing-btp-force-local-zone.yaml",
+		"testdata/zone-aware-routing-btp-no-force-local-zone.yaml",
 		"testdata/zone-aware-routing-deployments.yaml",
+		"testdata/zone-aware-routing-gateways.yaml",
 	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		t.Run("topology aware routing - only local zone should get requests", func(t *testing.T) {
@@ -39,12 +42,12 @@ var ZoneAwareRoutingTest = suite.ConformanceTest{
 				"zone-aware-backend-local":    sendRequests,
 				"zone-aware-backend-nonlocal": 0,
 			}
-			runWeightedBackendTest(t, suite, "topology-aware-routing", "/topology-aware-routing", "zone-aware-backend", expected)
+			runWeightedBackendTest(t, suite, nil, "topology-aware-routing", "/topology-aware-routing", "zone-aware-backend", expected)
 		})
-		t.Run("BackendTrafficPolicy - only local zone should get requests", func(t *testing.T) {
+		t.Run("BackendTrafficPolicy - ForceLocalZone - only local zone should get requests", func(t *testing.T) {
 			BackendTrafficPolicyMustBeAccepted(t,
 				suite.Client,
-				types.NamespacedName{Name: "btp-zone-aware", Namespace: "gateway-conformance-infra"},
+				types.NamespacedName{Name: "btp-force-local-zone", Namespace: "gateway-conformance-infra"},
 				suite.ControllerName,
 				gwapiv1a2.ParentReference{
 					Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
@@ -60,7 +63,53 @@ var ZoneAwareRoutingTest = suite.ConformanceTest{
 				"zone-aware-backend-local":    sendRequests,
 				"zone-aware-backend-nonlocal": 0,
 			}
-			runWeightedBackendTest(t, suite, "btp-zone-aware", "/btp-zone-aware", "zone-aware-backend", expected)
+			runWeightedBackendTest(t, suite, nil, "btp-force-local-zone", "/btp-force-local-zone", "zone-aware-backend", expected)
+		})
+		t.Run("BackendTrafficPolicy - No ForceLocalZone - local zone should get around 75% of requests", func(t *testing.T) {
+			BackendTrafficPolicyMustBeAccepted(t,
+				suite.Client,
+				types.NamespacedName{Name: "btp-no-force-local-zone", Namespace: "gateway-conformance-infra"},
+				suite.ControllerName,
+				gwapiv1a2.ParentReference{
+					Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+					Kind:      gatewayapi.KindPtr(resource.KindGateway),
+					Namespace: gatewayapi.NamespacePtr("gateway-conformance-infra"),
+					Name:      gwapiv1.ObjectName("same-namespace"),
+				},
+			)
+
+			// Pods from the backend-local deployment have affinity for the Envoy Proxy pods.
+			// ForceLocal is not used, and overall we have 4 backend pods, 3 local and 1 non-local.
+			// Distribution of upstream is 75% local, 25% non-local. Distribution of envoy is 100% local.
+			// Expect local upstream to get around 75% of traffic.
+			expected := map[string]int{
+				"zone-aware-backend-local":    int(math.Round(sendRequests * .75)),
+				"zone-aware-backend-nonlocal": int(math.Round(sendRequests * .25)),
+			}
+			runWeightedBackendTest(t, suite, nil, "btp-no-force-local-zone", "/btp-no-force-local-zone", "zone-aware-backend", expected)
+		})
+		t.Run("BackendTrafficPolicy - No ForceLocalZone - Hardcoded service name in EnvoyProxy - local zone should get around 75% of requests", func(t *testing.T) {
+			BackendTrafficPolicyMustBeAccepted(t,
+				suite.Client,
+				types.NamespacedName{Name: "btp-no-force-local-zone-hardcoded-svc-name", Namespace: "gateway-conformance-infra"},
+				suite.ControllerName,
+				gwapiv1a2.ParentReference{
+					Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+					Kind:      gatewayapi.KindPtr(resource.KindGateway),
+					Namespace: gatewayapi.NamespacePtr("gateway-conformance-infra"),
+					Name:      gwapiv1.ObjectName("zone-aware-routing-gtw"),
+				},
+			)
+
+			// Pods from the backend-local deployment have affinity for the Envoy Proxy pods.
+			// ForceLocal is not used, and overall we have 4 backend pods, 3 local and 1 non-local.
+			// Distribution of upstream is 75% local, 25% non-local. Distribution of envoy is 100% local.
+			// Expect local upstream to get around 75% of traffic.
+			expected := map[string]int{
+				"zone-aware-backend-local":    int(math.Round(sendRequests * .75)),
+				"zone-aware-backend-nonlocal": int(math.Round(sendRequests * .25)),
+			}
+			runWeightedBackendTest(t, suite, &types.NamespacedName{Name: "zone-aware-routing-gtw", Namespace: "gateway-conformance-infra"}, "btp-no-force-local-zone-hardcoded-svc-name", "/btp-no-force-local-zone-hardcoded-svc-name", "zone-aware-backend", expected)
 		})
 	},
 }


### PR DESCRIPTION
**What type of PR is this?**

fix!: fix envoy service cluster name for zone-aware routing

**What this PR does / why we need it**:

Currently, the new zone aware routing is not always functional when not using ForceLocalZone and using Envoy's normal distributional zone-aware routing.

This is the case when having a hard-coded name for the envoy's service in EnvoyProxy. The code always assumes the service has an autogenerated name, and so in other cases the discovery fails for envoy endpoints.

I've moved the call for `processServiceCluster` in case of unmerged gateways down after we do the `processGatewayParamsRef`, so that we can fetch EnvoyProxy directly from the `resourceTree`. If this might cause any other unintended problems, I can move it to where it was, and fetch EnvoyProxy manually instead.

Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes/No
