### PR TITLE
Relax loopback address constraints for backends

### DIFF
--- a/internal/gatewayapi/backend.go
+++ b/internal/gatewayapi/backend.go
@@ -70,15 +70,10 @@ func validateBackend(backend *egv1a1.Backend, backendTLSPolicies []*gwapiv1a3.Ba
 				return routeErr
 			}
 		} else if ep.IP != nil {
-			ip, err := netip.ParseAddr(ep.IP.Address)
+			_, err := netip.ParseAddr(ep.IP.Address)
 			if err != nil {
 				return status.NewRouteStatusError(
 					fmt.Errorf("IP address %s is invalid", ep.IP.Address),
-					status.RouteReasonInvalidAddress,
-				)
-			} else if ip.IsLoopback() {
-				return status.NewRouteStatusError(
-					fmt.Errorf("IP address %s in the loopback range is not supported", ep.IP.Address),
 					status.RouteReasonInvalidAddress,
 				)
 			}

--- a/internal/gatewayapi/testdata/backend-invalid-hostname-address.in.yaml
+++ b/internal/gatewayapi/testdata/backend-invalid-hostname-address.in.yaml
@@ -22,16 +22,6 @@ backends:
   - apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: Backend
     metadata:
-      name: backend-fqdn
-      namespace: default
-    spec:
-      endpoints:
-        - ip:
-            address: '127.0.0.3'
-            port: 3000
-  - apiVersion: gateway.envoyproxy.io/v1alpha1
-    kind: Backend
-    metadata:
       name: backend-ip
       namespace: default
     spec:

--- a/internal/gatewayapi/testdata/backend-invalid-hostname-address.out.yaml
+++ b/internal/gatewayapi/testdata/backend-invalid-hostname-address.out.yaml
@@ -40,25 +40,6 @@ backends:
   kind: Backend
   metadata:
     creationTimestamp: null
-    name: backend-fqdn
-    namespace: default
-  spec:
-    endpoints:
-    - ip:
-        address: 127.0.0.3
-        port: 3000
-  status:
-    conditions:
-    - lastTransitionTime: null
-      message: 'The Backend was not accepted: IP address 127.0.0.3 in the loopback
-        range is not supported'
-      reason: Accepted
-      status: "False"
-      type: Invalid
-- apiVersion: gateway.envoyproxy.io/v1alpha1
-  kind: Backend
-  metadata:
-    creationTimestamp: null
     name: backend-ip
     namespace: default
   spec:

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref.out.yaml
@@ -66,11 +66,10 @@ backends:
   status:
     conditions:
     - lastTransitionTime: null
-      message: 'The Backend was not accepted: IP address 127.0.0.1 in the loopback
-        range is not supported'
+      message: The Backend was accepted
       reason: Accepted
-      status: "False"
-      type: Invalid
+      status: "True"
+      type: Accepted
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: Backend
   metadata:
@@ -272,10 +271,9 @@ httpRoutes:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Failed to process route rule 0 backendRef 0: IP address 127.0.0.1
-          in the loopback range is not supported.'
-        reason: InvalidAddress
-        status: "False"
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
         type: ResolvedRefs
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
       parentRef:
@@ -448,8 +446,24 @@ xdsIR:
           distinct: false
           name: ""
           prefix: /2
-      - directResponse:
-          statusCode: 500
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-4
+            namespace: default
+          name: httproute/default/httproute-4/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 127.0.0.1
+              port: 3001
+            metadata:
+              kind: Backend
+              name: backend-ip-localhost
+              namespace: default
+            name: httproute/default/httproute-4/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
         hostname: '*'
         isHTTP2: false
         metadata:


### PR DESCRIPTION
This enables scenarios where Envoy needs to talk to a container in the same pod over 127.0.0.1.