### PR TITLE
fix: update distroless image to resolve glibc CVEs

### DIFF
--- a/tools/docker/envoy-gateway/Dockerfile
+++ b/tools/docker/envoy-gateway/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /var/lib/eg && chmod -R 0777 /var/lib/eg
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base-nossl:nonroot@sha256:8981b63f968e829d21351ea9d28cc21127e5f034707f1d8483d2993d9577be0b
+FROM gcr.io/distroless/base-nossl:nonroot@sha256:a1922debbf4ff2cc245d7c0d1e2021cfcee35fe24afae7505aeec59f7e7802f6
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/envoy-gateway /usr/local/bin/
 COPY --from=source /var/lib /var/lib


### PR DESCRIPTION
**What this PR does / why we need it**:
Update `gcr.io/distroless/base-nossl:nonroot` base image to latest digest to resolve 2 `glibc` CVEs:
<img width="688" height="135" alt="image" src="https://github.com/user-attachments/assets/55085522-bb52-4bb5-b78b-58186c038713" />


**Which issue(s) this PR fixes**:
Fixes #6950

Release Notes: No
