### PR TITLE
benchmark: upload report and fix the filename issue

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -246,8 +246,11 @@ jobs:
         BENCHMARK_REPORT_DIR: benchmark_report
       run: make benchmark
 
-    - name: Read Benchmark report
-      run: cat test/benchmark/benchmark_report/benchmark_report.md
+    - name: Upload Benchmark report
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      with:
+        name: benchmark-report
+        path: ./test/benchmark/benchmark_report/
 
   resilience-test:
     runs-on: ubuntu-latest

--- a/test/benchmark/suite/render.go
+++ b/test/benchmark/suite/render.go
@@ -145,7 +145,7 @@ func renderProfilesTable(writer io.Writer, target, key string, titleLevel int, r
 		rootDir := strings.SplitN(heapPprofPath, "/", 2)[0]
 		heapPprofPath = strings.TrimPrefix(heapPprofPath, rootDir+"/")
 		writeSection(writer, report.Name, titleLevel+1,
-			fmt.Sprintf("![%s-%s](%s.png)", key, friendlyFilename, strings.TrimSuffix(heapPprofPath, ".pprof")))
+			fmt.Sprintf("![%s-%s](%s.png)", key, report.Name, strings.TrimSuffix(heapPprofPath, ".pprof")))
 	}
 }
 

--- a/test/benchmark/suite/render.go
+++ b/test/benchmark/suite/render.go
@@ -135,7 +135,9 @@ func renderProfilesTable(writer io.Writer, target, key string, titleLevel int, r
 		})
 
 		heapPprof := sortedSamples[0].HeapProfile
-		heapPprofPath := path.Join(report.ProfilesOutputDir, fmt.Sprintf("heap.%s.pprof", report.Name))
+		// report name contains spaces, replace them with dashes to make it URL-friendly.
+		friendlyFilename := strings.ReplaceAll(report.Name, " ", "-")
+		heapPprofPath := path.Join(report.ProfilesOutputDir, fmt.Sprintf("heap.%s.pprof", friendlyFilename))
 		_ = os.WriteFile(heapPprofPath, heapPprof, 0o600)
 
 		// The image is not be rendered yet, so it is a placeholder for the path.
@@ -143,7 +145,7 @@ func renderProfilesTable(writer io.Writer, target, key string, titleLevel int, r
 		rootDir := strings.SplitN(heapPprofPath, "/", 2)[0]
 		heapPprofPath = strings.TrimPrefix(heapPprofPath, rootDir+"/")
 		writeSection(writer, report.Name, titleLevel+1,
-			fmt.Sprintf("![%s-%s](%s.png)", key, report.Name, strings.TrimSuffix(heapPprofPath, ".pprof")))
+			fmt.Sprintf("![%s-%s](%s.png)", key, friendlyFilename, strings.TrimSuffix(heapPprofPath, ".pprof")))
 	}
 }
 


### PR DESCRIPTION
1. Upload the report for easy verification
2. Fixed the issue where file names with spaces were not rendered correctly in markdown.