### PR TITLE
chore: Add support for X25519MLKEM768 for client mTLS

### DIFF
--- a/test/e2e/tests/client_mtls.go
+++ b/test/e2e/tests/client_mtls.go
@@ -139,6 +139,7 @@ var ClientMTLSTest = suite.ConformanceTest{
 			// check positive and negative curves
 			dialWithCurve(t, gwAddr, baseTLSConfig, tls.CurveP256, false)
 			dialWithCurve(t, gwAddr, baseTLSConfig, tls.X25519, false)
+			dialWithCurve(t, gwAddr, baseTLSConfig, tls.X25519MLKEM768, false)
 			dialWithCurve(t, gwAddr, baseTLSConfig, tls.CurveP521, true)
 
 			// Check ALPN


### PR DESCRIPTION


**What type of PR is this?**
chore: Add support for X25519MLKEM768 for client mTLS




**What this PR does / why we need it**:

goland 1.24 ships with X25519MLKEM768.

