### PR TITLE
docs(helm): document enabling Backend API via values.yaml and --set (…

### DIFF
--- a/site/content/en/latest/install/install-helm.md
+++ b/site/content/en/latest/install/install-helm.md
@@ -106,6 +106,29 @@ Some of the quick ways of using the helm install command for envoy gateway insta
 If you want to know all the available fields inside the values.yaml file, please see the [Helm Chart Values](./gateway-helm-api).
 {{% /alert %}}
 
+### Enable Backend API
+
+The Backend API is not enabled by default. Enable it via Helm values:
+
+```shell
+helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set config.envoyGateway.extensionApis.enableBackend=true
+```
+
+Or with a `values.yaml` file:
+
+```yaml
+config:
+  envoyGateway:
+    extensionApis:
+      enableBackend: true
+```
+
+Then install using the file:
+
+```shell
+helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace -f values.yaml
+```
+
 ### Increase the replicas
 
 ```shell

--- a/site/content/en/v1.5/install/install-helm.md
+++ b/site/content/en/v1.5/install/install-helm.md
@@ -106,6 +106,29 @@ Some of the quick ways of using the helm install command for envoy gateway insta
 If you want to know all the available fields inside the values.yaml file, please see the [Helm Chart Values](./gateway-helm-api).
 {{% /alert %}}
 
+### Enable Backend API
+
+The Backend API is not enabled by default. Enable it via Helm values:
+
+```shell
+helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set config.envoyGateway.extensionApis.enableBackend=true
+```
+
+Or with a `values.yaml` file:
+
+```yaml
+config:
+  envoyGateway:
+    extensionApis:
+      enableBackend: true
+```
+
+Then install using the file:
+
+```shell
+helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace -f values.yaml
+```
+
 ### Increase the replicas
 
 ```shell


### PR DESCRIPTION
docs: document helm values way to enable backend (fixes #6333)

**What type of PR is this?**
Documentation

**What this PR does / why we need it**:
This PR addresses issue #6333 by documenting how to enable the Backend API via Helm values in the Envoy Gateway installation documentation.

**Changes include**:
- Added section in Helm installation docs explaining Backend API enablement
- Documented the required Helm values configuration (`config.envoyGateway.extensionApis.enableBackend: true`)
- Provided clear examples of values.yaml configuration
- Added Helm install command examples showing how to apply the Backend-enabled configuration

**Problem solved**: Previously, users had to discover through trial and error how to enable Backend functionality when installing Envoy Gateway via Helm. The Backend API was not enabled by default, and the documentation didn't clearly explain the Helm values approach for enabling it.

**Which issue(s) this PR fixes**:
Fixes #6333

**Testing**:
- [x] Verified documentation renders correctly
- [x] Confirmed Helm values examples are syntactically correct
- [x] Validated that the documented approach enables Backend functionality

**Release Notes**: 
Yes

**Additional Notes**:
This documentation improvement helps users understand how to enable Backend API functionality during Helm-based installations, making the feature more discoverable and easier to use.

Closes #6333