### PR TITLE
fix: missing onInvalidMessage for ClientTrafficPolicy

### DIFF
--- a/internal/gatewayapi/clienttrafficpolicy.go
+++ b/internal/gatewayapi/clienttrafficpolicy.go
@@ -449,9 +449,11 @@ func (t *Translator) translateClientTrafficPolicyForListener(policy *egv1a1.Clie
 		}
 
 		// Translate HTTP2 Settings
-		if err = translateHTTP2Settings(policy.Spec.HTTP2, httpIR); err != nil {
+		if h2, err := buildIRHTTP2Settings(policy.Spec.HTTP2); err != nil {
 			err = perr.WithMessage(err, "HTTP2")
 			errs = errors.Join(errs, err)
+		} else {
+			httpIR.HTTP2 = h2
 		}
 
 		// enable http3 if set and TLS is enabled
@@ -743,52 +745,6 @@ func translateHTTP1Settings(http1Settings *egv1a1.HTTP1Settings, connection *ir.
 		}
 	}
 	return nil
-}
-
-func translateHTTP2Settings(http2Settings *egv1a1.HTTP2Settings, httpIR *ir.HTTPListener) error {
-	if http2Settings == nil {
-		return nil
-	}
-
-	var (
-		http2 = &ir.HTTP2Settings{}
-		errs  error
-	)
-
-	if http2Settings.InitialStreamWindowSize != nil {
-		initialStreamWindowSize, ok := http2Settings.InitialStreamWindowSize.AsInt64()
-		switch {
-		case !ok:
-			errs = errors.Join(errs, fmt.Errorf("invalid InitialStreamWindowSize value %s", http2Settings.InitialStreamWindowSize.String()))
-		case initialStreamWindowSize < MinHTTP2InitialStreamWindowSize || initialStreamWindowSize > MaxHTTP2InitialStreamWindowSize:
-			errs = errors.Join(errs, fmt.Errorf("InitialStreamWindowSize value %s is out of range, must be between %d and %d",
-				http2Settings.InitialStreamWindowSize.String(),
-				MinHTTP2InitialStreamWindowSize,
-				MaxHTTP2InitialStreamWindowSize))
-		default:
-			http2.InitialStreamWindowSize = ptr.To(uint32(initialStreamWindowSize))
-		}
-	}
-
-	if http2Settings.InitialConnectionWindowSize != nil {
-		initialConnectionWindowSize, ok := http2Settings.InitialConnectionWindowSize.AsInt64()
-		switch {
-		case !ok:
-			errs = errors.Join(errs, fmt.Errorf("invalid InitialConnectionWindowSize value %s", http2Settings.InitialConnectionWindowSize.String()))
-		case initialConnectionWindowSize < MinHTTP2InitialConnectionWindowSize || initialConnectionWindowSize > MaxHTTP2InitialConnectionWindowSize:
-			errs = errors.Join(errs, fmt.Errorf("InitialConnectionWindowSize value %s is out of range, must be between %d and %d",
-				http2Settings.InitialConnectionWindowSize.String(),
-				MinHTTP2InitialConnectionWindowSize,
-				MaxHTTP2InitialConnectionWindowSize))
-		default:
-			http2.InitialConnectionWindowSize = ptr.To(uint32(initialConnectionWindowSize))
-		}
-	}
-
-	http2.MaxConcurrentStreams = http2Settings.MaxConcurrentStreams
-
-	httpIR.HTTP2 = http2
-	return errs
 }
 
 func translateHealthCheckSettings(healthCheckSettings *egv1a1.HealthCheckSettings, httpIR *ir.HTTPListener) {

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-http2.in.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-http2.in.yaml
@@ -9,6 +9,7 @@ clientTrafficPolicies:
       initialStreamWindowSize: 64Ki
       initialConnectionWindowSize: 32Mi
       maxConcurrentStreams: 200
+      onInvalidMessage: TerminateConnection
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-http2.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-http2.out.yaml
@@ -9,6 +9,7 @@ clientTrafficPolicies:
       initialConnectionWindowSize: 32Mi
       initialStreamWindowSize: 64Ki
       maxConcurrentStreams: 200
+      onInvalidMessage: TerminateConnection
     targetRef:
       group: gateway.networking.k8s.io
       kind: Gateway
@@ -191,6 +192,7 @@ xdsIR:
         initialConnectionWindowSize: 65536
         initialStreamWindowSize: 33554432
         maxConcurrentStreams: 200
+        resetStreamOnError: false
       isHTTP2: false
       metadata:
         kind: Gateway
@@ -206,8 +208,6 @@ xdsIR:
       externalPort: 8080
       hostnames:
       - www.example.com
-      http2:
-        maxConcurrentStreams: 200
       isHTTP2: false
       metadata:
         kind: Gateway


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

fix: Bug fix - implements missing functionality for ClientTrafficPolicy HTTP/2 settings

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

This PR implements the missing onInvalidMessage plumbing for ClientTrafficPolicy (CTP), bringing it to feature parity with BackendTrafficPolicy (BTP) and ClusterSettings.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #7021

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes/No
