### PR TITLE
chore: revert OIDC test change

### DIFF
--- a/test/e2e/tests/oidc-backendcluster.go
+++ b/test/e2e/tests/oidc-backendcluster.go
@@ -23,10 +23,10 @@ func init() {
 var OIDCBackendClusterTest = suite.ConformanceTest{
 	ShortName:   "OIDC with BackendCluster",
 	Description: "Test OIDC authentication",
-	Manifests:   []string{"testdata/oidc-keycloak.yaml", "testdata/oidc-securitypolicy-backendcluster.yaml"},
+	Manifests:   []string{"testdata/oidc-keycloak.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		t.Run("oidc provider represented by a BackendCluster", func(t *testing.T) {
-			testOIDC(t, suite)
+			testOIDC(t, suite, "testdata/oidc-securitypolicy-backendcluster.yaml")
 		})
 	},
 }

--- a/test/e2e/tests/oidc.go
+++ b/test/e2e/tests/oidc.go
@@ -48,16 +48,22 @@ func init() {
 var OIDCTest = suite.ConformanceTest{
 	ShortName:   "OIDC",
 	Description: "Test OIDC authentication",
-	Manifests:   []string{"testdata/oidc-keycloak.yaml", "testdata/oidc-securitypolicy.yaml"},
+	Manifests:   []string{"testdata/oidc-keycloak.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		t.Run("oidc provider represented by a URL", func(t *testing.T) {
-			testOIDC(t, suite)
+			testOIDC(t, suite, "testdata/oidc-securitypolicy.yaml")
 		})
 
 		t.Run("oidc bypass", func(t *testing.T) {
 			ns := "gateway-conformance-infra"
+
+			podInitialized := corev1.PodCondition{Type: corev1.PodInitialized, Status: corev1.ConditionTrue}
 			// Wait for the keycloak pod to be configured with the test user and client
-			WaitForPods(t, suite.Client, ns, map[string]string{"app": "keycloak"}, corev1.PodRunning, &PodReady)
+			WaitForPods(t, suite.Client, ns, map[string]string{"job-name": "setup-keycloak"}, corev1.PodSucceeded, &podInitialized)
+
+			// Apply the security policy that configures OIDC authentication
+			suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, "testdata/oidc-securitypolicy.yaml", true)
+
 			routeWithOIDCNN := types.NamespacedName{Name: "http-with-oidc", Namespace: ns}
 			routeWithoutOIDCNN := types.NamespacedName{Name: "http-without-oidc", Namespace: ns}
 			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -112,7 +118,7 @@ var OIDCTest = suite.ConformanceTest{
 	},
 }
 
-func testOIDC(t *testing.T, suite *suite.ConformanceTestSuite) {
+func testOIDC(t *testing.T, suite *suite.ConformanceTestSuite, securityPolicyManifest string) {
 	var (
 		testURL   = "http://www.example.com/myapp"
 		logoutURL = "http://www.example.com/myapp/logout"
@@ -121,8 +127,12 @@ func testOIDC(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns        = "gateway-conformance-infra"
 	)
 
+	podInitialized := corev1.PodCondition{Type: corev1.PodInitialized, Status: corev1.ConditionTrue}
 	// Wait for the keycloak pod to be configured with the test user and client
-	WaitForPods(t, suite.Client, ns, map[string]string{"app": "keycloak"}, corev1.PodRunning, &PodReady)
+	WaitForPods(t, suite.Client, ns, map[string]string{"job-name": "setup-keycloak"}, corev1.PodSucceeded, &podInitialized)
+
+	// Apply the security policy that configures OIDC authentication
+	suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, securityPolicyManifest, true)
 
 	routeNN := types.NamespacedName{Name: route, Namespace: ns}
 	gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -179,6 +189,7 @@ func testOIDC(t *testing.T, suite *suite.ConformanceTestSuite) {
 					},
 				}
 				require.NoError(t, suite.Client.Delete(context.TODO(), existingSP))
+				suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, securityPolicyManifest, false)
 				SecurityPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: sp, Namespace: ns}, suite.ControllerName, ancestorRef)
 				return false, nil
 			}


### PR DESCRIPTION
Saw this [test failure](https://github.com/envoyproxy/gateway/actions/runs/18581894602/job/52984004045?pr=7252) after PR https://github.com/envoyproxy/gateway/pull/7196 , revert it.

```
    utils.go:135: 2025-10-17T04:36:52.402058174Z: SecurityPolicy not yet accepted: &{{ } {oidc-test  gateway-conformance-infra  b64afb8a-3dcc-41cc-b201-63d868d39849 8641 1 2025-10-17 04:35:21 +0000 UTC <nil> <nil> map[] map[] [] [] [{gateway-api-conformance.test::v1.3.0::OIDC with BackendCluster::unknownFeature Update gateway.envoyproxy.io/v1alpha1 2025-10-17 04:35:21 +0000 UTC FieldsV1 {"f:spec":{".":{},"f:oidc":{".":{},"f:clientIDRef":{".":{},"f:group":{},"f:kind":{},"f:name":{}},"f:clientSecret":{".":{},"f:group":{},"f:kind":{},"f:name":{}},"f:logoutPath":{},"f:provider":{".":{},"f:backendRefs":{},"f:backendSettings":{".":{},"f:retry":{".":{},"f:numRetries":{},"f:perRetry":{".":{},"f:backOff":{".":{},"f:baseInterval":{},"f:maxInterval":{}}},"f:retryOn":{".":{},"f:triggers":{}}}},"f:issuer":{}},"f:redirectURL":{}},"f:targetRefs":{}}} } {envoy-gateway Update gateway.envoyproxy.io/v1alpha1 2025-10-17 04:35:26 +0000 UTC FieldsV1 {"f:status":{".":{},"f:ancestors":{}}} status}]} {{<nil> [{{gateway.networking.k8s.io HTTPRoute http-with-oidc} <nil>}] []} <nil> <nil> <nil> <nil> 0xc001400900 <nil> <nil>} {[{{0xc0015b69e0 0xc0015b69f0 0xc0015b6a00 same-namespace <nil> <nil>} gateway.envoyproxy.io/gatewayclass-controller [{Accepted False 1 2025-10-17 04:35:26 +0000 UTC Invalid OIDC: error fetching endpoints from issuer: Get "https://keycloak.gateway-conformance-infra/realms/master/.well-known/openid-configuration": dial tcp 10.96.31.12:443: connect: connection refused.}]}]}}
    oidc.go:139: 
        	Error Trace:	/home/runner/work/gateway/gateway/test/e2e/tests/utils.go:139
        	            				/home/runner/work/gateway/gateway/test/e2e/tests/oidc.go:139
        	            				/home/runner/work/gateway/gateway/test/e2e/tests/oidc-backendcluster.go:29
        	Error:      	Received unexpected error:
        	            	error fetching SecurityPolicy: context deadline exceeded
        	Test:       	TestE2E/OIDC_with_BackendCluster/oidc_provider_represented_by_a_BackendCluster
```