### PR TITLE
fix: memory leak

### DIFF
--- a/internal/message/types.go
+++ b/internal/message/types.go
@@ -85,6 +85,7 @@ type GatewayAPIStatuses struct {
 }
 
 func (s *GatewayAPIStatuses) Close() {
+	s.GatewayClassStatuses.Close()
 	s.GatewayStatuses.Close()
 	s.HTTPRouteStatuses.Close()
 	s.GRPCRouteStatuses.Close()
@@ -116,6 +117,7 @@ type ExtensionStatuses struct {
 
 func (p *PolicyStatuses) Close() {
 	p.ClientTrafficPolicyStatuses.Close()
+	p.BackendTrafficPolicyStatuses.Close()
 	p.SecurityPolicyStatuses.Close()
 	p.EnvoyPatchPolicyStatuses.Close()
 	p.BackendTLSPolicyStatuses.Close()


### PR DESCRIPTION
**What type of PR is this?**

Bugfix.

**What this PR does / why we need it**:

Two watchable.Maps were never closed when shutting down the provider:
- GatewayClassStatuses.Close() - missing in GatewayAPIStatuses.Close()
- BackendTrafficPolicyStatuses.Close() - missing in PolicyStatuses.Close()

Each unclosed map leaked 3 goroutines:
1. Internal watchable.Map.coalesce goroutine
2. HandleSubscription goroutine blocked on channel read
3. Error handler goroutine blocked on channel read

**Which issue(s) this PR fixes**:

N/A

Release Notes: TODO.

--

<details>
<summary>Click to expand the goleak-based test that reproduced the issue.</summary>

```go
// Copyright Envoy Gateway Authors
// SPDX-License-Identifier: Apache-2.0
// The full text of the Apache license is available in the LICENSE file at
// the root of the repo.

package message_test

import (
	"context"
	"testing"
	"time"

	"go.uber.org/goleak"
	"k8s.io/apimachinery/pkg/types"
	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"

	"github.com/envoyproxy/gateway/internal/message"
)

func TestMain(m *testing.M) {
	goleak.VerifyTestMain(m)
}

// TestGatewayAPIStatuses_ProperClose verifies proper cleanup of all status maps.
// This test would detect goroutine leaks if GatewayClassStatuses.Close() was missing.
func TestGatewayAPIStatuses_ProperClose(t *testing.T) {
	defer goleak.VerifyNone(t)

	statuses := &message.GatewayAPIStatuses{}

	subscription := statuses.GatewayClassStatuses.Subscribe(context.Background())

	go func() {
		statuses.GatewayClassStatuses.Store(
			types.NamespacedName{Name: "test-class"},
			&gwapiv1.GatewayClassStatus{},
		)
		time.Sleep(50 * time.Millisecond)
	}()

	done := make(chan struct{})
	go func() {
		defer close(done)
		message.HandleSubscription(
			message.Metadata{Runner: "test", Message: "test"},
			subscription,
			func(update message.Update[types.NamespacedName, *gwapiv1.GatewayClassStatus], errChans chan error) {
				// Process update
			},
		)
	}()

	time.Sleep(100 * time.Millisecond)

	// Properly close all statuses including GatewayClassStatuses
	statuses.Close()

	// Wait for goroutine to exit
	<-done
}

// TestPolicyStatuses_ProperClose verifies proper cleanup of all policy status maps.
// This test would detect goroutine leaks if BackendTrafficPolicyStatuses.Close() was missing.
func TestPolicyStatuses_ProperClose(t *testing.T) {
	defer goleak.VerifyNone(t)

	statuses := &message.PolicyStatuses{}

	subscription := statuses.BackendTrafficPolicyStatuses.Subscribe(context.Background())

	go func() {
		statuses.BackendTrafficPolicyStatuses.Store(
			types.NamespacedName{Name: "test-policy", Namespace: "default"},
			&gwapiv1.PolicyStatus{},
		)
		time.Sleep(50 * time.Millisecond)
	}()

	done := make(chan struct{})
	go func() {
		defer close(done)
		message.HandleSubscription(
			message.Metadata{Runner: "test", Message: "test"},
			subscription,
			func(update message.Update[types.NamespacedName, *gwapiv1.PolicyStatus], errChans chan error) {
				// Process update
			},
		)
	}()

	time.Sleep(100 * time.Millisecond)

	// Properly close all statuses including BackendTrafficPolicyStatuses
	statuses.Close()

	// Wait for goroutine to exit
	<-done
}
```
</details>