### PR TITLE
feat: support ir metadata to tcproute/udproute

### DIFF
--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -151,6 +151,7 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR resource
 						Address:      address,
 						Port:         uint32(containerPort),
 						ExternalPort: uint32(listener.Port),
+						Metadata:     buildListenerMetadata(listener, gateway),
 						IPFamily:     ipFamily,
 					},
 
@@ -168,6 +169,7 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR resource
 						Address:      address,
 						Port:         uint32(containerPort),
 						ExternalPort: uint32(listener.Port),
+						Metadata:     buildListenerMetadata(listener, gateway),
 					},
 				}
 				xdsIR[irKey].UDP = append(xdsIR[irKey].UDP, irListener)

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -1163,7 +1163,8 @@ func (t *Translator) processUDPRouteParentRefs(udpRoute *UDPRouteContext, resour
 					Destination: &ir.RouteDestination{
 						Name:     destName,
 						Settings: destSettings,
-						Metadata: buildResourceMetadata(udpRoute, nil),
+						// udpRoute Must have a single rule, so can use index 0.
+						Metadata: buildResourceMetadata(udpRoute, udpRoute.Spec.Rules[0].Name),
 					},
 				}
 				irListener.Route = irRoute
@@ -1310,7 +1311,8 @@ func (t *Translator) processTCPRouteParentRefs(tcpRoute *TCPRouteContext, resour
 					Destination: &ir.RouteDestination{
 						Name:     destName,
 						Settings: destSettings,
-						Metadata: buildResourceMetadata(tcpRoute, nil),
+						// tcpRoute Must have a single rule, so can use index 0.
+						Metadata: buildResourceMetadata(tcpRoute, tcpRoute.Spec.Rules[0].Name),
 					},
 				}
 

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions.out.yaml
@@ -680,5 +680,10 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 53
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-2/tcp
       port: 10053

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-gateway.out.yaml
@@ -259,6 +259,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 8089
+      metadata:
+        kind: Gateway
+        name: tcp-gateway
+        namespace: default
+        sectionName: bar
       name: default/tcp-gateway/bar
       port: 8089
       routes:
@@ -328,6 +333,11 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 8162
+      metadata:
+        kind: Gateway
+        name: tcp-gateway
+        namespace: default
+        sectionName: foo
       name: default/tcp-gateway/foo
       port: 8162
       route:

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-route.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-route.out.yaml
@@ -332,6 +332,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 8089
+      metadata:
+        kind: Gateway
+        name: tcp-gateway
+        namespace: default
+        sectionName: bar
       name: default/tcp-gateway/bar
       port: 8089
       routes:
@@ -401,6 +406,11 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 8162
+      metadata:
+        kind: Gateway
+        name: tcp-gateway
+        namespace: default
+        sectionName: foo
       name: default/tcp-gateway/foo
       port: 8162
       route:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-for-tcp-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-for-tcp-listeners.out.yaml
@@ -216,6 +216,11 @@ xdsIR:
           closeDelay: 10s
           value: 3
       externalPort: 443
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls-1
       name: envoy-gateway/gateway-1/tls-1
       port: 10443
       proxyProtocol: {}
@@ -288,6 +293,11 @@ xdsIR:
           closeDelay: 10s
           value: 3
       externalPort: 8080
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp-1
       name: envoy-gateway/gateway-1/tcp-1
       port: 8080
       proxyProtocol: {}

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-invalid-settings.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-invalid-settings.out.yaml
@@ -957,6 +957,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 8443
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+        sectionName: tcp-1
       name: default/gateway-1/tcp-1
       port: 8443
       tls:
@@ -969,6 +974,11 @@ xdsIR:
         minVersion: "1.2"
     - address: 0.0.0.0
       externalPort: 5000
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+        sectionName: tcp-2
       name: default/gateway-1/tcp-2
       port: 5000
       routes:
@@ -1050,6 +1060,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 8443
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: default
+        sectionName: tcp-1
       name: default/gateway-2/tcp-1
       port: 8443
       tls:
@@ -1062,6 +1077,11 @@ xdsIR:
         minVersion: "1.2"
     - address: 0.0.0.0
       externalPort: 5000
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: default
+        sectionName: tcp-2
       name: default/gateway-2/tcp-2
       port: 5000
   default/gateway-3:
@@ -1133,6 +1153,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 8443
+      metadata:
+        kind: Gateway
+        name: gateway-3
+        namespace: default
+        sectionName: tcp-1
       name: default/gateway-3/tcp-1
       port: 8443
       tls:
@@ -1145,5 +1170,10 @@ xdsIR:
         minVersion: "1.2"
     - address: 0.0.0.0
       externalPort: 5000
+      metadata:
+        kind: Gateway
+        name: gateway-3
+        namespace: default
+        sectionName: tcp-2
       name: default/gateway-3/tcp-2
       port: 5000

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-client-verification.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-client-verification.out.yaml
@@ -640,6 +640,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 6443
+      metadata:
+        kind: Gateway
+        name: gateway-3
+        namespace: envoy-gateway
+        sectionName: tls-1
       name: envoy-gateway/gateway-3/tls-1
       port: 6443
       routes:

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-proxyprotocol-legacy-mixed.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-proxyprotocol-legacy-mixed.out.yaml
@@ -300,6 +300,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 9090
+      metadata:
+        kind: Gateway
+        name: gateway-legacy-only
+        namespace: envoy-gateway
+        sectionName: tcp-1
       name: envoy-gateway/gateway-legacy-only/tcp-1
       port: 9090
       proxyProtocol: {}

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions.out.yaml
@@ -566,6 +566,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 53
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-2/tcp
       port: 10053
   envoy-gateway/gateway-3:

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions.out.yaml
@@ -680,5 +680,10 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 53
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-2/tcp
       port: 10053

--- a/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid-ns.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid-ns.out.yaml
@@ -287,6 +287,10 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 445
+      metadata:
+        kind: Gateway
+        name: gateway-tls
+        namespace: envoy-gateway
       name: envoy-gateway/gateway-tls/
       port: 10445
       routes:

--- a/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid.out.yaml
@@ -286,6 +286,10 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 445
+      metadata:
+        kind: Gateway
+        name: gateway-tls
+        namespace: envoy-gateway
       name: envoy-gateway/gateway-tls/
       port: 10445
       routes:

--- a/internal/gatewayapi/testdata/envoyproxy-tls-settings.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tls-settings.out.yaml
@@ -323,6 +323,10 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 445
+      metadata:
+        kind: Gateway
+        name: gateway-tls
+        namespace: envoy-gateway
       name: envoy-gateway/gateway-tls/
       port: 10445
       routes:

--- a/internal/gatewayapi/testdata/extensions/extensionpolicy-tcp-listener.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/extensionpolicy-tcp-listener.out.yaml
@@ -252,6 +252,11 @@ xdsIR:
                 type: Accepted
               controllerName: gateway.envoyproxy.io/gatewayclass-controller
       externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp1
       name: envoy-gateway/gateway-1/tcp1
       port: 10080
     - address: 0.0.0.0
@@ -283,5 +288,10 @@ xdsIR:
                 type: Accepted
               controllerName: gateway.envoyproxy.io/gatewayclass-controller
       externalPort: 81
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp2
       name: envoy-gateway/gateway-1/tcp2
       port: 10081

--- a/internal/gatewayapi/testdata/extensions/extensionpolicy-udp-listener.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/extensionpolicy-udp-listener.out.yaml
@@ -252,6 +252,11 @@ xdsIR:
                 type: Accepted
               controllerName: gateway.envoyproxy.io/gatewayclass-controller
       externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp1
       name: envoy-gateway/gateway-1/udp1
       port: 10162
     - address: 0.0.0.0
@@ -283,5 +288,10 @@ xdsIR:
                 type: Accepted
               controllerName: gateway.envoyproxy.io/gatewayclass-controller
       externalPort: 163
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp2
       name: envoy-gateway/gateway-1/udp2
       port: 10163

--- a/internal/gatewayapi/testdata/gateway-with-addresses-with-ipaddress.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-addresses-with-ipaddress.out.yaml
@@ -92,5 +92,10 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-1/tcp
       port: 10080

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-mismatch-port-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-mismatch-port-protocol.out.yaml
@@ -117,6 +117,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-1/tcp
       port: 10162
       routes:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-backends.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-backends.out.yaml
@@ -121,6 +121,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-1/tcp
       port: 10080
       routes:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-rules.out.yaml
@@ -117,5 +117,10 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-1/tcp
       port: 10080

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
@@ -250,6 +250,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls-passthrough
       name: envoy-gateway/gateway-1/tls-passthrough
       port: 10090
       routes:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-mismatch-port-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-mismatch-port-protocol.out.yaml
@@ -117,6 +117,11 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp
       name: envoy-gateway/gateway-1/udp
       port: 10162
       route:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-backends.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-backends.out.yaml
@@ -121,6 +121,11 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp
       name: envoy-gateway/gateway-1/udp
       port: 10080
       route:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-rules.out.yaml
@@ -117,5 +117,10 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp
       name: envoy-gateway/gateway-1/udp
       port: 10080

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-tcproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-tcproute.out.yaml
@@ -85,5 +85,10 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-1/tcp
       port: 10080

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-udproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-udproute.out.yaml
@@ -85,5 +85,10 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp
       name: envoy-gateway/gateway-1/udp
       port: 10080

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
@@ -148,6 +148,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-1/tcp
       port: 10162
       routes:

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-udproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-udproutes.out.yaml
@@ -148,6 +148,11 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp
       name: envoy-gateway/gateway-1/udp
       port: 10162
       route:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-or-tls-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-or-tls-port.out.yaml
@@ -141,6 +141,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp1
       name: envoy-gateway/gateway-1/tcp1
       port: 10162
       routes:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-udp-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-udp-port.out.yaml
@@ -144,6 +144,11 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp1
       name: envoy-gateway/gateway-1/udp1
       port: 10162
       route:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
@@ -235,6 +235,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-1/tcp
       port: 10080
       routes:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
@@ -235,6 +235,11 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp
       name: envoy-gateway/gateway-1/udp
       port: 10080
       route:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-with-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-with-sectionname.out.yaml
@@ -186,6 +186,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp1
       name: envoy-gateway/gateway-1/tcp1
       port: 10162
       routes:
@@ -210,6 +215,11 @@ xdsIR:
         name: tcproute/default/tcproute-1
     - address: 0.0.0.0
       externalPort: 163
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp2
       name: envoy-gateway/gateway-1/tcp2
       port: 10163
       routes:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
@@ -182,6 +182,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 161
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp1
       name: envoy-gateway/gateway-1/tcp1
       port: 10161
       routes:
@@ -206,6 +211,11 @@ xdsIR:
         name: tcproute/default/tcproute-1
     - address: 0.0.0.0
       externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp2
       name: envoy-gateway/gateway-1/tcp2
       port: 10162
       routes:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-with-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-with-sectionname.out.yaml
@@ -186,6 +186,11 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp1
       name: envoy-gateway/gateway-1/udp1
       port: 10162
       route:
@@ -210,6 +215,11 @@ xdsIR:
         name: udproute/default/udproute-1
     - address: 0.0.0.0
       externalPort: 163
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp2
       name: envoy-gateway/gateway-1/udp2
       port: 10163
       route:

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-without-sectionname.out.yaml
@@ -182,6 +182,11 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 161
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp1
       name: envoy-gateway/gateway-1/udp1
       port: 10161
       route:
@@ -206,6 +211,11 @@ xdsIR:
         name: udproute/default/udproute-1
     - address: 0.0.0.0
       externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp2
       name: envoy-gateway/gateway-1/udp2
       port: 10162
       route:

--- a/internal/gatewayapi/testdata/merge-invalid-multiple-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/merge-invalid-multiple-gateways.out.yaml
@@ -178,5 +178,10 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+        sectionName: udp
       name: envoy-gateway/gateway-2/udp
       port: 10080

--- a/internal/gatewayapi/testdata/securitypolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-status-conditions.out.yaml
@@ -524,5 +524,10 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 53
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-2/tcp
       port: 10053

--- a/internal/gatewayapi/testdata/tcproute-attaching-to-gateway-with-listener-tls-terminate.out.yaml
+++ b/internal/gatewayapi/testdata/tcproute-attaching-to-gateway-with-listener-tls-terminate.out.yaml
@@ -192,6 +192,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
       name: envoy-gateway/gateway-1/tls
       port: 10090
       routes:
@@ -229,6 +234,11 @@ xdsIR:
           privateKey: '[redacted]'
     - address: 0.0.0.0
       externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls-hostname
       name: envoy-gateway/gateway-1/tls-hostname
       port: 10090
       routes:

--- a/internal/gatewayapi/testdata/tcproute-rule-with-multiple-backends-and-zero-weights.out.yaml
+++ b/internal/gatewayapi/testdata/tcproute-rule-with-multiple-backends-and-zero-weights.out.yaml
@@ -127,6 +127,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-1/tcp
       port: 10090
       routes:

--- a/internal/gatewayapi/testdata/tcproute-with-backend.in.yaml
+++ b/internal/gatewayapi/testdata/tcproute-with-backend.in.yaml
@@ -24,7 +24,8 @@ tcpRoutes:
         - namespace: envoy-gateway
           name: gateway-1
       rules:
-        - backendRefs:
+        - name: rule-1
+          backendRefs:
             - group: gateway.envoyproxy.io
               kind: Backend
               name: backend-ip

--- a/internal/gatewayapi/testdata/tcproute-with-backend.out.yaml
+++ b/internal/gatewayapi/testdata/tcproute-with-backend.out.yaml
@@ -92,6 +92,7 @@ tcpRoutes:
       - group: gateway.envoyproxy.io
         kind: Backend
         name: backend-ip
+      name: rule-1
   status:
     parents:
     - conditions:
@@ -137,6 +138,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp
       name: envoy-gateway/gateway-1/tcp
       port: 10090
       routes:
@@ -145,6 +151,7 @@ xdsIR:
             kind: TCPRoute
             name: tcproute-1
             namespace: default
+            sectionName: rule-1
           name: tcproute/default/tcproute-1/rule/-1
           settings:
           - addressType: IP

--- a/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
@@ -120,6 +120,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
       name: envoy-gateway/gateway-1/tls
       port: 10090
       routes:

--- a/internal/gatewayapi/testdata/tlsroute-invalid-reference-grant.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-invalid-reference-grant.out.yaml
@@ -123,5 +123,10 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 443
+      metadata:
+        kind: Gateway
+        name: gateway-tlsroute-referencegrant
+        namespace: gateway-conformance-infra
+        sectionName: https
       name: gateway-conformance-infra/gateway-tlsroute-referencegrant/https
       port: 10443

--- a/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
@@ -154,6 +154,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 91
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
       name: envoy-gateway/gateway-1/tls
       port: 10091
       routes:

--- a/internal/gatewayapi/testdata/tlsroute-with-backend.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-backend.out.yaml
@@ -140,6 +140,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
       name: envoy-gateway/gateway-1/tls
       port: 10090
       routes:

--- a/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -121,6 +121,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
       name: envoy-gateway/gateway-1/tls
       port: 10090
       routes:

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
@@ -119,6 +119,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 91
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
       name: envoy-gateway/gateway-1/tls
       port: 10091
       routes:

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
@@ -121,6 +121,11 @@ xdsIR:
     tcp:
     - address: 0.0.0.0
       externalPort: 91
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
       name: envoy-gateway/gateway-1/tls
       port: 10091
       routes:

--- a/internal/gatewayapi/testdata/udproute-rule-with-multiple-backends-and-zero-weights.out.yaml
+++ b/internal/gatewayapi/testdata/udproute-rule-with-multiple-backends-and-zero-weights.out.yaml
@@ -127,6 +127,11 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp
       name: envoy-gateway/gateway-1/udp
       port: 10090
       route:

--- a/internal/gatewayapi/testdata/udproute-with-backend.in.yaml
+++ b/internal/gatewayapi/testdata/udproute-with-backend.in.yaml
@@ -24,7 +24,8 @@ udpRoutes:
         - namespace: envoy-gateway
           name: gateway-1
       rules:
-        - backendRefs:
+        - name: rule-1
+          backendRefs:
             - group: gateway.envoyproxy.io
               kind: Backend
               name: backend-ip

--- a/internal/gatewayapi/testdata/udproute-with-backend.out.yaml
+++ b/internal/gatewayapi/testdata/udproute-with-backend.out.yaml
@@ -92,6 +92,7 @@ udpRoutes:
       - group: gateway.envoyproxy.io
         kind: Backend
         name: backend-ip
+      name: rule-1
   status:
     parents:
     - conditions:
@@ -137,6 +138,11 @@ xdsIR:
     udp:
     - address: 0.0.0.0
       externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp
       name: envoy-gateway/gateway-1/udp
       port: 10090
       route:
@@ -145,6 +151,7 @@ xdsIR:
             kind: UDPRoute
             name: udproute-1
             namespace: default
+            sectionName: rule-1
           name: udproute/default/udproute-1/rule/-1
           settings:
           - addressType: IP


### PR DESCRIPTION
**What this PR does / why we need it**:
Add IR metadata to tcproute/udproute.

BackendTrafficPolicy supports attaching to tcproute/udproute.
Section name info is required when supporting section targeting (Gateway Listener / Route Rule) in BackendTrafficPolicy.
Section name metadata is used to identify the target listener or route rule for applying the policy.
e.g. https://github.com/envoyproxy/gateway/blob/main/internal/gatewayapi/envoyextensionpolicy.go#L492

Related Issue : #6607 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
