### PR TITLE
 fix: merge xRoute/xPolicy statuses across controllers in provider runner

### DIFF
--- a/internal/gatewayapi/extensionserverpolicy_test.go
+++ b/internal/gatewayapi/extensionserverpolicy_test.go
@@ -123,3 +123,115 @@ func TestExtractTargetRefs(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeAncestorsForExtensionServerPolicies(t *testing.T) {
+	tests := []struct {
+		aggStatus *gwapiv1.PolicyStatus
+		newStatus *gwapiv1.PolicyStatus
+		noStatus  bool
+	}{
+		{
+			aggStatus: &gwapiv1.PolicyStatus{
+				Ancestors: []gwapiv1.PolicyAncestorStatus{
+					{
+						AncestorRef: gwapiv1.ParentReference{
+							Name: "gateway-1",
+						},
+					},
+				},
+			},
+			newStatus: &gwapiv1.PolicyStatus{
+				Ancestors: []gwapiv1.PolicyAncestorStatus{
+					{
+						AncestorRef: gwapiv1.ParentReference{
+							Name: "gateway-2",
+						},
+					},
+				},
+			},
+		},
+		{
+			aggStatus: &gwapiv1.PolicyStatus{},
+			newStatus: &gwapiv1.PolicyStatus{
+				Ancestors: []gwapiv1.PolicyAncestorStatus{
+					{
+						AncestorRef: gwapiv1.ParentReference{
+							Name: "gateway-2",
+						},
+					},
+				},
+			},
+		},
+		{
+			aggStatus: &gwapiv1.PolicyStatus{
+				Ancestors: []gwapiv1.PolicyAncestorStatus{
+					{
+						AncestorRef: gwapiv1.ParentReference{
+							Name: "gateway-1",
+						},
+					},
+				},
+			},
+			newStatus: &gwapiv1.PolicyStatus{},
+		},
+		{
+			aggStatus: &gwapiv1.PolicyStatus{},
+			newStatus: &gwapiv1.PolicyStatus{},
+		},
+		{
+			aggStatus: nil,
+			newStatus: &gwapiv1.PolicyStatus{
+				Ancestors: []gwapiv1.PolicyAncestorStatus{
+					{
+						AncestorRef: gwapiv1.ParentReference{
+							Name: "gateway-1",
+						},
+					},
+				},
+			},
+		},
+		{
+			aggStatus: &gwapiv1.PolicyStatus{
+				Ancestors: []gwapiv1.PolicyAncestorStatus{
+					{
+						AncestorRef: gwapiv1.ParentReference{
+							Name: "gateway-1",
+						},
+					},
+				},
+			},
+			newStatus: nil,
+		},
+		{
+			aggStatus: nil,
+			newStatus: nil,
+		},
+	}
+
+	for _, test := range tests {
+		aggPolicy := unstructured.Unstructured{Object: make(map[string]interface{})}
+		newPolicy := unstructured.Unstructured{Object: make(map[string]interface{})}
+		desiredMergedStatus := gwapiv1.PolicyStatus{}
+
+		// aggStatus == nil, means simulate not setting status at all within the policy.
+		if test.aggStatus != nil {
+			aggPolicy.Object["status"] = PolicyStatusToUnstructured(*test.aggStatus)
+			desiredMergedStatus.Ancestors = append(desiredMergedStatus.Ancestors, test.aggStatus.Ancestors...)
+		}
+
+		// newStatus == nil, means simulate not setting status at all within the policy.
+		if test.newStatus != nil {
+			newPolicy.Object["status"] = PolicyStatusToUnstructured(*test.newStatus)
+			desiredMergedStatus.Ancestors = append(desiredMergedStatus.Ancestors, test.newStatus.Ancestors...)
+		}
+
+		MergeAncestorsForExtensionServerPolicies(&aggPolicy, &newPolicy)
+
+		// The product object will always have an existing `status`, even if with 0 ancestors.
+		newAggPolicy := ExtServerPolicyStatusAsPolicyStatus(&aggPolicy)
+		require.Len(t, newAggPolicy.Ancestors, len(desiredMergedStatus.Ancestors))
+		for i := range newAggPolicy.Ancestors {
+			require.Equal(t, desiredMergedStatus.Ancestors[i].AncestorRef.Name, newAggPolicy.Ancestors[i].AncestorRef.Name)
+		}
+	}
+}

--- a/test/e2e/testdata/policy-status-cleanup-multiple-ancestors-multiple-gwcs.yaml
+++ b/test/e2e/testdata/policy-status-cleanup-multiple-ancestors-multiple-gwcs.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: backendtrafficpolicy-multiple-ancestors-same-gwc
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: same-namespace
+  # This gateway (and its gatewayclass) is created through `status-cleanup-gateway-different-gwc.yaml` manifest.
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway-2

--- a/test/e2e/testdata/policy-status-cleanup-multiple-ancestors-same-gwc.yaml
+++ b/test/e2e/testdata/policy-status-cleanup-multiple-ancestors-same-gwc.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: backendtrafficpolicy-multiple-ancestors-same-gwc
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: same-namespace
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: all-namespaces

--- a/test/e2e/testdata/policy-status-cleanup-no-ancestor.yaml
+++ b/test/e2e/testdata/policy-status-cleanup-no-ancestor.yaml
@@ -1,0 +1,10 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: backendtrafficpolicy-multiple-ancestors-same-gwc
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: other-controller-ancestor

--- a/test/e2e/testdata/policy-status-cleanup-single-ancestor.yaml
+++ b/test/e2e/testdata/policy-status-cleanup-single-ancestor.yaml
@@ -1,0 +1,10 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: backendtrafficpolicy-multiple-ancestors-same-gwc
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: same-namespace

--- a/test/e2e/testdata/route-status-cleanup-multiple-parents-multiple-gwcs.yaml
+++ b/test/e2e/testdata/route-status-cleanup-multiple-parents-multiple-gwcs.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-1
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: foo
+    protocol: TCP
+    port: 8080
+    allowedRoutes:
+      kinds:
+      - kind: TCPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: tcp-route-status-cleanup
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-1
+    sectionName: foo
+  # This gateway (and its gatewayclass) is created through `status-cleanup-gateway-different-gwc.yaml` manifest.
+  - name: gateway-2
+    sectionName: foo
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/test/e2e/testdata/route-status-cleanup-multiple-parents-same-gwc.yaml
+++ b/test/e2e/testdata/route-status-cleanup-multiple-parents-same-gwc.yaml
@@ -1,0 +1,45 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-1
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: foo
+    protocol: TCP
+    port: 8080
+    allowedRoutes:
+      kinds:
+      - kind: TCPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-2
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: foo
+    protocol: TCP
+    port: 8080
+    allowedRoutes:
+      kinds:
+      - kind: TCPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: tcp-route-status-cleanup
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-1
+    sectionName: foo
+  - name: gateway-2
+    sectionName: foo
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/test/e2e/testdata/route-status-cleanup-single-parent.yaml
+++ b/test/e2e/testdata/route-status-cleanup-single-parent.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: tcp-route-status-cleanup
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-1
+    sectionName: foo
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/test/e2e/testdata/status-cleanup-gateway-different-gwc.yaml
+++ b/test/e2e/testdata/status-cleanup-gateway-different-gwc.yaml
@@ -1,0 +1,34 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: status-cleanup
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-2
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: status-cleanup
+  listeners:
+  - name: foo
+    protocol: TCP
+    port: 8080
+    allowedRoutes:
+      kinds:
+      - kind: TCPRoute
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: status-cleanup
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: status-cleanup
+  namespace: gateway-conformance-infra
+spec:
+  ipFamily: IPv4

--- a/test/e2e/tests/policy_status_cleanup.go
+++ b/test/e2e/tests/policy_status_cleanup.go
@@ -1,0 +1,169 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+//go:build e2e
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/gatewayapi"
+	"github.com/envoyproxy/gateway/internal/gatewayapi/resource"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, PolicyStatusCleanupSameGatewayClass, PolicyStatusCleanupMultipleGatewayClasses)
+}
+
+var PolicyStatusCleanupSameGatewayClass = suite.ConformanceTest{
+	ShortName:   "PolicyStatusCleanupSameGatewayClass",
+	Description: "Testing Policy Status Cleanup With Ancestors of The Same GatewayClass",
+	Manifests:   []string{"testdata/policy-status-cleanup-multiple-ancestors-same-gwc.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		t.Run("PolicyStatusCleanup", func(t *testing.T) {
+			ns := "gateway-conformance-infra"
+			gw1NN, gw2NN := types.NamespacedName{Name: "same-namespace", Namespace: ns}, types.NamespacedName{Name: "all-namespaces", Namespace: ns}
+
+			policyNamespacedName := types.NamespacedName{Name: "backendtrafficpolicy-multiple-ancestors-same-gwc", Namespace: ns}
+
+			// Check the policy has two ancestors in its status.
+			BackendTrafficPolicyMustBeAcceptedByAllAncestors(t,
+				suite.Client,
+				policyNamespacedName,
+				suite.ControllerName,
+				gwapiv1.ParentReference{
+					Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+					Kind:      gatewayapi.KindPtr(resource.KindGateway),
+					Namespace: gatewayapi.NamespacePtr(gw1NN.Namespace),
+					Name:      gwapiv1.ObjectName(gw1NN.Name),
+				},
+				gwapiv1.ParentReference{
+					Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+					Kind:      gatewayapi.KindPtr(resource.KindGateway),
+					Namespace: gatewayapi.NamespacePtr(gw2NN.Namespace),
+					Name:      gwapiv1.ObjectName(gw2NN.Name),
+				},
+			)
+
+			// Change the policy to have a single ancestor, and check its status.
+			suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, "testdata/policy-status-cleanup-single-ancestor.yaml", false)
+			BackendTrafficPolicyMustBeAcceptedByAllAncestors(t,
+				suite.Client,
+				policyNamespacedName,
+				suite.ControllerName,
+				gwapiv1.ParentReference{
+					Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+					Kind:      gatewayapi.KindPtr(resource.KindGateway),
+					Namespace: gatewayapi.NamespacePtr(gw1NN.Namespace),
+					Name:      gwapiv1.ObjectName(gw1NN.Name),
+				},
+			)
+
+			// Update the policy status to include a status ancestor of another controller.
+			policy := &egv1a1.BackendTrafficPolicy{}
+			err := suite.Client.Get(context.Background(), policyNamespacedName, policy)
+			require.NoErrorf(t, err, "error getting BackendTrafficPolicy %s", policyNamespacedName.String())
+			otherControllerAncestor := gwapiv1.PolicyAncestorStatus{
+				AncestorRef: gwapiv1.ParentReference{
+					Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+					Kind:      gatewayapi.KindPtr(resource.KindGateway),
+					Name:      "other-controller-ancestor",
+					Namespace: gatewayapi.NamespacePtr(policy.Namespace),
+				},
+				ControllerName: "gateway.envoyproxy.io/other-gatewayclass-controller",
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(gwapiv1.PolicyConditionAccepted),
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(time.Now()),
+						Reason:             string(gwapiv1.PolicyConditionAccepted),
+					},
+				},
+			}
+			policy.Status.Ancestors = append(policy.Status.Ancestors, otherControllerAncestor)
+			err = suite.Client.Status().Update(context.Background(), policy)
+			require.NoErrorf(t, err, "error updating BackendTrafficPolicy status %s", policyNamespacedName.String())
+
+			// Change the policy spec to have a corresponding ancestor and trigger reconciliation.
+			suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, "testdata/policy-status-cleanup-no-ancestor.yaml", false)
+
+			// Check its status to only have the ancestor from the other controller.
+			BackendTrafficPolicyMustBeAcceptedByAllAncestors(t,
+				suite.Client,
+				policyNamespacedName,
+				"gateway.envoyproxy.io/other-gatewayclass-controller",
+				[]gwapiv1.ParentReference{
+					{
+						Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+						Kind:      gatewayapi.KindPtr(resource.KindGateway),
+						Name:      "other-controller-ancestor",
+						Namespace: gatewayapi.NamespacePtr(policy.Namespace),
+					},
+				}...,
+			)
+		})
+	},
+}
+
+var PolicyStatusCleanupMultipleGatewayClasses = suite.ConformanceTest{
+	ShortName:   "PolicyStatusCleanupMultipleGatewayClasses",
+	Description: "Testing Policy Status Cleanup With Ancestors of Multiple GatewayClasses",
+	Manifests:   []string{"testdata/policy-status-cleanup-multiple-ancestors-multiple-gwcs.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		t.Run("PolicyStatusCleanup", func(t *testing.T) {
+			// Create the second gateway of a different gatewayclass, which the backendtrafficpolicy is already attached to.
+			prevGwc := suite.Applier.GatewayClass
+			suite.Applier.GatewayClass = "status-cleanup"
+			suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, "testdata/status-cleanup-gateway-different-gwc.yaml", true)
+			suite.Applier.GatewayClass = prevGwc
+
+			ns := "gateway-conformance-infra"
+			gw1NN, gw2NN := types.NamespacedName{Name: "same-namespace", Namespace: ns}, types.NamespacedName{Name: "gateway-2", Namespace: ns}
+
+			// Check the policy has two ancestors in its status.
+			BackendTrafficPolicyMustBeAcceptedByAllAncestors(t,
+				suite.Client,
+				types.NamespacedName{Name: "backendtrafficpolicy-multiple-ancestors-same-gwc", Namespace: ns},
+				suite.ControllerName,
+				gwapiv1.ParentReference{
+					Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+					Kind:      gatewayapi.KindPtr(resource.KindGateway),
+					Namespace: gatewayapi.NamespacePtr(gw1NN.Namespace),
+					Name:      gwapiv1.ObjectName(gw1NN.Name),
+				},
+				gwapiv1.ParentReference{
+					Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+					Kind:      gatewayapi.KindPtr(resource.KindGateway),
+					Namespace: gatewayapi.NamespacePtr(gw2NN.Namespace),
+					Name:      gwapiv1.ObjectName(gw2NN.Name),
+				},
+			)
+
+			// Change the policy to have a single ancestor, and check its status.
+			suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, "testdata/policy-status-cleanup-single-ancestor.yaml", false)
+			BackendTrafficPolicyMustBeAcceptedByAllAncestors(t,
+				suite.Client,
+				types.NamespacedName{Name: "backendtrafficpolicy-multiple-ancestors-same-gwc", Namespace: ns},
+				suite.ControllerName,
+				gwapiv1.ParentReference{
+					Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+					Kind:      gatewayapi.KindPtr(resource.KindGateway),
+					Namespace: gatewayapi.NamespacePtr(gw1NN.Namespace),
+					Name:      gwapiv1.ObjectName(gw1NN.Name),
+				},
+			)
+		})
+	},
+}

--- a/test/e2e/tests/route_status_cleanup.go
+++ b/test/e2e/tests/route_status_cleanup.go
@@ -1,0 +1,105 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+// This file contains code derived from upstream gateway-api, it will be moved to upstream.
+
+//go:build e2e
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, RouteStatusCleanupSameGatewayClass, RouteStatusCleanupMultipleGatewayClasses)
+}
+
+var RouteStatusCleanupSameGatewayClass = suite.ConformanceTest{
+	ShortName:   "RouteStatusCleanupSameGatewayClass",
+	Description: "Testing Route Status Cleanup With Parents of The Same GatewayClass",
+	Manifests:   []string{"testdata/route-status-cleanup-multiple-parents-same-gwc.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		t.Run("RouteStatusCleanup", func(t *testing.T) {
+			ns := "gateway-conformance-infra"
+			routeNN := types.NamespacedName{Name: "tcp-route-status-cleanup", Namespace: ns}
+			gw1NN, gw2NN := types.NamespacedName{Name: "gateway-1", Namespace: ns}, types.NamespacedName{Name: "gateway-2", Namespace: ns}
+			gwRefs := []GatewayRef{NewGatewayRef(gw1NN), NewGatewayRef(gw2NN)}
+			gwAddrs := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, gwRefs, routeNN)
+			OkResp := http.ExpectedResponse{
+				Request: http.Request{
+					Path: "/",
+				},
+				Response: http.Response{
+					StatusCodes: []int{200},
+				},
+				Namespace: ns,
+			}
+
+			// Send a request to an valid path and expect a successful response
+			require.Len(t, gwAddrs, 2)
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddrs[0], OkResp)
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddrs[1], OkResp)
+
+			// Change the route to have a single parent, and check its status
+			suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, "testdata/route-status-cleanup-single-parent.yaml", false)
+			gwRefs = []GatewayRef{NewGatewayRef(gw1NN)}
+			gwAddrs = GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, gwRefs, routeNN)
+
+			// Send a request to an valid path and expect a successful response
+			require.Len(t, gwAddrs, 1)
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddrs[0], OkResp)
+		})
+	},
+}
+
+var RouteStatusCleanupMultipleGatewayClasses = suite.ConformanceTest{
+	ShortName:   "RouteStatusCleanupMultipleGatewayClasses",
+	Description: "Testing Route Status Cleanup With Parents of Multiple GatewayClasses",
+	Manifests:   []string{"testdata/route-status-cleanup-multiple-parents-multiple-gwcs.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		t.Run("RouteStatusCleanup", func(t *testing.T) {
+			// Create the second gateway of a different gatewayclass, which the route is already attached to.
+			prevGwc := suite.Applier.GatewayClass
+			suite.Applier.GatewayClass = "status-cleanup"
+			suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, "testdata/status-cleanup-gateway-different-gwc.yaml", true)
+			suite.Applier.GatewayClass = prevGwc
+
+			ns := "gateway-conformance-infra"
+			routeNN := types.NamespacedName{Name: "tcp-route-status-cleanup", Namespace: ns}
+			gw1NN, gw2NN := types.NamespacedName{Name: "gateway-1", Namespace: ns}, types.NamespacedName{Name: "gateway-2", Namespace: ns}
+			gwRefs := []GatewayRef{NewGatewayRef(gw1NN), NewGatewayRef(gw2NN)}
+			gwAddrs := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, gwRefs, routeNN)
+			OkResp := http.ExpectedResponse{
+				Request: http.Request{
+					Path: "/",
+				},
+				Response: http.Response{
+					StatusCodes: []int{200},
+				},
+				Namespace: ns,
+			}
+
+			// Send a request to an valid path and expect a successful response
+			require.Len(t, gwAddrs, 2)
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddrs[0], OkResp)
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddrs[1], OkResp)
+
+			// Change the route to have a single parent, and check its status
+			suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, "testdata/route-status-cleanup-single-parent.yaml", false)
+			gwRefs = []GatewayRef{NewGatewayRef(gw1NN)}
+			gwAddrs = GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, gwRefs, routeNN)
+
+			// Send a request to an valid path and expect a successful response
+			require.Len(t, gwAddrs, 1)
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddrs[0], OkResp)
+		})
+	},
+}

--- a/test/e2e/tests/stat_name.go
+++ b/test/e2e/tests/stat_name.go
@@ -121,7 +121,7 @@ var TCPRouteStatNameTest = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "tcp-route-stat-name", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "tcp-stat-name-backend-gateway", Namespace: ns}
-		gwAddr := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, NewGatewayRef(gwNN), routeNN)
+		gwAddrs := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, []GatewayRef{NewGatewayRef(gwNN)}, routeNN)
 
 		t.Run("prometheus", func(t *testing.T) {
 			expectedResponse := httputils.ExpectedResponse{
@@ -135,7 +135,7 @@ var TCPRouteStatNameTest = suite.ConformanceTest{
 			}
 
 			// make sure listener is ready
-			httputils.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
+			httputils.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddrs[0], expectedResponse)
 			verifyMetrics(t, suite, `envoy_tcp_downstream_cx_total{envoy_tcp_prefix="gateway-conformance-infra/tcp-route-stat-name"}`)
 		})
 	},

--- a/test/e2e/tests/tcproute.go
+++ b/test/e2e/tests/tcproute.go
@@ -44,7 +44,8 @@ var TCPRouteTest = suite.ConformanceTest{
 			ns := "gateway-conformance-infra"
 			routeNN := types.NamespacedName{Name: "tcp-app-1", Namespace: ns}
 			gwNN := types.NamespacedName{Name: "my-tcp-gateway", Namespace: ns}
-			gwAddr := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, NewGatewayRef(gwNN), routeNN)
+			gwRefs := []GatewayRef{NewGatewayRef(gwNN)}
+			gwAddrs := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, gwRefs, routeNN)
 			OkResp := http.ExpectedResponse{
 				Request: http.Request{
 					Path: "/",
@@ -56,13 +57,15 @@ var TCPRouteTest = suite.ConformanceTest{
 			}
 
 			// Send a request to an valid path and expect a successful response
-			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, OkResp)
+			require.Len(t, gwAddrs, 1)
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddrs[0], OkResp)
 		})
 		t.Run("tcp-route-2", func(t *testing.T) {
 			ns := "gateway-conformance-infra"
 			routeNN := types.NamespacedName{Name: "tcp-app-2", Namespace: ns}
 			gwNN := types.NamespacedName{Name: "my-tcp-gateway", Namespace: ns}
-			gwAddr := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, NewGatewayRef(gwNN), routeNN)
+			gwRefs := []GatewayRef{NewGatewayRef(gwNN)}
+			gwAddrs := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, gwRefs, routeNN)
 			OkResp := http.ExpectedResponse{
 				Request: http.Request{
 					Path: "/",
@@ -74,7 +77,8 @@ var TCPRouteTest = suite.ConformanceTest{
 			}
 
 			// Send a request to a valid path and expect a successful response
-			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, OkResp)
+			require.Len(t, gwAddrs, 1)
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddrs[0], OkResp)
 		})
 	},
 }
@@ -101,9 +105,9 @@ var TCPMTLSRouteTest = suite.ConformanceTest{
 		validPolicyNN := types.NamespacedName{Name: "tls-backend-policy", Namespace: ns}
 		kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, validPolicyNN, gwNN, acceptedCond)
 		kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, validPolicyNN, gwNN, resolvedRefsCond)
-		gwAddr := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, NewGatewayRef(gwNN), routeNN)
+		gwAddrs := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, []GatewayRef{NewGatewayRef(gwNN)}, routeNN)
 
-		http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+		http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddrs[0], http.ExpectedResponse{
 			Request: http.Request{
 				Path: "/",
 			},
@@ -115,7 +119,7 @@ var TCPMTLSRouteTest = suite.ConformanceTest{
 	},
 }
 
-func GatewayAndTCPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutConfig *config.TimeoutConfig, controllerName string, gw GatewayRef, routeNNs ...types.NamespacedName) string {
+func GatewayAndTCPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutConfig *config.TimeoutConfig, controllerName string, gws []GatewayRef, routeNNs ...types.NamespacedName) []string {
 	t.Helper()
 
 	if timeoutConfig == nil {
@@ -127,44 +131,47 @@ func GatewayAndTCPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutCon
 	if err != nil {
 		tlog.Logf(t, "error fetching TCPRoute: %v", err)
 	}
-	sectionName := ""
-	if tcpRoute.Spec.ParentRefs[0].SectionName != nil {
-		sectionName = string(*tcpRoute.Spec.ParentRefs[0].SectionName)
-	}
-	gwAddr, err := WaitForGatewayAddress(t, c, timeoutConfig, gw.NamespacedName, sectionName)
-	require.NoErrorf(t, err, "timed out waiting for Gateway address to be assigned")
 
-	ns := gwapiv1.Namespace(gw.Namespace)
-	kind := gwapiv1.Kind("Gateway")
+	gwAddrs := make([]string, 0, len(gws))
+	for _, gw := range gws {
+		sectionName := ""
+		if tcpRoute.Spec.ParentRefs[0].SectionName != nil {
+			sectionName = string(*tcpRoute.Spec.ParentRefs[0].SectionName)
+		}
+		gwAddr, err := WaitForGatewayAddress(t, c, timeoutConfig, gw.NamespacedName, sectionName)
+		require.NoErrorf(t, err, "timed out waiting for Gateway address to be assigned")
+		gwAddrs = append(gwAddrs, gwAddr)
+	}
 
 	for _, routeNN := range routeNNs {
-		namespaceRequired := true
-		if routeNN.Namespace == gw.Namespace {
-			namespaceRequired = false
-		}
-
 		var parents []gwapiv1.RouteParentStatus
-		for _, listener := range gw.listenerNames {
-			parents = append(parents, gwapiv1.RouteParentStatus{
-				ParentRef: gwapiv1.ParentReference{
-					Group:       (*gwapiv1.Group)(&gwapiv1.GroupVersion.Group),
-					Kind:        &kind,
-					Name:        gwapiv1.ObjectName(gw.Name),
-					Namespace:   &ns,
-					SectionName: listener,
-				},
-				ControllerName: gwapiv1.GatewayController(controllerName),
-				Conditions: []metav1.Condition{{
-					Type:   string(gwapiv1.RouteConditionAccepted),
-					Status: metav1.ConditionTrue,
-					Reason: string(gwapiv1.RouteReasonAccepted),
-				}},
-			})
+		var namespaceRequired []bool
+		for _, gw := range gws {
+			ns := gwapiv1.Namespace(gw.Namespace)
+			kind := gwapiv1.Kind("Gateway")
+			namespaceRequired = append(namespaceRequired, routeNN.Namespace != gw.Namespace)
+			for _, listener := range gw.listenerNames {
+				parents = append(parents, gwapiv1.RouteParentStatus{
+					ParentRef: gwapiv1.ParentReference{
+						Group:       (*gwapiv1.Group)(&gwapiv1.GroupVersion.Group),
+						Kind:        &kind,
+						Name:        gwapiv1.ObjectName(gw.Name),
+						Namespace:   &ns,
+						SectionName: listener,
+					},
+					ControllerName: gwapiv1.GatewayController(controllerName),
+					Conditions: []metav1.Condition{{
+						Type:   string(gwapiv1.RouteConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: string(gwapiv1.RouteReasonAccepted),
+					}},
+				})
+			}
 		}
 		TCPRouteMustHaveParents(t, c, timeoutConfig, routeNN, parents, namespaceRequired)
 	}
 
-	return gwAddr
+	return gwAddrs
 }
 
 // WaitForGatewayAddress waits until at least one IP Address has been set in the
@@ -213,7 +220,7 @@ func WaitForGatewayAddress(t *testing.T, client client.Client, timeoutConfig *co
 	return net.JoinHostPort(ipAddr, port), waitErr
 }
 
-func TCPRouteMustHaveParents(t *testing.T, client client.Client, timeoutConfig *config.TimeoutConfig, routeName types.NamespacedName, parents []gwapiv1.RouteParentStatus, namespaceRequired bool) {
+func TCPRouteMustHaveParents(t *testing.T, client client.Client, timeoutConfig *config.TimeoutConfig, routeName types.NamespacedName, parents []gwapiv1.RouteParentStatus, namespaceRequired []bool) {
 	t.Helper()
 
 	if timeoutConfig == nil {

--- a/test/e2e/tests/tcproute_authorization_client_ip.go
+++ b/test/e2e/tests/tcproute_authorization_client_ip.go
@@ -36,7 +36,7 @@ var TCPRouteAuthzWithClientIP = suite.ConformanceTest{
 		tcpRouteNN := types.NamespacedName{Name: "tcp-backend-authorization-ip", Namespace: ns}
 		tcpRouteFqdnNN := types.NamespacedName{Name: "tcp-backend-authorization-fqdn", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "tcp-authorization-backend", Namespace: ns}
-		GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, NewGatewayRef(gwNN), tcpRouteNN, tcpRouteFqdnNN)
+		GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, []GatewayRef{NewGatewayRef(gwNN)}, tcpRouteNN, tcpRouteFqdnNN)
 
 		// Test the blocked route (ip section)
 		ipSection := gwapiv1.SectionName("ip")
@@ -74,10 +74,10 @@ func testTCPRouteWithBackendBlocked(t *testing.T, suite *suite.ConformanceTestSu
 	ns := "gateway-conformance-infra"
 	routeNN := types.NamespacedName{Name: routeName, Namespace: ns}
 	gwNN := types.NamespacedName{Name: gwName, Namespace: ns}
-	gwAddr := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, NewGatewayRef(gwNN), routeNN)
+	gwAddr := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, []GatewayRef{NewGatewayRef(gwNN)}, routeNN)
 	BackendMustBeAccepted(t, suite.Client, types.NamespacedName{Name: backendName, Namespace: ns})
 
-	testTCPConnectionBlocked(t, gwAddr)
+	testTCPConnectionBlocked(t, gwAddr[0])
 }
 
 func testTCPConnectionBlocked(t *testing.T, gwAddr string) {

--- a/test/e2e/tests/tcproute_with_backend.go
+++ b/test/e2e/tests/tcproute_with_backend.go
@@ -12,6 +12,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
@@ -61,7 +62,7 @@ func testTCPRouteWithBackend(t *testing.T, suite *suite.ConformanceTestSuite, gw
 	ns := "gateway-conformance-infra"
 	routeNN := types.NamespacedName{Name: routeName, Namespace: ns}
 	gwNN := types.NamespacedName{Name: gwName, Namespace: ns}
-	gwAddr := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, NewGatewayRef(gwNN), routeNN)
+	gwAddrs := GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, &suite.TimeoutConfig, suite.ControllerName, []GatewayRef{NewGatewayRef(gwNN)}, routeNN)
 	BackendMustBeAccepted(t, suite.Client, types.NamespacedName{Name: backendName, Namespace: ns})
 	OkResp := http.ExpectedResponse{
 		Request: http.Request{
@@ -74,5 +75,6 @@ func testTCPRouteWithBackend(t *testing.T, suite *suite.ConformanceTestSuite, gw
 	}
 
 	// Send a request to a valid path and expect a successful response
-	http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, OkResp)
+	require.Len(t, gwAddrs, 1)
+	http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddrs[0], OkResp)
 }

--- a/test/e2e/tests/udproute.go
+++ b/test/e2e/tests/udproute.go
@@ -136,13 +136,13 @@ func GatewayAndUDPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutCon
 				},
 			})
 		}
-		UDPRouteMustHaveParents(t, c, timeoutConfig, routeNN, parents, namespaceRequired)
+		UDPRouteMustHaveParents(t, c, timeoutConfig, routeNN, parents, []bool{namespaceRequired})
 	}
 
 	return gwAddr
 }
 
-func UDPRouteMustHaveParents(t *testing.T, client client.Client, timeoutConfig *config.TimeoutConfig, routeName types.NamespacedName, parents []gwapiv1.RouteParentStatus, namespaceRequired bool) {
+func UDPRouteMustHaveParents(t *testing.T, client client.Client, timeoutConfig *config.TimeoutConfig, routeName types.NamespacedName, parents []gwapiv1.RouteParentStatus, namespaceRequired []bool) {
 	t.Helper()
 
 	if timeoutConfig == nil {
@@ -163,7 +163,7 @@ func UDPRouteMustHaveParents(t *testing.T, client client.Client, timeoutConfig *
 	require.NoErrorf(t, waitErr, "error waiting for UDPRoute to have parents matching expectations")
 }
 
-func parentsForRouteMatch(t *testing.T, routeName types.NamespacedName, expected, actual []gwapiv1.RouteParentStatus, namespaceRequired bool) bool {
+func parentsForRouteMatch(t *testing.T, routeName types.NamespacedName, expected, actual []gwapiv1.RouteParentStatus, namespaceRequired []bool) bool {
 	t.Helper()
 
 	if len(expected) != len(actual) {
@@ -190,7 +190,7 @@ func parentsForRouteMatch(t *testing.T, routeName types.NamespacedName, expected
 			return false
 		}
 		if !reflect.DeepEqual(actualParent.ParentRef.Namespace, expectedParent.ParentRef.Namespace) {
-			if namespaceRequired || actualParent.ParentRef.Namespace != nil {
+			if namespaceRequired[i] || actualParent.ParentRef.Namespace != nil {
 				tlog.Logf(t, "Route %s/%s expected ParentReference.Namespace to be %v, got %v", routeName.Namespace, routeName.Name, expectedParent.ParentRef.Namespace, actualParent.ParentRef.Namespace)
 				return false
 			}

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -192,6 +192,31 @@ func BackendTrafficPolicyMustBeAccepted(t *testing.T, client client.Client, poli
 	require.NoErrorf(t, waitErr, "error waiting for BackendTrafficPolicy to be accepted")
 }
 
+// BackendTrafficPolicyMustBeAccepted waits for the specified BackendTrafficPolicy to be accepted.
+func BackendTrafficPolicyMustBeAcceptedByAllAncestors(
+	t *testing.T, client client.Client, policyName types.NamespacedName,
+	controllerName string, ancestorRefs ...gwapiv1.ParentReference,
+) {
+	t.Helper()
+
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		policy := &egv1a1.BackendTrafficPolicy{}
+		err := client.Get(ctx, policyName, policy)
+		if err != nil {
+			return false, fmt.Errorf("error fetching BackendTrafficPolicy: %w", err)
+		}
+
+		if ancestorsForPolicyMatch(t, policyName, ancestorRefs, policy.Status.Ancestors, controllerName) {
+			return true, nil
+		}
+
+		tlog.Logf(t, "BackendTrafficPolicy not yet accepted: %v", policy)
+		return false, nil
+	})
+
+	require.NoErrorf(t, waitErr, "error waiting for BackendTrafficPolicy to be accepted")
+}
+
 // BackendTrafficPolicyMustFail waits for an BackendTrafficPolicy to fail with the specified reason.
 func BackendTrafficPolicyMustFail(
 	t *testing.T, client client.Client, policyName types.NamespacedName,
@@ -316,6 +341,36 @@ func policyAcceptedByAncestor(ancestors []gwapiv1.PolicyAncestorStatus, controll
 		}
 	}
 	return false
+}
+
+func ancestorsForPolicyMatch(t *testing.T, policyName types.NamespacedName, expected []gwapiv1.ParentReference, actual []gwapiv1.PolicyAncestorStatus, controllerName string) bool {
+	t.Helper()
+
+	if len(expected) != len(actual) {
+		tlog.Logf(t, "Policy %s/%s expected %d ancestors got %d", policyName.Namespace, policyName.Name, len(expected), len(actual))
+		return false
+	}
+
+	for i, expectedAncestor := range expected {
+		actualAncestor := actual[i]
+		accepted := false
+		if string(actualAncestor.ControllerName) == controllerName && cmp.Equal(actualAncestor.AncestorRef, expectedAncestor) {
+			for _, condition := range actualAncestor.Conditions {
+				if condition.Type == string(gwapiv1.PolicyConditionAccepted) && condition.Status == metav1.ConditionTrue {
+					accepted = true
+					break
+				}
+			}
+			if !accepted {
+				tlog.Logf(t, "Policy %s/%s expected Accepted condition on ancestor %s", policyName.Namespace, policyName.Name, actualAncestor.AncestorRef.Name)
+				return false
+			}
+		} else {
+			tlog.Logf(t, "Policy %s/%s expected Ancestor %s", policyName.Namespace, policyName.Name, actualAncestor.AncestorRef.Name)
+			return false
+		}
+	}
+	return true
 }
 
 // EnvoyExtensionPolicyMustFail waits for an EnvoyExtensionPolicy to fail with the specified reason.

--- a/test/e2e/tests/xlistenerset.go
+++ b/test/e2e/tests/xlistenerset.go
@@ -213,7 +213,7 @@ var XListenerSetTCPTest = suite.ConformanceTest{
 			createXListenerSetParent(suite.ControllerName, "xlistener-set-tcp", "extra-tcp"),
 		}
 
-		TCPRouteMustHaveParents(t, suite.Client, &suite.TimeoutConfig, routeNN, parents, false)
+		TCPRouteMustHaveParents(t, suite.Client, &suite.TimeoutConfig, routeNN, parents, []bool{false})
 
 		expected := http.ExpectedResponse{
 			Request: http.Request{
@@ -249,7 +249,7 @@ var XListenerSetUDPTest = suite.ConformanceTest{
 			createXListenerSetParent(suite.ControllerName, "xlistener-set-udp", "extra-udp"),
 		}
 
-		UDPRouteMustHaveParents(t, suite.Client, &suite.TimeoutConfig, routeNN, parents, false)
+		UDPRouteMustHaveParents(t, suite.Client, &suite.TimeoutConfig, routeNN, parents, []bool{false})
 
 		domain := "foo.bar.com."
 		msg := new(dns.Msg)
@@ -384,7 +384,7 @@ func TLSRouteMustHaveParents(t *testing.T, client client.Client, timeoutConfig *
 		}
 
 		actual = route.Status.Parents
-		return parentsForRouteMatch(t, routeName, parents, actual, false), nil
+		return parentsForRouteMatch(t, routeName, parents, actual, []bool{false}), nil
 	})
 	require.NoErrorf(t, waitErr, "error waiting for TLSRoute to have parents matching expectations")
 }


### PR DESCRIPTION
Second and last PR split from #7307 (includes the changes of #7557, will rebase when it's merged)
E2e tests should be successful here.