### PR TITLE
chore: test jwt claim authz using access token

### DIFF
--- a/test/e2e/testdata/oidc-securitypolicy-backendcluster.yaml
+++ b/test/e2e/testdata/oidc-securitypolicy-backendcluster.yaml
@@ -81,6 +81,23 @@ spec:
       name: "oidctest-secret"
     redirectURL: "http://www.example.com/myapp/oauth2/callback"
     logoutPath: "/myapp/logout"
+    forwardAccessToken: true
+  jwt:
+    providers:
+    - name: keycloak
+      remoteJWKS:
+        uri: http://keycloak.gateway-conformance-infra/realms/master/protocol/openid-connect/certs
+  authorization:  # test jwt claim authorization using the access token retrieved from keycloak
+    defaultAction: Deny
+    rules:
+    - name: "allow"
+      action: Allow
+      principal:
+        jwt:
+          provider: keycloak
+          claims:
+          - name: client_id
+            values: ["oidctest"]
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend


### PR DESCRIPTION
Add e2e test to verify jwt claim based authz works with OIDC access token.

https://envoyproxy.slack.com/archives/C03E6NHLESV/p1755170401648619?thread_ts=1754587464.212079&cid=C03E6NHLESV