### PR TITLE
perf: avoid loop variable in k8s provider

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -751,14 +751,15 @@ func (r *gatewayAPIReconciler) processBackendRefs(ctx context.Context, gwcResour
 				r.log.Error(err, "failed to get EndpointSlices", "namespace", string(*backendRef.Namespace),
 					backendRefKind, string(backendRef.Name))
 			} else {
-				for _, endpointSlice := range endpointSliceList.Items {
-					key := utils.NamespacedName(&endpointSlice).String()
+				for i := range endpointSliceList.Items {
+					endpointSlice := &endpointSliceList.Items[i]
+					key := utils.NamespacedName(endpointSlice).String()
 					if !resourceMappings.allAssociatedEndpointSlices.Has(key) {
 						resourceMappings.allAssociatedEndpointSlices.Insert(key)
 						r.log.Info("added EndpointSlice to resource tree",
 							"namespace", endpointSlice.Namespace,
 							"name", endpointSlice.Name)
-						gwcResource.EndpointSlices = append(gwcResource.EndpointSlices, &endpointSlice)
+						gwcResource.EndpointSlices = append(gwcResource.EndpointSlices, endpointSlice)
 					}
 				}
 			}
@@ -1560,14 +1561,14 @@ func (r *gatewayAPIReconciler) processEnvoyPatchPolicies(ctx context.Context, re
 		return fmt.Errorf("error listing EnvoyPatchPolicies: %w", err)
 	}
 
-	for _, policy := range envoyPatchPolicies.Items {
-		envoyPatchPolicy := policy //nolint:copyloopvar
+	for i := range envoyPatchPolicies.Items {
+		envoyPatchPolicy := &envoyPatchPolicies.Items[i]
 		// Discard Status to reduce memory consumption in watchable
 		// It will be recomputed by the gateway-api layer
 		envoyPatchPolicy.Status = gwapiv1a2.PolicyStatus{}
-		if !resourceMap.allAssociatedEnvoyPatchPolicies.Has(utils.NamespacedName(&envoyPatchPolicy).String()) {
-			resourceMap.allAssociatedEnvoyPatchPolicies.Insert(utils.NamespacedName(&envoyPatchPolicy).String())
-			resourceTree.EnvoyPatchPolicies = append(resourceTree.EnvoyPatchPolicies, &envoyPatchPolicy)
+		if !resourceMap.allAssociatedEnvoyPatchPolicies.Has(utils.NamespacedName(envoyPatchPolicy).String()) {
+			resourceMap.allAssociatedEnvoyPatchPolicies.Insert(utils.NamespacedName(envoyPatchPolicy).String())
+			resourceTree.EnvoyPatchPolicies = append(resourceTree.EnvoyPatchPolicies, envoyPatchPolicy)
 		}
 	}
 	return nil
@@ -1582,14 +1583,14 @@ func (r *gatewayAPIReconciler) processClientTrafficPolicies(
 		return fmt.Errorf("error listing ClientTrafficPolicies: %w", err)
 	}
 
-	for _, policy := range clientTrafficPolicies.Items {
-		clientTrafficPolicy := policy //nolint:copyloopvar
+	for i := range clientTrafficPolicies.Items {
+		clientTrafficPolicy := &clientTrafficPolicies.Items[i]
 		// Discard Status to reduce memory consumption in watchable
 		// It will be recomputed by the gateway-api layer
 		clientTrafficPolicy.Status = gwapiv1a2.PolicyStatus{}
-		if !resourceMap.allAssociatedClientTrafficPolicies.Has(utils.NamespacedName(&clientTrafficPolicy).String()) {
-			resourceMap.allAssociatedClientTrafficPolicies.Insert(utils.NamespacedName(&clientTrafficPolicy).String())
-			resourceTree.ClientTrafficPolicies = append(resourceTree.ClientTrafficPolicies, &clientTrafficPolicy)
+		if !resourceMap.allAssociatedClientTrafficPolicies.Has(utils.NamespacedName(clientTrafficPolicy).String()) {
+			resourceMap.allAssociatedClientTrafficPolicies.Insert(utils.NamespacedName(clientTrafficPolicy).String())
+			resourceTree.ClientTrafficPolicies = append(resourceTree.ClientTrafficPolicies, clientTrafficPolicy)
 		}
 	}
 
@@ -1604,14 +1605,14 @@ func (r *gatewayAPIReconciler) processBackendTrafficPolicies(ctx context.Context
 		return fmt.Errorf("error listing BackendTrafficPolicies: %w", err)
 	}
 
-	for _, policy := range backendTrafficPolicies.Items {
-		backendTrafficPolicy := policy //nolint:copyloopvar
+	for i := range backendTrafficPolicies.Items {
+		backendTrafficPolicy := &backendTrafficPolicies.Items[i]
 		// Discard Status to reduce memory consumption in watchable
 		// It will be recomputed by the gateway-api layer
 		backendTrafficPolicy.Status = gwapiv1a2.PolicyStatus{}
-		if !resourceMap.allAssociatedBackendTrafficPolicies.Has(utils.NamespacedName(&backendTrafficPolicy).String()) {
-			resourceMap.allAssociatedBackendTrafficPolicies.Insert(utils.NamespacedName(&backendTrafficPolicy).String())
-			resourceTree.BackendTrafficPolicies = append(resourceTree.BackendTrafficPolicies, &backendTrafficPolicy)
+		if !resourceMap.allAssociatedBackendTrafficPolicies.Has(utils.NamespacedName(backendTrafficPolicy).String()) {
+			resourceMap.allAssociatedBackendTrafficPolicies.Insert(utils.NamespacedName(backendTrafficPolicy).String())
+			resourceTree.BackendTrafficPolicies = append(resourceTree.BackendTrafficPolicies, backendTrafficPolicy)
 		}
 	}
 	return r.processBtpConfigMapRefs(ctx, resourceTree, resourceMap)
@@ -1626,14 +1627,14 @@ func (r *gatewayAPIReconciler) processSecurityPolicies(
 		return fmt.Errorf("error listing SecurityPolicies: %w", err)
 	}
 
-	for _, policy := range securityPolicies.Items {
-		securityPolicy := policy //nolint:copyloopvar
+	for i := range securityPolicies.Items {
+		securityPolicy := &securityPolicies.Items[i]
 		// Discard Status to reduce memory consumption in watchable
 		// It will be recomputed by the gateway-api layer
 		securityPolicy.Status = gwapiv1a2.PolicyStatus{}
-		if !resourceMap.allAssociatedSecurityPolicies.Has(utils.NamespacedName(&securityPolicy).String()) {
-			resourceMap.allAssociatedSecurityPolicies.Insert(utils.NamespacedName(&securityPolicy).String())
-			resourceTree.SecurityPolicies = append(resourceTree.SecurityPolicies, &securityPolicy)
+		if !resourceMap.allAssociatedSecurityPolicies.Has(utils.NamespacedName(securityPolicy).String()) {
+			resourceMap.allAssociatedSecurityPolicies.Insert(utils.NamespacedName(securityPolicy).String())
+			resourceTree.SecurityPolicies = append(resourceTree.SecurityPolicies, securityPolicy)
 		}
 	}
 
@@ -1650,14 +1651,14 @@ func (r *gatewayAPIReconciler) processBackendTLSPolicies(
 		return fmt.Errorf("error listing BackendTLSPolicies: %w", err)
 	}
 
-	for _, policy := range backendTLSPolicies.Items {
-		backendTLSPolicy := policy //nolint:copyloopvar
+	for i := range backendTLSPolicies.Items {
+		backendTLSPolicy := &backendTLSPolicies.Items[i]
 		// Discard Status to reduce memory consumption in watchable
 		// It will be recomputed by the gateway-api layer
 		backendTLSPolicy.Status = gwapiv1a2.PolicyStatus{}
-		if !resourceMap.allAssociatedBackendTLSPolicies.Has(utils.NamespacedName(&backendTLSPolicy).String()) {
-			resourceMap.allAssociatedBackendTLSPolicies.Insert(utils.NamespacedName(&backendTLSPolicy).String())
-			resourceTree.BackendTLSPolicies = append(resourceTree.BackendTLSPolicies, &backendTLSPolicy)
+		if !resourceMap.allAssociatedBackendTLSPolicies.Has(utils.NamespacedName(backendTLSPolicy).String()) {
+			resourceMap.allAssociatedBackendTLSPolicies.Insert(utils.NamespacedName(backendTLSPolicy).String())
+			resourceTree.BackendTLSPolicies = append(resourceTree.BackendTLSPolicies, backendTLSPolicy)
 		}
 	}
 
@@ -2572,14 +2573,14 @@ func (r *gatewayAPIReconciler) processEnvoyExtensionPolicies(
 		return fmt.Errorf("error listing EnvoyExtensionPolicies: %w", err)
 	}
 
-	for _, policy := range envoyExtensionPolicies.Items {
-		envoyExtensionPolicy := policy //nolint:copyloopvar
+	for i := range envoyExtensionPolicies.Items {
+		envoyExtensionPolicy := &envoyExtensionPolicies.Items[i]
 		// Discard Status to reduce memory consumption in watchable
 		// It will be recomputed by the gateway-api layer
 		envoyExtensionPolicy.Status = gwapiv1a2.PolicyStatus{}
-		if !resourceMap.allAssociatedEnvoyExtensionPolicies.Has(utils.NamespacedName(&envoyExtensionPolicy).String()) {
-			resourceMap.allAssociatedEnvoyExtensionPolicies.Insert(utils.NamespacedName(&envoyExtensionPolicy).String())
-			resourceTree.EnvoyExtensionPolicies = append(resourceTree.EnvoyExtensionPolicies, &envoyExtensionPolicy)
+		if !resourceMap.allAssociatedEnvoyExtensionPolicies.Has(utils.NamespacedName(envoyExtensionPolicy).String()) {
+			resourceMap.allAssociatedEnvoyExtensionPolicies.Insert(utils.NamespacedName(envoyExtensionPolicy).String())
+			resourceTree.EnvoyExtensionPolicies = append(resourceTree.EnvoyExtensionPolicies, envoyExtensionPolicy)
 		}
 	}
 

--- a/internal/provider/kubernetes/routes.go
+++ b/internal/provider/kubernetes/routes.go
@@ -36,10 +36,10 @@ func (r *gatewayAPIReconciler) processTLSRoutes(ctx context.Context, gatewayName
 		return err
 	}
 
-	for _, tlsRoute := range tlsRouteList.Items {
-		tlsRoute := tlsRoute //nolint:copyloopvar
+	for i := range tlsRouteList.Items {
+		tlsRoute := &tlsRouteList.Items[i]
 		if r.namespaceLabel != nil {
-			if ok, err := r.checkObjectNamespaceLabels(&tlsRoute); err != nil {
+			if ok, err := r.checkObjectNamespaceLabels(tlsRoute); err != nil {
 				r.log.Error(err, "failed to check namespace labels for TLSRoute %s in namespace %s: %w", tlsRoute.GetName(), tlsRoute.GetNamespace())
 				continue
 			} else if !ok {
@@ -47,7 +47,7 @@ func (r *gatewayAPIReconciler) processTLSRoutes(ctx context.Context, gatewayName
 			}
 		}
 
-		key := utils.NamespacedName(&tlsRoute).String()
+		key := utils.NamespacedName(tlsRoute).String()
 		if resourceMap.allAssociatedTLSRoutes.Has(key) {
 			r.log.Info("current TLSRoute has been processed already", "namespace", tlsRoute.Namespace, "name", tlsRoute.Name)
 			continue
@@ -81,7 +81,7 @@ func (r *gatewayAPIReconciler) processTLSRoutes(ctx context.Context, gatewayName
 		// Discard Status to reduce memory consumption in watchable
 		// It will be recomputed by the gateway-api layer
 		tlsRoute.Status = gwapiv1a2.TLSRouteStatus{}
-		resourceTree.TLSRoutes = append(resourceTree.TLSRoutes, &tlsRoute)
+		resourceTree.TLSRoutes = append(resourceTree.TLSRoutes, tlsRoute)
 	}
 
 	return nil
@@ -101,10 +101,10 @@ func (r *gatewayAPIReconciler) processGRPCRoutes(ctx context.Context, gatewayNam
 		return err
 	}
 
-	for _, grpcRoute := range grpcRouteList.Items {
-		grpcRoute := grpcRoute //nolint:copyloopvar
+	for i := range grpcRouteList.Items {
+		grpcRoute := &grpcRouteList.Items[i]
 		if r.namespaceLabel != nil {
-			if ok, err := r.checkObjectNamespaceLabels(&grpcRoute); err != nil {
+			if ok, err := r.checkObjectNamespaceLabels(grpcRoute); err != nil {
 				r.log.Error(err, "failed to check namespace labels for GRPCRoute %s in namespace %s: %w", grpcRoute.GetName(), grpcRoute.GetNamespace())
 				continue
 			} else if !ok {
@@ -112,7 +112,7 @@ func (r *gatewayAPIReconciler) processGRPCRoutes(ctx context.Context, gatewayNam
 			}
 		}
 
-		key := utils.NamespacedName(&grpcRoute).String()
+		key := utils.NamespacedName(grpcRoute).String()
 		if resourceMap.allAssociatedGRPCRoutes.Has(key) {
 			r.log.Info("current GRPCRoute has been processed already", "namespace", grpcRoute.Namespace, "name", grpcRoute.Name)
 			continue
@@ -189,7 +189,7 @@ func (r *gatewayAPIReconciler) processGRPCRoutes(ctx context.Context, gatewayNam
 		// Discard Status to reduce memory consumption in watchable
 		// It will be recomputed by the gateway-api layer
 		grpcRoute.Status = gwapiv1.GRPCRouteStatus{}
-		resourceTree.GRPCRoutes = append(resourceTree.GRPCRoutes, &grpcRoute)
+		resourceTree.GRPCRoutes = append(resourceTree.GRPCRoutes, grpcRoute)
 	}
 
 	return nil
@@ -228,10 +228,10 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 		return err
 	}
 
-	for _, httpRoute := range httpRouteList.Items {
-		httpRoute := httpRoute //nolint:copyloopvar
+	for i := range httpRouteList.Items {
+		httpRoute := &httpRouteList.Items[i]
 		if r.namespaceLabel != nil {
-			if ok, err := r.checkObjectNamespaceLabels(&httpRoute); err != nil {
+			if ok, err := r.checkObjectNamespaceLabels(httpRoute); err != nil {
 				r.log.Error(err, "failed to check namespace labels for HTTPRoute %s in namespace %s: %w", httpRoute.GetName(), httpRoute.GetNamespace())
 				continue
 			} else if !ok {
@@ -239,7 +239,7 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 			}
 		}
 
-		key := utils.NamespacedName(&httpRoute).String()
+		key := utils.NamespacedName(httpRoute).String()
 		if resourceMap.allAssociatedHTTPRoutes.Has(key) {
 			r.log.Info("current HTTPRoute has been processed already", "namespace", httpRoute.Namespace, "name", httpRoute.Name)
 			continue
@@ -270,19 +270,19 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 						"httpRoute", httpRoute, "backendRef", backendRef.BackendObjectReference)
 				}
 
-				for i := range backendRef.Filters {
+				for j := range backendRef.Filters {
 					// Some of the validation logic in processHTTPRouteFilter is not needed for backendRef filters.
 					// However, we reuse the same function to avoid code duplication.
-					if err := r.processHTTPRouteFilter(ctx, &backendRef.Filters[i], &httpRoute, resourceMap, resourceTree); err != nil {
-						r.log.Error(err, "bypassing backendRef filter", "index", i)
+					if err := r.processHTTPRouteFilter(ctx, &backendRef.Filters[j], httpRoute, resourceMap, resourceTree); err != nil {
+						r.log.Error(err, "bypassing backendRef filter", "index", j)
 						continue
 					}
 				}
 			}
 
-			for i := range rule.Filters {
-				if err := r.processHTTPRouteFilter(ctx, &rule.Filters[i], &httpRoute, resourceMap, resourceTree); err != nil {
-					r.log.Error(err, "bypassing filter rule", "index", i)
+			for j := range rule.Filters {
+				if err := r.processHTTPRouteFilter(ctx, &rule.Filters[j], httpRoute, resourceMap, resourceTree); err != nil {
+					r.log.Error(err, "bypassing filter rule", "index", j)
 					continue
 				}
 			}
@@ -293,7 +293,7 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 		// Discard Status to reduce memory consumption in watchable
 		// It will be recomputed by the gateway-api layer
 		httpRoute.Status = gwapiv1.HTTPRouteStatus{}
-		resourceTree.HTTPRoutes = append(resourceTree.HTTPRoutes, &httpRoute)
+		resourceTree.HTTPRoutes = append(resourceTree.HTTPRoutes, httpRoute)
 	}
 
 	return nil
@@ -406,10 +406,10 @@ func (r *gatewayAPIReconciler) processTCPRoutes(ctx context.Context, gatewayName
 		return err
 	}
 
-	for _, tcpRoute := range tcpRouteList.Items {
-		tcpRoute := tcpRoute //nolint:copyloopvar
+	for i := range tcpRouteList.Items {
+		tcpRoute := &tcpRouteList.Items[i]
 		if r.namespaceLabel != nil {
-			if ok, err := r.checkObjectNamespaceLabels(&tcpRoute); err != nil {
+			if ok, err := r.checkObjectNamespaceLabels(tcpRoute); err != nil {
 				r.log.Error(err, "failed to check namespace labels for TCPRoute %s in namespace %s: %w", tcpRoute.GetName(), tcpRoute.GetNamespace())
 				continue
 			} else if !ok {
@@ -417,7 +417,7 @@ func (r *gatewayAPIReconciler) processTCPRoutes(ctx context.Context, gatewayName
 			}
 		}
 
-		key := utils.NamespacedName(&tcpRoute).String()
+		key := utils.NamespacedName(tcpRoute).String()
 		if resourceMap.allAssociatedTCPRoutes.Has(key) {
 			r.log.Info("current TCPRoute has been processed already", "namespace", tcpRoute.Namespace, "name", tcpRoute.Name)
 			continue
@@ -451,7 +451,7 @@ func (r *gatewayAPIReconciler) processTCPRoutes(ctx context.Context, gatewayName
 		// Discard Status to reduce memory consumption in watchable
 		// It will be recomputed by the gateway-api layer
 		tcpRoute.Status = gwapiv1a2.TCPRouteStatus{}
-		resourceTree.TCPRoutes = append(resourceTree.TCPRoutes, &tcpRoute)
+		resourceTree.TCPRoutes = append(resourceTree.TCPRoutes, tcpRoute)
 	}
 
 	return nil
@@ -470,10 +470,10 @@ func (r *gatewayAPIReconciler) processUDPRoutes(ctx context.Context, gatewayName
 		return err
 	}
 
-	for _, udpRoute := range udpRouteList.Items {
-		udpRoute := udpRoute //nolint:copyloopvar
+	for i := range udpRouteList.Items {
+		udpRoute := &udpRouteList.Items[i]
 		if r.namespaceLabel != nil {
-			if ok, err := r.checkObjectNamespaceLabels(&udpRoute); err != nil {
+			if ok, err := r.checkObjectNamespaceLabels(udpRoute); err != nil {
 				r.log.Error(err, "failed to check namespace labels for UDPRoute %s in namespace %s: %w", udpRoute.GetName(), udpRoute.GetNamespace())
 				continue
 			} else if !ok {
@@ -481,7 +481,7 @@ func (r *gatewayAPIReconciler) processUDPRoutes(ctx context.Context, gatewayName
 			}
 		}
 
-		key := utils.NamespacedName(&udpRoute).String()
+		key := utils.NamespacedName(udpRoute).String()
 		if resourceMap.allAssociatedUDPRoutes.Has(key) {
 			r.log.Info("current UDPRoute has been processed already", "namespace", udpRoute.Namespace, "name", udpRoute.Name)
 			continue
@@ -515,7 +515,7 @@ func (r *gatewayAPIReconciler) processUDPRoutes(ctx context.Context, gatewayName
 		// Discard Status to reduce memory consumption in watchable
 		// It will be recomputed by the gateway-api layer
 		udpRoute.Status = gwapiv1a2.UDPRouteStatus{}
-		resourceTree.UDPRoutes = append(resourceTree.UDPRoutes, &udpRoute)
+		resourceTree.UDPRoutes = append(resourceTree.UDPRoutes, udpRoute)
 	}
 
 	return nil


### PR DESCRIPTION
* reduces heap allocs
* also removes the copyloopvar lint error

```
  - HTTPRoutePointerRetention-12 time: copy loop 53.050µs ±14%; indexed loop 1.216µs ±10% → -97.71% vs base (p=0.000, n=10).
  - HTTPRoutePointerRetention-12 bytes: copy loop 196.751KiB ±0%; indexed loop 4.750KiB ±0% → -97.59%.
  - HTTPRoutePointerRetention-12 allocs: copy loop 513 per op; indexed loop 1 per op → -99.81%.
  ```