### PR TITLE
fix: enable kubernetesAttributes preset for OpenTelemetry Collector

### DIFF
--- a/charts/gateway-addons-helm/README.md
+++ b/charts/gateway-addons-helm/README.md
@@ -185,6 +185,7 @@ helm uninstall eg-addons -n monitoring
 | opentelemetry-collector.ports.envoy-als.hostPort | int | `9000` |  |
 | opentelemetry-collector.ports.envoy-als.protocol | string | `"TCP"` |  |
 | opentelemetry-collector.ports.envoy-als.servicePort | int | `9000` |  |
+| opentelemetry-collector.presets.kubernetesAttributes.enabled | bool | `true` |  |
 | prometheus.alertmanager.enabled | bool | `false` |  |
 | prometheus.enabled | bool | `true` |  |
 | prometheus.kube-state-metrics.customResourceState.config.kind | string | `"CustomResourceStateMetrics"` |  |

--- a/charts/gateway-addons-helm/values.yaml
+++ b/charts/gateway-addons-helm/values.yaml
@@ -860,6 +860,11 @@ opentelemetry-collector:
       hostPort: 8126
       protocol: TCP
   fullnameOverride: otel-collector
+  # Enable kubernetesAttributes preset to ensure RBAC is created
+  # when the collector is enabled (required for k8s discovery)
+  presets:
+    kubernetesAttributes:
+      enabled: true
   mode: deployment
   image:
     repository: "otel/opentelemetry-collector-contrib"
@@ -951,3 +956,4 @@ opentelemetry-collector:
             - datadog
             - otlp
             - zipkin
+            

--- a/site/content/en/latest/install/gateway-addons-helm-api.md
+++ b/site/content/en/latest/install/gateway-addons-helm-api.md
@@ -164,6 +164,7 @@ An Add-ons Helm chart for Envoy Gateway
 | opentelemetry-collector.ports.envoy-als.hostPort | int | `9000` |  |
 | opentelemetry-collector.ports.envoy-als.protocol | string | `"TCP"` |  |
 | opentelemetry-collector.ports.envoy-als.servicePort | int | `9000` |  |
+| opentelemetry-collector.presets.kubernetesAttributes.enabled | bool | `true` |  |
 | prometheus.alertmanager.enabled | bool | `false` |  |
 | prometheus.enabled | bool | `true` |  |
 | prometheus.kube-state-metrics.customResourceState.config.kind | string | `"CustomResourceStateMetrics"` |  |

--- a/test/helm/gateway-addons-helm/e2e.out.yaml
+++ b/test/helm/gateway-addons-helm/e2e.out.yaml
@@ -332,6 +332,43 @@ data:
         endpoint: '[${env:MY_POD_IP}]:13133'
     processors:
       batch: {}
+      k8sattributes:
+        extract:
+          metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.pod.start_time
+          - k8s.deployment.name
+          - k8s.replicaset.name
+          - k8s.replicaset.uid
+          - k8s.daemonset.name
+          - k8s.daemonset.uid
+          - k8s.job.name
+          - k8s.job.uid
+          - k8s.container.name
+          - k8s.cronjob.name
+          - k8s.statefulset.name
+          - k8s.statefulset.uid
+          - container.image.tag
+          - container.image.name
+          - k8s.cluster.uid
+          - service.namespace
+          - service.name
+          - service.version
+          - service.instance.id
+          otel_annotations: true
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
       memory_limiter:
         check_interval: 5s
         limit_percentage: 80
@@ -380,6 +417,7 @@ data:
           exporters:
           - otlphttp/loki
           processors:
+          - k8sattributes
           - transform/loki
           receivers:
           - otlp
@@ -388,6 +426,7 @@ data:
           exporters:
           - prometheus
           processors:
+          - k8sattributes
           - memory_limiter
           - batch
           receivers:
@@ -397,6 +436,7 @@ data:
           exporters:
           - otlp
           processors:
+          - k8sattributes
           - memory_limiter
           - batch
           receivers:
@@ -10188,6 +10228,30 @@ rules:
   resources: ["configmaps", "secrets"]
   verbs: ["get", "watch", "list"]
 ---
+# Source: gateway-addons-helm/charts/opentelemetry-collector/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.142.2
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: gateway-addons-helm
+    app.kubernetes.io/version: "0.142.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
 # Source: gateway-addons-helm/charts/prometheus/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -10278,6 +10342,28 @@ roleRef:
   kind: ClusterRole
   name: loki-clusterrole
   apiGroup: rbac.authorization.k8s.io
+---
+# Source: gateway-addons-helm/charts/opentelemetry-collector/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.142.2
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: gateway-addons-helm
+    app.kubernetes.io/version: "0.142.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-collector
+    app.kubernetes.io/component: standalone-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-collector
+subjects:
+- kind: ServiceAccount
+  name: otel-collector
+  namespace: monitoring
 ---
 # Source: gateway-addons-helm/charts/prometheus/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10653,7 +10739,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c1e28c33bb38e36c7a1c59d812ecb5423b9cc1aa1bcb86c3b255d4fe89828388
+        checksum/config: 6d4a1dbfa1a9a8ec0cba4ee15200ffa34ae09d513e11b3ca0018de9c654c9ebc
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector


### PR DESCRIPTION
## What this PR fixes

When deploying the `gateway-addons-helm` chart with only OpenTelemetry Collector enabled (`opentelemetry-collector.enabled: true`), the collector pod logs RBAC errors because no ClusterRole/ClusterRoleBinding is created for the `otel-collector` service account.

Error example from issue #7726:
`pods is forbidden: User "system:serviceaccount:gateway-api-resources:otel-collector" cannot list resource "pods" at the cluster scope
replicasets.apps is forbidden: User "system:serviceaccount:gateway-api-resources:otel-collector" cannot list resource "replicasets"
namespaces "kube-system" is forbidden: User "system:serviceaccount:gateway-api-resources:otel-collector" cannot list resource "namespaces"`


## Root cause

The OpenTelemetry Collector subchart only creates RBAC when either:
1. `clusterRole.create: true` OR
2. One of the presets is enabled (like `kubernetesAttributes.enabled: true`)

The `gateway-addons-helm` chart's default values don't enable any presets, so when users enable only the collector, they get no RBAC.

## Solution

Enable the `kubernetesAttributes` preset by default in the OpenTelemetry Collector configuration. This preset provides exactly the permissions shown in the error logs:
- `pods` and `namespaces` (for Kubernetes discovery)
- `replicasets` (for pod owner references)

The change adds 5 lines after `fullnameOverride: otel-collector` in `values.yaml`:
```yaml
  # Enable kubernetesAttributes preset to ensure RBAC is created
  # when the collector is enabled (required for k8s discovery)
  presets:
    kubernetesAttributes:
      enabled: true