### PR TITLE
bugfix: handle millisecond-level retry durations and token TTLs in OIDC authn

### DIFF
--- a/internal/utils/ratelimit/unit.go
+++ b/internal/utils/ratelimit/unit.go
@@ -6,6 +6,8 @@
 package ratelimit
 
 import (
+	"time"
+
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -34,7 +36,5 @@ func UnitToSeconds(unit egv1a1.RateLimitUnit) int64 {
 
 func UnitToDuration(unit ir.RateLimitUnit) *durationpb.Duration {
 	seconds := UnitToSeconds(egv1a1.RateLimitUnit(unit))
-	return &durationpb.Duration{
-		Seconds: seconds,
-	}
+	return durationpb.New(time.Duration(seconds) * time.Second)
 }

--- a/internal/xds/translator/extauth.go
+++ b/internal/xds/translator/extauth.go
@@ -8,7 +8,6 @@ package translator
 import (
 	"errors"
 	"net/url"
-	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -126,7 +125,7 @@ func extAuthConfig(extAuth *ir.ExtAuth) *extauthv3.ExtAuthz {
 		}
 	}
 
-	timeout := durationpb.New(time.Duration(defaultExtServiceRequestTimeout) * time.Second)
+	timeout := durationpb.New(defaultExtServiceRequestTimeout)
 	if extAuth.Timeout != nil {
 		timeout = durationpb.New(extAuth.Timeout.Duration)
 	}

--- a/internal/xds/translator/extauth_test.go
+++ b/internal/xds/translator/extauth_test.go
@@ -33,7 +33,7 @@ func TestExtAuthConfigWithTimeout(t *testing.T) {
 					Authority:   "test-authority",
 				},
 			},
-			expectedTimeout: durationpb.New(time.Duration(defaultExtServiceRequestTimeout) * time.Second),
+			expectedTimeout: durationpb.New(defaultExtServiceRequestTimeout),
 		},
 		{
 			name: "GRPC custom timeout specified in milliseconds - should use custom timeout",

--- a/internal/xds/translator/extensionserver_test.go
+++ b/internal/xds/translator/extensionserver_test.go
@@ -309,7 +309,7 @@ func (t *testingExtensionServer) PostTranslateModify(_ context.Context, req *pb.
 	for idx, cluster := range req.Clusters {
 		response.Clusters[idx] = proto.Clone(cluster).(*clusterV3.Cluster)
 		if cluster.Name == "first-route" {
-			response.Clusters[idx].ConnectTimeout = durationpb.New(time.Second * 3)
+			response.Clusters[idx].ConnectTimeout = durationpb.New(time.Second * 30)
 		}
 	}
 

--- a/internal/xds/translator/extensionserver_test.go
+++ b/internal/xds/translator/extensionserver_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	clusterV3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	coreV3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -308,7 +309,7 @@ func (t *testingExtensionServer) PostTranslateModify(_ context.Context, req *pb.
 	for idx, cluster := range req.Clusters {
 		response.Clusters[idx] = proto.Clone(cluster).(*clusterV3.Cluster)
 		if cluster.Name == "first-route" {
-			response.Clusters[idx].ConnectTimeout = &durationpb.Duration{Seconds: 30}
+			response.Clusters[idx].ConnectTimeout = durationpb.New(time.Second * 3)
 		}
 	}
 

--- a/internal/xds/translator/extproc.go
+++ b/internal/xds/translator/extproc.go
@@ -95,9 +95,7 @@ func extProcConfig(extProc ir.ExtProc) *extprocv3.ExternalProcessor {
 			TargetSpecifier: &corev3.GrpcService_EnvoyGrpc_{
 				EnvoyGrpc: grpcExtProcService(extProc),
 			},
-			Timeout: &durationpb.Duration{
-				Seconds: defaultExtServiceRequestTimeout,
-			},
+			Timeout: durationpb.New(defaultExtServiceRequestTimeout),
 		},
 	}
 

--- a/internal/xds/translator/jwt.go
+++ b/internal/xds/translator/jwt.go
@@ -8,6 +8,7 @@ package translator
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -156,9 +157,9 @@ func buildJWTAuthn(irListener *ir.HTTPListener) (*jwtauthnv3.JwtAuthentication, 
 							HttpUpstreamType: &corev3.HttpUri_Cluster{
 								Cluster: jwksCluster,
 							},
-							Timeout: &durationpb.Duration{Seconds: defaultExtServiceRequestTimeout},
+							Timeout: durationpb.New(defaultExtServiceRequestTimeout),
 						},
-						CacheDuration: &durationpb.Duration{Seconds: 5 * 60},
+						CacheDuration: durationpb.New(5 * time.Minute),
 						AsyncFetch:    &jwtauthnv3.JwksAsyncFetch{},
 					},
 				}

--- a/internal/xds/translator/oidc.go
+++ b/internal/xds/translator/oidc.go
@@ -132,9 +132,7 @@ func oauth2Config(securityFeatures *ir.SecurityFeatures) (*oauth2v3.OAuth2, erro
 				HttpUpstreamType: &corev3.HttpUri_Cluster{
 					Cluster: tokenEndpointCluster,
 				},
-				Timeout: &durationpb.Duration{
-					Seconds: defaultExtServiceRequestTimeout,
-				},
+				Timeout: durationpb.New(defaultExtServiceRequestTimeout),
 			},
 			AuthorizationEndpoint: oidc.Provider.AuthorizationEndpoint,
 			RedirectUri:           oidc.RedirectURL,
@@ -190,15 +188,11 @@ func oauth2Config(securityFeatures *ir.SecurityFeatures) (*oauth2v3.OAuth2, erro
 	}
 
 	if oidc.DefaultTokenTTL != nil {
-		oauth2.Config.DefaultExpiresIn = &durationpb.Duration{
-			Seconds: int64(oidc.DefaultTokenTTL.Seconds()),
-		}
+		oauth2.Config.DefaultExpiresIn = durationpb.New(oidc.DefaultTokenTTL.Duration)
 	}
 
 	if oidc.DefaultRefreshTokenTTL != nil {
-		oauth2.Config.DefaultRefreshTokenExpiresIn = &durationpb.Duration{
-			Seconds: int64(oidc.DefaultRefreshTokenTTL.Seconds()),
-		}
+		oauth2.Config.DefaultRefreshTokenExpiresIn = durationpb.New(oidc.DefaultRefreshTokenTTL.Duration)
 	}
 
 	if oidc.CookieNameOverrides != nil &&
@@ -364,12 +358,8 @@ func buildNonRouteRetryPolicy(rr *ir.Retry) (*corev3.RetryPolicy, error) {
 
 	if rr.PerRetry != nil && rr.PerRetry.BackOff != nil {
 		rp.RetryBackOff = &corev3.BackoffStrategy{
-			BaseInterval: &durationpb.Duration{
-				Seconds: int64(rr.PerRetry.BackOff.BaseInterval.Seconds()),
-			},
-			MaxInterval: &durationpb.Duration{
-				Seconds: int64(rr.PerRetry.BackOff.MaxInterval.Seconds()),
-			},
+			BaseInterval: durationpb.New(rr.PerRetry.BackOff.BaseInterval.Duration),
+			MaxInterval:  durationpb.New(rr.PerRetry.BackOff.MaxInterval.Duration),
 		}
 	}
 

--- a/internal/xds/translator/testdata/in/xds-ir/oidc-backend-cluster-provider.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/oidc-backend-cluster-provider.yaml
@@ -54,7 +54,7 @@ http:
               numRetries: 3
               perRetry:
                 backOff:
-                  baseInterval: 1s
+                  baseInterval: 500ms
                   maxInterval: 5s
               retryOn:
                 triggers:

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.listeners.yaml
@@ -52,7 +52,7 @@
               retryPolicy:
                 numRetries: 3
                 retryBackOff:
-                  baseInterval: 1s
+                  baseInterval: 0.500s
                   maxInterval: 5s
                 retryOn: 5xx,gateway-error,reset
               signoutPath:

--- a/internal/xds/translator/utils.go
+++ b/internal/xds/translator/utils.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -27,7 +28,7 @@ import (
 const (
 	defaultHTTPSPort                uint64 = 443
 	defaultHTTPPort                 uint64 = 80
-	defaultExtServiceRequestTimeout        = 10 // 10 seconds
+	defaultExtServiceRequestTimeout        = 10 * time.Second
 )
 
 // urlCluster is a cluster that is created from a URL.

--- a/internal/xds/translator/wasm.go
+++ b/internal/xds/translator/wasm.go
@@ -125,9 +125,7 @@ func wasmConfig(wasm ir.Wasm) (*wasmfilterv3.Wasm, error) {
 						HttpUpstreamType: &corev3.HttpUri_Cluster{
 							Cluster: wasmHTTPServiceClusterName,
 						},
-						Timeout: &durationpb.Duration{
-							Seconds: defaultExtServiceRequestTimeout,
-						},
+						Timeout: durationpb.New(defaultExtServiceRequestTimeout),
 					},
 					Sha256: wasm.Code.SHA256,
 				},

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -17,6 +17,7 @@ bug fixes: |
   Fixed log formatting of improper key-value pairs to avoid DPANIC in controller-runtime logger.
   Fixed handling of context-related transient errors to prevent incorrect state reconciliation and unintended behavior.
   Fixed the controller cannot read the EnvoyProxy attached gatewayclass only.
+  Fixed handling of millisecond-level retry durations in OIDC and JWT authn callouts.
 
 # Enhancements that improve performance.
 performance improvements: |

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -17,7 +17,7 @@ bug fixes: |
   Fixed log formatting of improper key-value pairs to avoid DPANIC in controller-runtime logger.
   Fixed handling of context-related transient errors to prevent incorrect state reconciliation and unintended behavior.
   Fixed the controller cannot read the EnvoyProxy attached gatewayclass only.
-  Fixed handling of millisecond-level retry durations in OIDC and JWT authn callouts.
+  Fixed handling of millisecond-level retry durations and token TTLs in OIDC authn.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
**What type of PR is this?**

1. bugfix: handle millisecond-level retry durations and token TTLs in OIDC authn
2. cleanup: replace all raw construction of `durationpb.Duration` with `durationpb.New()` function call

**What this PR does / why we need it**:
https://github.com/envoyproxy/gateway/pull/6915/files#r2331553784 shows there is a bug in handling retry durations. The milliseconds/microseconds/nanoseconds gets chopped off, resulting in the duration being truncated to the `Second` mark.

This PR replaces all calls of `durationpb.Duration` with `durationpb.New()` to correctly create the duration proto (without truncation). This preserves time units smaller than seconds correctly.

The main user-facing bugfix is in the `oidc.go` where the user-provided TTL and retry durations get truncated. All other replacements are primarily for code cleanup and consistency (no behavior change).

**Which issue(s) this PR fixes**:
No OSS issue, but this bug was discovered in https://github.com/envoyproxy/gateway/pull/6915

Release Notes: Yes
