### PR TITLE
delay migrating to XDS Name Scheme V2 by default

### DIFF
--- a/site/content/en/latest/tasks/extensibility/envoy-patch-policy.md
+++ b/site/content/en/latest/tasks/extensibility/envoy-patch-policy.md
@@ -104,9 +104,9 @@ Because [EnvoyPatchPolicy][] relies on specific xDS resource names, it’s impor
 |                      | V2 (HTTPS)     | `https-<Port>`                                                              | `https-443`                      |
 
 
-This change is gated by the XDSNameSchemeV2 runtime flag. The flag is disabled by default in v1.5 and will be enabled by default in a future release.
+This change is gated by the XDSNameSchemeV2 runtime flag. The flag is disabled by default in v1.5 and will be enabled by default starting in v1.10.
 
-We recommend users begin migrating their [EnvoyPatchPolicy][] resources to use the version 2 naming scheme.
+We recommend users begin migrating their [EnvoyPatchPolicy][] resources to use the version 2 naming scheme before upgrading to v1.10.
 
 To opt in to the new naming scheme early, add the`XDSNameSchemeV2` runtime flag to the `runtimeFlags.enabled` field in your [EnvoyGateway][] configuration.
 

--- a/site/content/en/news/releases/v1.5.md
+++ b/site/content/en/news/releases/v1.5.md
@@ -27,7 +27,7 @@ Envoy Gateway v1.5.0 introduces powerful enhancements, resolves critical issues,
 - **Endpoint Removal Behavior**: Endpoints absent from service discovery are removed even if their active health checks succeed.
 - **xDS Listener Naming**: Listeners are now named based on listening port and protocol instead of Gateway and section names.  
   - This affects existing `EnvoyPatchPolicies` and `ExtensionManagers`.  
-  - Controlled by the `XDSNameSchemeV2` runtime flag (disabled by default).
+  - Controlled by the `XDSNameSchemeV2` runtime flag (disabled by default in v1.5, enabled in v1.10).
   - See the [migration guide](../../v1.5/tasks/extensibility/envoy-patch-policy#xds-name-scheme-v2) to prepare.
 - **Metrics Label Change**: Removed `xds-translator` and `xds-server` values from the `runner` label in `watchable_subscribe_total`; use `xds` instead.
 - **ALS Access Loggers**: ALS now has HTTP/2 enabled on the cluster by default.

--- a/site/content/en/v1.5/tasks/extensibility/envoy-patch-policy.md
+++ b/site/content/en/v1.5/tasks/extensibility/envoy-patch-policy.md
@@ -104,9 +104,9 @@ Because [EnvoyPatchPolicy][] relies on specific xDS resource names, it’s impor
 |                      | V2 (HTTPS)     | `https-<Port>`                                                              | `https-443`                      |
 
 
-This change is gated by the XDSNameSchemeV2 runtime flag. The flag is disabled by default in v1.5 and will be enabled by default in a future release.
+This change is gated by the XDSNameSchemeV2 runtime flag. The flag is disabled by default in v1.5 and will be enabled by default starting in v1.10.
 
-We recommend users begin migrating their [EnvoyPatchPolicy][] resources to use the version 2 naming scheme.
+We recommend users begin migrating their [EnvoyPatchPolicy][] resources to use the version 2 naming scheme before upgrading to v1.10.
 
 To opt in to the new naming scheme early, add the`XDSNameSchemeV2` runtime flag to the `runtimeFlags.enabled` field in your [EnvoyGateway][] configuration.
 


### PR DESCRIPTION
The cost of migrating envoy patch policies to the new naming scheme is higher than the impact of staying on the V1 scheme
