### PR TITLE
Bump envoyproxy image release/v1.6

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -23,7 +23,7 @@ const (
 	// DefaultDeploymentMemoryResourceRequests for deployment memory resource
 	DefaultDeploymentMemoryResourceRequests = "512Mi"
 	// DefaultEnvoyProxyImage is the default image used by envoyproxy
-	DefaultEnvoyProxyImage = "docker.io/envoyproxy/envoy:distroless-v1.36.2"
+	DefaultEnvoyProxyImage = "docker.io/envoyproxy/envoy:distroless-v1.36.3"
 	// DefaultShutdownManagerCPUResourceRequests for shutdown manager cpu resource
 	DefaultShutdownManagerCPUResourceRequests = "10m"
 	// DefaultShutdownManagerMemoryResourceRequests for shutdown manager memory resource

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
@@ -71,7 +71,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
@@ -170,7 +170,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
@@ -236,7 +236,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
@@ -230,7 +230,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
@@ -226,7 +226,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
@@ -73,7 +73,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -75,7 +75,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -75,7 +75,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
@@ -240,7 +240,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -174,7 +174,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
@@ -226,7 +226,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
@@ -240,7 +240,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
@@ -226,7 +226,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -234,7 +234,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
@@ -227,7 +227,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -230,7 +230,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -77,7 +77,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -229,7 +229,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
@@ -240,7 +240,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -660,7 +660,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:


### PR DESCRIPTION
Address CVEs causing envoy crashes. Ref [v1.36.3](https://github.com/envoyproxy/envoy/releases/tag/v1.36.3)
