### PR TITLE
chore: add reminder for go-control-plane

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,10 @@ updates:
       k8s.io:
         patterns:
           - "k8s.io/*"
+      envoyproxy.io:
+        patterns:
+          # This won't pass CI, but give us a reminder.
+          - "github.com/envoyproxy/*"
   - package-ecosystem: npm
     directories:
       - /site


### PR DESCRIPTION
It would be better keep this updated, `gen-check` won't pass but this's a good reminder.