### PR TITLE
 feat: Make xDS Service name configurable via ENVOY_GATEWAY_SERVICE_NAME (refs #6997)

### DIFF
--- a/internal/crypto/certgen.go
+++ b/internal/crypto/certgen.go
@@ -22,9 +22,6 @@ import (
 )
 
 const (
-	// DefaultEnvoyGatewayDNSPrefix defines the default Envoy Gateway DNS prefix.
-	DefaultEnvoyGatewayDNSPrefix = config.EnvoyGatewayServiceName
-
 	// DefaultEnvoyDNSPrefix defines the default Envoy DNS prefix.
 	DefaultEnvoyDNSPrefix = "*"
 
@@ -99,7 +96,7 @@ func GenerateCerts(cfg *config.Server) (*Certificates, error) {
 	case ProviderTypeEnvoyGateway:
 		now := time.Now()
 		expiry := now.Add(24 * time.Duration(DefaultCertificateLifetime) * time.Hour)
-		caCertPEM, caKeyPEM, err := newCA(DefaultEnvoyGatewayDNSPrefix, expiry)
+		caCertPEM, caKeyPEM, err := newCA(config.GetEnvoyGatewayServiceName(), expiry)
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +105,7 @@ func GenerateCerts(cfg *config.Server) (*Certificates, error) {
 		egProvider := cfg.EnvoyGateway.GetEnvoyGatewayProvider().Type
 		switch egProvider {
 		case egv1a1.ProviderTypeKubernetes:
-			egDNSNames = kubeServiceNames(DefaultEnvoyGatewayDNSPrefix, cfg.ControllerNamespace, cfg.DNSDomain)
+			egDNSNames = kubeServiceNames(config.GetEnvoyGatewayServiceName(), cfg.ControllerNamespace, cfg.DNSDomain)
 			envoyDNSNames = append(envoyDNSNames, fmt.Sprintf("*.%s", cfg.ControllerNamespace))
 		default:
 			// Kubernetes is the only supported Envoy Gateway provider.
@@ -119,7 +116,7 @@ func GenerateCerts(cfg *config.Server) (*Certificates, error) {
 			caCertPEM:  caCertPEM,
 			caKeyPEM:   caKeyPEM,
 			expiry:     expiry,
-			commonName: DefaultEnvoyGatewayDNSPrefix,
+			commonName: config.GetEnvoyGatewayServiceName(),
 			altNames:   egDNSNames,
 		}
 

--- a/internal/envoygateway/config/config.go
+++ b/internal/envoygateway/config/config.go
@@ -20,7 +20,7 @@ const (
 	DefaultNamespace = "envoy-gateway-system"
 	// DefaultDNSDomain is the default DNS domain used by k8s services.
 	DefaultDNSDomain = "cluster.local"
-	// EnvoyGatewayServiceName is the name of the Envoy Gateway service.
+	// EnvoyGatewayServiceName is the default name of the Envoy Gateway service.
 	EnvoyGatewayServiceName = "envoy-gateway"
 	// EnvoyPrefix is the prefix applied to the Envoy ConfigMap, Service, Deployment, and ServiceAccount.
 	EnvoyPrefix = "envoy"
@@ -65,4 +65,9 @@ func (s *Server) Validate() error {
 	}
 
 	return nil
+}
+
+// GetEnvoyGatewayServiceName returns the xDS Service name from ENVOY_GATEWAY_SERVICE_NAME or the default.
+func GetEnvoyGatewayServiceName() string {
+	return env.Lookup("ENVOY_GATEWAY_SERVICE_NAME", EnvoyGatewayServiceName)
 }

--- a/internal/infrastructure/kubernetes/proxy/resource.go
+++ b/internal/infrastructure/kubernetes/proxy/resource.go
@@ -111,7 +111,7 @@ func expectedProxyContainers(infra *ir.ProxyInfra,
 			TrustedCA:   filepath.Join("/sds", common.SdsCAFilename),
 		},
 		MaxHeapSizeBytes:         maxHeapSizeBytes,
-		XdsServerHost:            ptr.To(fmt.Sprintf("%s.%s.svc.%s.", config.EnvoyGatewayServiceName, controllerNamespace, dnsDomain)),
+		XdsServerHost:            ptr.To(fmt.Sprintf("%s.%s.svc.%s.", config.GetEnvoyGatewayServiceName(), controllerNamespace, dnsDomain)),
 		TopologyInjectorDisabled: topologyInjectorDisabled,
 	}
 
@@ -356,7 +356,7 @@ func (r *ResourceRender) expectedVolumes(pod *egv1a1.KubernetesPodSpec) []corev1
 				},
 			},
 		}
-		saAudience := fmt.Sprintf("%s.%s.svc.%s", config.EnvoyGatewayServiceName, r.ControllerNamespace(), r.DNSDomain)
+		saAudience := fmt.Sprintf("%s.%s.svc.%s", config.GetEnvoyGatewayServiceName(), r.ControllerNamespace(), r.DNSDomain)
 		saTokenProjectedVolume := corev1.Volume{
 			Name: "sa-token",
 			VolumeSource: corev1.VolumeSource{

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	netutils "github.com/envoyproxy/gateway/internal/utils/net"
 	"github.com/envoyproxy/gateway/internal/utils/regex"
 )
@@ -24,9 +25,6 @@ import (
 const (
 	// envoyCfgFileName is the name of the Envoy configuration file.
 	envoyCfgFileName = "bootstrap.yaml"
-	// envoyGatewayXdsServerHost is the DNS name of the Xds Server within Envoy Gateway.
-	// It defaults to the Envoy Gateway Kubernetes service.
-	envoyGatewayXdsServerHost = "envoy-gateway"
 	// EnvoyAdminAddress is the listening v4 address of the envoy admin interface.
 	EnvoyAdminAddress   = "127.0.0.1"
 	EnvoyAdminAddressV6 = "::1"
@@ -251,7 +249,7 @@ func GetRenderedBootstrapConfig(opts *RenderBootstrapConfigOptions) (string, err
 	cfg := &bootstrapConfig{
 		parameters: bootstrapParameters{
 			XdsServer: serverParameters{
-				Address: envoyGatewayXdsServerHost,
+				Address: config.GetEnvoyGatewayServiceName(),
 				Port:    DefaultXdsServerPort,
 			},
 			AdminServer: adminServerParameters{

--- a/internal/xds/runner/runner.go
+++ b/internal/xds/runner/runner.go
@@ -123,7 +123,7 @@ func (r *Runner) Start(ctx context.Context) (err error) {
 		if err != nil {
 			return fmt.Errorf("failed to create Kubernetes client: %w", err)
 		}
-		saAudience := fmt.Sprintf("%s.%s.svc.%s", config.EnvoyGatewayServiceName, r.ControllerNamespace, r.DNSDomain)
+		saAudience := fmt.Sprintf("%s.%s.svc.%s", config.GetEnvoyGatewayServiceName(), r.ControllerNamespace, r.DNSDomain)
 		jwtInterceptor := kubejwt.NewJWTAuthInterceptor(
 			r.Logger,
 			clientset,


### PR DESCRIPTION
**What type of PR is this?**

`feat`: New feature - adds configurability for Envoy Gateway service name

**What this PR does / why we need it**:

This PR makes the Envoy Gateway service name configurable through the `ENVOY_GATEWAY_SERVICE_NAME` environment variable, solving the issue where multiple gateway instances couldn't run in the same namespace due to hardcoded service name.

**Problem**: The service name was hardcoded to `"envoy-gateway"` throughout the codebase, preventing multiple gateway deployments in the same namespace with different service names.

**Solution**: 
- Introduces `GetEnvoyGatewayServiceName()` that reads `ENVOY_GATEWAY_SERVICE_NAME` (defaults to `"envoy-gateway"`)
- Updates xDS host configuration in bootstrap and proxy resources
- Aligns certificate generation and service account audience with configurable service name
- Maintains backward compatibility

**Files modified**:
- `internal/envoygateway/config/config.go`: Added helper function
- `internal/infrastructure/kubernetes/proxy/resource.go`: xDS host and SA audience
- `internal/xds/runner/runner.go`: SA audience validation
- `internal/xds/bootstrap/bootstrap.go`: default xDS host
- `internal/crypto/certgen.go`: certificate CN and SANs

**Usage**:
```yaml
env:
- name: ENVOY_GATEWAY_SERVICE_NAME
  value: "my-custom-gateway"
```

**Which issue(s) this PR fixes**:

Fixes #6997
Closes #6997

**Release Notes**: Yes