### PR TITLE
docs: correction in Rewrite URL Path with Regex

### DIFF
--- a/site/content/en/latest/tasks/traffic/http-urlrewrite.md
+++ b/site/content/en/latest/tasks/traffic/http-urlrewrite.md
@@ -377,8 +377,7 @@ The HTTPRoute status should indicate that it has been accepted and is bound to t
 kubectl get httproute/http-filter-url-regex-rewrite -o yaml
 ```
 
-Querying `http://${GATEWAY_HOST}/service/foo/v1/api` should rewrite the request to
-`http://${GATEWAY_HOST}/service/foo/v1/api`.
+Querying `http://${GATEWAY_HOST}/service/foo/v1/api` should rewrite the request to `http://${GATEWAY_HOST}/v1/api/instance/foo`.
 
 ```console
 $ curl -L -vvv --header "Host: path.regex.rewrite.example" "http://${GATEWAY_HOST}/service/foo/v1/api"


### PR DESCRIPTION
As I was going through the docs site, I noticed a small error which initially lead to a little confusion for me as I read.

I've made a small update to reflect what I believe is the intended wording.

Release Notes: No
