### PR TITLE
chore: use envoy gateway website instead of httpbin for test

### DIFF
--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.in.yaml
@@ -35,7 +35,7 @@ securityPolicies:
       name: gateway-1
     oidc:
       provider:
-        issuer: "https://httpbin.org/"
+        issuer: "https://gateway.envoyproxy.io"
       clientID: "client1.apps.foo.bar.com"
       clientSecret:
         name: "client1-secret"

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.out.yaml
@@ -73,7 +73,7 @@ securityPolicies:
         kind: null
         name: client1-secret
       provider:
-        issuer: https://httpbin.org/
+        issuer: https://gateway.envoyproxy.io
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway
@@ -87,7 +87,7 @@ securityPolicies:
         namespace: default
       conditions:
       - lastTransitionTime: null
-        message: 'OIDC: failed fetching openid-configuration from issuer URL: https://httpbin.org/,
+        message: 'OIDC: failed fetching openid-configuration from issuer URL: https://gateway.envoyproxy.io,
           status code: 404.'
         reason: Invalid
         status: "False"


### PR DESCRIPTION
> Isaac
  [Today at 4:27 AM](https://envoyproxy.slack.com/archives/C09KHT77402/p1761769666344909)
Is there an alternative to using httpbin in internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.in.yaml? I've been seeing that fail at a high rate recently

