### PR TITLE
fix: the wrongHTTPRoute status when the EnvoyProxy tls client cert ns is ""

### DIFF
--- a/internal/gatewayapi/backendtlspolicy.go
+++ b/internal/gatewayapi/backendtlspolicy.go
@@ -194,7 +194,7 @@ func (t *Translator) applyEnvoyProxyBackendTLSSetting(tlsConfig *ir.TLSUpstreamC
 		}
 	}
 	if ep.Spec.BackendTLS != nil && ep.Spec.BackendTLS.ClientCertificateRef != nil {
-		ns := string(ptr.Deref(ep.Spec.BackendTLS.ClientCertificateRef.Namespace, ""))
+		ns := string(ptr.Deref(ep.Spec.BackendTLS.ClientCertificateRef.Namespace, "default"))
 
 		var err error
 		if ns != ep.Namespace {


### PR DESCRIPTION
cherry pick for #7342

#7342 includes changes from #7113, which makes it difficult for the release manger to cherry pick.