### PR TITLE
fix: prevent panic when sanitize is enabled without forwardClientIDHe…

### DIFF
--- a/internal/xds/translator/api_key_auth.go
+++ b/internal/xds/translator/api_key_auth.go
@@ -160,8 +160,8 @@ func buildAPIKeyAuthFilterConfig(apiKeyAuth *ir.APIKeyAuth) *apikeyauthv3.ApiKey
 	sanitize := ptr.Deref(apiKeyAuth.Sanitize, false)
 	if clientIDHeader != "" || sanitize {
 		apiKeyAuthProto.Forwarding = &apikeyauthv3.Forwarding{
-			Header:          *apiKeyAuth.ForwardClientIDHeader,
-			HideCredentials: ptr.Deref(apiKeyAuth.Sanitize, false),
+			Header:          clientIDHeader,
+			HideCredentials: sanitize,
 		}
 	}
 

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -32,6 +32,7 @@ bug fixes: |
   Fixed service account token handling in GatewayNamespaceMode to use SDS for properly refreshing expired token.
   Fixed handling of regex meta characters in prefix match replace for URL rewrite.
   Disabled the default emission of `x-envoy-ratelimited` headers from the rate limit filter; re-enable with the `enableEnvoyHeaders` setting in ClientTrafficPolicy.
+  Fixed a nil pointer panic in the XDS translator when building API key authentication filter configurations with `sanitize` enabled and no `forwardClientIDHeader` set.
 
 # Enhancements that improve performance.
 performance improvements: |

--- a/test/e2e/testdata/api-key-auth.yaml
+++ b/test/e2e/testdata/api-key-auth.yaml
@@ -167,3 +167,37 @@ spec:
     credentialRefs:
       - name: "api-key-auth-users-secret-1"
       - name: "api-key-auth-users-secret-2"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-with-api-key-auth-header-sanitized-without-forward-client-id-header
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /api-key-auth-header-sanitized
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: api-key-auth-header-sanitized-without-forward-client-id-header
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: http-with-api-key-auth-header-sanitized-without-forward-client-id-header
+  apiKeyAuth:
+    extractFrom:
+      - headers: ["X-API-KEY"]
+    credentialRefs:
+      - name: "api-key-auth-users-secret-1"
+    sanitize: true

--- a/test/e2e/tests/api_key_auth.go
+++ b/test/e2e/tests/api_key_auth.go
@@ -211,5 +211,55 @@ var APIKeyAuthTest = suite.ConformanceTest{
 
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 		})
+		t.Run("api-key auth with header sanitized without forward client id header", func(t *testing.T) {
+			ns := "gateway-conformance-infra"
+			routeNN := types.NamespacedName{Name: "http-with-api-key-auth-header-sanitized-without-forward-client-id-header", Namespace: ns}
+			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+			ancestorRef := gwapiv1a2.ParentReference{
+				Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+				Kind:      gatewayapi.KindPtr(resource.KindGateway),
+				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
+				Name:      gwapiv1.ObjectName(gwNN.Name),
+			}
+			SecurityPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "api-key-auth-header-sanitized-without-forward-client-id-header", Namespace: ns}, suite.ControllerName, ancestorRef)
+
+			expectedResponse := http.ExpectedResponse{
+				Request: http.Request{
+					Path: "/api-key-auth-header-sanitized",
+					Headers: map[string]string{
+						"X-API-KEY": "key1",
+					},
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/api-key-auth-header-sanitized",
+					},
+					AbsentHeaders: []string{"X-API-KEY"},
+				},
+				Response: http.Response{
+					StatusCode: 200,
+				},
+				Namespace: ns,
+			}
+
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
+
+			expectedResponse = http.ExpectedResponse{
+				Request: http.Request{
+					Path: "/api-key-auth-header-sanitized",
+					Headers: map[string]string{
+						"X-API-KEY": "invalid",
+					},
+				},
+				Response: http.Response{
+					StatusCode: 401,
+				},
+				Namespace: ns,
+			}
+
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
+		})
 	},
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

When `sanitize` is enabled in `apiKeyAuth` without specifying a `forwardClientIDHeader`, the translator dereferences a nil pointer, causing a panic that crashes the controller.

The proposed changes fix this by safely handling missing `forwardClientIDHeader` values when `sanitize` is enabled, preventing the panic and ensuring the controller remains stable.

Release Notes: Yes
