### PR TITLE
ci: pin checkout action

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -259,7 +259,7 @@ jobs:
     - build
     - changes
     steps:
-    - uses: actions/checkout@v5.0.0
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
     - uses: ./tools/github-actions/setup-deps
     - name: Resilience Test
       env:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing SHA pinning to checkout action in 'Build and Test' workflow.

Release Notes: No
