### PR TITLE
Remove v1.4.7 notes

### DIFF
--- a/release-notes/v1.4.7.yaml
+++ b/release-notes/v1.4.7.yaml
@@ -1,5 +1,0 @@
-date: December 4, 2025
-
-# Updates addressing vulnerabilities, security flaws, or compliance requirements.
-security updates: |
-  Patches for EnvoyProxy CVE-2025-64527, CVE-2025-66220, and CVE-2025-64763. Ref https://github.com/envoyproxy/envoy/releases/tag/v1.34.11


### PR DESCRIPTION
Follow-up from https://github.com/envoyproxy/gateway/pull/7661. v1.4.x has reached end of support.