### PR TITLE
chore: increase backend endpoints max item to 256

### DIFF
--- a/api/v1alpha1/backend_types.go
+++ b/api/v1alpha1/backend_types.go
@@ -143,7 +143,7 @@ type BackendSpec struct {
 	// Endpoints defines the endpoints to be used when connecting to the backend.
 	//
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=64
+	// +kubebuilder:validation:MaxItems=256
 	// +kubebuilder:validation:XValidation:rule="self.all(f, has(f.fqdn)) || !self.exists(f, has(f.fqdn))",message="fqdn addresses cannot be mixed with other address types"
 	Endpoints []BackendEndpoint `json:"endpoints,omitempty"`
 

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backends.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backends.yaml
@@ -147,7 +147,7 @@ spec:
                     rule: ((has(self.fqdn) && !(has(self.ip) || has(self.unix))) ||
                       (has(self.ip) && !(has(self.fqdn) || has(self.unix))) || (has(self.unix)
                       && !(has(self.ip) || has(self.fqdn))))
-                maxItems: 64
+                maxItems: 256
                 minItems: 1
                 type: array
                 x-kubernetes-validations:

--- a/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_backends.yaml
+++ b/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_backends.yaml
@@ -146,7 +146,7 @@ spec:
                     rule: ((has(self.fqdn) && !(has(self.ip) || has(self.unix))) ||
                       (has(self.ip) && !(has(self.fqdn) || has(self.unix))) || (has(self.unix)
                       && !(has(self.ip) || has(self.fqdn))))
-                maxItems: 64
+                maxItems: 256
                 minItems: 1
                 type: array
                 x-kubernetes-validations:

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -20967,7 +20967,7 @@ spec:
                     rule: ((has(self.fqdn) && !(has(self.ip) || has(self.unix))) ||
                       (has(self.ip) && !(has(self.fqdn) || has(self.unix))) || (has(self.unix)
                       && !(has(self.ip) || has(self.fqdn))))
-                maxItems: 64
+                maxItems: 256
                 minItems: 1
                 type: array
                 x-kubernetes-validations:

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -147,7 +147,7 @@ spec:
                     rule: ((has(self.fqdn) && !(has(self.ip) || has(self.unix))) ||
                       (has(self.ip) && !(has(self.fqdn) || has(self.unix))) || (has(self.unix)
                       && !(has(self.ip) || has(self.fqdn))))
-                maxItems: 64
+                maxItems: 256
                 minItems: 1
                 type: array
                 x-kubernetes-validations:


### PR DESCRIPTION
**What this PR does / why we need it**:
increase the max items in backend endpoints validation. (64 to 256)
In my company use case, may hit the current limit.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
