### PR TITLE
ci: make license scan blocking again

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -19,9 +19,8 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - name: Run scanner
       uses: google/osv-scanner-action/osv-scanner-action@456ceb78310755116e0a3738121351006286b797  # v2.2.1
-      continue-on-error: true  # remove this after https://github.com/google/deps.dev/issues/146 has been resolved
       with:
-        scan-args: |-
-          --licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib
+        scan-args: |-  # See allowed licenses at https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md#approved-licenses-for-allowlist
+          --licenses=Apache-2.0,0BSD,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,MIT-0,ISC,OpenSSL,OpenSSL-standalone,PSF-2.0,Python-2.0,Python-2.0.1,PostgreSQL,SSLeay-standalone,UPL-1.0,X11,Zlib
           --config tools/osv-scanner/license-scan-config.toml
           ./

--- a/tools/osv-scanner/license-scan-config.toml
+++ b/tools/osv-scanner/license-scan-config.toml
@@ -5,88 +5,39 @@ ecosystem = "Go"
 vulnerability.ignore = true
 
 [[PackageOverrides]]
-name = "github.com/AdaLogics/go-fuzz-headers"
-version = "0.0.0-20230811130428-ced1acdcaa24"
-ecosystem = "Go"
-license.override = ["Apache-2.0"]
-reason = "Unidentified license since package version is missing in pkg.go.dev"
-
-[[PackageOverrides]]
-name = "github.com/asaskevich/govalidator"
-version = "0.0.0-20230301143203-a9d515a09cc2"
-ecosystem = "Go"
-license.override = ["MIT"]
-reason = "Unidentified license, remove once https://github.com/google/deps.dev/issues/87 is resolved"
-
-[[PackageOverrides]]
-name = "github.com/distribution/distribution/v3"
-version = "3.0.0-beta.1"
-ecosystem = "Go"
-license.override = ["Apache-2.0"]
-reason = "Unidentified license, remove once https://github.com/google/deps.dev/issues/105 is resolved"
-
-[[PackageOverrides]]
-name = "github.com/docker/go-metrics"
-version = "0.0.1"
-ecosystem = "Go"
-license.override = ["Apache-2.0"]
-reason = "This package has dual license - the code is licensed under the Apache 2.0 license and the docs under CC-BY-SA-4.0 license"
-
-[[PackageOverrides]]
 name = "github.com/go-sql-driver/mysql"
-version = "1.8.1"
+version = "1.9.3"
 ecosystem = "Go"
 license.ignore = true
-reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
+reason = "This package is licensed under the MPL-2.0 license, which is not included in the CNCF allowlist, but it is covered by an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
 
 [[PackageOverrides]]
 name = "github.com/hashicorp/errwrap"
 version = "1.1.0"
 ecosystem = "Go"
 license.ignore = true
-reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
+reason = "This package is licensed under the MPL-2.0 license, which is not included in the CNCF allowlist, but it is covered by an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
 
 [[PackageOverrides]]
 name = "github.com/hashicorp/go-multierror"
 version = "1.1.1"
 ecosystem = "Go"
 license.ignore = true
-reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
+reason = "This package is licensed under the MPL-2.0 license, which is not included in the CNCF allowlist, but it is covered by an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
 
 [[PackageOverrides]]
-name = "github.com/hashicorp/hcl"
-version = "1.0.0"
+name = "github.com/hashicorp/golang-lru/v2"
+version = "2.0.7"
 ecosystem = "Go"
 license.ignore = true
-reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
+reason = "This package is licensed under the MPL-2.0 license, which is not included in the CNCF allowlist, but it is covered by an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv"
 
 [[PackageOverrides]]
 name = "github.com/opencontainers/go-digest"
 version = "1.0.0"
 ecosystem = "Go"
 license.override = ["Apache-2.0"]
-reason = "This package has dual license - the code is licensed under the Apache 2.0 license and the docs under CC-BY-SA-4.0 license"
-
-[[PackageOverrides]]
-name = "github.com/shoenig/go-m1cpu"
-version = "0.1.6"
-ecosystem = "Go"
-license.ignore = true
-reason = "This package has MPL-2.0 which is not approved in CNCF Allowlist, but it has an exception. See https://github.com/cncf/foundation/blob/main/license-exceptions/cncf-exceptions-2023-08-31.spdx"
-
-[[PackageOverrides]]
-name = "github.com/golang/groupcache"
-version = "0.0.0-20241129210726-2c02b8208cf8"
-ecosystem = "Go"
-license.override = ["Apache-2.0"]
-reason = "Unidentified license, remove once https://github.com/google/deps.dev/issues/119 is resolved"
-
-[[PackageOverrides]]
-name = "golang.org/x/crypto"
-version = "0.31.0"
-ecosystem = "Go"
-license.override = ["BSD-3-Clause"]
-reason = "Unidentified license, remove once https://github.com/google/deps.dev/issues/120 is resolved"
+reason = "This package is dual-licensed: the code under the Apache 2.0 license and the documentation under the CC-BY-SA-4.0 license"
 
 [[PackageOverrides]]
 name = "stdlib"


### PR DESCRIPTION
**What this PR does / why we need it**:
Now that deps.dev go packages sync [issue](https://github.com/google/deps.dev/issues/147) is resolved and go tools were [moved](https://github.com/envoyproxy/gateway/pull/6824) into a separate package license scan can be run in blocking mode again.

* Organized license scan config
* Updated CNCF approved licenses list in license scan workflow according to https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md#approved-licenses-for-allowlist

**Which issue(s) this PR fixes**:
Fixes #4945

Release Notes: No
