### PR TITLE
fix:  error handling for fetching oidc config from well-known endpoint

### DIFF
--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -1399,7 +1399,7 @@ func (t *Translator) buildOIDCProvider(policy *egv1a1.SecurityPolicy, resources 
 	if provider.TokenEndpoint == nil || provider.AuthorizationEndpoint == nil {
 		discoveredConfig, err := fetchEndpointsFromIssuer(provider.Issuer, providerTLS)
 		if err != nil {
-			return nil, fmt.Errorf("error fetching endpoints from issuer: %w", err)
+			return nil, err
 		}
 		tokenEndpoint = discoveredConfig.TokenEndpoint
 		authorizationEndpoint = discoveredConfig.AuthorizationEndpoint
@@ -1475,6 +1475,16 @@ type OpenIDConfig struct {
 	EndSessionEndpoint    *string `json:"end_session_endpoint,omitempty"`
 }
 
+func (o *OpenIDConfig) validate() error {
+	if o.TokenEndpoint == "" {
+		return errors.New("token_endpoint not found in OpenID configuration")
+	}
+	if o.AuthorizationEndpoint == "" {
+		return errors.New("authorization_endpoint not found in OpenID configuration")
+	}
+	return nil
+}
+
 func fetchEndpointsFromIssuer(issuerURL string, providerTLS *ir.TLSUpstreamConfig) (*OpenIDConfig, error) {
 	var (
 		tlsConfig *tls.Config
@@ -1498,19 +1508,45 @@ func fetchEndpointsFromIssuer(issuerURL string, providerTLS *ir.TLSUpstreamConfi
 	var config OpenIDConfig
 	if err = backoff.Retry(func() error {
 		resp, err := client.Get(fmt.Sprintf("%s/.well-known/openid-configuration", issuerURL))
+		// Retry on transport errors
 		if err != nil {
 			return err
 		}
+
 		defer resp.Body.Close()
-		if err = json.NewDecoder(resp.Body).Decode(&config); err != nil {
-			return err
+		switch {
+		// Retry on transient errors
+		case retryable(resp.StatusCode):
+			return fmt.Errorf("transient error fetching openid-configuration from issuer URL: %s, status code: %d", issuerURL, resp.StatusCode)
+		// Do not retry on client errors
+		case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest:
+			return &backoff.PermanentError{Err: fmt.Errorf("failed fetching openid-configuration from issuer URL: %s, status code: %d", issuerURL, resp.StatusCode)}
+		case resp.StatusCode == http.StatusOK:
+			// Do not retry if decoding fails
+			if err = json.NewDecoder(resp.Body).Decode(&config); err != nil {
+				return &backoff.PermanentError{Err: fmt.Errorf("error decoding openid-configuration response: %w", err)}
+			}
+		default:
+			// Do not retry on other status codes
+			return &backoff.PermanentError{Err: fmt.Errorf("unexpected status code %d when fetching openid-configuration from issuer URL: %s", resp.StatusCode, issuerURL)}
 		}
 		return nil
 	}, backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(5*time.Second))); err != nil {
 		return nil, err
 	}
 
+	if err = config.validate(); err != nil {
+		return nil, fmt.Errorf("invalid openid-configuration from issuer URL %s: %w", issuerURL, err)
+	}
+
 	return &config, nil
+}
+
+func retryable(code int) bool {
+	return code >= 500 &&
+		(code != http.StatusNotImplemented &&
+			code != http.StatusHTTPVersionNotSupported &&
+			code != http.StatusNetworkAuthenticationRequired)
 }
 
 // validateTokenEndpoint validates the token endpoint URL

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.out.yaml
@@ -87,8 +87,8 @@ securityPolicies:
         namespace: default
       conditions:
       - lastTransitionTime: null
-        message: 'OIDC: error fetching endpoints from issuer: invalid character ''<''
-          looking for beginning of value.'
+        message: 'OIDC: failed fetching openid-configuration from issuer URL: https://httpbin.org/,
+          status code: 404.'
         reason: Invalid
         status: "False"
         type: Accepted


### PR DESCRIPTION
Found this while debugging https://github.com/envoyproxy/gateway/issues/7295