### PR TITLE
feat: support retry policy for gRPC ExtAuth SecurityPolicy

### DIFF
--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-serviceimport-retry.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-serviceimport-retry.in.yaml
@@ -1,0 +1,208 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      namespace: default
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      hostnames:
+        - www.foo.com
+      parentRefs:
+        - namespace: default
+          name: gateway-1
+          sectionName: http
+      rules:
+        - matches:
+            - path:
+                value: /foo1
+          backendRefs:
+            - name: service-1
+              port: 8080
+        - matches:
+            - path:
+                value: /foo2
+          backendRefs:
+            - name: service-2
+              port: 8080
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-2
+    spec:
+      hostnames:
+        - www.bar.com
+      parentRefs:
+        - namespace: default
+          name: gateway-1
+          sectionName: http
+      rules:
+        - matches:
+            - path:
+                value: /bar
+          backendRefs:
+            - name: service-3
+              port: 8080
+serviceImports:
+  - apiVersion: multicluster.x-k8s.io/v1alpha1
+    kind: ServiceImport
+    metadata:
+      name: http-backend
+      namespace: envoy-gateway
+    spec:
+      ips:
+        - 7.7.7.7
+      ports:
+        - port: 80
+          name: http
+          # Missing protocol here is intentional to test the default protocol handling.
+  - apiVersion: multicluster.x-k8s.io/v1alpha1
+    kind: ServiceImport
+    metadata:
+      name: grpc-backend
+      namespace: default
+    spec:
+      ips:
+        - 8.8.8.8
+      ports:
+        - port: 9000
+          name: grpc
+          protocol: TCP
+endpointSlices:
+  - apiVersion: discovery.k8s.io/v1
+    kind: EndpointSlice
+    metadata:
+      name: endpointslice-http-backend
+      namespace: envoy-gateway
+      labels:
+        multicluster.kubernetes.io/service-name: http-backend
+    addressType: IPv4
+    ports:
+      - name: http
+        protocol: TCP
+        port: 80
+    endpoints:
+      - addresses:
+          - 7.7.7.7
+        conditions:
+          ready: true
+  - apiVersion: discovery.k8s.io/v1
+    kind: EndpointSlice
+    metadata:
+      name: endpointslice-grpc-backend
+      namespace: default
+      labels:
+        multicluster.kubernetes.io/service-name: grpc-backend
+    addressType: IPv4
+    ports:
+      - name: grpc
+        protocol: TCP
+        port: 9000
+    endpoints:
+      - addresses:
+          - 8.8.8.8
+        conditions:
+          ready: true
+referenceGrants:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    kind: ReferenceGrant
+    metadata:
+      namespace: envoy-gateway
+      name: referencegrant-1
+    spec:
+      from:
+        - group: gateway.envoyproxy.io
+          kind: SecurityPolicy
+          namespace: default
+      to:
+        - group: multicluster.x-k8s.io
+          kind: ServiceImport
+securityPolicies:
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: SecurityPolicy
+    metadata:
+      namespace: default
+      name: policy-for-http-route-1
+    spec:
+      targetRef:
+        group: gateway.networking.k8s.io
+        kind: HTTPRoute
+        name: httproute-1
+      extAuth:
+        failOpen: true
+        headersToExtAuth:
+          - header1
+          - header2
+        grpc:
+          backendRefs:
+            - group: multicluster.x-k8s.io
+              kind: ServiceImport
+              name: grpc-backend
+              port: 9000
+          backendSettings:
+            retry:
+              numRetries: 2
+              retryOn:
+                triggers:
+                  - 5xx
+                  - unavailable
+                  - internal
+                  - deadline-exceeded
+              perRetry:
+                timeout: "3s"
+                backOff:
+                  baseInterval: "0.2s"
+                  maxInterval: "3s"
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: SecurityPolicy
+    metadata:
+      namespace: default
+      # This will only apply to the httproute-2
+      name: policy-for-gateway-1
+    spec:
+      targetRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+      extAuth:
+        failOpen: false
+        http:
+          backendRefs:
+            - Group: multicluster.x-k8s.io
+              Kind: ServiceImport
+              Name: http-backend
+              Namespace: envoy-gateway
+              Port: 80
+          Path: /auth
+          headersToBackend:
+            - header1
+            - header2
+          backendSettings:
+            retry:
+              numRetries: 2
+              retryOn:
+                triggers:
+                  - 5xx
+                  - unavailable
+                  - internal
+                  - deadline-exceeded
+              perRetry:
+                timeout: "3s"
+                backOff:
+                  baseInterval: "0.2s"
+                  maxInterval: "3s"

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-serviceimport-retry.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-serviceimport-retry.out.yaml
@@ -1,0 +1,507 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    creationTimestamp: null
+    name: gateway-1
+    namespace: default
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    creationTimestamp: null
+    name: httproute-1
+    namespace: default
+  spec:
+    hostnames:
+    - www.foo.com
+    parentRefs:
+    - name: gateway-1
+      namespace: default
+      sectionName: http
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          value: /foo1
+    - backendRefs:
+      - name: service-2
+        port: 8080
+      matches:
+      - path:
+          value: /foo2
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: default
+        sectionName: http
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    creationTimestamp: null
+    name: httproute-2
+    namespace: default
+  spec:
+    hostnames:
+    - www.bar.com
+    parentRefs:
+    - name: gateway-1
+      namespace: default
+      sectionName: http
+    rules:
+    - backendRefs:
+      - name: service-3
+        port: 8080
+      matches:
+      - path:
+          value: /bar
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: default
+        sectionName: http
+infraIR:
+  default/gateway-1:
+    proxy:
+      listeners:
+      - address: null
+        name: default/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: default
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: default/gateway-1
+      namespace: envoy-gateway-system
+securityPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: SecurityPolicy
+  metadata:
+    creationTimestamp: null
+    name: policy-for-http-route-1
+    namespace: default
+  spec:
+    extAuth:
+      failOpen: true
+      grpc:
+        backendRefs:
+        - group: multicluster.x-k8s.io
+          kind: ServiceImport
+          name: grpc-backend
+          port: 9000
+        backendSettings:
+          retry:
+            numRetries: 2
+            perRetry:
+              backOff:
+                baseInterval: 0.2s
+                maxInterval: 3s
+              timeout: 3s
+            retryOn:
+              triggers:
+              - 5xx
+              - unavailable
+              - internal
+              - deadline-exceeded
+      headersToExtAuth:
+      - header1
+      - header2
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httproute-1
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+        sectionName: http
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: SecurityPolicy
+  metadata:
+    creationTimestamp: null
+    name: policy-for-gateway-1
+    namespace: default
+  spec:
+    extAuth:
+      failOpen: false
+      http:
+        backendRefs:
+        - group: multicluster.x-k8s.io
+          kind: ServiceImport
+          name: http-backend
+          namespace: envoy-gateway
+          port: 80
+        backendSettings:
+          retry:
+            numRetries: 2
+            perRetry:
+              backOff:
+                baseInterval: 0.2s
+                maxInterval: 3s
+              timeout: 3s
+            retryOn:
+              triggers:
+              - 5xx
+              - unavailable
+              - internal
+              - deadline-exceeded
+        headersToBackend:
+        - header1
+        - header2
+        path: /auth
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-1
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: 'This policy is being overridden by other securityPolicies for these
+          routes: [default/httproute-1]'
+        reason: Overridden
+        status: "True"
+        type: Overridden
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+xdsIR:
+  default/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        name: default/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            name: envoy-default-gateway-1-bfd08ef4
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: default/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+        sectionName: http
+      name: default/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-1
+            namespace: default
+          name: httproute/default/httproute-1/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-1/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: www.foo.com
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-1
+          namespace: default
+        name: httproute/default/httproute-1/rule/0/match/0/www_foo_com
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /foo1
+        security:
+          extAuth:
+            failOpen: true
+            grpc:
+              authority: grpc-backend.default:9000
+              destination:
+                metadata:
+                  kind: SecurityPolicy
+                  name: policy-for-http-route-1
+                  namespace: default
+                name: securitypolicy/default/policy-for-http-route-1/extauth/0
+                settings:
+                - addressType: IP
+                  endpoints:
+                  - host: 8.8.8.8
+                    port: 9000
+                  metadata:
+                    kind: ServiceImport
+                    name: grpc-backend
+                    namespace: default
+                    sectionName: "9000"
+                  name: securitypolicy/default/policy-for-http-route-1/extauth/0/backend/0
+                  protocol: GRPC
+                  weight: 1
+            headersToExtAuth:
+            - header1
+            - header2
+            name: securitypolicy/default/policy-for-http-route-1
+            traffic:
+              retry:
+                numRetries: 2
+                perRetry:
+                  backOff:
+                    baseInterval: 200ms
+                    maxInterval: 3s
+                  timeout: 3s
+                retryOn:
+                  triggers:
+                  - 5xx
+                  - deadline-exceeded
+                  - internal
+                  - unavailable
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-1
+            namespace: default
+          name: httproute/default/httproute-1/rule/1
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              name: service-2
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-1/rule/1/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: www.foo.com
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-1
+          namespace: default
+        name: httproute/default/httproute-1/rule/1/match/0/www_foo_com
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /foo2
+        security:
+          extAuth:
+            failOpen: true
+            grpc:
+              authority: grpc-backend.default:9000
+              destination:
+                metadata:
+                  kind: SecurityPolicy
+                  name: policy-for-http-route-1
+                  namespace: default
+                name: securitypolicy/default/policy-for-http-route-1/extauth/0
+                settings:
+                - addressType: IP
+                  endpoints:
+                  - host: 8.8.8.8
+                    port: 9000
+                  metadata:
+                    kind: ServiceImport
+                    name: grpc-backend
+                    namespace: default
+                    sectionName: "9000"
+                  name: securitypolicy/default/policy-for-http-route-1/extauth/0/backend/0
+                  protocol: GRPC
+                  weight: 1
+            headersToExtAuth:
+            - header1
+            - header2
+            name: securitypolicy/default/policy-for-http-route-1
+            traffic:
+              retry:
+                numRetries: 2
+                perRetry:
+                  backOff:
+                    baseInterval: 200ms
+                    maxInterval: 3s
+                  timeout: 3s
+                retryOn:
+                  triggers:
+                  - 5xx
+                  - deadline-exceeded
+                  - internal
+                  - unavailable
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-2
+            namespace: default
+          name: httproute/default/httproute-2/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              name: service-3
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-2/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: www.bar.com
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-2
+          namespace: default
+        name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /bar
+        security:
+          extAuth:
+            failOpen: false
+            http:
+              authority: http-backend.envoy-gateway:80
+              destination:
+                metadata:
+                  kind: SecurityPolicy
+                  name: policy-for-gateway-1
+                  namespace: default
+                name: securitypolicy/default/policy-for-gateway-1/extauth/0
+                settings:
+                - addressType: IP
+                  metadata:
+                    kind: ServiceImport
+                    name: http-backend
+                    namespace: envoy-gateway
+                    sectionName: "80"
+                  name: securitypolicy/default/policy-for-gateway-1/extauth/0/backend/0
+                  protocol: HTTP
+                  weight: 1
+              headersToBackend:
+              - header1
+              - header2
+              path: /auth
+            name: securitypolicy/default/policy-for-gateway-1
+            traffic:
+              retry:
+                numRetries: 2
+                perRetry:
+                  backOff:
+                    baseInterval: 200ms
+                    maxInterval: 3s
+                  timeout: 3s
+                retryOn:
+                  triggers:
+                  - 5xx
+                  - deadline-exceeded
+                  - internal
+                  - unavailable
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/internal/xds/translator/extauth.go
+++ b/internal/xds/translator/extauth.go
@@ -7,6 +7,7 @@ package translator
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -71,7 +72,10 @@ func (*extAuth) patchHCM(mgr *hcmv3.HttpConnectionManager, irListener *ir.HTTPLi
 
 // buildHCMExtAuthFilter returns an ext_authz HTTP filter from the provided IR HTTPRoute.
 func buildHCMExtAuthFilter(extAuth *ir.ExtAuth) (*hcmv3.HttpFilter, error) {
-	extAuthProto := extAuthConfig(extAuth)
+	extAuthProto, err := extAuthConfig(extAuth)
+	if err != nil {
+		return nil, err
+	}
 	extAuthAny, err := anypb.New(extAuthProto)
 	if err != nil {
 		return nil, err
@@ -90,7 +94,7 @@ func extAuthFilterName(extAuth *ir.ExtAuth) string {
 	return perRouteFilterName(egv1a1.EnvoyFilterExtAuthz, extAuth.Name)
 }
 
-func extAuthConfig(extAuth *ir.ExtAuth) *extauthv3.ExtAuthz {
+func extAuthConfig(extAuth *ir.ExtAuth) (*extauthv3.ExtAuthz, error) {
 	config := &extauthv3.ExtAuthz{
 		TransportApiVersion: corev3.ApiVersion_V3,
 	}
@@ -134,18 +138,28 @@ func extAuthConfig(extAuth *ir.ExtAuth) *extauthv3.ExtAuthz {
 		config.Services = &extauthv3.ExtAuthz_HttpService{
 			HttpService: httpService(extAuth.HTTP, timeout),
 		}
+		// Retry policy is not supported for HTTP service.
 	} else if extAuth.GRPC != nil {
-		config.Services = &extauthv3.ExtAuthz_GrpcService{
-			GrpcService: &corev3.GrpcService{
-				TargetSpecifier: &corev3.GrpcService_EnvoyGrpc_{
-					EnvoyGrpc: grpcService(extAuth.GRPC),
-				},
-				Timeout: timeout,
+		service := &corev3.GrpcService{
+			TargetSpecifier: &corev3.GrpcService_EnvoyGrpc_{
+				EnvoyGrpc: grpcService(extAuth.GRPC),
 			},
+			Timeout: timeout,
+		}
+		// Set the retry policy if it exists.
+		if extAuth.Traffic != nil && extAuth.Traffic.Retry != nil {
+			rp, err := buildNonRouteRetryPolicy(extAuth.Traffic.Retry)
+			if err != nil {
+				return nil, fmt.Errorf("build retry policy for gRPC service: %w", err)
+			}
+			service.RetryPolicy = rp
+		}
+		config.Services = &extauthv3.ExtAuthz_GrpcService{
+			GrpcService: service,
 		}
 	}
 
-	return config
+	return config, nil
 }
 
 func httpService(http *ir.HTTPExtAuthService, timeout *durationpb.Duration) *extauthv3.HttpService {

--- a/internal/xds/translator/extauth_test.go
+++ b/internal/xds/translator/extauth_test.go
@@ -76,7 +76,8 @@ func TestExtAuthConfigWithTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := extAuthConfig(tt.extAuth)
+			config, err := extAuthConfig(tt.extAuth)
+			require.NoError(t, err)
 			require.NotNil(t, config)
 
 			if tt.extAuth.GRPC != nil {

--- a/internal/xds/translator/testdata/in/xds-ir/ext-auth-retry.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/ext-auth-retry.yaml
@@ -1,0 +1,178 @@
+http:
+  - address: 0.0.0.0
+    hostnames:
+      - '*'
+    isHTTP2: false
+    name: default/gateway-1/http
+    path:
+      escapedSlashesAction: UnescapeAndRedirect
+      mergeSlashes: true
+    port: 10080
+    routes:
+      - name: httproute/default/httproute-1/rule/0/match/0/www_foo_com
+        hostname: www.foo.com
+        isHTTP2: false
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /foo1
+        backendWeights:
+          invalid: 0
+          valid: 0
+        destination:
+          name: httproute/default/httproute-1/rule/0
+          settings:
+            - addressType: IP
+              endpoints:
+                - host: 7.7.7.7
+                  port: 8080
+              protocol: HTTP
+              weight: 1
+              name: httproute/default/httproute-1/rule/0/backend/0
+        security:
+          extAuth:
+            name: securitypolicy/default/policy-for-http-route-1
+            traffic:
+              retry:
+                numRetries: 2
+                perRetry:
+                  backOff:
+                    baseInterval: 200ms
+                    maxInterval: 3s
+                  timeout: 3s
+                retryOn:
+                  triggers:
+                    - 5xx
+                    - deadline-exceeded
+                    - internal
+                    - unavailable
+            failOpen: false
+            grpc:
+              authority: grpc-backend.default:9000
+              destination:
+                name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
+                settings:
+                  - addressType: IP
+                    endpoints:
+                      - host: 8.8.4.4
+                        port: 9001
+                    protocol: GRPC
+                    weight: 1
+                    name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend/backend/0
+                  - addressType: IP
+                    endpoints:
+                      - host: 8.8.8.8
+                        port: 9000
+                    protocol: GRPC
+                    weight: 1
+                    name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend/backend/1
+            headersToExtAuth:
+              - header1
+              - header2
+      - name: httproute/default/httproute-1/rule/1/match/0/www_foo_com
+        hostname: www.foo.com
+        isHTTP2: false
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /foo2
+        backendWeights:
+          invalid: 0
+          valid: 0
+        destination:
+          name: httproute/default/httproute-1/rule/1
+          settings:
+            - addressType: IP
+              endpoints:
+                - host: 7.7.7.7
+                  port: 8080
+              protocol: HTTP
+              weight: 1
+              name: httproute/default/httproute-1/rule/1/backend/0
+        security:
+          extAuth:
+            name: securitypolicy/default/policy-for-http-route-1
+            traffic:
+              retry:
+                numRetries: 2
+                perRetry:
+                  backOff:
+                    baseInterval: 200ms
+                    maxInterval: 3s
+                  timeout: 3s
+                retryOn:
+                  triggers:
+                    - 5xx
+                    - deadline-exceeded
+                    - internal
+                    - unavailable
+            failOpen: false
+            grpc:
+              authority: grpc-backend.default:9000
+              destination:
+                name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
+                settings:
+                  - addressType: IP
+                    endpoints:
+                      - host: 8.8.8.8
+                        port: 9000
+                    protocol: GRPC
+                    weight: 1
+                    name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend/backend/0
+            headersToExtAuth:
+              - header1
+              - header2
+      - name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
+        hostname: www.bar.com
+        isHTTP2: false
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /bar
+        backendWeights:
+          invalid: 0
+          valid: 0
+        destination:
+          name: httproute/default/httproute-2/rule/0
+          settings:
+            - addressType: IP
+              endpoints:
+                - host: 7.7.7.7
+                  port: 8080
+              protocol: HTTP
+              weight: 1
+              name: httproute/default/httproute-2/rule/0/backend/0
+        security:
+          extAuth:
+            name: securitypolicy/default/policy-for-gateway-1
+            traffic:
+              retry:
+                numRetries: 2
+                perRetry:
+                  backOff:
+                    baseInterval: 200ms
+                    maxInterval: 3s
+                  timeout: 3s
+                retryOn:
+                  triggers:
+                    - 5xx
+                    - deadline-exceeded
+                    - internal
+                    - unavailable
+            failOpen: true
+            http:
+              authority: http-backend.envoy-gateway:80
+              destination:
+                name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
+                settings:
+                  - addressType: IP
+                    endpoints:
+                      - host: 7.7.7.7
+                        port: 80
+                    protocol: HTTP
+                    weight: 1
+                    name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend/backend/0
+              headersToBackend:
+                - header1
+                - header2
+              path: /auth

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-retry.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-retry.clusters.yaml
@@ -1,0 +1,127 @@
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: httproute/default/httproute-1/rule/0
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: httproute/default/httproute-1/rule/0
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: httproute/default/httproute-1/rule/1
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: httproute/default/httproute-1/rule/1
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: httproute/default/httproute-2/rule/0
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: httproute/default/httproute-2/rule/0
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
+  perConnectionBufferLimitBytes: 32768
+  type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-retry.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-retry.endpoints.yaml
@@ -1,0 +1,70 @@
+- clusterName: httproute/default/httproute-1/rule/0
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 7.7.7.7
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: httproute/default/httproute-1/rule/0/backend/0
+- clusterName: httproute/default/httproute-1/rule/1
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 7.7.7.7
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: httproute/default/httproute-1/rule/1/backend/0
+- clusterName: httproute/default/httproute-2/rule/0
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 7.7.7.7
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: httproute/default/httproute-2/rule/0/backend/0
+- clusterName: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 8.8.4.4
+            portValue: 9001
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: securitypolicy/default/policy-for-http-route-1/default/grpc-backend/backend/0
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 8.8.8.8
+            portValue: 9000
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: securitypolicy/default/policy-for-http-route-1/default/grpc-backend/backend/1
+- clusterName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 7.7.7.7
+            portValue: 80
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend/backend/0

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-retry.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-retry.listeners.yaml
@@ -1,0 +1,76 @@
+- address:
+    socketAddress:
+      address: 0.0.0.0
+      portValue: 10080
+  defaultFilterChain:
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        commonHttpProtocolOptions:
+          headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
+        httpFilters:
+        - disabled: true
+          name: envoy.filters.http.ext_authz/securitypolicy/default/policy-for-gateway-1
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+            failureModeAllow: true
+            httpService:
+              authorizationResponse:
+                allowedUpstreamHeaders:
+                  patterns:
+                  - exact: header1
+                    ignoreCase: true
+                  - exact: header2
+                    ignoreCase: true
+              pathPrefix: /auth
+              serverUri:
+                cluster: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
+                timeout: 10s
+                uri: http://http-backend.envoy-gateway:80/auth
+            transportApiVersion: V3
+        - disabled: true
+          name: envoy.filters.http.ext_authz/securitypolicy/default/policy-for-http-route-1
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+            allowedHeaders:
+              patterns:
+              - exact: header1
+                ignoreCase: true
+              - exact: header2
+                ignoreCase: true
+            grpcService:
+              envoyGrpc:
+                authority: grpc-backend.default:9000
+                clusterName: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
+              retryPolicy:
+                numRetries: 2
+                retryBackOff:
+                  baseInterval: 0.200s
+                  maxInterval: 3s
+                retryOn: 5xx,deadline-exceeded,internal,unavailable
+              timeout: 10s
+            transportApiVersion: V3
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            suppressEnvoyHeaders: true
+        mergeSlashes: true
+        normalizePath: true
+        pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: default/gateway-1/http
+        serverHeaderTransformation: PASS_THROUGH
+        statPrefix: http-10080
+        useRemoteAddress: true
+    name: default/gateway-1/http
+  maxConnectionsToAcceptPerSocketEvent: 1
+  name: default/gateway-1/http
+  perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-retry.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-retry.routes.yaml
@@ -1,0 +1,44 @@
+- ignorePortInHostMatching: true
+  name: default/gateway-1/http
+  virtualHosts:
+  - domains:
+    - www.foo.com
+    name: default/gateway-1/http/www_foo_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /foo1
+      name: httproute/default/httproute-1/rule/0/match/0/www_foo_com
+      route:
+        cluster: httproute/default/httproute-1/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ext_authz/securitypolicy/default/policy-for-http-route-1:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}
+    - match:
+        pathSeparatedPrefix: /foo2
+      name: httproute/default/httproute-1/rule/1/match/0/www_foo_com
+      route:
+        cluster: httproute/default/httproute-1/rule/1
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ext_authz/securitypolicy/default/policy-for-http-route-1:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}
+  - domains:
+    - www.bar.com
+    name: default/gateway-1/http/www_bar_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /bar
+      name: httproute/default/httproute-2/rule/0/match/0/www_bar_com
+      route:
+        cluster: httproute/default/httproute-2/rule/0
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ext_authz/securitypolicy/default/policy-for-gateway-1:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -9,6 +9,7 @@ security updates: |
 # New features or capabilities added in this release.
 new features: |
   Added support for mTLS configuration for ExtensionServer.
+  Added support for RetryPolicy in gRPC ExtAuth callouts via SecurityPolicy backend settings fields.
   Added support for late response headers in ClientTrafficPolicy.
 
 bug fixes: |


### PR DESCRIPTION
**What type of PR is this?**
feat: support retry policy for gRPC ExtAuth SecurityPolicy

**What this PR does / why we need it**:
`SecurityPolicy` allows you to specify a `Retry` for various features. However, this retry feature is currently not implemented for ext auth callouts (gRPC and HTTP ext auth service).

This PR implements retry policy for **gRPC** ext auth callouts.

**Which issue(s) this PR fixes**:
Related to https://github.com/envoyproxy/gateway/issues/6914, but let's keep it open for the long-term validation/docs fix.

Release Notes: Yes
