### PR TITLE
bump golang to 1.25.3

### DIFF
--- a/examples/envoy-ext-auth/Dockerfile
+++ b/examples/envoy-ext-auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.8 AS builder
+FROM golang:1.25.3 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/envoy-ext-auth/go.mod
+++ b/examples/envoy-ext-auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-grcp-ext-auth
 
-go 1.24.8
+go 1.25.3
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.35.0

--- a/examples/extension-server/go.mod
+++ b/examples/extension-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/exampleorg/envoygateway-extension
 
-go 1.24.8
+go 1.25.3
 
 require (
 	github.com/envoyproxy/gateway v1.3.1

--- a/examples/grpc-ext-proc/Dockerfile
+++ b/examples/grpc-ext-proc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.8 AS builder
+FROM golang:1.25.3 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/grpc-ext-proc/go.mod
+++ b/examples/grpc-ext-proc/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-grpc-ext-proc
 
-go 1.24.8
+go 1.25.3
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.35.0

--- a/examples/preserve-case-backend/Dockerfile
+++ b/examples/preserve-case-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.8 AS builder
+FROM golang:1.25.3 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/preserve-case-backend/go.mod
+++ b/examples/preserve-case-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-preserve-case-backend
 
-go 1.24.8
+go 1.25.3
 
 require github.com/valyala/fasthttp v1.67.0
 

--- a/examples/simple-extension-server/Dockerfile
+++ b/examples/simple-extension-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.8 AS builder
+FROM golang:1.25.3 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/simple-extension-server/go.mod
+++ b/examples/simple-extension-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-simple-extension-server
 
-go 1.24.8
+go 1.25.3
 
 require (
 	github.com/envoyproxy/gateway v1.5.3

--- a/examples/static-file-server/Dockerfile
+++ b/examples/static-file-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.8 AS builder
+FROM golang:1.25.3 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/static-file-server/go.mod
+++ b/examples/static-file-server/go.mod
@@ -1,3 +1,3 @@
 module github.com/envoyproxy/static-file-server
 
-go 1.24.8
+go 1.25.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway
 
-go 1.24.8
+go 1.25.3
 
 require (
 	fortio.org/fortio v1.73.0

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/docsy-example
 
-go 1.24.8
+go 1.25.3
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 // indirect

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.24.8
+go 1.25.3
 
 tool (
 	github.com/bufbuild/buf/cmd/buf

--- a/tools/hack/bump-golang.sh
+++ b/tools/hack/bump-golang.sh
@@ -2,17 +2,16 @@
 
 # shellcheck disable=SC2038
 
-FROM_GOLANG_VERSION=${1:-"1.23.6"}
-TO_GOLANG_VERSION=${2:-"1.24.0"}
+TO_GOLANG_VERSION=${1:-"1.25.3"}
 
 echo "Bumping golang version from $FROM_GOLANG_VERSION to $TO_GOLANG_VERSION"
 
 # detect gnu-sed or sed
 GNU_SED=$(sed --version >/dev/null 2>&1 && echo "yes" || echo "no")
 if [ "$GNU_SED" == "yes" ]; then
-    find . -type f -name "Dockerfile" | xargs sed -i'' "s/FROM golang:$FROM_GOLANG_VERSION AS builder/FROM golang:$TO_GOLANG_VERSION AS builder/g"
-    find . -type f -name "go.mod" | xargs sed -i'' "s/go $FROM_GOLANG_VERSION/go $TO_GOLANG_VERSION/g"
+    find . -type f -name "Dockerfile" | xargs sed -i'' "s/^FROM golang:.*\$/FROM golang:$TO_GOLANG_VERSION AS builder/g"
+    find . -type f -name "go.mod" | xargs sed -i'' "s/^go.*\$/go $TO_GOLANG_VERSION/g"
 else
-    find . -type f -name "Dockerfile" | xargs sed -i '' "s/FROM golang:$FROM_GOLANG_VERSION AS builder/FROM golang:$TO_GOLANG_VERSION AS builder/g"
-    find . -type f -name "go.mod" | xargs sed -i '' "s/go $FROM_GOLANG_VERSION/go $TO_GOLANG_VERSION/g"
+    find . -type f -name "Dockerfile" | xargs sed -i '' "s/^FROM golang:.*\$/FROM golang:$TO_GOLANG_VERSION AS builder/g"
+    find . -type f -name "go.mod" | xargs sed -i '' "s/^go.*\$/go $TO_GOLANG_VERSION/g"
 fi


### PR DESCRIPTION
this's same as https://github.com/envoyproxy/gateway/pull/7236 but use 1.25.3 for main branch.