### PR TITLE
chore: enable dependabot for gateway addons helm chart

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,3 +70,8 @@ updates:
       - /tools/src/yamllint
     schedule:
       interval: weekly
+  - package-ecosystem: "helm"
+    directories:
+      - "/charts/gateway-addons-helm"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
The dependabot can only update the addons helm chart directly but will not able to fix other things like the gen check, but it can serve as a reminder of outdated dependencies.