### PR TITLE
fix: use Patch instead of Update for resource status updates

### DIFF
--- a/internal/provider/kubernetes/status_updater.go
+++ b/internal/provider/kubernetes/status_updater.go
@@ -113,7 +113,10 @@ func (u *UpdateHandler) apply(update Update) {
 
 		newObj.SetUID(obj.GetUID())
 
-		return u.client.Status().Update(context.Background(), newObj)
+		// Use Patch instead of Update to avoid conflicts when multiple controllers
+		// try to update the same resource simultaneously
+		patch := client.MergeFrom(obj)
+		return u.client.Status().Patch(context.Background(), newObj, patch)
 	}); err != nil {
 		log.Error(err, "unable to update status")
 


### PR DESCRIPTION
**What type of PR is this?**
fix: replace Status().Update() with Status().Patch() to avoid conflicts

**What this PR does / why we need it**:
This PR fixes issue #6946 by replacing `client.Status().Update()` with `client.Status().Patch()` in the status updater to avoid conflicts when multiple controllers try to update the same resource simultaneously. The change uses `client.MergeFrom(obj)` patch instead of direct update, which prevents race conditions and conflicts that can occur when multiple controllers attempt to modify the same resource's status concurrently.

**Which issue(s) this PR fixes**:
Fixes #6946

Release Notes: Yes