### PR TITLE
fix: use lock when accessing mergeGateways Set

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/telepresenceio/watchable"
@@ -68,6 +69,7 @@ type gatewayAPIReconciler struct {
 	namespaceLabel       *metav1.LabelSelector
 	envoyGateway         *egv1a1.EnvoyGateway
 	mergeGateways        sets.Set[string]
+	mergeGatewaysMu      sync.RWMutex
 	resources            *message.ProviderResources
 	subscriptions        *subscriptions
 	extGVKs              []schema.GroupVersionKind
@@ -91,6 +93,24 @@ type gatewayAPIReconciler struct {
 	udpRouteCRDExists      bool
 
 	clusterTrustBundleExits bool
+}
+
+// isGatewayClassMerged reports whether the supplied GatewayClass has mergeGateways enabled.
+func (r *gatewayAPIReconciler) isGatewayClassMerged(name string) bool {
+	r.mergeGatewaysMu.RLock()
+	defer r.mergeGatewaysMu.RUnlock()
+	return r.mergeGateways.Has(name)
+}
+
+// setGatewayClassMerge toggles mergeGateways tracking for the supplied GatewayClass.
+func (r *gatewayAPIReconciler) setGatewayClassMerge(name string, merged bool) {
+	r.mergeGatewaysMu.Lock()
+	defer r.mergeGatewaysMu.Unlock()
+	if merged {
+		r.mergeGateways.Insert(name)
+		return
+	}
+	r.mergeGateways.Delete(name)
 }
 
 type subscriptions struct {
@@ -493,11 +513,7 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 		}
 
 		if gwcResource.EnvoyProxyForGatewayClass != nil && gwcResource.EnvoyProxyForGatewayClass.Spec.MergeGateways != nil {
-			if *gwcResource.EnvoyProxyForGatewayClass.Spec.MergeGateways {
-				r.mergeGateways.Insert(managedGC.Name)
-			} else {
-				r.mergeGateways.Delete(managedGC.Name)
-			}
+			r.setGatewayClassMerge(managedGC.Name, *gwcResource.EnvoyProxyForGatewayClass.Spec.MergeGateways)
 		}
 
 		if len(gwcResource.Gateways) == 0 {
@@ -1401,7 +1417,7 @@ func (r *gatewayAPIReconciler) processGateways(ctx context.Context, managedGC *g
 	}
 
 	mergedGateways := false
-	if r.mergeGateways.Has(managedGC.Name) {
+	if r.isGatewayClassMerged(managedGC.Name) {
 		mergedGateways = true
 		// processGatewayClassParamsRef has been called for this GatewayClass, its EnvoyProxy should exist in resourceTree
 		r.processServiceClusterForGatewayClass(resourceTree.EnvoyProxyForGatewayClass, managedGC, resourceMap)


### PR DESCRIPTION
* accessed in multiple goroutines to map proxy fleet to resource via labels

Fixes this panic

```
fatal error: concurrent map read and map write

   4 internal/runtime/maps.fatal({0x3b83570?, 0x8b3de58?})
   5     /opt/hostedtoolcache/go/1.24.7/x64/src/runtime/panic.go:1058 +0x18
   6 k8s.io/apimachinery/pkg/util/sets.Set[...[].Has(...)
   7     /home/runner/go/pkg/mod/k8s.io/apimachinery@v0.33.3/pkg/util/sets/set.go:78
   8 github.com/envoyproxy/gateway/internal/provider/kubernetes.(*gatewayAPIReconciler).envoyObjectForGateway.func1({0x8bc2dc8, 0xc0054163f0})
   9     /home/runner/work/gateway/gateway/internal/provider/kubernetes/predicates.go:666 +0x7b
  10 github.com/envoyproxy/gateway/internal/provider/kubernetes.(*gatewayAPIReconciler).envoyObjectForGateway(0xc0018858e8?, {0x8ba6648?, 0xc0009c8b90?}, 0x11?)
  11     /home/runner/work/gateway/gateway/internal/provider/kubernetes/predicates.go:682 +0x5e
  12 github.com/envoyproxy/gateway/internal/provider/kubernetes.(*gatewayAPIReconciler).updateStatusForGateway(0xc000516600, {0x8ba6648, 0xc0009c8b90}, 0xc00541a380)
  13     /home/runner/work/gateway/gateway/internal/provider/kubernetes/status.go:579 +0x5a
  14 github.com/envoyproxy/gateway/internal/provider/kubernetes.(*gatewayAPIReconciler).subscribeAndUpdateStatus.func2.1({{{0xc0096a7e46, 0x7}, {0xc001944cc0, 0x11}}, 0x0, 0xc0052fa690}, 0xc00a582a1     0)
```

Relates to https://github.com/envoyproxy/gateway/issues/7115#issuecomment-3359379988