### PR TITLE
fix: flaky test - use gateway website instead of nghttp2.org

### DIFF
--- a/test/e2e/tests/httproute_with_dynamic_resolver_backend.go
+++ b/test/e2e/tests/httproute_with_dynamic_resolver_backend.go
@@ -80,12 +80,9 @@ var DynamicResolverBackendTest = suite.ConformanceTest{
 				},
 			})
 
-			// test with nghttp2.org, it support http2.0
-			// https://github.com/postmanlabs/httpbin/issues/373#issuecomment-354534597
 			req := http.MakeRequest(t, &http.ExpectedResponse{
 				Request: http.Request{
-					Host: "nghttp2.org",
-					Path: "httpbin/status/200",
+					Host: "gateway.envoyproxy.io", // gateway website supports http2.0
 				},
 				Response: http.Response{
 					StatusCodes: []int{200},


### PR DESCRIPTION
fixes: https://productionresultssa3.blob.core.windows.net/actions-results/20f93ee9-7395-41e0-b853-255aecc825f8/workflow-job-run-815794b7-292d-587a-b759-111efa976165/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-01-09T08%3A57%3A33Z&sig=qCChYSnFPnKymhlL45fdGvKlVhiuq1bLZU%2BDV91OCaU%3D&ske=2026-01-09T18%3A46%3A07Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-01-09T06%3A46%3A07Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-01-09T08%3A47%3A28Z&sv=2025-11-05


```
2026-01-09T08:28:57.1130344Z     http.go:282: 2026-01-09T08:28:57.111857659Z: Request passed
2026-01-09T08:28:57.1131942Z     httproute_with_dynamic_resolver_backend.go:85: 2026-01-09T08:28:57.111876655Z: Making GET request to host nghttp2.org via http://172.18.0.203/httpbin/status/200
2026-01-09T08:28:57.1133145Z     roundtripper.go:234: 2026-01-09T08:28:57.11203462Z: Sending Request:
2026-01-09T08:28:57.1133726Z         < GET /httpbin/status/200 HTTP/1.1
2026-01-09T08:28:57.1134341Z         < Host: nghttp2.org
2026-01-09T08:28:57.1134899Z         < User-Agent: Go-http-client/1.1
2026-01-09T08:28:57.1135481Z         < X-Echo-Set-Header: 
2026-01-09T08:28:57.1135990Z         < Accept-Encoding: gzip
2026-01-09T08:28:57.1136404Z         < 
2026-01-09T08:28:57.1136656Z         < 
2026-01-09T08:28:57.1136964Z         
2026-01-09T08:28:57.1137204Z         
2026-01-09T08:29:07.1131574Z     roundtripper.go:248: 2026-01-09T08:29:07.112816576Z: Error sending request: Get "http://172.18.0.203/httpbin/status/200": context deadline exceeded (no response)
```