### PR TITLE
fix: setting externalTrafficPolicy for NodePort service type

### DIFF
--- a/internal/infrastructure/kubernetes/resource/resource.go
+++ b/internal/infrastructure/kubernetes/resource/resource.go
@@ -29,7 +29,8 @@ func ExpectedServiceSpec(service *egv1a1.KubernetesServiceSpec) corev1.ServiceSp
 	if service.ExternalTrafficPolicy == nil {
 		service.ExternalTrafficPolicy = egv1a1.DefaultKubernetesServiceExternalTrafficPolicy()
 	}
-	if *service.Type == egv1a1.ServiceTypeLoadBalancer {
+	switch *service.Type {
+	case egv1a1.ServiceTypeLoadBalancer:
 		if service.LoadBalancerClass != nil {
 			serviceSpec.LoadBalancerClass = service.LoadBalancerClass
 		}
@@ -42,6 +43,8 @@ func ExpectedServiceSpec(service *egv1a1.KubernetesServiceSpec) corev1.ServiceSp
 		if service.LoadBalancerIP != nil {
 			serviceSpec.LoadBalancerIP = *service.LoadBalancerIP
 		}
+		serviceSpec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicy(*service.ExternalTrafficPolicy)
+	case egv1a1.ServiceTypeNodePort:
 		serviceSpec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicy(*service.ExternalTrafficPolicy)
 	}
 

--- a/internal/infrastructure/kubernetes/resource/resource_test.go
+++ b/internal/infrastructure/kubernetes/resource/resource_test.go
@@ -111,6 +111,29 @@ func TestExpectedServiceSpec(t *testing.T) {
 				SessionAffinity: corev1.ServiceAffinityNone,
 			},
 		},
+		{
+			name: "NodePort",
+			args: args{service: &egv1a1.KubernetesServiceSpec{
+				Type: egv1a1.GetKubernetesServiceType(egv1a1.ServiceTypeNodePort),
+			}},
+			want: corev1.ServiceSpec{
+				Type:                  corev1.ServiceTypeNodePort,
+				SessionAffinity:       corev1.ServiceAffinityNone,
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+			},
+		},
+		{
+			name: "NodePortWithExternalTrafficPolicyCluster",
+			args: args{service: &egv1a1.KubernetesServiceSpec{
+				Type:                  egv1a1.GetKubernetesServiceType(egv1a1.ServiceTypeNodePort),
+				ExternalTrafficPolicy: egv1a1.GetKubernetesServiceExternalTrafficPolicy(egv1a1.ServiceExternalTrafficPolicyCluster),
+			}},
+			want: corev1.ServiceSpec{
+				Type:                  corev1.ServiceTypeNodePort,
+				SessionAffinity:       corev1.ServiceAffinityNone,
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -24,6 +24,7 @@ bug fixes: |
   Fixed an issue where BackendTrafficPolicy does not validate maximum value of requestBuffer limit.
   Fixed an issue where observedGeneration is missing from the EnvoyPatchPolicy status.
   Fixed a nil pointer error when applying BackendTrafficPolicy to HTTPRoutes with no backendRefs.
+  Fixed ExternalTrafficPolicy not being applied to Envoy Service when ServiceType is NodePort.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->
fix: setting externalTrafficPolicy for NodePort service type

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
`ExternalTrafficPolicy` is supported for both `LoadBalancer` and `NodePort` service types.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #7768

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes
