### PR TITLE
perf: reuse route rule metadata

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -903,22 +903,12 @@ func filterEGPrefix(in map[string]string) map[string]string {
 		return nil
 	}
 
-	// check if any EG-prefixed annotations exist
-	hasEGAnnotations := false
-	for k := range in {
-		if strings.HasPrefix(k, egPrefix) {
-			hasEGAnnotations = true
-			break
-		}
-	}
-
-	if !hasEGAnnotations {
-		return nil
-	}
-
-	out := make(map[string]string, len(in))
+	var out map[string]string
 	for k, v := range in {
 		if strings.HasPrefix(k, egPrefix) {
+			if out == nil {
+				out = make(map[string]string, len(in))
+			}
 			out[strings.TrimPrefix(k, egPrefix)] = v
 		}
 	}


### PR DESCRIPTION
* build it once and pass it in the caller
* also since EG annotations are rare, make sure to return early and reduce allocations
