### PR TITLE
[release/v1.6] Cherry-pick reclaim-storage step for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: ./tools/github-actions/reclaim-storage
 
       - name: Extract Release Tag and Commit SHA
         id: vars

--- a/tools/hack/reclaim-storage.sh
+++ b/tools/hack/reclaim-storage.sh
@@ -7,6 +7,7 @@ log "Initial disk usage:"
 df -h || true
 
 # Remove large, unused language/tool runtimes
+# To figure out what to remove. We can SSH into the GitHub Actions runner using: https://github.com/mxschmitt/action-tmate and then run: df -h
 TO_DELETE=(
   /usr/local/lib/android
   /usr/share/dotnet


### PR DESCRIPTION
Fix failing release workflow for v1.6.1 - https://github.com/envoyproxy/gateway/actions/runs/19963690127