### PR TITLE
fix: backend tls default namespace

### DIFF
--- a/internal/gatewayapi/backend.go
+++ b/internal/gatewayapi/backend.go
@@ -159,7 +159,7 @@ func validateBackendTLSSettings(backend *egv1a1.Backend, backendTLSPolicies []*g
 	}
 
 	if backend.Spec.TLS.BackendTLSConfig != nil && backend.Spec.TLS.ClientCertificateRef != nil {
-		ns := string(ptr.Deref(backend.Spec.TLS.ClientCertificateRef.Namespace, "default"))
+		ns := NamespaceDerefOr(backend.Spec.TLS.ClientCertificateRef.Namespace, backend.Namespace)
 		if ns != backend.Namespace {
 			return status.NewRouteStatusError(
 				fmt.Errorf("clientCertificateRef Secret is not located in the same namespace as Backend. Secret namespace: %s does not match Backend namespace: %s", ns, backend.Namespace),

--- a/internal/gatewayapi/backendtlspolicy.go
+++ b/internal/gatewayapi/backendtlspolicy.go
@@ -365,7 +365,7 @@ func (t *Translator) processClientTLSSettings(
 			ownerResource = "Backend"
 		}
 
-		ns := string(ptr.Deref(clientTLS.ClientCertificateRef.Namespace, "default"))
+		ns := NamespaceDerefOr(clientTLS.ClientCertificateRef.Namespace, ownerNs)
 		if ns != ownerNs {
 			err = fmt.Errorf("ClientCertificateRef Secret is not located in the same namespace as %s. Secret namespace: %s does not match %s namespace: %s", ownerResource, ns, ownerResource, ownerNs)
 			return tlsConfig, err

--- a/internal/gatewayapi/testdata/backend-tls-settings.in.yaml
+++ b/internal/gatewayapi/testdata/backend-tls-settings.in.yaml
@@ -9,7 +9,6 @@ envoyProxyForGatewayClass:
       clientCertificateRef:
         group: ""
         kind: Secret
-        namespace: envoy-gateway-system
         name: client-auth
       ciphers:
         - ECDHE-RSA-AES128-GCM-SHA256
@@ -149,7 +148,7 @@ httpRoutes:
   - apiVersion: gateway.networking.k8s.io/v1
     kind: HTTPRoute
     metadata:
-      namespace: default
+      namespace: envoy-gateway
       name: httproute-7-override-client-tls-settings
     spec:
       parentRefs:
@@ -265,7 +264,7 @@ secrets:
     kind: Secret
     metadata:
       name: client-auth-override
-      namespace: default
+      namespace: envoy-gateway
     type: kubernetes.io/tls
     data:
       tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKRENDQWd5Z0F3SUJBZ0lVU3JTYktMZjBiTEVHb2dXeC9nQ3cyR0N0dnhFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0V6RVJNQThHQTFVRUF3d0lWR1Z6ZENCSmJtTXdIaGNOTWpRd01qSTVNRGt6TURFd1doY05NelF3TWpJMgpNRGt6TURFd1dqQVRNUkV3RHdZRFZRUUREQWhVWlhOMElFbHVZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBSzFKempQSWlXZzNxb0hTckFkZGtlSmphTVA5aXlNVGkvQlBvOWNKUG9SRThaaTcKV2FwVXJYTC85QTlyK2pITXlHSVpOWk5kY1o1Y1kyWHYwTFA4WnhWeTJsazArM3d0WXpIbnBHWUdWdHlxMnRldApEaEZzaVBsODJZUmpDMG16V2E0UU16NFNYekZITmdJRHBSZGhmcm92bXNldVdHUUU4cFY0VWQ5VUsvU0tpbE1PCnF0QjVKaXJMUDJWczVUMW9XaWNXTFF2ZmJHd3Y3c0ZEZHI5YkcwWHRTUXAxN0hTZ281MFNERTUrQmpTbXB0RncKMVZjS0xscWFoTVhCRERpb3Jnd2hJaEdHS3BFU2VNMFA3YkZoVm1rTTNhc2gyeFNUQnVGVUJEbEU0Sk9haHp3cwpEWHJ1cFVoRGRTMWhkYzJmUHJqaEZBbEpmV0VZWjZCbFpqeXNpVlVDQXdFQUFhTndNRzR3SFFZRFZSME9CQllFCkZCUXVmSzFMaWJ1Vm05VHMvVmpCeDhMM3VpTmVNQjhHQTFVZEl3UVlNQmFBRkJRdWZLMUxpYnVWbTlUcy9WakIKeDhMM3VpTmVNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdHd1lEVlIwUkJCUXdFb0lCS29JTktpNWxlR0Z0Y0d4bApMbU52YlRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWZQUzQxYWdldldNVjNaWHQwQ09GRzN1WWZQRlhuVnc2ClA0MXA5TzZHa2RZc3VxRnZQZVR5eUgyL2RBSUtLd1N6TS9wdGhnOEtuOExabG1KeUZObkExc3RKeG41WGRiVjEKcFBxajhVdllDQnp5ak1JcW1SeW9peUxpUWxib2hNYTBVZEVCS2NIL1BkTEU5SzhUR0pyWmdvR1hxcTFXbWl0RAozdmNQalNlUEtFaVVKVlM5bENoeVNzMEtZNUIraFVRRDBKajZucEZENFprMHhxZHhoMHJXdWVDcXE3dmpxRVl6CnBqNFB3cnVmbjFQQlRtZnhNdVYvVUpWNWViaWtldVpQMzVrV3pMUjdaV0FMN3d1RGRXcC82bzR5azNRTGFuRFEKQ3dnQ0ZjWCtzcyswVnl1TTNZZXJUT1VVOFFWSkp4NFVaQU5aeDYrNDNwZEpaT2NudFBaNENBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
@@ -354,14 +353,13 @@ backends:
     kind: Backend
     metadata:
       name: backend-7      # this backend should be accepted and override the client TLS settings from EnvoyProxy
-      namespace: default
+      namespace: envoy-gateway
     spec:
       tls:
         wellKnownCACertificates: System
         clientCertificateRef:
           group: ""
           kind: Secret
-          namespace: default
           name: client-auth-override
         alpnProtocols:
           - HTTP/2

--- a/internal/gatewayapi/testdata/backend-tls-settings.out.yaml
+++ b/internal/gatewayapi/testdata/backend-tls-settings.out.yaml
@@ -236,7 +236,7 @@ backends:
   kind: Backend
   metadata:
     name: backend-7
-    namespace: default
+    namespace: envoy-gateway
   spec:
     endpoints:
     - ip:
@@ -249,7 +249,6 @@ backends:
         group: ""
         kind: Secret
         name: client-auth-override
-        namespace: default
       wellKnownCACertificates: System
   status:
     conditions:
@@ -513,7 +512,7 @@ httpRoutes:
   kind: HTTPRoute
   metadata:
     name: httproute-7-override-client-tls-settings
-    namespace: default
+    namespace: envoy-gateway
   spec:
     parentRefs:
     - name: gateway-1
@@ -565,7 +564,6 @@ infraIR:
               group: ""
               kind: Secret
               name: client-auth
-              namespace: envoy-gateway-system
             ecdhCurves:
             - ECDHE-RSA-AES128-GCM-SHA256
             - ECDHE-ECDSA-AES256-GCM-SHA384
@@ -876,8 +874,8 @@ xdsIR:
           metadata:
             kind: HTTPRoute
             name: httproute-7-override-client-tls-settings
-            namespace: default
-          name: httproute/default/httproute-7-override-client-tls-settings/rule/0
+            namespace: envoy-gateway
+          name: httproute/envoy-gateway/httproute-7-override-client-tls-settings/rule/0
           settings:
           - addressType: IP
             endpoints:
@@ -886,20 +884,20 @@ xdsIR:
             metadata:
               kind: Backend
               name: backend-7
-              namespace: default
-            name: httproute/default/httproute-7-override-client-tls-settings/rule/0/backend/0
+              namespace: envoy-gateway
+            name: httproute/envoy-gateway/httproute-7-override-client-tls-settings/rule/0/backend/0
             protocol: HTTP
             tls:
               alpnProtocols:
               - HTTP/2
               caCertificate:
-                name: backend-7/default-ca
+                name: backend-7/envoy-gateway-ca
               ciphers:
               - ECDHE-RSA-AES128-GCM-SHA256
               - ECDHE-ECDSA-AES256-GCM-SHA384
               clientCertificates:
               - certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKRENDQWd5Z0F3SUJBZ0lVU3JTYktMZjBiTEVHb2dXeC9nQ3cyR0N0dnhFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0V6RVJNQThHQTFVRUF3d0lWR1Z6ZENCSmJtTXdIaGNOTWpRd01qSTVNRGt6TURFd1doY05NelF3TWpJMgpNRGt6TURFd1dqQVRNUkV3RHdZRFZRUUREQWhVWlhOMElFbHVZekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBSzFKempQSWlXZzNxb0hTckFkZGtlSmphTVA5aXlNVGkvQlBvOWNKUG9SRThaaTcKV2FwVXJYTC85QTlyK2pITXlHSVpOWk5kY1o1Y1kyWHYwTFA4WnhWeTJsazArM3d0WXpIbnBHWUdWdHlxMnRldApEaEZzaVBsODJZUmpDMG16V2E0UU16NFNYekZITmdJRHBSZGhmcm92bXNldVdHUUU4cFY0VWQ5VUsvU0tpbE1PCnF0QjVKaXJMUDJWczVUMW9XaWNXTFF2ZmJHd3Y3c0ZEZHI5YkcwWHRTUXAxN0hTZ281MFNERTUrQmpTbXB0RncKMVZjS0xscWFoTVhCRERpb3Jnd2hJaEdHS3BFU2VNMFA3YkZoVm1rTTNhc2gyeFNUQnVGVUJEbEU0Sk9haHp3cwpEWHJ1cFVoRGRTMWhkYzJmUHJqaEZBbEpmV0VZWjZCbFpqeXNpVlVDQXdFQUFhTndNRzR3SFFZRFZSME9CQllFCkZCUXVmSzFMaWJ1Vm05VHMvVmpCeDhMM3VpTmVNQjhHQTFVZEl3UVlNQmFBRkJRdWZLMUxpYnVWbTlUcy9WakIKeDhMM3VpTmVNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdHd1lEVlIwUkJCUXdFb0lCS29JTktpNWxlR0Z0Y0d4bApMbU52YlRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWZQUzQxYWdldldNVjNaWHQwQ09GRzN1WWZQRlhuVnc2ClA0MXA5TzZHa2RZc3VxRnZQZVR5eUgyL2RBSUtLd1N6TS9wdGhnOEtuOExabG1KeUZObkExc3RKeG41WGRiVjEKcFBxajhVdllDQnp5ak1JcW1SeW9peUxpUWxib2hNYTBVZEVCS2NIL1BkTEU5SzhUR0pyWmdvR1hxcTFXbWl0RAozdmNQalNlUEtFaVVKVlM5bENoeVNzMEtZNUIraFVRRDBKajZucEZENFprMHhxZHhoMHJXdWVDcXE3dmpxRVl6CnBqNFB3cnVmbjFQQlRtZnhNdVYvVUpWNWViaWtldVpQMzVrV3pMUjdaV0FMN3d1RGRXcC82bzR5azNRTGFuRFEKQ3dnQ0ZjWCtzcyswVnl1TTNZZXJUT1VVOFFWSkp4NFVaQU5aeDYrNDNwZEpaT2NudFBaNENBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-                name: default/client-auth-override
+                name: envoy-gateway/client-auth-override
                 privateKey: '[redacted]'
               ecdhCurves:
               - ECDHE-RSA-AES128-GCM-SHA256
@@ -916,8 +914,8 @@ xdsIR:
         metadata:
           kind: HTTPRoute
           name: httproute-7-override-client-tls-settings
-          namespace: default
-        name: httproute/default/httproute-7-override-client-tls-settings/rule/0/match/0/*
+          namespace: envoy-gateway
+        name: httproute/envoy-gateway/httproute-7-override-client-tls-settings/rule/0/match/0/*
         pathMatch:
           distinct: false
           name: ""


### PR DESCRIPTION
Fixes: the default namespace for `SecretObjectReference`  should be the owner namespace, not default.

The condition `The Backend was not accepted: clientCertificateRef Secret is not located
      in the same namespace as Backend. Secret namespace: default does not match Backend
      namespace: httpbin-tls` is wrong in the following example.
      
```yaml
apiVersion: gateway.envoyproxy.io/v1alpha1
kind: Backend
metadata:
  name: httpbin-mtls-httpbin-tls-be
  namespace: httpbin-tls
  resourceVersion: "1768671158131743002"
  uid: 1cb357df-44b9-4204-87b0-dbeb4cf86b7d
spec:
  endpoints:
  - fqdn:
      hostname: httpbin-tls.httpbin-tls.svc.cluster.local
      port: 8443
  tls:
    caCertificateRefs:
    - group: ""
      kind: Secret
      name: httpbin-mtls-ssl
    clientCertificateRef:
      group: ""
      kind: Secret
      name: httpbin-mtls-ssl
      namespace: httpbin-tls
    insecureSkipVerify: false
  type: Endpoints
status:
  conditions:
  - lastTransitionTime: "2026-01-17T17:32:38Z"
    message: 'The Backend was not accepted: clientCertificateRef Secret is not located
      in the same namespace as Backend. Secret namespace: default does not match Backend
      namespace: httpbin-tls'
    observedGeneration: 2
    reason: Accepted
    status: "False"
    type: Invalid
  - lastTransitionTime: "2026-01-17T17:32:38Z"
    message: The Backend was accepted
    observedGeneration: 3
    reason: Accepted
    status: "True"
    type: Accepted
  ```