### PR TITLE
chore: fix lint.codespell failed to run

### DIFF
--- a/tools/make/lint.mk
+++ b/tools/make/lint.mk
@@ -53,7 +53,7 @@ lint.codespell: $(tools/codespell)
 # one shell, this is because we want the ::remove-matcher lines to get
 # printed whether or not it finds complaints.
 	@PS4=; set -e; { \
-	  if test -n "$$GITHUB_ACTION"; then \
+	  if test -n "$${GITHUB_ACTION-}"; then \
 	    printf '::add-matcher::$(CURDIR)/tools/linter/codespell/matcher.json\n'; \
 	    trap "printf '::remove-matcher owner=codespell-matcher-default::\n::remove-matcher owner=codespell-matcher-specified::\n'" EXIT; \
 	  fi; \


### PR DESCRIPTION
fix error:
```console
===========> Running lint.codespell ... 
bash: line 2: GITHUB_ACTION: unbound variable
make[1]: *** [tools/make/lint.mk:46: lint.codespell] Error 1
make[1]: Leaving directory '/Users/zirain/Codes/servicemesh/gateway'
make: *** [Makefile:18: _run] Error 2
```