### PR TITLE
feat: add support for go test bench

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -86,6 +86,17 @@ jobs:
         verbose: true
         use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
 
+  go-benchmark-test:
+    runs-on: ubuntu-latest
+    needs:
+    - changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_test_workflow == 'true' }}
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - uses: ./tools/github-actions/setup-deps
+    - name: Run Go Benchmark Tests
+      run: make go-benchmark
+
   build:
     runs-on: ubuntu-latest
     needs: [changes, lint, gen-check, license-check, coverage-test]

--- a/test/gobench/translate_test.go
+++ b/test/gobench/translate_test.go
@@ -313,17 +313,17 @@ func BenchmarkGatewayAPItoXDS(b *testing.B) {
 		yaml string
 	}
 	medium := baseYAML + backendYAML + tlsSecretYAML + clientTrafficPolicyYAML +
-		genHTTPRoutes(100) +
-		genGRPCRoutes(50) +
-		genUDPRoutes(20) +
-		genSecurityPolicies(100) +
-		genBackendTrafficPolicies(100)
+		genHTTPRoutes(50) +
+		genGRPCRoutes(25) +
+		genUDPRoutes(10) +
+		genSecurityPolicies(50) +
+		genBackendTrafficPolicies(50)
 	large := baseYAML + backendYAML + tlsSecretYAML + clientTrafficPolicyYAML +
-		genHTTPRoutes(1000) +
-		genGRPCRoutes(500) +
+		genHTTPRoutes(500) +
+		genGRPCRoutes(250) +
 		genUDPRoutes(100) +
-		genSecurityPolicies(1000) +
-		genBackendTrafficPolicies(1000)
+		genSecurityPolicies(500) +
+		genBackendTrafficPolicies(500)
 
 	cases := []benchCase{
 		{

--- a/tools/make/golang.mk
+++ b/tools/make/golang.mk
@@ -81,6 +81,11 @@ go.test.cel: manifests # Run the CEL validation tests
          go test ./test/cel-validation --tags celvalidation -race || exit 1; \
     done
 
+.PHONY: go.test.benchmark
+go.test.benchmark: ## Run benchmark tests for translation performance
+	@$(LOG_TARGET)
+	go test -timeout=10m -run='^$$' -bench=. -benchmem -benchtime=1x -count=3 ./test/gobench
+
 .PHONY: go.clean
 go.clean: ## Clean the building output files
 	@$(LOG_TARGET)
@@ -139,3 +144,7 @@ clean: go.clean
 .PHONY: testdata
 testdata: ## Override the testdata with new configurations.
 testdata: go.testdata.complete
+
+.PHONY: go-benchmark
+go-benchmark: ## Run benchmark tests for translation performance.
+go-benchmark: go.test.benchmark


### PR DESCRIPTION
* added a new `make go-benchmark` target to run the go test bench

* added it in CI

```
make go-benchmark
===========> Running go.test.benchmark ... 
go test -timeout=10m -run='^$' -bench=. -benchmem -benchtime=1x -count=3 ./test/gobench
goos: darwin
goarch: amd64
pkg: github.com/envoyproxy/gateway/test/gobench
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkGatewayAPItoXDS/small-12         	       1	   6602082 ns/op	 3877448 B/op	   34546 allocs/op
BenchmarkGatewayAPItoXDS/small-12         	       1	   2169150 ns/op	  739464 B/op	   11733 allocs/op
BenchmarkGatewayAPItoXDS/small-12         	       1	   2571734 ns/op	  739336 B/op	   11722 allocs/op
BenchmarkGatewayAPItoXDS/medium-12        	       1	  19143276 ns/op	 8374856 B/op	  133406 allocs/op
BenchmarkGatewayAPItoXDS/medium-12        	       1	  18260830 ns/op	 8369504 B/op	  133373 allocs/op
BenchmarkGatewayAPItoXDS/medium-12        	       1	  17725715 ns/op	 8370272 B/op	  133420 allocs/op
BenchmarkGatewayAPItoXDS/large-12         	       1	 222206713 ns/op	79619016 B/op	 1236811 allocs/op
BenchmarkGatewayAPItoXDS/large-12         	       1	 179579488 ns/op	79612904 B/op	 1236716 allocs/op
BenchmarkGatewayAPItoXDS/large-12         	       1	 168891225 ns/op	79601088 B/op	 1236542 allocs/op
PASS
ok  	github.com/envoyproxy/gateway/test/gobench	273.101s
```

Fixes: https://github.com/envoyproxy/gateway/issues/6705
