### PR TITLE
fix(translator): Fix panic with request mirror + grpcroute

### DIFF
--- a/internal/gatewayapi/filters.go
+++ b/internal/gatewayapi/filters.go
@@ -941,7 +941,7 @@ func (t *Translator) processRequestMirrorFilterCommon(
 	mirrorFilter *gwapiv1.HTTPRequestMirrorFilter,
 	filterContext *HTTPFiltersContext,
 	resources *resource.Resources,
-	backendRef interface{}, // Can be either gwapiv1.HTTPBackendRef or gwapiv1.GRPCBackendRef
+	backendRef interface{}, // Must be gwapiv1.HTTPBackendRef for HTTP routes or gwapiv1.GRPCBackendRef for gRPC routes
 	routeKind gwapiv1.Kind,
 ) (err status.Error) {
 	// Make sure the config actually exists
@@ -949,11 +949,9 @@ func (t *Translator) processRequestMirrorFilterCommon(
 		return nil
 	}
 
-	mirrorBackend := mirrorFilter.BackendRef
-
 	// This sets the status on the Route, should the usage be changed so that the status message reflects that the backendRef is from the filter?
 	filterNs := filterContext.Route.GetNamespace()
-	serviceNamespace := NamespaceDerefOr(mirrorBackend.Namespace, filterNs)
+	serviceNamespace := NamespaceDerefOr(mirrorFilter.BackendRef.Namespace, filterNs)
 	err = t.validateBackendRef(backendRef, filterContext.Route,
 		resources, serviceNamespace, routeKind)
 	if err != nil {
@@ -994,7 +992,7 @@ func (t *Translator) processRequestMirrorFilter(
 		return nil
 	}
 
-	// Wrap the filter's BackendObjectReference into a BackendRef so we can use existing tooling to check it
+	// Wrap the filter's BackendObjectReference into an HTTPBackendRef so we can use existing tooling to check it
 	weight := int32(1)
 	mirrorBackendRef := gwapiv1.HTTPBackendRef{
 		BackendRef: gwapiv1.BackendRef{
@@ -1017,7 +1015,7 @@ func (t *Translator) processGRPCRequestMirrorFilter(
 		return nil
 	}
 
-	// Wrap the filter's BackendObjectReference into a BackendRef so we can use existing tooling to check it
+	// Wrap the filter's BackendObjectReference into a GRPCBackendRef so we can use existing tooling to check it
 	weight := int32(1)
 	mirrorBackendRef := gwapiv1.GRPCBackendRef{
 		BackendRef: gwapiv1.BackendRef{

--- a/internal/gatewayapi/filters.go
+++ b/internal/gatewayapi/filters.go
@@ -951,7 +951,7 @@ func (t *Translator) processRequestMirrorFilter(
 	mirrorBackend := mirrorFilter.BackendRef
 
 	// Create the appropriate BackendRef type based on the route type
-	var mirrorBackendRef interface{}
+	var mirrorBackendRef BackendRefContext
 	if routeType == resource.KindGRPCRoute {
 		mirrorBackendRef = gwapiv1.GRPCBackendRef{
 			BackendRef: gwapiv1.BackendRef{

--- a/internal/gatewayapi/filters.go
+++ b/internal/gatewayapi/filters.go
@@ -1001,7 +1001,6 @@ func (t *Translator) processRequestMirrorFilter(
 	return nil
 }
 
-
 func (t *Translator) processCORSFilter(
 	corsFilter *gwapiv1.HTTPCORSFilter,
 	filterContext *HTTPFiltersContext,

--- a/internal/gatewayapi/filters.go
+++ b/internal/gatewayapi/filters.go
@@ -1011,7 +1011,7 @@ func (t *Translator) processGRPCRequestMirrorFilter(
 		},
 	}
 
-	// This sets the status on the HTTPRoute, should the usage be changed so that the status message reflects that the backendRef is from the filter?
+	// This sets the status on the GRPCRoute, should the usage be changed so that the status message reflects that the backendRef is from the filter?
 	filterNs := filterContext.Route.GetNamespace()
 	serviceNamespace := NamespaceDerefOr(mirrorBackend.Namespace, filterNs)
 	err = t.validateBackendRef(mirrorBackendRef, filterContext.Route,

--- a/internal/gatewayapi/filters.go
+++ b/internal/gatewayapi/filters.go
@@ -147,7 +147,7 @@ func (t *Translator) ProcessGRPCFilters(parentRef *RouteParentContext,
 		case gwapiv1.GRPCRouteFilterResponseHeaderModifier:
 			t.processResponseHeaderModifierFilter(filter.ResponseHeaderModifier, httpFiltersContext)
 		case gwapiv1.GRPCRouteFilterRequestMirror:
-			err := t.processGRPCRequestMirrorFilter(i, filter.RequestMirror, httpFiltersContext, resources)
+			err := t.processRequestMirrorFilter(i, filter.RequestMirror, httpFiltersContext, resources)
 			if err != nil {
 				return nil, err
 			}
@@ -1001,16 +1001,6 @@ func (t *Translator) processRequestMirrorFilter(
 	return nil
 }
 
-func (t *Translator) processGRPCRequestMirrorFilter(
-	filterIdx int,
-	mirrorFilter *gwapiv1.HTTPRequestMirrorFilter,
-	filterContext *HTTPFiltersContext,
-	resources *resource.Resources,
-) (err status.Error) {
-	// Simply delegate to the unified processRequestMirrorFilter function
-	// which now handles both HTTP and gRPC routes
-	return t.processRequestMirrorFilter(filterIdx, mirrorFilter, filterContext, resources)
-}
 
 func (t *Translator) processCORSFilter(
 	corsFilter *gwapiv1.HTTPCORSFilter,

--- a/internal/gatewayapi/testdata/grpcroute-with-mirror.in.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-mirror.in.yaml
@@ -1,0 +1,42 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+grpcRoutes:
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: GRPCRoute
+  metadata:
+    namespace: default
+    name: grpcroute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - headers:
+        - type: Exact
+          name: magic
+          value: foo
+      backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+        - type: RequestMirror
+          requestMirror:
+            backendRef:
+                kind: Service
+                name: service-2
+                port: 8080

--- a/internal/gatewayapi/testdata/grpcroute-with-mirror.in.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-mirror.in.yaml
@@ -29,9 +29,9 @@ grpcRoutes:
       - name: service-1
         port: 8080
       filters:
-        - type: RequestMirror
-          requestMirror:
-            backendRef:
-                kind: Service
-                name: service-2
-                port: 8080
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            kind: Service
+            name: service-2
+            port: 8080

--- a/internal/gatewayapi/testdata/grpcroute-with-mirror.in.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-mirror.in.yaml
@@ -25,12 +25,7 @@ grpcRoutes:
       name: gateway-1
       sectionName: http
     rules:
-    - matches:
-      - headers:
-        - type: Exact
-          name: magic
-          value: foo
-      backendRefs:
+    - backendRefs:
       - name: service-1
         port: 8080
       filters:

--- a/internal/gatewayapi/testdata/grpcroute-with-mirror.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-mirror.out.yaml
@@ -124,6 +124,8 @@ xdsIR:
     http:
       - address: 0.0.0.0
         externalPort: 80
+        hostnames:
+          - "*"
         isHTTP2: true
         metadata:
           kind: Gateway
@@ -154,8 +156,8 @@ xdsIR:
                   name: grpcroute/default/grpcroute-1/rule/0/backend/0
                   protocol: GRPC
                   weight: 1
-            hostname: gateway.envoyproxy.io
-            isHTTP2: false
+            hostname: "*"
+            isHTTP2: true
             metadata:
               kind: GRPCRoute
               name: grpcroute-1
@@ -169,17 +171,13 @@ xdsIR:
                         - host: 7.7.7.7
                           port: 8080
                       metadata:
-                        name: service-1
+                        name: service-2
                         namespace: default
                         sectionName: "8080"
-                      name: httproute/default/grpcroute-1/rule/0-mirror-0/backend/-1
+                      name: grpcroute/default/grpcroute-1/rule/0-mirror-0/backend/-1
                       protocol: GRPC
                       weight: 1
-            name: httproute/default/grpcroute-1/rule/0/match/0/gateway_envoyproxy_io
-            pathMatch:
-              distinct: false
-              name: ""
-              prefix: /
+            name: grpcroute/default/grpcroute-1/rule/0/match/-1/*
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/grpcroute-with-mirror.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-mirror.out.yaml
@@ -1,0 +1,1 @@
+# unsure what output should be currently

--- a/internal/gatewayapi/testdata/grpcroute-with-mirror.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-mirror.out.yaml
@@ -1,97 +1,96 @@
 gateways:
-  - apiVersion: gateway.networking.k8s.io/v1
-    kind: Gateway
-    metadata:
-      creationTimestamp: null
-      name: gateway-1
-      namespace: envoy-gateway
-    spec:
-      gatewayClassName: envoy-gateway-class
-      listeners:
-        - allowedRoutes:
-            namespaces:
-              from: All
-          hostname: null
-          name: http
-          port: 80
-          protocol: HTTP
-    status:
-      listeners:
-        - attachedRoutes: 1
-          conditions:
-            - lastTransitionTime: null
-              message: Sending translated listener configuration to the data plane
-              reason: Programmed
-              status: "True"
-              type: Programmed
-            - lastTransitionTime: null
-              message: Listener has been successfully translated
-              reason: Accepted
-              status: "True"
-              type: Accepted
-            - lastTransitionTime: null
-              message: Listener references have been resolved
-              reason: ResolvedRefs
-              status: "True"
-              type: ResolvedRefs
-          name: http
-          supportedKinds:
-            - group: gateway.networking.k8s.io
-              kind: HTTPRoute
-            - group: gateway.networking.k8s.io
-              kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
 grpcRoutes:
-  - apiVersion: gateway.networking.k8s.io/v1alpha2
-    kind: GRPCRoute
-    metadata:
-      creationTimestamp: null
-      name: grpcroute-1
-      namespace: default
-    spec:
-      parentRefs:
-        - name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
-      rules:
-        - backendRefs:
-            - name: service-1
-              port: 8080
-          filters:
-            - requestMirror:
-                backendRef:
-                  kind: Service
-                  name: service-2
-                  port: 8080
-              type: RequestMirror
-    status:
-      parents:
-        - conditions:
-            - lastTransitionTime: null
-              message: Route is accepted
-              reason: Accepted
-              status: "True"
-              type: Accepted
-            - lastTransitionTime: null
-              message: Resolved all the Object references for the Route
-              reason: ResolvedRefs
-              status: "True"
-              type: ResolvedRefs
-          controllerName: gateway.envoyproxy.io/gatewayclass-controller
-          parentRef:
-            name: gateway-1
-            namespace: envoy-gateway
-            sectionName: http
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: GRPCRoute
+  metadata:
+    creationTimestamp: null
+    name: grpcroute-1
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+      sectionName: http
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      filters:
+      - requestMirror:
+          backendRef:
+            kind: Service
+            name: service-2
+            port: 8080
+        type: RequestMirror
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
       listeners:
-        - address: null
-          name: envoy-gateway/gateway-1/http
-          ports:
-            - containerPort: 10080
-              name: http-80
-              protocol: HTTP
-              servicePort: 80
+      - address: null
+        name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -105,79 +104,79 @@ xdsIR:
   envoy-gateway/gateway-1:
     accessLog:
       json:
-        - path: /dev/stdout
+      - path: /dev/stdout
     globalResources:
       proxyServiceCluster:
         name: envoy-gateway/gateway-1
         settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            name: envoy-envoy-gateway-gateway-1-196ae069
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: envoy-gateway/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      isHTTP2: true
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          metadata:
+            kind: GRPCRoute
+            name: grpcroute-1
+            namespace: default
+          name: grpcroute/default/grpcroute-1/rule/0
+          settings:
           - addressType: IP
             endpoints:
-              - host: 7.6.5.4
-                port: 8080
-                zone: zone1
+            - host: 7.7.7.7
+              port: 8080
             metadata:
-              name: envoy-envoy-gateway-gateway-1-196ae069
-              namespace: envoy-gateway-system
+              name: service-1
+              namespace: default
               sectionName: "8080"
-            name: envoy-gateway/gateway-1
-            protocol: TCP
-    http:
-      - address: 0.0.0.0
-        externalPort: 80
-        hostnames:
-          - "*"
+            name: grpcroute/default/grpcroute-1/rule/0/backend/0
+            protocol: GRPC
+            weight: 1
+        hostname: '*'
         isHTTP2: true
         metadata:
-          kind: Gateway
-          name: gateway-1
-          namespace: envoy-gateway
-          sectionName: http
-        name: envoy-gateway/gateway-1/http
-        path:
-          escapedSlashesAction: UnescapeAndRedirect
-          mergeSlashes: true
-        port: 10080
-        routes:
-          - destination:
+          kind: GRPCRoute
+          name: grpcroute-1
+          namespace: default
+        mirrors:
+        - destination:
+            name: grpcroute/default/grpcroute-1/rule/0-mirror-0
+            settings:
+            - addressType: IP
+              endpoints:
+              - host: 7.7.7.7
+                port: 8080
               metadata:
-                kind: GRPCRoute
-                name: grpcroute-1
+                name: service-2
                 namespace: default
-              name: grpcroute/default/grpcroute-1/rule/0
-              settings:
-                - addressType: IP
-                  endpoints:
-                    - host: 7.7.7.7
-                      port: 8080
-                  metadata:
-                    name: service-1
-                    namespace: default
-                    sectionName: "8080"
-                  name: grpcroute/default/grpcroute-1/rule/0/backend/0
-                  protocol: GRPC
-                  weight: 1
-            hostname: "*"
-            isHTTP2: true
-            metadata:
-              kind: GRPCRoute
-              name: grpcroute-1
-              namespace: default
-            mirrors:
-              - destination:
-                  name: grpcroute/default/grpcroute-1/rule/0-mirror-0
-                  settings:
-                    - addressType: IP
-                      endpoints:
-                        - host: 7.7.7.7
-                          port: 8080
-                      metadata:
-                        name: service-2
-                        namespace: default
-                        sectionName: "8080"
-                      name: grpcroute/default/grpcroute-1/rule/0-mirror-0/backend/-1
-                      protocol: GRPC
-                      weight: 1
-            name: grpcroute/default/grpcroute-1/rule/0/match/-1/*
+                sectionName: "8080"
+              name: grpcroute/default/grpcroute-1/rule/0-mirror-0/backend/-1
+              protocol: GRPC
+              weight: 1
+        name: grpcroute/default/grpcroute-1/rule/0/match/-1/*
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/grpcroute-with-mirror.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-mirror.out.yaml
@@ -1,1 +1,187 @@
-# unsure what output should be currently
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      creationTimestamp: null
+      name: gateway-1
+      namespace: envoy-gateway
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - allowedRoutes:
+            namespaces:
+              from: All
+          hostname: null
+          name: http
+          port: 80
+          protocol: HTTP
+    status:
+      listeners:
+        - attachedRoutes: 1
+          conditions:
+            - lastTransitionTime: null
+              message: Sending translated listener configuration to the data plane
+              reason: Programmed
+              status: "True"
+              type: Programmed
+            - lastTransitionTime: null
+              message: Listener has been successfully translated
+              reason: Accepted
+              status: "True"
+              type: Accepted
+            - lastTransitionTime: null
+              message: Listener references have been resolved
+              reason: ResolvedRefs
+              status: "True"
+              type: ResolvedRefs
+          name: http
+          supportedKinds:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+            - group: gateway.networking.k8s.io
+              kind: GRPCRoute
+grpcRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: GRPCRoute
+    metadata:
+      creationTimestamp: null
+      name: grpcroute-1
+      namespace: default
+    spec:
+      parentRefs:
+        - name: gateway-1
+          namespace: envoy-gateway
+          sectionName: http
+      rules:
+        - backendRefs:
+            - name: service-1
+              port: 8080
+          filters:
+            - requestMirror:
+                backendRef:
+                  kind: Service
+                  name: service-2
+                  port: 8080
+              type: RequestMirror
+    status:
+      parents:
+        - conditions:
+            - lastTransitionTime: null
+              message: Route is accepted
+              reason: Accepted
+              status: "True"
+              type: Accepted
+            - lastTransitionTime: null
+              message: Resolved all the Object references for the Route
+              reason: ResolvedRefs
+              status: "True"
+              type: ResolvedRefs
+          controllerName: gateway.envoyproxy.io/gatewayclass-controller
+          parentRef:
+            name: gateway-1
+            namespace: envoy-gateway
+            sectionName: http
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      listeners:
+        - address: null
+          name: envoy-gateway/gateway-1/http
+          ports:
+            - containerPort: 10080
+              name: http-80
+              protocol: HTTP
+              servicePort: 80
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-1
+      namespace: envoy-gateway-system
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      json:
+        - path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        name: envoy-gateway/gateway-1
+        settings:
+          - addressType: IP
+            endpoints:
+              - host: 7.6.5.4
+                port: 8080
+                zone: zone1
+            metadata:
+              name: envoy-envoy-gateway-gateway-1-196ae069
+              namespace: envoy-gateway-system
+              sectionName: "8080"
+            name: envoy-gateway/gateway-1
+            protocol: TCP
+    http:
+      - address: 0.0.0.0
+        externalPort: 80
+        isHTTP2: true
+        metadata:
+          kind: Gateway
+          name: gateway-1
+          namespace: envoy-gateway
+          sectionName: http
+        name: envoy-gateway/gateway-1/http
+        path:
+          escapedSlashesAction: UnescapeAndRedirect
+          mergeSlashes: true
+        port: 10080
+        routes:
+          - destination:
+              metadata:
+                kind: GRPCRoute
+                name: grpcroute-1
+                namespace: default
+              name: grpcroute/default/grpcroute-1/rule/0
+              settings:
+                - addressType: IP
+                  endpoints:
+                    - host: 7.7.7.7
+                      port: 8080
+                  metadata:
+                    name: service-1
+                    namespace: default
+                    sectionName: "8080"
+                  name: grpcroute/default/grpcroute-1/rule/0/backend/0
+                  protocol: GRPC
+                  weight: 1
+            hostname: gateway.envoyproxy.io
+            isHTTP2: false
+            metadata:
+              kind: GRPCRoute
+              name: grpcroute-1
+              namespace: default
+            mirrors:
+              - destination:
+                  name: grpcroute/default/grpcroute-1/rule/0-mirror-0
+                  settings:
+                    - addressType: IP
+                      endpoints:
+                        - host: 7.7.7.7
+                          port: 8080
+                      metadata:
+                        name: service-1
+                        namespace: default
+                        sectionName: "8080"
+                      name: httproute/default/grpcroute-1/rule/0-mirror-0/backend/-1
+                      protocol: GRPC
+                      weight: 1
+            name: httproute/default/grpcroute-1/rule/0/match/0/gateway_envoyproxy_io
+            pathMatch:
+              distinct: false
+              name: ""
+              prefix: /
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an unconditional panic when the RequestMirror filter is used with GRPCRoutes

**Which issue(s) this PR fixes**:

Fixes #6874

Release Notes: No
