### PR TITLE
docs: clarify Bearer prefix handling in API key authentication

### DIFF
--- a/site/content/en/latest/tasks/security/apikey-auth.md
+++ b/site/content/en/latest/tasks/security/apikey-auth.md
@@ -19,7 +19,36 @@ This instantiated resource can be linked to a [Gateway][], [HTTPRoute][] or [GRP
 API Key must be stored in a kubernetes secret and referenced in the [SecurityPolicy][] configuration.
 The secret is an Opaque secret, with each API key stored under a key corresponding to the client ID.
 
-### Create a API Key Secret
+> **Important**
+>
+> When API keys are extracted from the `Authorization` header, the value stored in the Kubernetes
+> Secret **must not include the `Bearer` prefix**.
+>
+> Envoy Gateway compares the extracted header value directly against the stored secret value.
+> Authentication scheme prefixes (such as `Bearer`) are not stripped automatically.
+>
+> For example:
+>
+> **Non-working configuration**
+> ```yaml
+> stringData:
+>   client1: "Bearer my-api-key"
+> ```
+>
+> **Working configuration**
+> ```yaml
+> stringData:
+>   client1: "my-api-key"
+> ```
+>
+> Clients may still send requests using:
+> ```http
+> Authorization: Bearer my-api-key
+> ```
+
+
+
+### Create an API Key Secret
 
 Create an Opaque Secret containing the client ID and its corresponding API key
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR clarifies the expected behavior of API key authentication when using
the `Authorization` header.

It documents that API keys stored in Kubernetes Secrets must not include
authentication scheme prefixes such as `Bearer`, since Envoy Gateway performs
a direct value comparison against the extracted header value.

**Which issue(s) this PR fixes**:
Fixes #7706

Release Notes: No