### PR TITLE
Update Helm install command for Envoy Gateway

### DIFF
--- a/site/content/en/latest/tasks/quickstart.md
+++ b/site/content/en/latest/tasks/quickstart.md
@@ -20,7 +20,7 @@ so the `Gateway` resource has an Address associated with it. We recommend using 
 Install the Gateway API CRDs and Envoy Gateway:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
+helm install eg oci://docker.io/envoyproxy/gateway-helm -n envoy-gateway-system --create-namespace
 ```
 
 Wait for Envoy Gateway to become available:


### PR DESCRIPTION
**What type of PR is this?**
* "docs: fix grammar error"

**What this PR does / why we need it**:

Removed version specification from Helm install command.
The generated version in the helm install command was "v0.0.0-latest"!

<img width="929" height="267" alt="image" src="https://github.com/user-attachments/assets/7abbb992-7534-457a-acba-058d899a4186" />

