### PR TITLE
chore: disabled debug log in e2e

### DIFF
--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -36,8 +36,10 @@ E2E_TIMEOUT ?= 20m
 # E2E_REDIRECT allow you specified a redirect when run e2e test locally, e.g. `>> test_output.out 2>&1`
 E2E_REDIRECT ?=
 E2E_TEST_ARGS ?= -v -tags e2e -timeout $(E2E_TIMEOUT)
+# If E2E_DEBUG is not explicitly defined, set it based on the ACTIONS_STEP_DEBUG environment variable.
+E2E_DEBUG ?= $(if $(filter true yes 1,$(ACTIONS_STEP_DEBUG)),true,false)
 # If you want to skip crds version check, add `--allow-crds-mismatch` to E2E_TEST_SUITE_ARGS
-E2E_TEST_SUITE_ARGS ?= --debug=true
+E2E_TEST_SUITE_ARGS ?= --debug=$(E2E_DEBUG)
 
 CONFORMANCE_RUN_TEST ?=
 CONFORMANCE_TEST_ARGS ?= -v -tags conformance -timeout $(E2E_TIMEOUT)


### PR DESCRIPTION
I spend some time to debug the flaky e2e test, and the debug log make it's hard open the github action page.
This RP disabled the debug log by default, you can enabled it in two ways:
- export E2E_DEBUG=true
- enable [debug-logging](https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging) for Github action 

<img width="1498" height="976" alt="image" src="https://github.com/user-attachments/assets/ad49672b-e231-4cd7-a2bb-fcbd6e96ce78" />
