### PR TITLE
docs: added information about configuring External Processing with sidecar support

### DIFF
--- a/site/content/en/latest/tasks/extensibility/ext-proc.md
+++ b/site/content/en/latest/tasks/extensibility/ext-proc.md
@@ -268,7 +268,8 @@ For latency-sensitive use cases, you can deploy the external processing gRPC ser
 This allows communication over `localhost`, which avoids pod-to-pod networking overhead.
 
 ### Step 1: Enable Extension APIs
-Enable the `EnvoyPatchPolicy` and `Backend` APIs in your Envoy Gateway configuration.
+
+Enable the `Backend` APIs in your Envoy Gateway configuration.
 This is done by editing the `envoy-gateway-config` ConfigMap in the `envoy-gateway-system` namespace.
 
 ```yaml
@@ -287,11 +288,11 @@ data:
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
     extensionApis:
-      enableEnvoyPatchPolicy: true
       enableBackend: true
 ```
 
 ### Step 2: Add the Sidecar Container with EnvoyProxy
+
 Use an `EnvoyProxy` resource to patch the Envoy Deployment and include your gRPC service container:
 
 ```yaml

--- a/site/content/en/v1.5/tasks/extensibility/ext-proc.md
+++ b/site/content/en/v1.5/tasks/extensibility/ext-proc.md
@@ -268,7 +268,8 @@ For latency-sensitive use cases, you can deploy the external processing gRPC ser
 This allows communication over `localhost`, which avoids pod-to-pod networking overhead.
 
 ### Step 1: Enable Extension APIs
-Enable the `EnvoyPatchPolicy` and `Backend` APIs in your Envoy Gateway configuration.
+
+Enable the `Backend` APIs in your Envoy Gateway configuration.
 This is done by editing the `envoy-gateway-config` ConfigMap in the `envoy-gateway-system` namespace.
 
 ```yaml
@@ -287,11 +288,11 @@ data:
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
     extensionApis:
-      enableEnvoyPatchPolicy: true
       enableBackend: true
 ```
 
 ### Step 2: Add the Sidecar Container with EnvoyProxy
+
 Use an `EnvoyProxy` resource to patch the Envoy Deployment and include your gRPC service container:
 
 ```yaml


### PR DESCRIPTION
**What type of PR is this?**
docs: Added information about configuring External Processing with sidecar support

**What this PR does / why we need it**:

This PR updates the External Processing documentation to include instructions for running the gRPC ExtProc service as a sidecar container within the Envoy Gateway pod.

**Which issue(s) this PR fixes**:

Fixes #[6526](https://github.com/envoyproxy/gateway/issues/6526)

Release Notes: No
