### PR TITLE
perf: improve mem allocation in TruncatePolicyAncestors

### DIFF
--- a/internal/gatewayapi/testdata/backendtlspolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-status-conditions-truncated.out.yaml
@@ -179,8 +179,8 @@ backendTLSPolicies:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated
@@ -365,8 +365,8 @@ backendTLSPolicies:
         status: "False"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions-truncated.out.yaml
@@ -213,8 +213,8 @@ backendTrafficPolicies:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-7, gateway-8'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated
@@ -440,8 +440,8 @@ backendTrafficPolicies:
         status: "False"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated
@@ -651,8 +651,8 @@ backendTrafficPolicies:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions-truncated.out.yaml
@@ -255,8 +255,8 @@ envoyExtensionPolicies:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated
@@ -533,8 +533,8 @@ envoyExtensionPolicies:
         status: "False"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions-truncated.out.yaml
@@ -213,8 +213,8 @@ envoyExtensionPolicies:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-7, gateway-8'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated
@@ -440,8 +440,8 @@ envoyExtensionPolicies:
         status: "False"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated
@@ -651,8 +651,8 @@ envoyExtensionPolicies:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated

--- a/internal/gatewayapi/testdata/securitypolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-status-conditions-truncated.out.yaml
@@ -1960,8 +1960,8 @@ securityPolicies:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-7, gateway-8'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated
@@ -2187,8 +2187,8 @@ securityPolicies:
         status: "False"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated
@@ -2398,8 +2398,8 @@ securityPolicies:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: 'Ancestors have been aggregated because the number of policy ancestors
-          exceeds 16. The aggregated ancestors: gateway-8, gateway-9'
+        message: Ancestors have been truncated because the number of policy ancestors
+          exceeds 16.
         reason: Aggregated
         status: "True"
         type: Aggregated


### PR DESCRIPTION
3x slower, with a ~60% mem improvement
```
go test -bench=BenchmarkComparison -benchmem ./internal/gatewayapi/status/
goos: darwin
goarch: amd64
pkg: github.com/envoyproxy/gateway/internal/gatewayapi/status
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkComparison/Old_Implementation-12         	    6001	    172984 ns/op	   72331 B/op	     230 allocs/op
BenchmarkComparison/New_Implementation-12         	    2230	    565019 ns/op	   28105 B/op	     229 allocs/op
```

Relates to https://github.com/envoyproxy/gateway/issues/6919
