### PR TITLE
fix: use compile_native_go_fuzzer_v2 compiler for OSS-Fuzz build.

### DIFF
--- a/test/fuzz/oss_fuzz_build.sh
+++ b/test/fuzz/oss_fuzz_build.sh
@@ -9,13 +9,8 @@
 # from the source file https://github.com/istio/istio/blob/master/tests/fuzz/oss_fuzz_build.sh
 # and is provided here subject to the following: Copyright Istio Authors SPDX-License-Identifier: Apache-2.0
 
-# Required by `compile_native_go_fuzzer`
-# Ref: https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/#buildsh
-cd "$SRC"
-git clone --depth=1 https://github.com/AdamKorcz/go-118-fuzz-build --branch=include-all-test-files
-cd go-118-fuzz-build
-go build .
-mv go-118-fuzz-build /root/go/bin/
+# Using `compile_native_go_fuzzer_v2`
+# Ref: https://github.com/google/oss-fuzz/pull/13835
 
 cd "$SRC"/gateway
 
@@ -24,16 +19,8 @@ set -o pipefail
 set -o errexit
 set -x
 
-# Create empty file that imports "github.com/AdamKorcz/go-118-fuzz-build/testing"
-# This is a small hack to install this dependency, since it is not used anywhere,
-# and Go would therefore remove it from go.mod once we run "go mod tidy && go mod vendor".
-printf "package envoygateway\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > register.go
-go mod edit -replace github.com/AdamKorcz/go-118-fuzz-build="$SRC"/go-118-fuzz-build
-go mod tidy
-
-
 # compile native-format fuzzers
-compile_native_go_fuzzer github.com/envoyproxy/gateway/test/fuzz FuzzGatewayAPIToXDS FuzzGatewayAPIToXDS
+compile_native_go_fuzzer_v2 github.com/envoyproxy/gateway/test/fuzz FuzzGatewayAPIToXDS FuzzGatewayAPIToXDS
 
 # add seed corpus
 zip -j $OUT/FuzzGatewayAPIToXDS_seed_corpus.zip "$SRC"/gateway/test/fuzz/testdata/FuzzGatewayAPIToXDS/*


### PR DESCRIPTION
Many Go projects, including Envoy Gateway, had been facing issues with coverage builds in OSS-Fuzz.  
To address this, OSS-Fuzz has introduced `compile_native_go_fuzzer_v2`.

This PR updates our fuzzing build script to use the new `compile_native_go_fuzzer_v2`.

Ref: [google/oss-fuzz#13835](https://github.com/google/oss-fuzz/pull/13835)
