### PR TITLE
 feat: reclaim space in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-
+      - uses: ./tools/github-actions/reclaim-storage
       - name: Extract Release Tag and Commit SHA
         id: vars
         shell: bash


### PR DESCRIPTION
Adds reclaim-storage step to v1.4 release worklow. Relates to  https://github.com/envoyproxy/gateway/pull/7587 and fixes failing pipeline here - https://github.com/envoyproxy/gateway/actions/runs/19566911461