### PR TITLE
fix: properly generate infra envoy proxy args and fix bootstrap yaml format for Host provider

### DIFF
--- a/internal/infrastructure/common/proxy_args.go
+++ b/internal/infrastructure/common/proxy_args.go
@@ -64,22 +64,25 @@ func BuildProxyArgs(
 
 	logging := infra.Config.Spec.Logging
 
+	// The func-e library used by the infrastructure provider parses the arguments and does not support the '=' syntax.
+	// It is important to make sure each element of the array is a single string to make sure arguments are properly
+	// processed.
 	args := []string{
-		fmt.Sprintf("--service-cluster %s", serviceCluster),
-		fmt.Sprintf("--service-node %s", serviceNode),
-		fmt.Sprintf("--config-yaml %s", bootstrapConfigurations),
-		fmt.Sprintf("--log-level %s", logging.DefaultEnvoyProxyLoggingLevel()),
+		"--service-cluster", serviceCluster,
+		"--service-node", serviceNode,
+		"--config-yaml", bootstrapConfigurations,
+		"--log-level", string(logging.DefaultEnvoyProxyLoggingLevel()),
 		"--cpuset-threads",
-		"--drain-strategy immediate",
+		"--drain-strategy", "immediate",
 	}
 
 	if infra.Config != nil &&
 		infra.Config.Spec.Concurrency != nil {
-		args = append(args, fmt.Sprintf("--concurrency %d", *infra.Config.Spec.Concurrency))
+		args = append(args, "--concurrency", fmt.Sprintf("%d", *infra.Config.Spec.Concurrency))
 	}
 
 	if componentsLogLevel := logging.GetEnvoyProxyComponentLevel(); componentsLogLevel != "" {
-		args = append(args, fmt.Sprintf("--component-log-level %s", componentsLogLevel))
+		args = append(args, "--component-log-level", componentsLogLevel)
 	}
 
 	// Default drain timeout.
@@ -91,7 +94,7 @@ func BuildProxyArgs(
 		}
 		drainTimeout = d.Seconds()
 	}
-	args = append(args, fmt.Sprintf("--drain-time-s %.0f", drainTimeout))
+	args = append(args, "--drain-time-s", fmt.Sprintf("%.0f", drainTimeout))
 
 	if infra.Config != nil {
 		args = append(args, infra.Config.Spec.ExtraArgs...)

--- a/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
+++ b/internal/infrastructure/kubernetes/proxy/resource_provider_test.go
@@ -633,7 +633,7 @@ func TestDeployment(t *testing.T) {
 		{
 			caseName:  "with-extra-args",
 			infra:     newTestInfra(),
-			extraArgs: []string{"--key1 val1", "--key2 val2"},
+			extraArgs: []string{"--key1", "val1", "--key2", "val2"},
 		},
 		{
 			caseName: "with-empty-memory-limits",
@@ -1114,7 +1114,7 @@ func TestDaemonSet(t *testing.T) {
 		{
 			caseName:  "with-extra-args",
 			infra:     newTestInfra(),
-			extraArgs: []string{"--key1 val1", "--key2 val2"},
+			extraArgs: []string{"--key1", "val1", "--key2", "val2"},
 		},
 		{
 			caseName: "with-name",

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
@@ -40,14 +40,21 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
-        - --config-yaml test bootstrap config
-        - --log-level error
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
+        - test bootstrap config
+        - --log-level
+        - error
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level filter:info
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - filter:info
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
@@ -41,10 +41,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -209,11 +212,15 @@ spec:
               - name: "envoy.resource_monitors.fixed_heap"
                 threshold:
                   value: 0.98
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -208,11 +211,15 @@ spec:
               - name: "envoy.resource_monitors.fixed_heap"
                 threshold:
                   value: 0.98
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -193,11 +196,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
@@ -36,10 +36,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -142,11 +145,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -208,11 +211,15 @@ spec:
               - name: "envoy.resource_monitors.fixed_heap"
                 threshold:
                   value: 0.98
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
@@ -43,10 +43,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster ns1/gateway-1
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - ns1/gateway-1
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -209,11 +212,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
@@ -49,10 +49,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -202,11 +205,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -193,11 +196,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -193,11 +196,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -193,11 +196,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 30
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "30"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -208,11 +211,15 @@ spec:
               - name: "envoy.resource_monitors.fixed_heap"
                 threshold:
                   value: 0.98
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
@@ -45,10 +45,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -198,11 +201,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
@@ -40,15 +40,23 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
-        - --config-yaml test bootstrap config
-        - --log-level warn
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
+        - test bootstrap config
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --concurrency 4
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --concurrency
+        - "4"
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -193,13 +196,19 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
-        - --key1 val1
-        - --key2 val2
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
+        - --key1
+        - val1
+        - --key2
+        - val2
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -193,11 +196,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -193,11 +196,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -193,11 +196,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -193,11 +196,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -44,14 +44,21 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
-        - --config-yaml test bootstrap config
-        - --log-level warn
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
+        - test bootstrap config
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -44,14 +44,21 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
-        - --config-yaml test bootstrap config
-        - --log-level trace
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
+        - test bootstrap config
+        - --log-level
+        - trace
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level filter:info
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - filter:info
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
@@ -47,10 +47,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster ns1/gateway-1
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - ns1/gateway-1
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -213,11 +216,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -46,10 +46,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -214,11 +217,15 @@ spec:
               - name: "envoy.resource_monitors.fixed_heap"
                 threshold:
                   value: 0.98
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -46,10 +46,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -214,11 +217,15 @@ spec:
               - name: "envoy.resource_monitors.fixed_heap"
                 threshold:
                   value: 0.98
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -45,10 +45,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -213,11 +216,15 @@ spec:
               - name: "envoy.resource_monitors.fixed_heap"
                 threshold:
                   value: 0.98
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -44,10 +44,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -197,11 +200,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -40,10 +40,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -146,11 +149,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
@@ -44,10 +44,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -198,11 +201,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -45,10 +45,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -213,11 +216,15 @@ spec:
               - name: "envoy.resource_monitors.fixed_heap"
                 threshold:
                   value: 0.98
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
@@ -47,10 +47,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster ns1/gateway-1
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - ns1/gateway-1
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -213,11 +216,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
@@ -44,10 +44,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -198,11 +201,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -53,10 +53,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -206,11 +209,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
@@ -46,10 +46,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -199,11 +202,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -44,10 +44,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -197,11 +200,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -44,10 +44,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -197,11 +200,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 30
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "30"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -45,10 +45,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -213,11 +216,15 @@ spec:
               - name: "envoy.resource_monitors.fixed_heap"
                 threshold:
                   value: 0.98
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -49,10 +49,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -202,11 +205,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -44,15 +44,23 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
-        - --config-yaml test bootstrap config
-        - --log-level warn
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
+        - test bootstrap config
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --concurrency 4
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --concurrency
+        - "4"
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -44,10 +44,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -197,11 +200,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -44,10 +44,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -197,13 +200,19 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
-        - --key1 val1
-        - --key2 val2
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
+        - --key1
+        - val1
+        - --key2
+        - val2
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -44,10 +44,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -197,11 +200,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
@@ -44,10 +44,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -197,11 +200,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -44,10 +44,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -197,11 +200,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -44,10 +44,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster default
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - default
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -197,11 +200,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
@@ -47,10 +47,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster namespace-1/gateway-1
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - namespace-1/gateway-1
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -213,11 +216,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:
@@ -461,10 +468,13 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --service-cluster namespace-2/gateway-2
-        - --service-node $(ENVOY_POD_NAME)
+        - --service-cluster
+        - namespace-2/gateway-2
+        - --service-node
+        - $(ENVOY_POD_NAME)
+        - --config-yaml
         - |
-          --config-yaml admin:
+          admin:
             access_log:
             - name: envoy.access_loggers.file
               typed_config:
@@ -627,11 +637,15 @@ spec:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
                 max_active_downstream_connections: 50000
-        - --log-level warn
+        - --log-level
+        - warn
         - --cpuset-threads
-        - --drain-strategy immediate
-        - --component-log-level misc:error
-        - --drain-time-s 60
+        - --drain-strategy
+        - immediate
+        - --component-log-level
+        - misc:error
+        - --drain-time-s
+        - "60"
         command:
         - envoy
         env:

--- a/internal/utils/proto/proto.go
+++ b/internal/utils/proto/proto.go
@@ -22,7 +22,10 @@ import (
 )
 
 var (
-	marshaler   = &jsonpb.Marshaler{}
+	// Setting the OrigName flag to true will preserve the expected snake case field names in the JSON output.
+	// Otherwise, camel case is produced, and it causes issues with the func-e library used to unmarshal the
+	// bootstrap configuration.
+	marshaler   = &jsonpb.Marshaler{OrigName: true}
 	unmarshaler = &jsonpb.Unmarshaler{AllowUnknownFields: true}
 )
 

--- a/internal/xds/bootstrap/testdata/merge/default.out.yaml
+++ b/internal/xds/bootstrap/testdata/merge/default.out.yaml
@@ -1,143 +1,143 @@
 admin:
-  accessLog:
+  access_log:
   - name: envoy.access_loggers.file
-    typedConfig:
+    typed_config:
       '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
       path: /dev/null
   address:
-    socketAddress:
+    socket_address:
       address: 127.0.0.1
-      portValue: 20000
-clusterManager:
-  localClusterName: local_cluster
-dynamicResources:
-  adsConfig:
-    apiType: DELTA_GRPC
-    grpcServices:
-    - envoyGrpc:
-        clusterName: xds_cluster
-    setNodeOnFirstMessageOnly: true
-    transportApiVersion: V3
-  cdsConfig:
+      port_value: 20000
+cluster_manager:
+  local_cluster_name: local_cluster
+dynamic_resources:
+  ads_config:
+    api_type: DELTA_GRPC
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
+    set_node_on_first_message_only: true
+    transport_api_version: V3
+  cds_config:
     ads: {}
-    resourceApiVersion: V3
-  ldsConfig:
+    resource_api_version: V3
+  lds_config:
     ads: {}
-    resourceApiVersion: V3
-layeredRuntime:
+    resource_api_version: V3
+layered_runtime:
   layers:
   - name: global_config
-    staticLayer:
+    static_layer:
       envoy.restart_features.use_eds_cache_for_ads: true
       re2.max_program_size.error_level: 4294967295
       re2.max_program_size.warn_level: 1000
   - name: runtime-0
-    rtdsLayer:
+    rtds_layer:
       name: runtime-0
-      rtdsConfig:
+      rtds_config:
         ads: {}
-        resourceApiVersion: V3
+        resource_api_version: V3
 node:
   locality:
     zone: $(ENVOY_SERVICE_ZONE)
-overloadManager:
-  refreshInterval: 0.250s
-  resourceMonitors:
+overload_manager:
+  refresh_interval: 0.250s
+  resource_monitors:
   - name: envoy.resource_monitors.global_downstream_max_connections
-    typedConfig:
+    typed_config:
       '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
-      maxActiveDownstreamConnections: "50000"
-staticResources:
+      max_active_downstream_connections: "50000"
+static_resources:
   clusters:
-  - connectTimeout: 0.250s
-    loadAssignment:
-      clusterName: prometheus_stats
+  - connect_timeout: 0.250s
+    load_assignment:
+      cluster_name: prometheus_stats
       endpoints:
-      - lbEndpoints:
+      - lb_endpoints:
         - endpoint:
             address:
-              socketAddress:
+              socket_address:
                 address: 127.0.0.1
-                portValue: 19000
+                port_value: 19000
     name: prometheus_stats
     type: STATIC
-  - connectTimeout: 10s
-    edsClusterConfig:
-      edsConfig:
+  - connect_timeout: 10s
+    eds_cluster_config:
+      eds_config:
         ads: {}
-        resourceApiVersion: V3
-      serviceName: local_cluster
-    loadBalancingPolicy:
+        resource_api_version: V3
+      service_name: local_cluster
+    load_balancing_policy:
       policies:
-      - typedExtensionConfig:
+      - typed_extension_config:
           name: envoy.load_balancing_policies.least_request
-          typedConfig:
+          typed_config:
             '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
-            localityLbConfig:
-              zoneAwareLbConfig:
-                minClusterSize: "1"
+            locality_lb_config:
+              zone_aware_lb_config:
+                min_cluster_size: "1"
     name: local_cluster
     type: EDS
-  - connectTimeout: 10s
-    loadAssignment:
-      clusterName: xds_cluster
+  - connect_timeout: 10s
+    load_assignment:
+      cluster_name: xds_cluster
       endpoints:
-      - lbEndpoints:
+      - lb_endpoints:
         - endpoint:
             address:
-              socketAddress:
+              socket_address:
                 address: envoy-gateway
-                portValue: 18000
-          loadBalancingWeight: 1
-        loadBalancingWeight: 1
+                port_value: 18000
+          load_balancing_weight: 1
+        load_balancing_weight: 1
     name: xds_cluster
-    transportSocket:
+    transport_socket:
       name: envoy.transport_sockets.tls
-      typedConfig:
+      typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-        commonTlsContext:
-          tlsCertificateSdsSecretConfigs:
+        common_tls_context:
+          tls_certificate_sds_secret_configs:
           - name: xds_certificate
-            sdsConfig:
-              pathConfigSource:
+            sds_config:
+              path_config_source:
                 path: /sds/xds-certificate.json
-              resourceApiVersion: V3
-          tlsParams:
-            tlsMaximumProtocolVersion: TLSv1_3
-          validationContextSdsSecretConfig:
+              resource_api_version: V3
+          tls_params:
+            tls_maximum_protocol_version: TLSv1_3
+          validation_context_sds_secret_config:
             name: xds_trusted_ca
-            sdsConfig:
-              pathConfigSource:
+            sds_config:
+              path_config_source:
                 path: /sds/xds-trusted-ca.json
-              resourceApiVersion: V3
+              resource_api_version: V3
     type: STRICT_DNS
-    typedExtensionProtocolOptions:
+    typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions:
-            connectionKeepalive:
+        explicit_http_config:
+          http2_protocol_options:
+            connection_keepalive:
               interval: 30s
               timeout: 5s
   listeners:
   - address:
-      socketAddress:
+      socket_address:
         address: 0.0.0.0
-        portValue: 19001
-    bypassOverloadManager: true
-    filterChains:
+        port_value: 19001
+    bypass_overload_manager: true
+    filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
-        typedConfig:
+        typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          httpFilters:
+          http_filters:
           - name: envoy.filters.http.router
-            typedConfig:
+            typed_config:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          normalizePath: true
-          routeConfig:
+          normalize_path: true
+          route_config:
             name: local_route
-            virtualHosts:
+            virtual_hosts:
             - domains:
               - '*'
               name: prometheus_stats
@@ -145,10 +145,10 @@ staticResources:
               - match:
                   headers:
                   - name: :method
-                    stringMatch:
+                    string_match:
                       exact: GET
                   path: /stats/prometheus
                 route:
                   cluster: prometheus_stats
-          statPrefix: eg-stats-http
+          stat_prefix: eg-stats-http
     name: envoy-gateway-proxy-stats-0.0.0.0-19001

--- a/internal/xds/bootstrap/testdata/merge/merge-user-bootstrap.out.yaml
+++ b/internal/xds/bootstrap/testdata/merge/merge-user-bootstrap.out.yaml
@@ -1,149 +1,149 @@
 admin:
-  accessLog:
+  access_log:
   - name: envoy.access_loggers.file
-    typedConfig:
+    typed_config:
       '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
       path: /dev/null
   address:
-    socketAddress:
+    socket_address:
       address: 127.0.0.1
-      portValue: 8080
-clusterManager:
-  localClusterName: local_cluster
-dynamicResources:
-  adsConfig:
-    apiType: DELTA_GRPC
-    grpcServices:
-    - envoyGrpc:
-        clusterName: xds_cluster
-    setNodeOnFirstMessageOnly: true
-    transportApiVersion: V3
-  cdsConfig:
+      port_value: 8080
+cluster_manager:
+  local_cluster_name: local_cluster
+dynamic_resources:
+  ads_config:
+    api_type: DELTA_GRPC
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
+    set_node_on_first_message_only: true
+    transport_api_version: V3
+  cds_config:
     ads: {}
-    resourceApiVersion: V3
-  ldsConfig:
+    resource_api_version: V3
+  lds_config:
     ads: {}
-    resourceApiVersion: V3
-layeredRuntime:
+    resource_api_version: V3
+layered_runtime:
   layers:
   - name: global_config
-    staticLayer:
+    static_layer:
       envoy.restart_features.use_eds_cache_for_ads: true
       re2.max_program_size.error_level: 4294967295
       re2.max_program_size.warn_level: 1000
 node:
   locality:
     zone: $(ENVOY_SERVICE_ZONE)
-overloadManager:
-  refreshInterval: 0.250s
-  resourceMonitors:
+overload_manager:
+  refresh_interval: 0.250s
+  resource_monitors:
   - name: envoy.resource_monitors.global_downstream_max_connections
-    typedConfig:
+    typed_config:
       '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
-      maxActiveDownstreamConnections: "50000"
-staticResources:
+      max_active_downstream_connections: "50000"
+static_resources:
   clusters:
-  - connectTimeout: 0.250s
-    loadAssignment:
-      clusterName: prometheus_stats
+  - connect_timeout: 0.250s
+    load_assignment:
+      cluster_name: prometheus_stats
       endpoints:
-      - lbEndpoints:
+      - lb_endpoints:
         - endpoint:
             address:
-              socketAddress:
+              socket_address:
                 address: 127.0.0.1
-                portValue: 19000
+                port_value: 19000
     name: prometheus_stats
     type: STATIC
-  - connectTimeout: 10s
-    edsClusterConfig:
-      edsConfig:
+  - connect_timeout: 10s
+    eds_cluster_config:
+      eds_config:
         ads: {}
-        resourceApiVersion: V3
-      serviceName: local_cluster
-    loadBalancingPolicy:
+        resource_api_version: V3
+      service_name: local_cluster
+    load_balancing_policy:
       policies:
-      - typedExtensionConfig:
+      - typed_extension_config:
           name: envoy.load_balancing_policies.least_request
-          typedConfig:
+          typed_config:
             '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
-            localityLbConfig:
-              zoneAwareLbConfig:
-                minClusterSize: "1"
+            locality_lb_config:
+              zone_aware_lb_config:
+                min_cluster_size: "1"
     name: local_cluster
     type: EDS
-  - connectTimeout: 10s
-    loadAssignment:
-      clusterName: xds_cluster
+  - connect_timeout: 10s
+    load_assignment:
+      cluster_name: xds_cluster
       endpoints:
-      - lbEndpoints:
+      - lb_endpoints:
         - endpoint:
             address:
-              socketAddress:
+              socket_address:
                 address: envoy-gateway
-                portValue: 18000
-          loadBalancingWeight: 1
-        loadBalancingWeight: 1
+                port_value: 18000
+          load_balancing_weight: 1
+        load_balancing_weight: 1
     name: xds_cluster
-    transportSocket:
+    transport_socket:
       name: envoy.transport_sockets.tls
-      typedConfig:
+      typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-        commonTlsContext:
-          tlsCertificateSdsSecretConfigs:
+        common_tls_context:
+          tls_certificate_sds_secret_configs:
           - name: xds_certificate
-            sdsConfig:
-              pathConfigSource:
+            sds_config:
+              path_config_source:
                 path: /sds/xds-certificate.json
-              resourceApiVersion: V3
-          tlsParams:
-            tlsMaximumProtocolVersion: TLSv1_3
-          validationContextSdsSecretConfig:
+              resource_api_version: V3
+          tls_params:
+            tls_maximum_protocol_version: TLSv1_3
+          validation_context_sds_secret_config:
             name: xds_trusted_ca
-            sdsConfig:
-              pathConfigSource:
+            sds_config:
+              path_config_source:
                 path: /sds/xds-trusted-ca.json
-              resourceApiVersion: V3
+              resource_api_version: V3
     type: STRICT_DNS
-    typedExtensionProtocolOptions:
+    typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions:
-            connectionKeepalive:
+        explicit_http_config:
+          http2_protocol_options:
+            connection_keepalive:
               interval: 30s
               timeout: 5s
-  - connectTimeout: 0.250s
-    loadAssignment:
-      clusterName: prometheus_stats
+  - connect_timeout: 0.250s
+    load_assignment:
+      cluster_name: prometheus_stats
       endpoints:
-      - lbEndpoints:
+      - lb_endpoints:
         - endpoint:
             address:
-              socketAddress:
+              socket_address:
                 address: 127.0.0.1
-                portValue: 19000
+                port_value: 19000
     name: prometheus_stats
     type: STATIC
   listeners:
   - address:
-      socketAddress:
+      socket_address:
         address: 0.0.0.0
-        portValue: 19001
-    bypassOverloadManager: true
-    filterChains:
+        port_value: 19001
+    bypass_overload_manager: true
+    filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
-        typedConfig:
+        typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          httpFilters:
+          http_filters:
           - name: envoy.filters.http.router
-            typedConfig:
+            typed_config:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          normalizePath: true
-          routeConfig:
+          normalize_path: true
+          route_config:
             name: local_route
-            virtualHosts:
+            virtual_hosts:
             - domains:
               - '*'
               name: prometheus_stats
@@ -151,10 +151,10 @@ staticResources:
               - match:
                   headers:
                   - name: :method
-                    stringMatch:
+                    string_match:
                       exact: GET
                   path: /stats/prometheus
                 route:
                   cluster: prometheus_stats
-          statPrefix: eg-stats-http
+          stat_prefix: eg-stats-http
     name: envoy-gateway-proxy-stats-0.0.0.0-19001

--- a/internal/xds/bootstrap/testdata/merge/stats_sinks.out.yaml
+++ b/internal/xds/bootstrap/testdata/merge/stats_sinks.out.yaml
@@ -1,160 +1,160 @@
 admin:
-  accessLog:
+  access_log:
   - name: envoy.access_loggers.file
-    typedConfig:
+    typed_config:
       '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
       path: /dev/null
   address:
-    socketAddress:
+    socket_address:
       address: 127.0.0.1
-      portValue: 19000
-clusterManager:
-  localClusterName: local_cluster
-dynamicResources:
-  adsConfig:
-    apiType: DELTA_GRPC
-    grpcServices:
-    - envoyGrpc:
-        clusterName: xds_cluster
-    setNodeOnFirstMessageOnly: true
-    transportApiVersion: V3
-  cdsConfig:
+      port_value: 19000
+cluster_manager:
+  local_cluster_name: local_cluster
+dynamic_resources:
+  ads_config:
+    api_type: DELTA_GRPC
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
+    set_node_on_first_message_only: true
+    transport_api_version: V3
+  cds_config:
     ads: {}
-    resourceApiVersion: V3
-  ldsConfig:
+    resource_api_version: V3
+  lds_config:
     ads: {}
-    resourceApiVersion: V3
-layeredRuntime:
+    resource_api_version: V3
+layered_runtime:
   layers:
   - name: global_config
-    staticLayer:
+    static_layer:
       envoy.restart_features.use_eds_cache_for_ads: true
       re2.max_program_size.error_level: 4294967295
       re2.max_program_size.warn_level: 1000
 node:
   locality:
     zone: $(ENVOY_SERVICE_ZONE)
-overloadManager:
-  refreshInterval: 0.250s
-  resourceMonitors:
+overload_manager:
+  refresh_interval: 0.250s
+  resource_monitors:
   - name: envoy.resource_monitors.global_downstream_max_connections
-    typedConfig:
+    typed_config:
       '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
-      maxActiveDownstreamConnections: "50000"
-staticResources:
+      max_active_downstream_connections: "50000"
+static_resources:
   clusters:
-  - connectTimeout: 0.250s
-    loadAssignment:
-      clusterName: prometheus_stats
+  - connect_timeout: 0.250s
+    load_assignment:
+      cluster_name: prometheus_stats
       endpoints:
-      - lbEndpoints:
+      - lb_endpoints:
         - endpoint:
             address:
-              socketAddress:
+              socket_address:
                 address: 127.0.0.1
-                portValue: 19000
+                port_value: 19000
     name: prometheus_stats
     type: STATIC
-  - connectTimeout: 10s
-    edsClusterConfig:
-      edsConfig:
+  - connect_timeout: 10s
+    eds_cluster_config:
+      eds_config:
         ads: {}
-        resourceApiVersion: V3
-      serviceName: local_cluster
-    loadBalancingPolicy:
+        resource_api_version: V3
+      service_name: local_cluster
+    load_balancing_policy:
       policies:
-      - typedExtensionConfig:
+      - typed_extension_config:
           name: envoy.load_balancing_policies.least_request
-          typedConfig:
+          typed_config:
             '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
-            localityLbConfig:
-              zoneAwareLbConfig:
-                minClusterSize: "1"
+            locality_lb_config:
+              zone_aware_lb_config:
+                min_cluster_size: "1"
     name: local_cluster
     type: EDS
-  - connectTimeout: 10s
-    loadAssignment:
-      clusterName: xds_cluster
+  - connect_timeout: 10s
+    load_assignment:
+      cluster_name: xds_cluster
       endpoints:
-      - lbEndpoints:
+      - lb_endpoints:
         - endpoint:
             address:
-              socketAddress:
+              socket_address:
                 address: envoy-gateway
-                portValue: 18000
-          loadBalancingWeight: 1
-        loadBalancingWeight: 1
+                port_value: 18000
+          load_balancing_weight: 1
+        load_balancing_weight: 1
     name: xds_cluster
-    transportSocket:
+    transport_socket:
       name: envoy.transport_sockets.tls
-      typedConfig:
+      typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-        commonTlsContext:
-          tlsCertificateSdsSecretConfigs:
+        common_tls_context:
+          tls_certificate_sds_secret_configs:
           - name: xds_certificate
-            sdsConfig:
-              pathConfigSource:
+            sds_config:
+              path_config_source:
                 path: /sds/xds-certificate.json
-              resourceApiVersion: V3
-          tlsParams:
-            tlsMaximumProtocolVersion: TLSv1_3
-          validationContextSdsSecretConfig:
+              resource_api_version: V3
+          tls_params:
+            tls_maximum_protocol_version: TLSv1_3
+          validation_context_sds_secret_config:
             name: xds_trusted_ca
-            sdsConfig:
-              pathConfigSource:
+            sds_config:
+              path_config_source:
                 path: /sds/xds-trusted-ca.json
-              resourceApiVersion: V3
+              resource_api_version: V3
     type: STRICT_DNS
-    typedExtensionProtocolOptions:
+    typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions:
-            connectionKeepalive:
+        explicit_http_config:
+          http2_protocol_options:
+            connection_keepalive:
               interval: 30s
               timeout: 5s
-  - connectTimeout: 1s
-    dnsLookupFamily: V4_ONLY
-    dnsRefreshRate: 30s
-    loadAssignment:
-      clusterName: metrics_cluster
+  - connect_timeout: 1s
+    dns_lookup_family: V4_ONLY
+    dns_refresh_rate: 30s
+    load_assignment:
+      cluster_name: metrics_cluster
       endpoints:
-      - lbEndpoints:
+      - lb_endpoints:
         - endpoint:
             address:
-              socketAddress:
+              socket_address:
                 address: skywalking-oap.skywalking
-                portValue: 11800
+                port_value: 11800
     name: metrics_cluster
-    respectDnsTtl: true
+    respect_dns_ttl: true
     type: STRICT_DNS
-    typedExtensionProtocolOptions:
+    typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions:
-            connectionKeepalive:
+        explicit_http_config:
+          http2_protocol_options:
+            connection_keepalive:
               interval: 30s
               timeout: 5s
   listeners:
   - address:
-      socketAddress:
+      socket_address:
         address: 0.0.0.0
-        portValue: 19001
-    bypassOverloadManager: true
-    filterChains:
+        port_value: 19001
+    bypass_overload_manager: true
+    filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
-        typedConfig:
+        typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          httpFilters:
+          http_filters:
           - name: envoy.filters.http.router
-            typedConfig:
+            typed_config:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          normalizePath: true
-          routeConfig:
+          normalize_path: true
+          route_config:
             name: local_route
-            virtualHosts:
+            virtual_hosts:
             - domains:
               - '*'
               name: prometheus_stats
@@ -162,18 +162,18 @@ staticResources:
               - match:
                   headers:
                   - name: :method
-                    stringMatch:
+                    string_match:
                       exact: GET
                   path: /stats/prometheus
                 route:
                   cluster: prometheus_stats
-          statPrefix: eg-stats-http
+          stat_prefix: eg-stats-http
     name: envoy-gateway-proxy-stats-0.0.0.0-19001
-statsSinks:
+stats_sinks:
 - name: envoy.stat_sinks.metrics_service
-  typedConfig:
+  typed_config:
     '@type': type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig
-    grpcService:
-      envoyGrpc:
-        clusterName: metrics_cluster
-    transportApiVersion: V3
+    grpc_service:
+      envoy_grpc:
+        cluster_name: metrics_cluster
+    transport_api_version: V3

--- a/internal/xds/translator/testdata/readylistener/dual.yaml
+++ b/internal/xds/translator/testdata/readylistener/dual.yaml
@@ -1,37 +1,37 @@
 address:
-  socketAddress:
+  socket_address:
     address: '::'
-    ipv4Compat: true
-    portValue: 19001
-bypassOverloadManager: true
-filterChains:
+    ipv4_compat: true
+    port_value: 19001
+bypass_overload_manager: true
+filter_chains:
 - filters:
   - name: envoy.filters.network.http_connection_manager
-    typedConfig:
+    typed_config:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-      httpFilters:
+      http_filters:
       - name: envoy.filters.http.health_check
-        typedConfig:
+        typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
           headers:
           - name: :path
-            stringMatch:
+            string_match:
               exact: /ready
-          passThroughMode: false
+          pass_through_mode: false
       - name: envoy.filters.http.router
-        typedConfig:
+        typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          suppressEnvoyHeaders: true
-      routeConfig:
+          suppress_envoy_headers: true
+      route_config:
         name: ready_route
-        virtualHosts:
+        virtual_hosts:
         - domains:
           - '*'
           name: ready_route
           routes:
-          - directResponse:
+          - direct_response:
               status: 500
             match:
               prefix: /
-      statPrefix: eg-ready-http
+      stat_prefix: eg-ready-http
 name: envoy-gateway-proxy-ready-::-19001

--- a/internal/xds/translator/testdata/readylistener/ipv4.yaml
+++ b/internal/xds/translator/testdata/readylistener/ipv4.yaml
@@ -1,36 +1,36 @@
 address:
-  socketAddress:
+  socket_address:
     address: 0.0.0.0
-    portValue: 19001
-bypassOverloadManager: true
-filterChains:
+    port_value: 19001
+bypass_overload_manager: true
+filter_chains:
 - filters:
   - name: envoy.filters.network.http_connection_manager
-    typedConfig:
+    typed_config:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-      httpFilters:
+      http_filters:
       - name: envoy.filters.http.health_check
-        typedConfig:
+        typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
           headers:
           - name: :path
-            stringMatch:
+            string_match:
               exact: /ready
-          passThroughMode: false
+          pass_through_mode: false
       - name: envoy.filters.http.router
-        typedConfig:
+        typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          suppressEnvoyHeaders: true
-      routeConfig:
+          suppress_envoy_headers: true
+      route_config:
         name: ready_route
-        virtualHosts:
+        virtual_hosts:
         - domains:
           - '*'
           name: ready_route
           routes:
-          - directResponse:
+          - direct_response:
               status: 500
             match:
               prefix: /
-      statPrefix: eg-ready-http
+      stat_prefix: eg-ready-http
 name: envoy-gateway-proxy-ready-0.0.0.0-19001

--- a/internal/xds/translator/testdata/readylistener/ipv6.yaml
+++ b/internal/xds/translator/testdata/readylistener/ipv6.yaml
@@ -1,37 +1,37 @@
 address:
-  socketAddress:
+  socket_address:
     address: '::'
-    ipv4Compat: true
-    portValue: 19001
-bypassOverloadManager: true
-filterChains:
+    ipv4_compat: true
+    port_value: 19001
+bypass_overload_manager: true
+filter_chains:
 - filters:
   - name: envoy.filters.network.http_connection_manager
-    typedConfig:
+    typed_config:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-      httpFilters:
+      http_filters:
       - name: envoy.filters.http.health_check
-        typedConfig:
+        typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
           headers:
           - name: :path
-            stringMatch:
+            string_match:
               exact: /ready
-          passThroughMode: false
+          pass_through_mode: false
       - name: envoy.filters.http.router
-        typedConfig:
+        typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          suppressEnvoyHeaders: true
-      routeConfig:
+          suppress_envoy_headers: true
+      route_config:
         name: ready_route
-        virtualHosts:
+        virtual_hosts:
         - domains:
           - '*'
           name: ready_route
           routes:
-          - directResponse:
+          - direct_response:
               status: 500
             match:
               prefix: /
-      statPrefix: eg-ready-http
+      stat_prefix: eg-ready-http
 name: envoy-gateway-proxy-ready-::-19001


### PR DESCRIPTION
**What type of PR is this?**

Fixes an issue where the arguments generated to start the Envoy Proxy were not properly set in the argument list. Instead of being one word per list element, the argument name and the value were combined into a single argument, causing issues in the Host infra provider implemented with the func-e library.

It also fixes another issue that manifests in the Host provider, where the generated bootstrap config is sometimes snake case and sometimes camel case, due to the marshaller configuration. The [first bootstrap generation](https://github.com/envoyproxy/gateway/blob/main/internal/infrastructure/common/proxy_args.go#L51) correctly uses snake case as it renders directly from the template. However, that is [regenerated](https://github.com/envoyproxy/gateway/blob/main/internal/infrastructure/common/proxy_args.go#L59) and changed to camel case because of the marshaller setup, causing issues in the func-e library. The PR configures the marshaller to preserve the original format and fix the issue.

**What this PR does / why we need it**:

Without this PR the admin server configuration is not properly generated in standalone mode, and the user configuration is not honored. Also the arguments passed to func-e are incorrectly grouped, making the Envoy startup process not use the arguments properly.

**Which issue(s) this PR fixes**:

N/A
