### PR TITLE
docs: fix missing backtick in route list formatting

### DIFF
--- a/site/content/en/v1.5/tasks/traffic/http-routing.md
+++ b/site/content/en/v1.5/tasks/traffic/http-routing.md
@@ -51,7 +51,7 @@ The three HTTPRoute resources create routing rules on the Gateway. In order to r
 an HTTPRoute must be configured with `parentRefs` which reference the parent Gateway(s) that it should be attached to.
 An HTTPRoute can match against a [single set of hostnames][spec]. These hostnames are matched before any other matching
 within the HTTPRoute takes place. Since `example.com`, `foo.example.com`, and `bar.example.com` are separate hosts with
-different routing requirements, each is deployed as its own HTTPRoute - `example-route, ``foo-route`, and `bar-route`.
+different routing requirements, each is deployed as its own HTTPRoute - `example-route`, `foo-route`, and `bar-route`.
 
 Check the status of the HTTPRoutes:
 


### PR DESCRIPTION
Fix formatting: add missing backtick in route list

This commit corrects a markdown formatting error in the route documentation 
where `foo-route` was missing its closing backtick. 

The route list now correctly displays:
* `example-route`
* `foo-route`
* `bar-route`

**What type of PR is this?**

docs: fix formatting in route list

**What this PR does / why we need it**:

This PR fixes a markdown formatting issue in the route documentation where 
`foo-route` was missing its closing backtick character. This ensures all 
route names in the list are consistently formatted as inline code blocks.

**Which issue(s) this PR fixes**:

Fixes #

**Release Notes**: 

No

<!--
This is a minor documentation formatting fix that doesn't require release notes.
-->