### PR TITLE
chore: fix 500 response err log

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -294,7 +294,7 @@ func (t *Translator) processHTTPRouteRules(httpRoute *HTTPRouteContext, parentRe
 				t.Logger.Info(
 					"setting 500 direct response in routes due to errors in processing destinations",
 					"routes", sets.List(routesWithDirectResponse),
-					"error", err,
+					"error", processDestinationError,
 				)
 			}
 		// return 503 if endpoints does not exist


### PR DESCRIPTION
Before:

```
2025-10-27T12:42:34.100Z	INFO	gateway-api	gatewayapi/route.go:294	setting 500 direct response in routes due to errors in processing destinations	{"runner": "gateway-api", "routes": ["httproute/default/backend/rule/0/match/0"], "error": null}
```

After:
```
2025-10-27T13:15:17.501Z	INFO	gateway-api	gatewayapi/route.go:294	setting 500 direct response in routes due to errors in processing destinations	{"runner": "gateway-api", "routes": ["httproute/default/backend/rule/0/match/0"], "error": "ClientCertificateRef Secret is not located in the same namespace as Backend. Secret namespace:  does not match Backend namespace: default"}
```