### PR TITLE
perf: reduce mem allocs in internal/metrics

### DIFF
--- a/internal/metrics/otel_label.go
+++ b/internal/metrics/otel_label.go
@@ -54,12 +54,11 @@ func (l LabelValue) Value() string {
 	return l.keyValue.Value.AsString()
 }
 
-func mergeLabelValues(attrs []attribute.KeyValue, labelValues []LabelValue) ([]attribute.KeyValue, attribute.Set) {
-	mergedAttrs := make([]attribute.KeyValue, 0, len(attrs)+len(labelValues))
-	mergedAttrs = append(mergedAttrs, attrs...)
-	for _, v := range labelValues {
-		mergedAttrs = append(mergedAttrs, v.keyValue)
+func mergeLabelValues(attrs []attribute.KeyValue, labelValues []LabelValue) []attribute.KeyValue {
+	mergedAttrs := make([]attribute.KeyValue, len(attrs)+len(labelValues))
+	copy(mergedAttrs, attrs)
+	for i, v := range labelValues {
+		mergedAttrs[len(attrs)+i] = v.keyValue
 	}
-
-	return mergedAttrs, attribute.NewSet(mergedAttrs...)
+	return mergedAttrs
 }

--- a/internal/metrics/otel_metric_counter.go
+++ b/internal/metrics/otel_metric_counter.go
@@ -36,12 +36,12 @@ func (f *Counter) Decrement() {
 }
 
 func (f *Counter) With(labelValues ...LabelValue) *Counter {
-	attrs, set := mergeLabelValues(f.attrs, labelValues)
+	mergedAttrs := mergeLabelValues(f.attrs, labelValues)
 	m := &Counter{
 		c:                f.c,
-		preRecordOptions: []api.AddOption{api.WithAttributeSet(set)},
+		preRecordOptions: []api.AddOption{api.WithAttributes(mergedAttrs...)},
 		name:             f.name,
-		attrs:            attrs,
+		attrs:            mergedAttrs,
 	}
 
 	return m

--- a/internal/metrics/otel_metric_gauge.go
+++ b/internal/metrics/otel_metric_gauge.go
@@ -42,17 +42,19 @@ func (f *Gauge) With(labelValues ...LabelValue) *Gauge {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
-	attrs, set := mergeLabelValues(f.attrs, labelValues)
+	mergedAttrs := mergeLabelValues(f.attrs, labelValues)
+	set := attribute.NewSet(mergedAttrs...)
+
 	m := &Gauge{
 		g:      f.g,
 		mutex:  f.mutex,
 		stores: f.stores,
 		name:   f.name,
-		attrs:  attrs,
+		attrs:  mergedAttrs,
 	}
 	if _, f := m.stores[set]; !f {
 		m.stores[set] = &GaugeValues{
-			opt: []api.ObserveOption{api.WithAttributeSet(set)},
+			opt: []api.ObserveOption{api.WithAttributes(mergedAttrs...)},
 		}
 	}
 	m.current = m.stores[set]

--- a/internal/metrics/otel_metric_histogram.go
+++ b/internal/metrics/otel_metric_histogram.go
@@ -29,12 +29,12 @@ func (f *Histogram) Record(value float64) {
 }
 
 func (f *Histogram) With(labelValues ...LabelValue) *Histogram {
-	attrs, set := mergeLabelValues(f.attrs, labelValues)
+	mergedAttrs := mergeLabelValues(f.attrs, labelValues)
 	m := &Histogram{
 		name:             f.name,
-		attrs:            attrs,
+		attrs:            mergedAttrs,
 		d:                f.d,
-		preRecordOptions: []api.RecordOption{api.WithAttributeSet(set)},
+		preRecordOptions: []api.RecordOption{api.WithAttributes(mergedAttrs...)},
 	}
 
 	return m


### PR DESCRIPTION
```
                         │   old.txt    │       new.txt       │
                         │    sec/op    │    sec/op     vs base   │
  MergeLabelValuesOld-12   354.6n ± 42%
  MergeLabelValuesNew-12                  131.6n ± 18%

                         │  old.txt   │      new.txt      │
                         │    B/op    │    B/op     vs base   │
  MergeLabelValuesOld-12   640.0 ± 0%
  MergeLabelValuesNew-12                320.0 ± 0%

                         │  old.txt   │      new.txt      │
                         │ allocs/op  │ allocs/op   vs base   │
  MergeLabelValuesOld-12   2.000 ± 0%
  MergeLabelValuesNew-12                1.000 ± 0%
```