### PR TITLE
docs: ignore hashicorp developer link in docs-check-links

### DIFF
--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -4,7 +4,7 @@ RELEASE_VERSIONS ?= $(foreach v,$(wildcard ${ROOT_DIR}/docs/*),$(notdir ${v}))
 #       find a way to remove github.com from ignore list
 # TODO: example.com is not a valid domain, we should remove it from ignore list
 # TODO: https://www.gnu.org/software/make became unstable, we should remove it from ignore list later
-LINKINATOR_IGNORE := "opentelemetry.io github.com jwt.io githubusercontent.com example.com github.io gnu.org _print canva.com sched.co sap.com httpbin.org nemlig.com verve.com"
+LINKINATOR_IGNORE := "opentelemetry.io github.com jwt.io githubusercontent.com example.com github.io gnu.org _print canva.com sched.co sap.com httpbin.org nemlig.com verve.com developer.hashicorp.com"
 CLEAN_NODE_MODULES ?= true
 
 ##@ Docs


### PR DESCRIPTION
What type of PR is this?
docs

What this PR does / why we need it:
This PR updates the documentation link checking configuration by ignoring the HashiCorp developer link:

https://developer.hashicorp.com/consul/tutorials/developer-mesh/terminating-gateways-connect-external-services


The link frequently returns 429 Too Many Requests, which causes docs-check-links in CI to fail. By adding this link (or domain) to the ignore list, we ensure CI runs reliably and is not affected by external rate limiting.

Which issue(s) this PR fixes:
Fixes #6937

Release Notes:
No release notes needed (internal docs CI configuration only).
