### PR TITLE
chore: move ratelimit per-route config to typedPerFilterConfig

### DIFF
--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.routes.yaml
@@ -10,52 +10,60 @@
       name: first-route
       route:
         cluster: first-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: first-route
-              descriptorValue: first-route
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
           requirementName: first-route
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: first-route
+                descriptorValue: first-route
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: second-route
-              descriptorValue: second-route
-          - requestHeaders:
-              descriptorKey: rule-0-match-0
-              headerName: x-user-id
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: second-route
+                descriptorValue: second-route
+            - requestHeaders:
+                descriptorKey: rule-0-match-0
+                headerName: x-user-id
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: third-route
-              descriptorValue: third-route
-          - genericKey:
-              descriptorKey: rule-0-match--1
-              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: third-route
+                descriptorValue: third-route
+            - genericKey:
+                descriptorKey: rule-0-match--1
+                descriptorValue: rule-0-match--1

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-both-type.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-both-type.routes.yaml
@@ -10,34 +10,29 @@
       name: first-route
       route:
         cluster: first-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: first-route
-              descriptorValue: first-route
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: first-route
+                descriptorValue: first-route
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: second-route
-              descriptorValue: second-route
-          - requestHeaders:
-              descriptorKey: rule-0-match-0
-              headerName: x-user-id
         upgradeConfigs:
         - upgradeType: websocket
       typedPerFilterConfig:
@@ -74,3 +69,13 @@
             fillInterval: 60s
             maxTokens: 10
             tokensPerFill: 10
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: second-route
+                descriptorValue: second-route
+            - requestHeaders:
+                descriptorKey: rule-0-match-0
+                headerName: x-user-id

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.routes.yaml
@@ -10,48 +10,57 @@
       name: first-route
       route:
         cluster: first-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: first-route
-              descriptorValue: first-route
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: first-route
+                descriptorValue: first-route
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: second-route
-              descriptorValue: second-route
-          - requestHeaders:
-              descriptorKey: rule-0-match-0
-              headerName: x-user-id
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: second-route
+                descriptorValue: second-route
+            - requestHeaders:
+                descriptorKey: rule-0-match-0
+                headerName: x-user-id
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: third-route
-              descriptorValue: third-route
-          - genericKey:
-              descriptorKey: rule-0-match--1
-              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: third-route
+                descriptorValue: third-route
+            - genericKey:
+                descriptorKey: rule-0-match--1
+                descriptorValue: rule-0-match--1

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.routes.yaml
@@ -10,48 +10,57 @@
       name: first-route
       route:
         cluster: first-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: first-route
-              descriptorValue: first-route
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: first-route
+                descriptorValue: first-route
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: second-route
-              descriptorValue: second-route
-          - requestHeaders:
-              descriptorKey: rule-0-match-0
-              headerName: x-user-id
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: second-route
+                descriptorValue: second-route
+            - requestHeaders:
+                descriptorKey: rule-0-match-0
+                headerName: x-user-id
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: third-route
-              descriptorValue: third-route
-          - genericKey:
-              descriptorKey: rule-0-match--1
-              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: third-route
+                descriptorValue: third-route
+            - genericKey:
+                descriptorKey: rule-0-match--1
+                descriptorValue: rule-0-match--1

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.routes.yaml
@@ -10,48 +10,57 @@
       name: first-route
       route:
         cluster: first-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: first-route
-              descriptorValue: first-route
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: first-route
+                descriptorValue: first-route
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: second-route
-              descriptorValue: second-route
-          - requestHeaders:
-              descriptorKey: rule-0-match-0
-              headerName: x-user-id
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: second-route
+                descriptorValue: second-route
+            - requestHeaders:
+                descriptorKey: rule-0-match-0
+                headerName: x-user-id
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: third-route
-              descriptorValue: third-route
-          - genericKey:
-              descriptorKey: rule-0-match--1
-              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: third-route
+                descriptorValue: third-route
+            - genericKey:
+                descriptorKey: rule-0-match--1
+                descriptorValue: rule-0-match--1

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-global-shared.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-global-shared.routes.yaml
@@ -10,78 +10,90 @@
       name: first-route
       route:
         cluster: first-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: test-namespace/test-policy-1/rule/0
-              descriptorValue: test-namespace/test-policy-1/rule/0
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit/test-namespace/test-policy-1:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: test-namespace/test-policy-1/rule/0
+                descriptorValue: test-namespace/test-policy-1/rule/0
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
     - match:
         path: foo/baz
       name: second-route
       route:
         cluster: second-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: test-namespace/test-policy-1/rule/0
-              descriptorValue: test-namespace/test-policy-1/rule/0
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit/test-namespace/test-policy-1:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: test-namespace/test-policy-1/rule/0
+                descriptorValue: test-namespace/test-policy-1/rule/0
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: test-namespace/test-policy-2/rule/0
-              descriptorValue: test-namespace/test-policy-2/rule/0
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: two
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit/test-namespace/test-policy-2:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: test-namespace/test-policy-2/rule/0
+                descriptorValue: test-namespace/test-policy-2/rule/0
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: two
     - match:
         path: foo/bar
       name: fourth-route
       route:
         cluster: fourth-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: fourth-route
-              descriptorValue: fourth-route
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: two
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: fourth-route
+                descriptorValue: fourth-route
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: two

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.routes.yaml
@@ -10,79 +10,88 @@
       name: first-route
       route:
         cluster: first-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: first-route
-              descriptorValue: first-route
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
-          - maskedRemoteAddress:
-              v4PrefixMaskLen: 16
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: first-route
+                descriptorValue: first-route
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
+            - maskedRemoteAddress:
+                v4PrefixMaskLen: 16
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: second-route
-              descriptorValue: second-route
-          - requestHeaders:
-              descriptorKey: rule-0-match-0
-              headerName: x-user-id
-          - requestHeaders:
-              descriptorKey: rule-0-match-1
-              headerName: foobar
-          - maskedRemoteAddress:
-              v4PrefixMaskLen: 16
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: second-route
+                descriptorValue: second-route
+            - requestHeaders:
+                descriptorKey: rule-0-match-0
+                headerName: x-user-id
+            - requestHeaders:
+                descriptorKey: rule-0-match-1
+                headerName: foobar
+            - maskedRemoteAddress:
+                v4PrefixMaskLen: 16
     - match:
         prefix: /
       name: third-route
       route:
         cluster: third-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: third-route
-              descriptorValue: third-route
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
-          - maskedRemoteAddress:
-              v4PrefixMaskLen: 16
-        - actions:
-          - genericKey:
-              descriptorKey: third-route
-              descriptorValue: third-route
-          - headerValueMatch:
-              descriptorKey: rule-1-match-0
-              descriptorValue: rule-1-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: two
-          - requestHeaders:
-              descriptorKey: rule-1-match-1
-              headerName: foobar
-          - maskedRemoteAddress:
-              v4PrefixMaskLen: 16
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: third-route
+                descriptorValue: third-route
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
+            - maskedRemoteAddress:
+                v4PrefixMaskLen: 16
+          - actions:
+            - genericKey:
+                descriptorKey: third-route
+                descriptorValue: third-route
+            - headerValueMatch:
+                descriptorKey: rule-1-match-0
+                descriptorValue: rule-1-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: two
+            - requestHeaders:
+                descriptorKey: rule-1-match-1
+                headerName: foobar
+            - maskedRemoteAddress:
+                v4PrefixMaskLen: 16

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-multi-global-shared.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-multi-global-shared.routes.yaml
@@ -10,70 +10,79 @@
       name: first-route
       route:
         cluster: first-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: test-namespace/test-policy-1/rule/0
-              descriptorValue: test-namespace/test-policy-1/rule/0
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit/test-namespace/test-policy-1:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: test-namespace/test-policy-1/rule/0
+                descriptorValue: test-namespace/test-policy-1/rule/0
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
     - match:
         path: foo/baz
       name: second-route
       route:
         cluster: second-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: test-namespace/test-policy-1/rule/0
-              descriptorValue: test-namespace/test-policy-1/rule/0
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit/test-namespace/test-policy-1:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: test-namespace/test-policy-1/rule/0
+                descriptorValue: test-namespace/test-policy-1/rule/0
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: test-namespace/test-policy-2/rule/0
-              descriptorValue: test-namespace/test-policy-2/rule/0
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: two
-        - actions:
-          - genericKey:
-              descriptorKey: test-namespace/test-policy-2/rule/1
-              descriptorValue: test-namespace/test-policy-2/rule/1
-          - headerValueMatch:
-              descriptorKey: rule-1-match-0
-              descriptorValue: rule-1-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: two
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit/test-namespace/test-policy-2:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: test-namespace/test-policy-2/rule/0
+                descriptorValue: test-namespace/test-policy-2/rule/0
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: two
+          - actions:
+            - genericKey:
+                descriptorKey: test-namespace/test-policy-2/rule/1
+                descriptorValue: test-namespace/test-policy-2/rule/1
+            - headerValueMatch:
+                descriptorKey: rule-1-match-0
+                descriptorValue: rule-1-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: two

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.routes.yaml
@@ -10,56 +10,68 @@
       name: first-route
       route:
         cluster: first-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: first-route
-              descriptorValue: first-route
-          - maskedRemoteAddress:
-              v4PrefixMaskLen: 16
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: first-route
+                descriptorValue: first-route
+            - maskedRemoteAddress:
+                v4PrefixMaskLen: 16
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: second-route
-              descriptorValue: second-route
-          - maskedRemoteAddress:
-              v4PrefixMaskLen: 24
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: second-route
+                descriptorValue: second-route
+            - maskedRemoteAddress:
+                v4PrefixMaskLen: 24
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: third-route
-              descriptorValue: third-route
-          - genericKey:
-              descriptorKey: rule-0-match--1
-              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: third-route
+                descriptorValue: third-route
+            - genericKey:
+                descriptorKey: rule-0-match--1
+                descriptorValue: rule-0-match--1
     - match:
         path: distinct
       name: fourth-route
       route:
         cluster: fourth-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: fourth-route
-              descriptorValue: fourth-route
-          - maskedRemoteAddress:
-              v4PrefixMaskLen: 16
-          - remoteAddress: {}
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: fourth-route
+                descriptorValue: fourth-route
+            - maskedRemoteAddress:
+                v4PrefixMaskLen: 16
+            - remoteAddress: {}

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.routes.yaml
@@ -10,71 +10,83 @@
       name: first-route
       route:
         cluster: first-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: first-route
-              descriptorValue: first-route
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: true
-              headers:
-              - name: x-user-id
-                stringMatch:
-                  exact: one
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: first-route
+                descriptorValue: first-route
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one
     - match:
         path: example
       name: second-route
       route:
         cluster: second-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: second-route
-              descriptorValue: second-route
-          - requestHeaders:
-              descriptorKey: rule-0-match-0
-              headerName: x-user-id
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: second-route
+                descriptorValue: second-route
+            - requestHeaders:
+                descriptorKey: rule-0-match-0
+                headerName: x-user-id
     - match:
         path: test
       name: third-route
       route:
         cluster: third-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: third-route
-              descriptorValue: third-route
-          - genericKey:
-              descriptorKey: rule-0-match--1
-              descriptorValue: rule-0-match--1
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: third-route
+                descriptorValue: third-route
+            - genericKey:
+                descriptorKey: rule-0-match--1
+                descriptorValue: rule-0-match--1
     - match:
         path: foo/bar/login
       name: fourth-route
       route:
         cluster: fourth-route-dest
-        rateLimits:
-        - actions:
-          - genericKey:
-              descriptorKey: fourth-route
-              descriptorValue: fourth-route
-          - headerValueMatch:
-              descriptorKey: rule-0-match-0
-              descriptorValue: rule-0-match-0
-              expectMatch: false
-              headers:
-              - name: x-org-id
-                stringMatch:
-                  exact: admin
         upgradeConfigs:
         - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: fourth-route
+                descriptorValue: fourth-route
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: false
+                headers:
+                - name: x-org-id
+                  stringMatch:
+                    exact: admin
     - match:
         path: foo/bar
       name: req-and-resp-cost

--- a/internal/xds/translator/translator_test.go
+++ b/internal/xds/translator/translator_test.go
@@ -273,12 +273,11 @@ func TestBuildRouteRateLimits(t *testing.T) {
 			// Process each route to get rate limit actions
 			for _, listener := range listeners {
 				for _, route := range listener.Routes {
-					rateLimits, costSpecified := buildRouteRateLimits(route)
+					rateLimits := buildRouteRateLimits(route)
 
 					output := rateLimitOutput{
-						RouteName:     route.Name,
-						RateLimits:    rateLimits,
-						CostSpecified: costSpecified,
+						RouteName:  route.Name,
+						RateLimits: rateLimits,
 					}
 					outputs = append(outputs, output)
 				}


### PR DESCRIPTION
This per route rate limit has been supported since envoy v1.33. It should be fine to move all ratelimit config to route now.
Fixes: #5750