### PR TITLE
chore: remove OSV scan config for golang stdlib

### DIFF
--- a/tools/osv-scanner/license-scan-config.toml
+++ b/tools/osv-scanner/license-scan-config.toml
@@ -38,9 +38,3 @@ version = "1.0.0"
 ecosystem = "Go"
 license.override = ["Apache-2.0"]
 reason = "This package is dual-licensed: the code under the Apache 2.0 license and the documentation under the CC-BY-SA-4.0 license"
-
-[[PackageOverrides]]
-name = "stdlib"
-ecosystem = "Go"
-license.override = ["BSD-3-Clause"]
-reason = "Unidentified license, remove once https://github.com/google/deps.dev/issues/86 is resolved"


### PR DESCRIPTION
xref: https://deps.dev/go/stdlib/1.25.4