### PR TITLE
chore: fix flaky weight test

### DIFF
--- a/test/e2e/testdata/weighted-backend-mixed-valid-and-invalid.yaml
+++ b/test/e2e/testdata/weighted-backend-mixed-valid-and-invalid.yaml
@@ -14,7 +14,7 @@ spec:
       backendRefs:
         - name: infra-backend-v1
           port: 8080
-          weight: 80
+          weight: 9
         - name: infra-backend-not-existing
           port: 8080
-          weight: 20
+          weight: 1

--- a/test/e2e/tests/weighted_backend.go
+++ b/test/e2e/tests/weighted_backend.go
@@ -168,7 +168,7 @@ func testMixedValidAndInvalid(t *testing.T, suite *suite.ConformanceTestSuite) {
 		}
 	}
 
-	if !AlmostEquals(successCount, 40, 5) { // The weight of valid backend is 80%, so the expected success count is 50*80%=40
+	if !AlmostEquals(successCount, sendRequests*.9, 3) { // The weight of valid backend is 90%
 		t.Errorf("The actual success count is not within the expected range, success %d", successCount)
 	}
 }


### PR DESCRIPTION
fix: #7572 

This PR uses the same weight and offset as the other weighted routing tests, so hopefully it won't be flaky anymore.

```
eighted_backend.go:172: The actual success count is not within the expected range, success 46
```