### PR TITLE
bump golang to 1.24.8

### DIFF
--- a/examples/envoy-ext-auth/Dockerfile
+++ b/examples/envoy-ext-auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.7 AS builder
+FROM golang:1.24.8 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/envoy-ext-auth/go.mod
+++ b/examples/envoy-ext-auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-grcp-ext-auth
 
-go 1.24.7
+go 1.24.8
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.35.0

--- a/examples/extension-server/go.mod
+++ b/examples/extension-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/exampleorg/envoygateway-extension
 
-go 1.24.7
+go 1.24.8
 
 require (
 	github.com/envoyproxy/gateway v1.3.1

--- a/examples/grpc-ext-proc/Dockerfile
+++ b/examples/grpc-ext-proc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.7 AS builder
+FROM golang:1.24.8 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/grpc-ext-proc/go.mod
+++ b/examples/grpc-ext-proc/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-grpc-ext-proc
 
-go 1.24.7
+go 1.24.8
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.35.0

--- a/examples/preserve-case-backend/Dockerfile
+++ b/examples/preserve-case-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.7 AS builder
+FROM golang:1.24.8 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/preserve-case-backend/go.mod
+++ b/examples/preserve-case-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-preserve-case-backend
 
-go 1.24.7
+go 1.24.8
 
 require github.com/valyala/fasthttp v1.65.0
 

--- a/examples/simple-extension-server/Dockerfile
+++ b/examples/simple-extension-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.7 AS builder
+FROM golang:1.24.8 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/simple-extension-server/go.mod
+++ b/examples/simple-extension-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-simple-extension-server
 
-go 1.24.7
+go 1.24.8
 
 require (
 	github.com/envoyproxy/gateway v1.5.0

--- a/examples/static-file-server/Dockerfile
+++ b/examples/static-file-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.7 AS builder
+FROM golang:1.24.8 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/static-file-server/go.mod
+++ b/examples/static-file-server/go.mod
@@ -1,3 +1,3 @@
 module github.com/envoyproxy/static-file-server
 
-go 1.24.7
+go 1.24.8

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway
 
-go 1.24.7
+go 1.24.8
 
 require (
 	fortio.org/fortio v1.72.0

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/docsy-example
 
-go 1.24.7
+go 1.24.8
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 // indirect

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.24.7
+go 1.24.8
 
 tool (
 	github.com/bufbuild/buf/cmd/buf


### PR DESCRIPTION
```
go1.24.8 (released 2025-10-07) includes security fixes to the archive/tar, crypto/tls, crypto/x509, encoding/asn1, encoding/pem, net/http, net/mail, net/textproto, and net/url packages, as well as bug fixes to the compiler, the linker, and the debug/pe, net/http, os, and sync/atomic packages. See the Go 1.24.8 milestone on our issue tracker for details.
```