### PR TITLE
[release/v1.6] bump proxy and ratelimit versions

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -23,7 +23,7 @@ const (
 	// DefaultDeploymentMemoryResourceRequests for deployment memory resource
 	DefaultDeploymentMemoryResourceRequests = "512Mi"
 	// DefaultEnvoyProxyImage is the default image used by envoyproxy
-	DefaultEnvoyProxyImage = "docker.io/envoyproxy/envoy:distroless-v1.36.3"
+	DefaultEnvoyProxyImage = "docker.io/envoyproxy/envoy:distroless-v1.36.4"
 	// DefaultShutdownManagerCPUResourceRequests for shutdown manager cpu resource
 	DefaultShutdownManagerCPUResourceRequests = "10m"
 	// DefaultShutdownManagerMemoryResourceRequests for shutdown manager memory resource
@@ -31,7 +31,7 @@ const (
 	// DefaultShutdownManagerImage is the default image used for the shutdown manager.
 	DefaultShutdownManagerImage = "docker.io/envoyproxy/gateway-dev:latest"
 	// DefaultRateLimitImage is the default image used by ratelimit.
-	DefaultRateLimitImage = "docker.io/envoyproxy/ratelimit:99d85510"
+	DefaultRateLimitImage = "docker.io/envoyproxy/ratelimit:a28b84d0"
 	// HTTPProtocol is the common-used http protocol.
 	HTTPProtocol = "http"
 	// GRPCProtocol is the common-used grpc protocol.

--- a/charts/gateway-helm/README.md
+++ b/charts/gateway-helm/README.md
@@ -103,7 +103,7 @@ helm uninstall eg -n envoy-gateway-system
 | global.images.envoyGateway.image | string | `nil` |  |
 | global.images.envoyGateway.pullPolicy | string | `nil` |  |
 | global.images.envoyGateway.pullSecrets | list | `[]` |  |
-| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:99d85510"` |  |
+| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:a28b84d0"` |  |
 | global.images.ratelimit.pullPolicy | string | `"IfNotPresent"` |  |
 | global.images.ratelimit.pullSecrets | list | `[]` |  |
 | hpa.behavior | object | `{}` |  |

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -19,7 +19,7 @@ global:
       pullSecrets: []
     ratelimit:
       # This is the full image name including the hub, repo, and tag.
-      image: "docker.io/envoyproxy/ratelimit:99d85510"
+      image: "docker.io/envoyproxy/ratelimit:a28b84d0"
       # Specify image pull policy if default behavior isn't desired.
       # Default behavior: latest images will be Always else IfNotPresent.
       pullPolicy: IfNotPresent

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
@@ -71,7 +71,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
@@ -170,7 +170,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
@@ -236,7 +236,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
@@ -230,7 +230,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
@@ -226,7 +226,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
@@ -73,7 +73,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
@@ -221,7 +221,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -75,7 +75,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -75,7 +75,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
@@ -240,7 +240,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -174,7 +174,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
@@ -226,7 +226,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
@@ -240,7 +240,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
@@ -226,7 +226,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -234,7 +234,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
@@ -227,7 +227,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -230,7 +230,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -77,7 +77,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -229,7 +229,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -225,7 +225,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
@@ -240,7 +240,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -660,7 +660,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-v1.36.3
+        image: docker.io/envoyproxy/envoy:distroless-v1.36.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:99d85510
+        image: docker.io/envoyproxy/ratelimit:a28b84d0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/disable-prometheus.yaml
@@ -74,7 +74,7 @@ spec:
           value: tcp
         - name: REDIS_URL
           value: redis.redis.svc:6379
-        image: docker.io/envoyproxy/ratelimit:99d85510
+        image: docker.io/envoyproxy/ratelimit:a28b84d0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing-custom.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing-custom.yaml
@@ -99,7 +99,7 @@ spec:
           value: "0.6"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://trace-collector.envoy-gateway-system.svc.cluster.local:4317
-        image: docker.io/envoyproxy/ratelimit:99d85510
+        image: docker.io/envoyproxy/ratelimit:a28b84d0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing.yaml
@@ -99,7 +99,7 @@ spec:
           value: "1.0"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://trace-collector.envoy-gateway-system.svc.cluster.local:4318
-        image: docker.io/envoyproxy/ratelimit:99d85510
+        image: docker.io/envoyproxy/ratelimit:a28b84d0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-annotations.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-annotations.yaml
@@ -86,7 +86,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:99d85510
+        image: docker.io/envoyproxy/ratelimit:a28b84d0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-labels.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-labels.yaml
@@ -86,7 +86,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:99d85510
+        image: docker.io/envoyproxy/ratelimit:a28b84d0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment-containers.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment-containers.yaml
@@ -86,7 +86,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:99d85510
+        image: docker.io/envoyproxy/ratelimit:a28b84d0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:99d85510
+        image: docker.io/envoyproxy/ratelimit:a28b84d0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-node-selector.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:99d85510
+        image: docker.io/envoyproxy/ratelimit:a28b84d0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-topology-spread-constraints.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:99d85510
+        image: docker.io/envoyproxy/ratelimit:a28b84d0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/site/content/en/latest/install/gateway-helm-api.md
+++ b/site/content/en/latest/install/gateway-helm-api.md
@@ -67,7 +67,7 @@ The Helm chart for Envoy Gateway
 | global.images.envoyGateway.image | string | `nil` |  |
 | global.images.envoyGateway.pullPolicy | string | `nil` |  |
 | global.images.envoyGateway.pullSecrets | list | `[]` |  |
-| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:99d85510"` |  |
+| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:a28b84d0"` |  |
 | global.images.ratelimit.pullPolicy | string | `"IfNotPresent"` |  |
 | global.images.ratelimit.pullSecrets | list | `[]` |  |
 | hpa.behavior | object | `{}` |  |

--- a/test/helm/gateway-helm/certgen-annotations.out.yaml
+++ b/test/helm/gateway-helm/certgen-annotations.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/certgen-args.out.yaml
+++ b/test/helm/gateway-helm/certgen-args.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/certgen-labels.out.yaml
+++ b/test/helm/gateway-helm/certgen-labels.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
+++ b/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
+++ b/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
@@ -53,7 +53,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/default-config.out.yaml
+++ b/test/helm/gateway-helm/default-config.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-annotations.out.yaml
+++ b/test/helm/gateway-helm/deployment-annotations.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-custom-topology.out.yaml
+++ b/test/helm/gateway-helm/deployment-custom-topology.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-images-config.out.yaml
+++ b/test/helm/gateway-helm/deployment-images-config.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-priorityclass.out.yaml
+++ b/test/helm/gateway-helm/deployment-priorityclass.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-repo-no-registry.out.yaml
+++ b/test/helm/gateway-helm/deployment-repo-no-registry.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-securitycontext.out.yaml
+++ b/test/helm/gateway-helm/deployment-securitycontext.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config-watch.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config-watch.out.yaml
@@ -40,7 +40,7 @@ data:
           type: GatewayNamespace
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config.out.yaml
@@ -40,7 +40,7 @@ data:
           type: GatewayNamespace
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
+++ b/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/service-customization.out.yaml
+++ b/test/helm/gateway-helm/service-customization.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/webhook-disabled.out.yaml
+++ b/test/helm/gateway-helm/webhook-disabled.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:99d85510
+            image: docker.io/envoyproxy/ratelimit:a28b84d0
           patch:
             type: StrategicMerge
             value:


### PR DESCRIPTION
Proxy [version](https://hub.docker.com/layers/envoyproxy/envoy/distroless-v1.36.4/images/sha256-2f71c5666a5209d6ee1ec519b17877ccb6d17be4d00e34de10f11e020ea8707a)
Ratelimit [version](https://hub.docker.com/layers/envoyproxy/ratelimit/a28b84d0/images/sha256-8edff6485256d6594707efd3625d4ca1cafe987f5bd8e50b5e14b4dda1a1138d)