### PR TITLE
feat: implement egctl config envoy-gateway command

### DIFF
--- a/internal/cmd/egctl/config_cmd.go
+++ b/internal/cmd/egctl/config_cmd.go
@@ -24,6 +24,7 @@ func newConfigCommand() *cobra.Command {
 
 	cfgCommand.AddCommand(proxyCommand())
 	cfgCommand.AddCommand(ratelimitCommand())
+	cfgCommand.AddCommand(gatewayCommand())
 
 	options.AddKubeConfigFlags(cfgCommand.PersistentFlags())
 
@@ -37,6 +38,21 @@ func newConfigCommand() *cobra.Command {
 
 func ratelimitCommand() *cobra.Command {
 	return ratelimitConfigCommand()
+}
+
+func gatewayCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "envoy-gateway",
+		Aliases: []string{"gateway", "eg"},
+		Long:    "Retrieve information from Envoy Gateway admin console.",
+	}
+
+	c.AddCommand(gatewayAllConfigCmd())
+	c.AddCommand(gatewaySummaryConfigCmd())
+	c.AddCommand(gatewayInfoCmd())
+	c.AddCommand(gatewayServerInfoCmd())
+
+	return c
 }
 
 func proxyCommand() *cobra.Command {

--- a/internal/cmd/egctl/config_gateway.go
+++ b/internal/cmd/egctl/config_gateway.go
@@ -1,0 +1,110 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package egctl
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+func gatewayAllConfigCmd() *cobra.Command {
+	configCmd := &cobra.Command{
+		Use:   "all",
+		Short: "Retrieves complete configuration dump from Envoy Gateway",
+		Long:  `Retrieves complete configuration dump including all provider resources from the Envoy Gateway admin console.`,
+		Example: `  # Retrieve complete configuration dump from Envoy Gateway
+  egctl config envoy-gateway all -n envoy-gateway-system
+
+  # Retrieve complete configuration dump as YAML
+  egctl config envoy-gateway all -n envoy-gateway-system -o yaml
+
+  # Retrieve complete configuration dump with short syntax
+  egctl c gateway all -n envoy-gateway-system
+`,
+		Run: func(c *cobra.Command, args []string) {
+			cmdutil.CheckErr(runGatewayConfig(c, args, "all"))
+		},
+	}
+
+	return configCmd
+}
+
+func gatewaySummaryConfigCmd() *cobra.Command {
+	configCmd := &cobra.Command{
+		Use:   "summary",
+		Short: "Retrieves summary configuration dump from Envoy Gateway",
+		Long:  `Retrieves summary configuration dump from the Envoy Gateway admin console.`,
+		Example: `  # Retrieve summary configuration dump from Envoy Gateway
+  egctl config envoy-gateway summary -n envoy-gateway-system
+
+  # Retrieve summary configuration dump as YAML
+  egctl config envoy-gateway summary -n envoy-gateway-system -o yaml
+
+  # Retrieve summary configuration dump with short syntax
+  egctl c gateway summary -n envoy-gateway-system
+`,
+		Run: func(c *cobra.Command, args []string) {
+			cmdutil.CheckErr(runGatewayConfig(c, args, "summary"))
+		},
+	}
+
+	return configCmd
+}
+
+func gatewayInfoCmd() *cobra.Command {
+	configCmd := &cobra.Command{
+		Use:   "info",
+		Short: "Retrieves system information from Envoy Gateway",
+		Long:  `Retrieves basic system information from the Envoy Gateway admin console.`,
+		Example: `  # Retrieve system information from Envoy Gateway
+  egctl config envoy-gateway info -n envoy-gateway-system
+
+  # Retrieve system information as YAML
+  egctl config envoy-gateway info -n envoy-gateway-system -o yaml
+`,
+		Run: func(c *cobra.Command, args []string) {
+			cmdutil.CheckErr(runGatewayConfig(c, args, "info"))
+		},
+	}
+
+	return configCmd
+}
+
+func gatewayServerInfoCmd() *cobra.Command {
+	configCmd := &cobra.Command{
+		Use:   "server-info",
+		Short: "Retrieves server status information from Envoy Gateway",
+		Long:  `Retrieves server status and component information from the Envoy Gateway admin console.`,
+		Example: `  # Retrieve server status information from Envoy Gateway
+  egctl config envoy-gateway server-info -n envoy-gateway-system
+
+  # Retrieve server status information as YAML
+  egctl config envoy-gateway server-info -n envoy-gateway-system -o yaml
+`,
+		Run: func(c *cobra.Command, args []string) {
+			cmdutil.CheckErr(runGatewayConfig(c, args, "server-info"))
+		},
+	}
+
+	return configCmd
+}
+
+func runGatewayConfig(c *cobra.Command, args []string, configType string) error {
+	configDump, err := retrieveGatewayConfigDump(args, configType)
+	if err != nil {
+		return err
+	}
+
+	out, err := marshalGatewayConfig(configDump, output)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintln(c.OutOrStdout(), string(out))
+	return err
+}


### PR DESCRIPTION
**What type of PR is this?**

`feat`: New feature - adds `egctl config envoy-gateway` command for retrieving Envoy Gateway configuration and system information

**What this PR does / why we need it**:

This PR implements the `egctl config envoy-gateway` command as requested in #6996, enabling users to retrieve configuration and system information directly from Envoy Gateway's admin console.

**Features implemented**:
- **4 Subcommands**: `all` (complete config dump), `summary` (default view), `info` (system info), `server-info` (server status)
- **API Integration**: Uses Envoy Gateway admin console endpoints (`/api/config_dump`, `/api/info`, `/api/server_info`)
- **User Experience**: Consistent with existing `egctl config envoy-proxy` commands, supports JSON/YAML output, comprehensive help text

**Implementation Details**:
- **Pod Discovery**: Uses `control-plane=envoy-gateway` label selector
- **Port Forwarding**: Reuses existing infrastructure (port 19000) 
- **Error Handling**: Comprehensive error handling for pod discovery, port forwarding, and API requests
- **Code Reuse**: Maximizes reuse of existing egctl patterns

**Usage Examples**:
```bash
# Get complete configuration dump
egctl config envoy-gateway all

# Get summary configuration dump  
egctl config envoy-gateway summary

# Get system information
egctl config envoy-gateway info

# With output formatting
egctl config envoy-gateway all -o yaml
```

**Files Changed**:
- `internal/cmd/egctl/config_cmd.go`: Added gateway command registration
- `internal/cmd/egctl/config_gateway.go`: New file with gateway subcommands  
- `internal/cmd/egctl/config.go`: Added gateway helper functions

**Testing**:
- ✅ Build compiles successfully
- ✅ Command structure properly registered
- ✅ All subcommands accessible with proper help text
- ✅ Examples and documentation comprehensive

**Which issue(s) this PR fixes**:

Fixes #6996

**Release Notes**: Yes