### PR TITLE
fix(extensions): handle case where multiple custom backendrefs are present

### DIFF
--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-weighted.in.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-weighted.in.yaml
@@ -1,0 +1,64 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.envoyproxy.io"
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: http
+    rules:
+    - matches:
+      - path:
+          value: "/service"
+      backendRefs:
+      - group: storage.example.io
+        kind: S3Backend
+        name: s3-backend-1
+        port: 443
+        weight: 8
+      - group: storage.example.io
+        kind: S3Backend
+        name: s3-backend-2
+        port: 443
+        weight: 2
+extensionRefFilters:
+- apiVersion: storage.example.io/v1alpha1
+  kind: S3Backend
+  metadata:
+    name: s3-backend-1
+    namespace: default
+  spec:
+    bucket: my-s3-bucket
+    region: us-west-2
+    endpoint: s3.amazonaws.com
+- apiVersion: storage.example.io/v1alpha1
+  kind: S3Backend
+  metadata:
+    name: s3-backend-2
+    namespace: default
+  spec:
+    bucket: my-s3-bucket
+    region: us-west-2
+    endpoint: s3.amazonaws.com
+

--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-weighted.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-weighted.out.yaml
@@ -1,0 +1,198 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      hostname: '*.envoyproxy.io'
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-1
+    namespace: default
+  spec:
+    hostnames:
+    - gateway.envoyproxy.io
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+      sectionName: http
+    rules:
+    - backendRefs:
+      - group: storage.example.io
+        kind: S3Backend
+        name: s3-backend-1
+        port: 443
+        weight: 8
+      - group: storage.example.io
+        kind: S3Backend
+        name: s3-backend-2
+        port: 443
+        weight: 2
+      matches:
+      - path:
+          value: /service
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      listeners:
+      - address: null
+        name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-1
+      namespace: ""
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-envoy-gateway-gateway-1-196ae069
+          sectionName: "8080"
+        name: envoy-gateway/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-envoy-gateway-gateway-1-196ae069
+            sectionName: "8080"
+          name: envoy-gateway/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*.envoyproxy.io'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-1
+            namespace: default
+          name: httproute/default/httproute-1/rule/0
+          settings:
+          - isCustomBackend: true
+            name: httproute/default/httproute-1/rule/0/backend/0
+            weight: 8
+          - isCustomBackend: true
+            name: httproute/default/httproute-1/rule/0/backend/1
+            weight: 2
+        extensionRefs:
+        - object:
+            apiVersion: storage.example.io/v1alpha1
+            kind: S3Backend
+            metadata:
+              name: s3-backend-1
+              namespace: default
+            spec:
+              bucket: my-s3-bucket
+              endpoint: s3.amazonaws.com
+              region: us-west-2
+        - object:
+            apiVersion: storage.example.io/v1alpha1
+            kind: S3Backend
+            metadata:
+              name: s3-backend-2
+              namespace: default
+            spec:
+              bucket: my-s3-bucket
+              endpoint: s3.amazonaws.com
+              region: us-west-2
+        hostname: gateway.envoyproxy.io
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-1
+          namespace: default
+        name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /service
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -1628,7 +1628,18 @@ func (r *RouteDestination) Validate() error {
 func (r *RouteDestination) NeedsClusterPerSetting() bool {
 	return r.HasMixedEndpoints() ||
 		r.HasFiltersInSettings() ||
+		r.HasCustomBackendInSettings() ||
 		(len(r.Settings) > 1 && r.HasPreferLocalZone())
+}
+
+// HasCustomBackendInSettings returns true if any setting in the destination has a custom backend
+func (r *RouteDestination) HasCustomBackendInSettings() bool {
+	for _, setting := range r.Settings {
+		if setting.IsCustomBackend {
+			return true
+		}
+	}
+	return false
 }
 
 // HasMixedEndpoints returns true if the RouteDestination has endpoints of multiple types

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -326,7 +326,7 @@ func buildXdsWeightedRouteAction(backendWeights *ir.BackendWeights, settings []*
 	}
 
 	for _, destinationSetting := range settings {
-		if len(destinationSetting.Endpoints) > 0 || destinationSetting.IsDynamicResolver { // Dynamic resolver has no endpoints
+		if len(destinationSetting.Endpoints) > 0 || destinationSetting.IsDynamicResolver || destinationSetting.IsCustomBackend { // Dynamic resolver and custom backend can have no endpoints
 			validCluster := &routev3.WeightedCluster_ClusterWeight{
 				Name:   destinationSetting.Name,
 				Weight: &wrapperspb.UInt32Value{Value: *destinationSetting.Weight},

--- a/internal/xds/translator/testdata/in/extension-xds-ir/http-route-custom-backend-weighted.yaml
+++ b/internal/xds/translator/testdata/in/extension-xds-ir/http-route-custom-backend-weighted.yaml
@@ -1,0 +1,47 @@
+http:
+- name: "custom-backend-weighted-listener"
+  address: "0.0.0.0"
+  port: 10080
+  hostnames:
+  - "*"
+  path:
+    mergeSlashes: true
+    escapedSlashesAction: UnescapeAndRedirect
+  routes:
+  - name: "httproute/default/httproute-1/rule/0/match/0/*"
+    hostname: "*"
+    pathMatch:
+      prefix: "/"
+    destination:
+      name: "httproute/default/httproute-1/rule/0"
+      settings:
+      - isCustomBackend: true
+        weight: 8
+        name: "httproute/default/httproute-1/rule/0/backend/0"
+      - isCustomBackend: true
+        weight: 2
+        name: "httproute/default/httproute-1/rule/0/backend/1"
+    extensionRefs:
+    - object:
+        apiVersion: inference.networking.x-k8s.io/v1alpha2
+        kind: InferencePool
+        metadata:
+          name: inference-pool-0
+        spec:
+          targetPortNumber: 8000
+          selector:
+            app: vllm-llama3-8b-instruct
+          extensionRef:
+            name: vllm-llama3-8b-instruct-epp
+    - object:
+        apiVersion: inference.networking.x-k8s.io/v1alpha2
+        kind: InferencePool
+        metadata:
+          name: inference-pool-1
+        spec:
+          targetPortNumber: 8080
+          selector:
+            app: vllm-llama3-8b-instruct
+          extensionRef:
+            name: vllm-llama3-8b-instruct-epp
+

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-weighted.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-weighted.clusters.yaml
@@ -1,0 +1,58 @@
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: httproute/default/httproute-1/rule/0/backend/0
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: httproute/default/httproute-1/rule/0/backend/0
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: httproute/default/httproute-1/rule/0/backend/1
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: httproute/default/httproute-1/rule/0/backend/1
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- loadAssignment:
+    clusterName: mock-extension-injected-cluster
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: exampleservice.examplenamespace.svc.cluster.local
+              portValue: 5000
+  name: mock-extension-injected-cluster

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-weighted.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-weighted.endpoints.yaml
@@ -1,0 +1,10 @@
+- clusterName: httproute/default/httproute-1/rule/0/backend/0
+  endpoints:
+  - loadBalancingWeight: 8
+    locality:
+      region: httproute/default/httproute-1/rule/0/backend/0
+- clusterName: httproute/default/httproute-1/rule/0/backend/1
+  endpoints:
+  - loadBalancingWeight: 2
+    locality:
+      region: httproute/default/httproute-1/rule/0/backend/1

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-weighted.listeners.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-weighted.listeners.yaml
@@ -1,0 +1,35 @@
+- address:
+    socketAddress:
+      address: 0.0.0.0
+      portValue: 10080
+  defaultFilterChain:
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        commonHttpProtocolOptions:
+          headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            suppressEnvoyHeaders: true
+        mergeSlashes: true
+        normalizePath: true
+        pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: custom-backend-weighted-listener
+        serverHeaderTransformation: PASS_THROUGH
+        statPrefix: http-10080
+        useRemoteAddress: true
+    name: custom-backend-weighted-listener
+  maxConnectionsToAcceptPerSocketEvent: 1
+  name: custom-backend-weighted-listener
+  perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-weighted.routes.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-weighted.routes.yaml
@@ -1,0 +1,55 @@
+- ignorePortInHostMatching: true
+  name: custom-backend-weighted-listener
+  virtualHosts:
+  - domains:
+    - '*'
+    name: custom-backend-weighted-listener/*
+    routes:
+    - match:
+        prefix: /
+      name: httproute/default/httproute-1/rule/0/match/0/*
+      responseHeadersToAdd:
+      - header:
+          key: mock-extension-was-here-route-name
+          value: httproute/default/httproute-1/rule/0/match/0/*
+      - header:
+          key: mock-extension-was-here-route-hostnames
+          value: '*'
+      - header:
+          key: mock-extension-was-here-extensionRef-name
+          value: inference-pool-0
+      - header:
+          key: mock-extension-was-here-extensionRef-namespace
+      - header:
+          key: mock-extension-was-here-extensionRef-kind
+          value: InferencePool
+      - header:
+          key: mock-extension-was-here-extensionRef-apiversion
+          value: inference.networking.x-k8s.io/v1alpha2
+      - header:
+          key: mock-extension-was-here-route-name
+          value: httproute/default/httproute-1/rule/0/match/0/*
+      - header:
+          key: mock-extension-was-here-route-hostnames
+          value: '*'
+      - header:
+          key: mock-extension-was-here-extensionRef-name
+          value: inference-pool-1
+      - header:
+          key: mock-extension-was-here-extensionRef-namespace
+      - header:
+          key: mock-extension-was-here-extensionRef-kind
+          value: InferencePool
+      - header:
+          key: mock-extension-was-here-extensionRef-apiversion
+          value: inference.networking.x-k8s.io/v1alpha2
+      route:
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+        upgradeConfigs:
+        - upgradeType: websocket
+        weightedClusters:
+          clusters:
+          - name: httproute/default/httproute-1/rule/0/backend/0
+            weight: 8
+          - name: httproute/default/httproute-1/rule/0/backend/1
+            weight: 2

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-weighted.secrets.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-weighted.secrets.yaml
@@ -1,0 +1,4 @@
+- genericSecret:
+    secret:
+      inlineString: super-secret-extension-secret
+  name: mock-extension-injected-secret


### PR DESCRIPTION
**What this PR does / why we need it**:
Only one custom backend ref is selected when multiple are present in an http route. What's expected is that Envoy Gateway configures a route which weighted round robins across the two corresponding clusters instead of nondeterministically selecting one.

**Which issue(s) this PR fixes**:
Fixes #7766 

Release Notes: No
