### PR TITLE
[release-v1.6] allow updating initial_fetch_timeout in bootstrap

### DIFF
--- a/internal/xds/bootstrap/testdata/validate/valid-user-bootstrap.yaml
+++ b/internal/xds/bootstrap/testdata/validate/valid-user-bootstrap.yaml
@@ -19,9 +19,11 @@ dynamicResources:
   ldsConfig:
     ads: {}
     resourceApiVersion: V3
+    initial_fetch_timeout: 0s
   cdsConfig:
     ads: {}
     resourceApiVersion: V3
+    initial_fetch_timeout: 0s
 staticResources:
   clusters:
   - connectTimeout: 10s

--- a/internal/xds/bootstrap/validate.go
+++ b/internal/xds/bootstrap/validate.go
@@ -10,6 +10,7 @@ import (
 
 	bootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -59,9 +60,10 @@ func Validate(boostrapConfig *egv1a1.ProxyBootstrap) error {
 		return err
 	}
 
-	// Ensure dynamic resources config is same
+	// Ensure dynamic resources config is same except for initial_fetch_timeout
 	if userBootstrap.DynamicResources == nil ||
-		cmp.Diff(userBootstrap.DynamicResources, defaultBootstrap.DynamicResources, protocmp.Transform()) != "" {
+		cmp.Diff(userBootstrap.DynamicResources, defaultBootstrap.DynamicResources, protocmp.Transform(),
+			protocmp.IgnoreFields(&corev3.ConfigSource{}, "initial_fetch_timeout")) != "" {
 		return fmt.Errorf("dynamic_resources cannot be modified")
 	}
 


### PR DESCRIPTION
Separated from https://github.com/envoyproxy/gateway/pull/7962, allow users to patch `initial_fetch_timeout`.
This's good for users who plan to stay in v1.6 for a while.