### PR TITLE
chore: fix invalid EnvoyProxy

### DIFF
--- a/test/config/envoy-gateaway-config/default.yaml
+++ b/test/config/envoy-gateaway-config/default.yaml
@@ -20,10 +20,8 @@ data:
         redis:
           url: redis.redis-system.svc.cluster.local:6379
     envoyProxy:
-      logging:
-        level: debug
       provider:
         kubernetes:
           envoyDeployment:
             container:
-              image: envoyproxy/envoy:distroless-dev-debug
+              image: envoyproxy/envoy:invalid-tag


### PR DESCRIPTION
xref: https://github.com/envoyproxy/gateway/pull/7698

```
2026-01-28T06:46:41.419Z        INFO    config-loader   loader/configloader.go:73       failed to decode config file    {"name": "/config/envoy-gateway.yaml", "error": "json: cannot unmarshal string into Go struct field ProxyLogging.EnvoyGatewaySpec.envoyProxy.logging.level of type map[v1alpha1.ProxyLogComponent]v1alpha1.LogLevel"}
```