### PR TITLE
docs(values): Add comment for LoadBalancer service configuration

### DIFF
--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -85,6 +85,9 @@ service:
   # If set to PreferClose, the Envoy fleet will prioritize connecting to the Envoy Gateway pods that are topologically closest to them.
   trafficDistribution: ""
   annotations: {}
+  # -- Service type. Can be set to LoadBalancer with specific IP, e.g.:
+  # type: LoadBalancer
+  # loadBalancerIP: 10.236.90.20
   type: "ClusterIP"
 
 hpa:


### PR DESCRIPTION
Added an explanatory comment to the service.type configuration in the Helm chart values.yaml file to clarify how to properly configure LoadBalancer services with specific IP addresses.

The code has been added by PR https://github.com/envoyproxy/gateway/pull/7700