### PR TITLE
test crd failure - just for testing, do not merge!

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -88,6 +88,7 @@ func server(ctx context.Context, stdout, stderr io.Writer, cfgPath string, hook 
 
 	l := loader.New(cfgPath, cfg, hook)
 	if err := l.Start(ctx, stdout); err != nil {
+		cfg.Logger.Error(err, "failed to start config loader")
 		return err
 	}
 


### PR DESCRIPTION
```
2026-01-24T02:33:28.540Z	ERROR	config-loader	loader/configloader.go:130	hook error	{"error": "failed to create kubernetes provider: failed to create provider Kubernetes: failed to create gatewayapi controller: error watching resources: failed to discover EnvoyProxy CRD: discover resources for gateway.envoyproxy.io/v1alpha1: fake discovery error"}
2026-01-24T02:33:28.540Z	ERROR	cmd/server.go:104	failed to start runners	{"error": "failed to create kubernetes provider: failed to create provider Kubernetes: failed to create gatewayapi controller: error watching resources: failed to discover EnvoyProxy CRD: discover resources for gateway.envoyproxy.io/v1alpha1: fake discovery error"}
Error: failed to create kubernetes provider: failed to create provider Kubernetes: failed to create gatewayapi controller: error watching resources: failed to discover EnvoyProxy CRD: discover resources for gateway.envoyproxy.io/v1alpha1: fake discovery error
Usage:
  envoy-gateway server [flags]

Aliases:
  server, serve

Flags:
  -c, --config-path string   The path to the configuration file.
  -h, --help                 help for server

failed to create kubernetes provider: failed to create provider Kubernetes: failed to create gatewayapi controller: error watching resources: failed to discover EnvoyProxy CRD: discover resources for gateway.envoyproxy.io/v1alpha1: fake discovery error
```

cc @arkodg 