### PR TITLE
fix: use maps for backendRefMappings instead of Sets

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -603,7 +603,7 @@ func (r *gatewayAPIReconciler) processBackendRefs(ctx context.Context, gwcResour
 	// All other errors are just logged and ignored - these errors result in missing referenced backend resources
 	// in the resource tree, which is acceptable as the Gateway API translation layer will handle them.
 	// The Gateway API translation layer will surface these errors in the status of the resources referencing them.
-	for backendRef := range resourceMappings.allAssociatedBackendRefs {
+	for _, backendRef := range resourceMappings.allAssociatedBackendRefs {
 		backendRefKind := gatewayapi.KindDerefOr(backendRef.Kind, resource.KindService)
 		backendNs, backendName := string(*backendRef.Namespace), string(backendRef.Name)
 		logger := r.log.WithValues("kind", backendRefKind, "namespace", backendNs,
@@ -964,6 +964,24 @@ func getBackendRefs(backendCluster egv1a1.BackendCluster) []gwapiv1.BackendObjec
 	return backendRefs
 }
 
+func backendRefKey(ref gwapiv1.BackendObjectReference) utils.NamespacedNameWithGroupKind {
+	namespace := gatewayapi.NamespaceDerefOr(ref.Namespace, "")
+	group := gatewayapi.GroupDerefOr(ref.Group, "")
+	kind := gatewayapi.KindDerefOr(ref.Kind, resource.KindService)
+	return utils.NamespacedNameWithGroupKind{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: string(ref.Name)},
+		GroupKind:      schema.GroupKind{Group: group, Kind: kind},
+	}
+}
+
+func (rm *resourceMappings) insertBackendRef(ref gwapiv1.BackendObjectReference) {
+	key := backendRefKey(ref)
+	if _, exists := rm.allAssociatedBackendRefs[key]; exists {
+		return
+	}
+	rm.allAssociatedBackendRefs[key] = ref
+}
+
 // processBackendRef adds the referenced BackendRef to the resourceMap for later processBackendRefs.
 // If BackendRef exists in a different namespace and there is a ReferenceGrant, adds ReferenceGrant to the resourceTree.
 func (r *gatewayAPIReconciler) processBackendRef(
@@ -976,12 +994,13 @@ func (r *gatewayAPIReconciler) processBackendRef(
 	backendRef gwapiv1.BackendObjectReference,
 ) error {
 	backendNamespace := gatewayapi.NamespaceDerefOr(backendRef.Namespace, ownerNS)
-	resourceMap.allAssociatedBackendRefs.Insert(gwapiv1.BackendObjectReference{
+	normalizedRef := gwapiv1.BackendObjectReference{
 		Group:     backendRef.Group,
 		Kind:      backendRef.Kind,
 		Namespace: gatewayapi.NamespacePtr(backendNamespace),
 		Name:      backendRef.Name,
-	})
+	}
+	resourceMap.insertBackendRef(normalizedRef)
 
 	if backendNamespace != ownerNS {
 		from := ObjectKindNamespacedName{
@@ -1516,7 +1535,7 @@ func (r *gatewayAPIReconciler) processServiceClusterForGatewayClass(ep *egv1a1.E
 		}
 	}
 
-	resourceMap.allAssociatedBackendRefs.Insert(gwapiv1.BackendObjectReference{
+	resourceMap.insertBackendRef(gwapiv1.BackendObjectReference{
 		Kind:      ptr.To(gwapiv1.Kind("Service")),
 		Namespace: gatewayapi.NamespacePtr(proxySvcNamespace),
 		Name:      gwapiv1.ObjectName(proxySvcName),
@@ -1545,7 +1564,7 @@ func (r *gatewayAPIReconciler) processServiceClusterForGateway(ep *egv1a1.EnvoyP
 		}
 	}
 
-	resourceMap.allAssociatedBackendRefs.Insert(gwapiv1.BackendObjectReference{
+	resourceMap.insertBackendRef(gwapiv1.BackendObjectReference{
 		Kind:      ptr.To(gwapiv1.Kind("Service")),
 		Namespace: gatewayapi.NamespacePtr(proxySvcNamespace),
 		Name:      gwapiv1.ObjectName(proxySvcName),
@@ -2456,12 +2475,13 @@ func (r *gatewayAPIReconciler) processEnvoyProxy(ep *egv1a1.EnvoyProxy, resource
 
 		for _, backendRef := range backendRefs {
 			backendNamespace := gatewayapi.NamespaceDerefOr(backendRef.Namespace, ep.Namespace)
-			resourceMap.allAssociatedBackendRefs.Insert(gwapiv1.BackendObjectReference{
+			normalizedRef := gwapiv1.BackendObjectReference{
 				Group:     backendRef.Group,
 				Kind:      backendRef.Kind,
 				Namespace: gatewayapi.NamespacePtr(backendNamespace),
 				Name:      backendRef.Name,
-			})
+			}
+			resourceMap.insertBackendRef(normalizedRef)
 		}
 	}
 

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -964,7 +964,10 @@ func getBackendRefs(backendCluster egv1a1.BackendCluster) []gwapiv1.BackendObjec
 	return backendRefs
 }
 
-func backendRefKey(ref gwapiv1.BackendObjectReference) utils.NamespacedNameWithGroupKind {
+func backendRefKey(ref *gwapiv1.BackendObjectReference) utils.NamespacedNameWithGroupKind {
+	if ref == nil {
+		return utils.NamespacedNameWithGroupKind{}
+	}
 	namespace := gatewayapi.NamespaceDerefOr(ref.Namespace, "")
 	group := gatewayapi.GroupDerefOr(ref.Group, "")
 	kind := gatewayapi.KindDerefOr(ref.Kind, resource.KindService)
@@ -975,7 +978,7 @@ func backendRefKey(ref gwapiv1.BackendObjectReference) utils.NamespacedNameWithG
 }
 
 func (rm *resourceMappings) insertBackendRef(ref gwapiv1.BackendObjectReference) {
-	key := backendRefKey(ref)
+	key := backendRefKey(&ref)
 	if _, exists := rm.allAssociatedBackendRefs[key]; exists {
 		return
 	}
@@ -999,6 +1002,7 @@ func (r *gatewayAPIReconciler) processBackendRef(
 		Kind:      backendRef.Kind,
 		Namespace: gatewayapi.NamespacePtr(backendNamespace),
 		Name:      backendRef.Name,
+		Port:      backendRef.Port,
 	}
 	resourceMap.insertBackendRef(normalizedRef)
 
@@ -2480,6 +2484,7 @@ func (r *gatewayAPIReconciler) processEnvoyProxy(ep *egv1a1.EnvoyProxy, resource
 				Kind:      backendRef.Kind,
 				Namespace: gatewayapi.NamespacePtr(backendNamespace),
 				Name:      backendRef.Name,
+				Port:      backendRef.Port,
 			}
 			resourceMap.insertBackendRef(normalizedRef)
 		}

--- a/internal/provider/kubernetes/controller_test.go
+++ b/internal/provider/kubernetes/controller_test.go
@@ -302,8 +302,8 @@ func TestProcessBackendRefsWithCustomBackends(t *testing.T) {
 			}
 
 			// Create resource mappings
-				resourceMappings := &resourceMappings{
-					allAssociatedBackendRefs:                make(map[utils.NamespacedNameWithGroupKind]gwapiv1.BackendObjectReference),
+			resourceMappings := &resourceMappings{
+				allAssociatedBackendRefs:                make(map[utils.NamespacedNameWithGroupKind]gwapiv1.BackendObjectReference),
 				allAssociatedNamespaces:                 sets.New[string](),
 				allAssociatedBackendRefExtensionFilters: sets.New[utils.NamespacedNameWithGroupKind](),
 				extensionRefFilters:                     tc.existingExtFilters,
@@ -1501,7 +1501,7 @@ func TestProcessBackendRefDeduplicatesLogicalBackend(t *testing.T) {
 	require.NoError(t, r.processBackendRef(t.Context(), resourceMap, resourceTree, resource.KindHTTPRoute, "default", "route-a", backendRef))
 	require.NoError(t, r.processBackendRef(t.Context(), resourceMap, resourceTree, resource.KindHTTPRoute, "default", "route-b", backendRef))
 
-	require.Equal(t, 1, len(resourceMap.allAssociatedBackendRefs))
+	require.Len(t, resourceMap.allAssociatedBackendRefs, 1)
 }
 
 func TestProcessBackendRefs(t *testing.T) {

--- a/internal/provider/kubernetes/controller_test.go
+++ b/internal/provider/kubernetes/controller_test.go
@@ -302,8 +302,8 @@ func TestProcessBackendRefsWithCustomBackends(t *testing.T) {
 			}
 
 			// Create resource mappings
-			resourceMappings := &resourceMappings{
-				allAssociatedBackendRefs:                make(map[utils.NamespacedNameWithGroupKind]gwapiv1.BackendObjectReference),
+				resourceMappings := &resourceMappings{
+					allAssociatedBackendRefs:                make(map[utils.NamespacedNameWithGroupKind]gwapiv1.BackendObjectReference),
 				allAssociatedNamespaces:                 sets.New[string](),
 				allAssociatedBackendRefExtensionFilters: sets.New[utils.NamespacedNameWithGroupKind](),
 				extensionRefFilters:                     tc.existingExtFilters,
@@ -1308,7 +1308,7 @@ func TestProcessServiceClusterForGatewayClass(t *testing.T) {
 				Namespace: gatewayapi.NamespacePtr(r.namespace),
 				Name:      gwapiv1.ObjectName(tc.expectedSvcName),
 			}
-			key := backendRefKey(expectedRef)
+			key := backendRefKey(&expectedRef)
 			require.Contains(t, resourceMap.allAssociatedBackendRefs, key)
 			require.Equal(t, expectedRef, resourceMap.allAssociatedBackendRefs[key])
 		})
@@ -1465,7 +1465,7 @@ func TestProcessServiceClusterForGateway(t *testing.T) {
 				Namespace: gatewayapi.NamespacePtr(tc.expectedSvcNamespace),
 				Name:      gwapiv1.ObjectName(tc.expectedSvcName),
 			}
-			key := backendRefKey(expectedRef)
+			key := backendRefKey(&expectedRef)
 			require.Contains(t, resourceMap.allAssociatedBackendRefs, key)
 			require.Equal(t, expectedRef, resourceMap.allAssociatedBackendRefs[key])
 		})

--- a/internal/provider/kubernetes/resource.go
+++ b/internal/provider/kubernetes/resource.go
@@ -46,8 +46,8 @@ type resourceMappings struct {
 	allAssociatedTCPRoutes sets.Set[string]
 	// Set for storing UDPRoutes' NamespacedNames attaching to various Gateway objects.
 	allAssociatedUDPRoutes sets.Set[string]
-	// Set for storing backendRefs' BackendObjectReference referred by various Route objects.
-	allAssociatedBackendRefs sets.Set[gwapiv1.BackendObjectReference]
+	// Map caching BackendObjectReferences keyed by their normalized identifier.
+	allAssociatedBackendRefs map[utils.NamespacedNameWithGroupKind]gwapiv1.BackendObjectReference
 	// Set for storing ClientTrafficPolicies' NamespacedNames referred by various Route objects.
 	allAssociatedClientTrafficPolicies sets.Set[string]
 	// Set for storing BackendTrafficPolicies' NamespacedNames referred by various Route objects.
@@ -90,7 +90,7 @@ func newResourceMapping() *resourceMappings {
 		allAssociatedGRPCRoutes:                 sets.New[string](),
 		allAssociatedTCPRoutes:                  sets.New[string](),
 		allAssociatedUDPRoutes:                  sets.New[string](),
-		allAssociatedBackendRefs:                sets.New[gwapiv1.BackendObjectReference](),
+		allAssociatedBackendRefs:                make(map[utils.NamespacedNameWithGroupKind]gwapiv1.BackendObjectReference),
 		allAssociatedClientTrafficPolicies:      sets.New[string](),
 		allAssociatedBackendTrafficPolicies:     sets.New[string](),
 		allAssociatedSecurityPolicies:           sets.New[string](),

--- a/internal/provider/kubernetes/routes_test.go
+++ b/internal/provider/kubernetes/routes_test.go
@@ -1302,7 +1302,7 @@ func TestProcessHTTPRoutesWithCustomBackends(t *testing.T) {
 			// Verify results
 			require.NoError(t, err)
 			require.Len(t, resourceMap.extensionRefFilters, tc.expectedExtFiltersCount)
-			require.Equal(t, tc.expectedBackendRefsCount, resourceMap.allAssociatedBackendRefs.Len())
+			require.Equal(t, tc.expectedBackendRefsCount, len(resourceMap.allAssociatedBackendRefs))
 
 			// Verify that HTTPRoutes were processed
 			require.Len(t, resourceTree.HTTPRoutes, 1)

--- a/internal/provider/kubernetes/routes_test.go
+++ b/internal/provider/kubernetes/routes_test.go
@@ -1302,7 +1302,7 @@ func TestProcessHTTPRoutesWithCustomBackends(t *testing.T) {
 			// Verify results
 			require.NoError(t, err)
 			require.Len(t, resourceMap.extensionRefFilters, tc.expectedExtFiltersCount)
-			require.Equal(t, tc.expectedBackendRefsCount, len(resourceMap.allAssociatedBackendRefs))
+			require.Len(t, resourceMap.allAssociatedBackendRefs, tc.expectedBackendRefsCount)
 
 			// Verify that HTTPRoutes were processed
 			require.Len(t, resourceTree.HTTPRoutes, 1)


### PR DESCRIPTION
* Sets compare by value and BackendRef contain multiple ptrs to Kind, Group and Namespace, so this Set didnt really serve us any good purpose of deduping same backendRefs
* Instead use maps keyed by a util string - NamespaceNameWithGroupKind similar to what we use for ExtentionRefFilters
