### PR TITLE
[release/v1.6] bump ratelimit version

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -31,7 +31,7 @@ const (
 	// DefaultShutdownManagerImage is the default image used for the shutdown manager.
 	DefaultShutdownManagerImage = "docker.io/envoyproxy/gateway-dev:latest"
 	// DefaultRateLimitImage is the default image used by ratelimit.
-	DefaultRateLimitImage = "docker.io/envoyproxy/ratelimit:a28b84d0"
+	DefaultRateLimitImage = "docker.io/envoyproxy/ratelimit:3fb70258"
 	// HTTPProtocol is the common-used http protocol.
 	HTTPProtocol = "http"
 	// GRPCProtocol is the common-used grpc protocol.

--- a/charts/gateway-helm/README.md
+++ b/charts/gateway-helm/README.md
@@ -103,7 +103,7 @@ helm uninstall eg -n envoy-gateway-system
 | global.images.envoyGateway.image | string | `nil` |  |
 | global.images.envoyGateway.pullPolicy | string | `nil` |  |
 | global.images.envoyGateway.pullSecrets | list | `[]` |  |
-| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:a28b84d0"` |  |
+| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:3fb70258"` |  |
 | global.images.ratelimit.pullPolicy | string | `"IfNotPresent"` |  |
 | global.images.ratelimit.pullSecrets | list | `[]` |  |
 | hpa.behavior | object | `{}` |  |

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -19,7 +19,7 @@ global:
       pullSecrets: []
     ratelimit:
       # This is the full image name including the hub, repo, and tag.
-      image: "docker.io/envoyproxy/ratelimit:a28b84d0"
+      image: "docker.io/envoyproxy/ratelimit:3fb70258"
       # Specify image pull policy if default behavior isn't desired.
       # Default behavior: latest images will be Always else IfNotPresent.
       pullPolicy: IfNotPresent

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:a28b84d0
+        image: docker.io/envoyproxy/ratelimit:3fb70258
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/disable-prometheus.yaml
@@ -74,7 +74,7 @@ spec:
           value: tcp
         - name: REDIS_URL
           value: redis.redis.svc:6379
-        image: docker.io/envoyproxy/ratelimit:a28b84d0
+        image: docker.io/envoyproxy/ratelimit:3fb70258
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing-custom.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing-custom.yaml
@@ -99,7 +99,7 @@ spec:
           value: "0.6"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://trace-collector.envoy-gateway-system.svc.cluster.local:4317
-        image: docker.io/envoyproxy/ratelimit:a28b84d0
+        image: docker.io/envoyproxy/ratelimit:3fb70258
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing.yaml
@@ -99,7 +99,7 @@ spec:
           value: "1.0"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://trace-collector.envoy-gateway-system.svc.cluster.local:4318
-        image: docker.io/envoyproxy/ratelimit:a28b84d0
+        image: docker.io/envoyproxy/ratelimit:3fb70258
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-annotations.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-annotations.yaml
@@ -86,7 +86,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:a28b84d0
+        image: docker.io/envoyproxy/ratelimit:3fb70258
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-labels.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-labels.yaml
@@ -86,7 +86,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:a28b84d0
+        image: docker.io/envoyproxy/ratelimit:3fb70258
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment-containers.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment-containers.yaml
@@ -86,7 +86,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:a28b84d0
+        image: docker.io/envoyproxy/ratelimit:3fb70258
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:a28b84d0
+        image: docker.io/envoyproxy/ratelimit:3fb70258
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-node-selector.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:a28b84d0
+        image: docker.io/envoyproxy/ratelimit:3fb70258
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-topology-spread-constraints.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:a28b84d0
+        image: docker.io/envoyproxy/ratelimit:3fb70258
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/site/content/en/latest/install/gateway-helm-api.md
+++ b/site/content/en/latest/install/gateway-helm-api.md
@@ -67,7 +67,7 @@ The Helm chart for Envoy Gateway
 | global.images.envoyGateway.image | string | `nil` |  |
 | global.images.envoyGateway.pullPolicy | string | `nil` |  |
 | global.images.envoyGateway.pullSecrets | list | `[]` |  |
-| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:a28b84d0"` |  |
+| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:3fb70258"` |  |
 | global.images.ratelimit.pullPolicy | string | `"IfNotPresent"` |  |
 | global.images.ratelimit.pullSecrets | list | `[]` |  |
 | hpa.behavior | object | `{}` |  |

--- a/test/helm/gateway-helm/certgen-annotations.out.yaml
+++ b/test/helm/gateway-helm/certgen-annotations.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/certgen-args.out.yaml
+++ b/test/helm/gateway-helm/certgen-args.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/certgen-labels.out.yaml
+++ b/test/helm/gateway-helm/certgen-labels.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
+++ b/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
+++ b/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
@@ -53,7 +53,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/default-config.out.yaml
+++ b/test/helm/gateway-helm/default-config.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-annotations.out.yaml
+++ b/test/helm/gateway-helm/deployment-annotations.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-custom-topology.out.yaml
+++ b/test/helm/gateway-helm/deployment-custom-topology.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-images-config.out.yaml
+++ b/test/helm/gateway-helm/deployment-images-config.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-priorityclass.out.yaml
+++ b/test/helm/gateway-helm/deployment-priorityclass.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-repo-no-registry.out.yaml
+++ b/test/helm/gateway-helm/deployment-repo-no-registry.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-securitycontext.out.yaml
+++ b/test/helm/gateway-helm/deployment-securitycontext.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config-watch.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config-watch.out.yaml
@@ -40,7 +40,7 @@ data:
           type: GatewayNamespace
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config.out.yaml
@@ -40,7 +40,7 @@ data:
           type: GatewayNamespace
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
+++ b/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/service-customization.out.yaml
+++ b/test/helm/gateway-helm/service-customization.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/webhook-disabled.out.yaml
+++ b/test/helm/gateway-helm/webhook-disabled.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:a28b84d0
+            image: docker.io/envoyproxy/ratelimit:3fb70258
           patch:
             type: StrategicMerge
             value:


### PR DESCRIPTION
Ratelimit [version](https://hub.docker.com/layers/envoyproxy/ratelimit/3fb70258/images/sha256-55b7e074ec2c5771ab06a7f0cf15d7fe30496ff1f3826b0dfa53733d101e4d40)