### PR TITLE
Fix fix golint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -518,7 +518,6 @@ require (
 
 tool (
 	github.com/bufbuild/buf/cmd/buf
-	github.com/daixiang0/gci/cmd/gci
 	github.com/elastic/crd-ref-docs
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	github.com/google/go-jsonnet/cmd/jsonnet

--- a/tools/make/lint.mk
+++ b/tools/make/lint.mk
@@ -69,13 +69,12 @@ lint.shellcheck: $(tools/shellcheck)
 	$(tools/shellcheck) tools/hack/*.sh
 
 .PHONY: fix-golint
-fix-golint: lint.fix-golint ## Run golangci-lint and gci to automatically fix code lint issues
+fix-golint: lint.fix-golint ## Run golangci-lint to automatically fix code lint issues
 
 .PHONY: lint.fix-golint
 lint.fix-golint:
 	@$(LOG_TARGET)
 	$(MAKE) lint.golint GOLANGCI_LINT_FLAGS="--fix"
-	find . -name "*.go" | xargs go tool gci write --skip-generated -s Standard -s Default -s "Prefix(github.com/envoyproxy/gateway)"
 
 .PHONY: gen-check
 gen-check: format generate manifests protos go.testdata.complete


### PR DESCRIPTION
**What this PR does / why we need it**:
When running `make fix-golint` it fails with the following error:
```log
===========> Running lint.fix-golint ... 
/Library/Developer/CommandLineTools/usr/bin/make lint.golint GOLANGCI_LINT_FLAGS="--fix"
===========> Running lint.golint ... 
find . -name "*.go" | xargs go tool gci write --skip-generated -s Standard -s Default -s "Prefix(github.com/envoyproxy/gateway)"
package github.com/daixiang0/gci/cmd/gci is not a main package
make[1]: *** [lint.fix-golint] Error 1
make: *** [_run] Error 2
```

According to golangci-lint [docs](https://golangci-lint.run/docs/formatters/configuration/#gci) gci supports autofix so gci tool can be removed.
I also verified this by reordering some import and then running `make fix-golint` which reordered it to the original state.
<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
