### PR TITLE
chore(examples): fix extensionserver build

### DIFF
--- a/examples/envoy-ext-auth/Makefile
+++ b/examples/envoy-ext-auth/Makefile
@@ -2,6 +2,7 @@
 IMAGE_PREFIX ?= envoyproxy/gateway-
 APP_NAME ?= envoy-ext-auth
 TAG ?= latest
+GO_LDFLAGS ?=
 
 .PHONY: docker-buildx
 docker-buildx:

--- a/examples/extension-server/Makefile
+++ b/examples/extension-server/Makefile
@@ -8,14 +8,15 @@ $(tools.bindir)/%: $(tools.srcdir)/%/pin.go $(tools.srcdir)/%/go.mod
 IMAGE_PREFIX ?= envoyproxy/gateway-
 APP_NAME ?= extension-server
 TAG ?= latest
+GO_LDFLAGS ?=
 
 .PHONY: docker-buildx
-docker-buildx:
-	docker buildx build -f tools/docker/extension-server/Dockerfile . -t $(IMAGE_PREFIX)$(APP_NAME):$(TAG) --build-arg GO_LDFLAGS="$(GO_LDFLAGS)" --load
+docker-buildx: build
+	docker buildx build -f tools/docker/extension-server/Dockerfile . -t $(IMAGE_PREFIX)$(APP_NAME):$(TAG) --load
 
 build: generate manifests
 	mkdir -p bin
-	CGO_ENABLED=0 go build -o bin/extension-server ./cmd/extension-server
+	CGO_ENABLED=0 go build -o bin/extension-server -ldflags "$(GO_LDFLAGS)" ./cmd/extension-server
 
 image: build
 	docker build -t extension-server:latest -f tools/docker/extension-server/Dockerfile .

--- a/examples/extension-server/charts/extension-server/crds/generated/example.extensions.io_listenercontextexamples.yaml
+++ b/examples/extension-server/charts/extension-server/crds/generated/example.extensions.io_listenercontextexamples.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: listenercontextexamples.example.extensions.io
 spec:
   group: example.extensions.io
@@ -17,7 +17,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ListenerContext provides an example extension policy context
+        description: ListenerContextExample provides an example extension policy context
           resource.
         properties:
           apiVersion:

--- a/examples/extension-server/internal/extensionserver/post_cluster_modify.go
+++ b/examples/extension-server/internal/extensionserver/post_cluster_modify.go
@@ -53,7 +53,7 @@ func (s *Server) PostClusterModify(ctx context.Context, req *pb.PostClusterModif
 			s.log.Info("found InferencePool for cluster modification",
 				slog.String("name", pool.GetName()),
 				slog.String("namespace", pool.GetNamespace()),
-				slog.Int("targetPortNumber", int(pool.Spec.TargetPortNumber)))
+				slog.Any("targetPorts", pool.Spec.TargetPorts))
 
 			inferencePoolConfigs = append(inferencePoolConfigs, &pool)
 		}

--- a/examples/extension-server/internal/extensionserver/post_route_modify.go
+++ b/examples/extension-server/internal/extensionserver/post_route_modify.go
@@ -62,7 +62,7 @@ func (s *Server) PostRouteModify(ctx context.Context, req *pb.PostRouteModifyReq
 			s.log.Info("found InferencePool backend",
 				slog.String("name", pool.GetName()),
 				slog.String("namespace", pool.GetNamespace()),
-				slog.Int("targetPortNumber", int(pool.Spec.TargetPortNumber)))
+				slog.Any("targetPorts", pool.Spec.TargetPorts))
 			break
 		}
 	}
@@ -92,7 +92,7 @@ func (s *Server) PostRouteModify(ctx context.Context, req *pb.PostRouteModifyReq
 		slog.String("route_name", modifiedRoute.GetName()),
 		slog.String("inference_pool_name", inferencePool.GetName()),
 		slog.String("inference_pool_namespace", inferencePool.GetNamespace()),
-		slog.Int("target_port", int(inferencePool.Spec.TargetPortNumber)))
+		slog.Any("target_ports", inferencePool.Spec.TargetPorts))
 
 	return &pb.PostRouteModifyResponse{
 		Route: modifiedRoute,

--- a/examples/extension-server/internal/extensionserver/server_test.go
+++ b/examples/extension-server/internal/extensionserver/server_test.go
@@ -32,7 +32,9 @@ func TestPostRouteModify_WithInferencePool(t *testing.T) {
 			"namespace": "default",
 		},
 		"spec": map[string]interface{}{
-			"targetPortNumber": 8000,
+			"targetPorts": []map[string]interface{}{
+				{"number": 8000},
+			},
 			"selector": map[string]interface{}{
 				"app": "vllm-llama3-8b-instruct",
 			},
@@ -188,7 +190,9 @@ func TestPostClusterModify_WithInferencePool(t *testing.T) {
 			"namespace": "default",
 		},
 		"spec": map[string]interface{}{
-			"targetPortNumber": 8000,
+			"targetPorts": []map[string]interface{}{
+				{"number": 8000},
+			},
 			"selector": map[string]interface{}{
 				"app": "vllm-llama3-8b-instruct",
 			},

--- a/examples/grpc-ext-proc/Makefile
+++ b/examples/grpc-ext-proc/Makefile
@@ -2,6 +2,7 @@
 IMAGE_PREFIX ?= envoyproxy/gateway-
 APP_NAME ?= grpc-ext-proc
 TAG ?= latest
+GO_LDFLAGS ?=
 
 .PHONY: docker-buildx
 docker-buildx:

--- a/examples/preserve-case-backend/Makefile
+++ b/examples/preserve-case-backend/Makefile
@@ -2,6 +2,7 @@
 IMAGE_PREFIX ?= envoyproxy/gateway-
 APP_NAME ?= preserve-case-backend
 TAG ?= latest
+GO_LDFLAGS ?=
 
 .PHONY: docker-buildx
 docker-buildx:

--- a/examples/simple-extension-server/Makefile
+++ b/examples/simple-extension-server/Makefile
@@ -2,6 +2,7 @@
 IMAGE_PREFIX ?= envoyproxy/gateway-
 APP_NAME ?= simple-extension-server
 TAG ?= latest
+GO_LDFLAGS ?=
 
 .PHONY: docker-buildx
 docker-buildx:

--- a/examples/static-file-server/Makefile
+++ b/examples/static-file-server/Makefile
@@ -2,6 +2,7 @@
 IMAGE_PREFIX ?= envoyproxy/gateway-
 APP_NAME ?= static-file-server
 TAG ?= latest
+GO_LDFLAGS ?=
 
 .PHONY: docker-buildx
 docker-buildx:


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

Chore

**What this PR does / why we need it**:

Fixes:

```console
$ make build
mkdir -p bin
CGO_ENABLED=0 go build -o bin/extension-server ./cmd/extension-server
# github.com/exampleorg/envoygateway-extension/internal/extensionserver
internal/extensionserver/post_cluster_modify.go:56:48: pool.Spec.TargetPortNumber undefined (type "sigs.k8s.io/gateway-api-inference-extension/api/v1".InferencePoolSpec has no field or method TargetPortNumber)
internal/extensionserver/post_route_modify.go:65:48: pool.Spec.TargetPortNumber undefined (type "sigs.k8s.io/gateway-api-inference-extension/api/v1".InferencePoolSpec has no field or method TargetPortNumber)
internal/extensionserver/post_route_modify.go:95:50: inferencePool.Spec.TargetPortNumber undefined (type "sigs.k8s.io/gateway-api-inference-extension/api/v1".InferencePoolSpec has no field or method TargetPortNumber)
make: *** [Makefile:18: build] Error 1
```

And:

```console
$ make docker-buildx
Makefile:14: warning: undefined variable 'GO_LDFLAGS'
docker buildx build -f tools/docker/extension-server/Dockerfile . -t envoyproxy/gateway-extension-server:latest --build-arg GO_LDFLAGS="" --load
[...]
#5 [2/2] COPY ./bin/extension-server /usr/local/bin/extension-server
#5 ERROR: failed to calculate checksum of ref ac1187db-1850-4397-a0f7-3b6e6ef293d6::9cgc996t9aj67kkk02n8ld2cr: "/bin/extension-server": not found
[...]
```

~Really lacking some basic automated build/lint/test 😅~ Actually #7387 seems to catch it

(I also find a little strange that the port is never used in the cluster configuration)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Follow up to #7389

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
