### PR TITLE
perf: do not set last transition time for status in watcher layer

### DIFF
--- a/internal/gatewayapi/status/backend.go
+++ b/internal/gatewayapi/status/backend.go
@@ -14,8 +14,6 @@
 package status
 
 import (
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -33,10 +31,10 @@ func computeBackendAcceptedCondition(be *egv1a1.Backend, accepted bool, msg stri
 	case true:
 		return newCondition(string(egv1a1.BackendReasonAccepted), metav1.ConditionTrue,
 			string(egv1a1.BackendConditionAccepted),
-			"The Backend was accepted", time.Now(), be.Generation)
+			"The Backend was accepted", be.Generation)
 	default:
 		return newCondition(string(egv1a1.BackendReasonInvalid), metav1.ConditionFalse,
 			string(egv1a1.BackendConditionAccepted),
-			msg, time.Now(), be.Generation)
+			msg, be.Generation)
 	}
 }

--- a/internal/gatewayapi/status/conditions.go
+++ b/internal/gatewayapi/status/conditions.go
@@ -14,7 +14,6 @@
 package status
 
 import (
-	"time"
 	"unicode"
 
 	"github.com/google/go-cmp/cmp"
@@ -42,7 +41,6 @@ func MergeConditions(conditions []metav1.Condition, updates ...metav1.Condition)
 					conditions[j].Reason = updates[i].Reason
 					conditions[j].Message = updates[i].Message
 					conditions[j].ObservedGeneration = updates[i].ObservedGeneration
-					conditions[j].LastTransitionTime = updates[i].LastTransitionTime
 					break
 				}
 			}
@@ -55,13 +53,12 @@ func MergeConditions(conditions []metav1.Condition, updates ...metav1.Condition)
 	return conditions
 }
 
-func newCondition(t string, status metav1.ConditionStatus, reason, msg string, lt time.Time, og int64) metav1.Condition {
+func newCondition(t string, status metav1.ConditionStatus, reason, msg string, og int64) metav1.Condition {
 	return metav1.Condition{
 		Type:               t,
 		Status:             status,
 		Reason:             reason,
 		Message:            truncateConditionMessage(msg),
-		LastTransitionTime: metav1.NewTime(lt),
 		ObservedGeneration: og,
 	}
 }

--- a/internal/gatewayapi/status/envoypatchpolicy.go
+++ b/internal/gatewayapi/status/envoypatchpolicy.go
@@ -7,7 +7,6 @@ package status
 
 import (
 	"strings"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -30,14 +29,14 @@ func SetProgrammedForEnvoyPatchPolicy(s *gwapiv1.PolicyStatus) {
 	}
 
 	message := "Patches have been successfully applied."
-	cond := newCondition(string(egv1a1.PolicyConditionProgrammed), metav1.ConditionTrue, string(egv1a1.PolicyReasonProgrammed), message, time.Now(), 0)
+	cond := newCondition(string(egv1a1.PolicyConditionProgrammed), metav1.ConditionTrue, string(egv1a1.PolicyReasonProgrammed), message, 0)
 	for i := range s.Ancestors {
 		s.Ancestors[i].Conditions = MergeConditions(s.Ancestors[i].Conditions, cond)
 	}
 }
 
 func SetTranslationErrorForEnvoyPatchPolicy(s *gwapiv1.PolicyStatus, errMsg string) {
-	cond := newCondition(string(egv1a1.PolicyConditionProgrammed), metav1.ConditionFalse, string(egv1a1.PolicyReasonInvalid), errMsg, time.Now(), 0)
+	cond := newCondition(string(egv1a1.PolicyConditionProgrammed), metav1.ConditionFalse, string(egv1a1.PolicyReasonInvalid), errMsg, 0)
 	for i := range s.Ancestors {
 		s.Ancestors[i].Conditions = MergeConditions(s.Ancestors[i].Conditions, cond)
 	}
@@ -45,7 +44,7 @@ func SetTranslationErrorForEnvoyPatchPolicy(s *gwapiv1.PolicyStatus, errMsg stri
 
 func SetResourceNotFoundErrorForEnvoyPatchPolicy(s *gwapiv1.PolicyStatus, notFoundResources []string) {
 	message := "Unable to find xds resources: " + strings.Join(notFoundResources, ",")
-	cond := newCondition(string(egv1a1.PolicyConditionProgrammed), metav1.ConditionFalse, string(egv1a1.PolicyReasonResourceNotFound), message, time.Now(), 0)
+	cond := newCondition(string(egv1a1.PolicyConditionProgrammed), metav1.ConditionFalse, string(egv1a1.PolicyReasonResourceNotFound), message, 0)
 	for i := range s.Ancestors {
 		s.Ancestors[i].Conditions = MergeConditions(s.Ancestors[i].Conditions, cond)
 	}

--- a/internal/gatewayapi/status/gatewayclass.go
+++ b/internal/gatewayapi/status/gatewayclass.go
@@ -14,8 +14,6 @@
 package status
 
 import (
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -56,7 +54,6 @@ func computeGatewayClassAcceptedCondition(gatewayClass *gwapiv1.GatewayClass,
 			Reason:             reason,
 			Message:            msg,
 			ObservedGeneration: gatewayClass.Generation,
-			LastTransitionTime: metav1.NewTime(time.Now()),
 		}
 	default:
 		return metav1.Condition{
@@ -65,7 +62,6 @@ func computeGatewayClassAcceptedCondition(gatewayClass *gwapiv1.GatewayClass,
 			Reason:             reason,
 			Message:            msg,
 			ObservedGeneration: gatewayClass.Generation,
-			LastTransitionTime: metav1.NewTime(time.Now()),
 		}
 	}
 }

--- a/internal/gatewayapi/status/policy.go
+++ b/internal/gatewayapi/status/policy.go
@@ -7,7 +7,6 @@ package status
 
 import (
 	"sort"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -104,14 +103,14 @@ func SetConditionForPolicyAncestor(policyStatus *gwapiv1.PolicyStatus, ancestorR
 			}
 
 			// Only create condition and merge if needed
-			cond := newCondition(string(conditionType), status, string(reason), sanitizedMessage, time.Now(), generation)
+			cond := newCondition(string(conditionType), status, string(reason), sanitizedMessage, generation)
 			policyStatus.Ancestors[i].Conditions = MergeConditions(policyStatus.Ancestors[i].Conditions, cond)
 			return
 		}
 	}
 
 	// Add condition for new PolicyAncestorStatus
-	cond := newCondition(string(conditionType), status, string(reason), sanitizedMessage, time.Now(), generation)
+	cond := newCondition(string(conditionType), status, string(reason), sanitizedMessage, generation)
 	policyStatus.Ancestors = append(policyStatus.Ancestors, gwapiv1.PolicyAncestorStatus{
 		AncestorRef:    *ancestorRef,
 		ControllerName: gwapiv1a2.GatewayController(controllerName),

--- a/internal/gatewayapi/status/route.go
+++ b/internal/gatewayapi/status/route.go
@@ -6,8 +6,6 @@
 package status
 
 import (
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -21,7 +19,6 @@ func SetRouteStatusCondition(route *gwapiv1.RouteStatus, routeParentStatusIdx in
 		Reason:             string(reason),
 		Message:            message,
 		ObservedGeneration: routeGeneration,
-		LastTransitionTime: metav1.NewTime(time.Now()),
 	}
 
 	route.Parents[routeParentStatusIdx].Conditions = MergeConditions(route.Parents[routeParentStatusIdx].Conditions, cond)


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->
perf: do not set last transition time for status in watcher layer

**What this PR does / why we need it**:
Prevents watcher from getting updates due to changes in `LastTransitionTime` in resource status conditions. Instead set `LastTransitionTime` for all status conditions before apply.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #7158 

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
