### PR TITLE
set default cpu limit for envoy-gateway

### DIFF
--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -41,6 +41,7 @@ deployment:
     imagePullSecrets: []
     resources:
       limits:
+        cpu: "1"
         memory: 1024Mi
       requests:
         cpu: 100m


### PR DESCRIPTION
We have already set the default memory limit, so we should also set the default CPU limit.