### PR TITLE
ci: release json report

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,12 @@ jobs:
           name: benchmark_report
           path: release-artifacts
 
+      # Make the JSON report be part of the release, so it would be easy to integrate with
+      # Performance Benchmark Report Explorer
+      - name: Unzip Benchmark Report
+        run: |
+          cd release-artifacts && unzip benchmark_report.zip
+
       - name: Build egctl multiarch binaries
         run: |
           make build-multiarch
@@ -109,6 +115,7 @@ jobs:
             release-artifacts/envoy-gateway-crds.yaml
             release-artifacts/release-notes.yaml
             release-artifacts/benchmark_report.zip
+            release-artifacts/benchmark_report/benchmark_result.json
             envoy-gateway_${{ env.release_tag }}_linux_amd64.tar.gz
             envoy-gateway_${{ env.release_tag }}_linux_arm64.tar.gz
             envoy-gateway_${{ env.release_tag }}_darwin_amd64.tar.gz


### PR DESCRIPTION
xref: https://github.com/envoyproxy/gateway/issues/8106


this will make the JSON report as part of the release, make it easier to integrate with `Performance Benchmark Report Explorer`.