### PR TITLE
refactor: use MakeRequestAndExpectEventuallyConsistentResponse in resilience tests

### DIFF
--- a/test/resilience/tests/envoygateway.go
+++ b/test/resilience/tests/envoygateway.go
@@ -106,20 +106,7 @@ var EGResilience = suite.ResilienceTest{
 				Namespace: ns,
 			}
 
-			req := http.MakeRequest(t, &expectedResponse, gwAddr, "http", "http")
-			http.AwaitConvergence(t, threshold, timeout, func(elapsed time.Duration) bool {
-				cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(req)
-				if err != nil {
-					tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)
-					return false
-				}
-
-				if err := http.CompareRequest(t, &req, cReq, cRes, expectedResponse); err != nil {
-					tlog.Logf(t, "Response expectation failed for request: %+v  not ready yet: %v (after %v)", req, err, elapsed)
-					return false
-				}
-				return true
-			})
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 		})
 
 		t.Run("EnvoyGateway reconciles missed resources and sync xDS after api server connectivity is restored", func(t *testing.T) {
@@ -165,20 +152,7 @@ var EGResilience = suite.ResilienceTest{
 				Namespace: ns,
 			}
 
-			req := http.MakeRequest(t, &expectedResponse, gwAddr, "http", "http")
-			http.AwaitConvergence(t, threshold, time.Minute, func(elapsed time.Duration) bool {
-				cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(req)
-				if err != nil {
-					tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)
-					return false
-				}
-
-				if err := http.CompareRequest(t, &req, cReq, cRes, expectedResponse); err != nil {
-					tlog.Logf(t, "Response expectation failed for request: %+v  not ready yet: %v (after %v)", req, err, elapsed)
-					return false
-				}
-				return true
-			})
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 
 			require.NoError(t, err, "Failed during connectivity checkup")
 		})
@@ -236,21 +210,7 @@ var EGResilience = suite.ResilienceTest{
 				Namespace: ns,
 			}
 
-			req := http.MakeRequest(t, &expectedResponse, gwAddr, "http", "http")
-
-			http.AwaitConvergence(t, threshold, timeout, func(elapsed time.Duration) bool {
-				cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(req)
-				if err != nil {
-					tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)
-					return false
-				}
-
-				if err := http.CompareRequest(t, &req, cReq, cRes, expectedResponse); err != nil {
-					tlog.Logf(t, "Response expectation failed for request: %+v  not ready yet: %v (after %v)", req, err, elapsed)
-					return false
-				}
-				return true
-			})
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 		})
 	},
 }

--- a/test/resilience/tests/envoyproxy.go
+++ b/test/resilience/tests/envoyproxy.go
@@ -76,19 +76,7 @@ var EPResilience = suite.ResilienceTest{
 				Namespace: ns,
 			}
 
-			req := http.MakeRequest(t, &expectedResponse, gwAddr, "http", "http")
-			http.AwaitConvergence(t, threshold, timeout, func(elapsed time.Duration) bool {
-				cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(req)
-				if err != nil {
-					tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)
-					return false
-				}
-				if err := http.CompareRequest(t, &req, cReq, cRes, expectedResponse); err != nil {
-					tlog.Logf(t, "Response expectation failed for request: %+v  not ready yet: %v (after %v)", req, err, elapsed)
-					return false
-				}
-				return true
-			})
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 		})
 	},
 }

--- a/test/resilience/tests/extensionserver.go
+++ b/test/resilience/tests/extensionserver.go
@@ -68,19 +68,7 @@ var ESResilience = suite.ResilienceTest{
 				Namespace: ns,
 			}
 
-			req := http.MakeRequest(t, &expectedResponse, gwAddr, "http", "http")
-			http.AwaitConvergence(t, threshold, timeout, func(elapsed time.Duration) bool {
-				cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(req)
-				if err != nil {
-					tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)
-					return false
-				}
-				if err := http.CompareRequest(t, &req, cReq, cRes, expectedResponse); err != nil {
-					tlog.Logf(t, "Response expectation failed for request: %+v  not ready yet: %v (after %v)", req, err, elapsed)
-					return false
-				}
-				return true
-			})
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 
 			t.Log("Check Route is modified by extension server")
 			// ensure the extension server is connected and mutating resources
@@ -95,19 +83,7 @@ var ESResilience = suite.ResilienceTest{
 				Namespace: ns,
 			}
 
-			req = http.MakeRequest(t, &expectedResponse, gwAddr, "http", "http")
-			http.AwaitConvergence(t, threshold, timeout, func(elapsed time.Duration) bool {
-				cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(req)
-				if err != nil {
-					tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)
-					return false
-				}
-				if err := http.CompareRequest(t, &req, cReq, cRes, expectedResponse); err != nil {
-					tlog.Logf(t, "Response expectation failed for request: %+v  not ready yet: %v (after %v)", req, err, elapsed)
-					return false
-				}
-				return true
-			})
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 
 			t.Log("Getting current error translation count")
 			translatorErrors, err := waitForMetricValueVerification(t, suite, PrometheusXDSTranslatorErrors, func(actual float64) bool {
@@ -137,19 +113,7 @@ var ESResilience = suite.ResilienceTest{
 			require.NoError(t, err, "Failed to scale deployment replicas")
 
 			// confirm that the old (pre-error) cache is preserved
-			req = http.MakeRequest(t, &expectedResponse, gwAddr, "http", "http")
-			http.AwaitConvergence(t, threshold, timeout, func(elapsed time.Duration) bool {
-				cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(req)
-				if err != nil {
-					tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)
-					return false
-				}
-				if err := http.CompareRequest(t, &req, cReq, cRes, expectedResponse); err != nil {
-					tlog.Logf(t, "Response expectation failed for request: %+v  not ready yet: %v (after %v)", req, err, elapsed)
-					return false
-				}
-				return true
-			})
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 
 			t.Log("Deleting control plane cache and confirming proxy cache is still preserved")
 			t.Log("Scaling down control plane")
@@ -173,19 +137,7 @@ var ESResilience = suite.ResilienceTest{
 			require.NoError(t, err, "Failed to capture envoy connection to control plane")
 
 			t.Log("Checking proxy cache is still preserved when connected to control plane with no snapshot")
-			req = http.MakeRequest(t, &expectedResponse, gwAddr, "http", "http")
-			http.AwaitConvergence(t, threshold, timeout, func(elapsed time.Duration) bool {
-				cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(req)
-				if err != nil {
-					tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)
-					return false
-				}
-				if err := http.CompareRequest(t, &req, cReq, cRes, expectedResponse); err != nil {
-					tlog.Logf(t, "Response expectation failed for request: %+v  not ready yet: %v (after %v)", req, err, elapsed)
-					return false
-				}
-				return true
-			})
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 
 			t.Log("Fixing translation error by changing the failing route")
 			ap.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, "testdata/route_fail_extension_manager_update.yaml", true)
@@ -202,20 +154,7 @@ var ESResilience = suite.ResilienceTest{
 				Namespace: ns,
 			}
 
-			req = http.MakeRequest(t, &expectedResponse, gwAddr, "http", "http")
-
-			http.AwaitConvergence(t, threshold, timeout, func(elapsed time.Duration) bool {
-				cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(req)
-				if err != nil {
-					tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)
-					return false
-				}
-				if err := http.CompareRequest(t, &req, cReq, cRes, expectedResponse); err != nil {
-					tlog.Logf(t, "Response expectation failed for request: %+v  not ready yet: %v (after %v)", req, err, elapsed)
-					return false
-				}
-				return true
-			})
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 		})
 	},
 }


### PR DESCRIPTION
## What type of PR is this?
refactor: use MakeRequestAndExpectEventuallyConsistentResponse in resilience tests

## What this PR does / why we need it:
Refactors resilience tests to use the standardized `MakeRequestAndExpectEventuallyConsistentResponse` utility function instead of manual `AwaitConvergence` patterns, improving code consistency across the test suite.

**Changes:**
- Modified 3 test files: `envoyproxy.go`, `extensionserver.go`, `envoygateway.go`
- Replaced 8 instances of manual convergence checking
- Net reduction of 113 lines of code

**Impact:**
- No functional changes to test behavior
- Improves maintainability and readability
- Low risk - uses proven utility function already widely adopted

## Which issue(s) this PR fixes:
Fixes #7104

Release Notes: No