### PR TITLE
docs: Update client-traffic-policy.md to remove the deprecated enableProxyProtocol property

### DIFF
--- a/site/content/en/contributions/design/client-traffic-policy.md
+++ b/site/content/en/contributions/design/client-traffic-policy.md
@@ -78,7 +78,7 @@ spec:
     kind: Gateway
     name: eg
     namespace: default
-  enableProxyProtocol: true
+  proxyProtocol: true
 ```
 
 ## Features / API Fields


### PR DESCRIPTION
**What type of PR is this?**
Docs:  Update client-traffic-policy.md to remove the deprecated enableProxyProtocol property

**What this PR does / why we need it**:
It updates the documentation of the ClientTrafficPolicy to match the new deprecation listed in the [1.5.0 release note](https://gateway.envoyproxy.io/news/releases/v1.5/#-deprecations)

Release Notes: No
