### PR TITLE
sort e2e tests by time

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -97,13 +97,18 @@ func TestE2E(t *testing.T) {
 		t.Fatalf("Failed to create ConformanceTestSuite: %v", err)
 	}
 
-	cSuite.Setup(t, tests.ConformanceTests)
+	recorder := NewTimingRecorder()
+	t.Cleanup(func() {
+		recorder.Report(t)
+	})
+	timedTests := WrapConformanceTestsWithTiming(tests.ConformanceTests, recorder)
+	cSuite.Setup(t, timedTests)
 	if cSuite.RunTest != "" {
 		tlog.Logf(t, "Running E2E test %s", cSuite.RunTest)
 	} else {
 		tlog.Logf(t, "Running %d E2E tests", len(tests.ConformanceTests))
 	}
-	err = cSuite.Run(t, tests.ConformanceTests)
+	err = cSuite.Run(t, timedTests)
 	if err != nil {
 		tlog.Fatalf(t, "Failed to run E2E tests: %v", err)
 	}

--- a/test/e2e/merge_gateways/merge_gateways_test.go
+++ b/test/e2e/merge_gateways/merge_gateways_test.go
@@ -63,8 +63,13 @@ func TestMergeGateways(t *testing.T) {
 	cSuite.Applier.GatewayClass = *flags.GatewayClassName
 	cSuite.ControllerName = kubernetes.GWCMustHaveAcceptedConditionTrue(t, cSuite.Client, cSuite.TimeoutConfig, cSuite.GatewayClassName)
 
+	recorder := e2e.NewTimingRecorder()
+	t.Cleanup(func() {
+		recorder.Report(t)
+	})
+	timedTests := e2e.WrapConformanceTestsWithTiming(tests.MergeGatewaysTests, recorder)
 	tlog.Logf(t, "Running %d MergeGateways tests", len(tests.MergeGatewaysTests))
-	err = cSuite.Run(t, tests.MergeGatewaysTests)
+	err = cSuite.Run(t, timedTests)
 	if err != nil {
 		t.Fatalf("Failed to run MergeGateways tests: %v", err)
 	}

--- a/test/e2e/multiple_gc/multiple_gc_test.go
+++ b/test/e2e/multiple_gc/multiple_gc_test.go
@@ -27,6 +27,10 @@ import (
 func TestMultipleGC(t *testing.T) {
 	flag.Parse()
 	c, cfg := kubetest.NewClient(t)
+	recorder := e2e.NewTimingRecorder()
+	t.Cleanup(func() {
+		recorder.Report(t)
+	})
 
 	if flags.RunTest != nil && *flags.RunTest != "" {
 		tlog.Logf(t, "Running E2E test %s with %s GatewayClass\n cleanup: %t\n debug: %t",
@@ -62,9 +66,10 @@ func TestMultipleGC(t *testing.T) {
 		internetGatewaySuite.Applier.GatewayClass = internetGatewaySuiteGatewayClassName
 		internetGatewaySuite.ControllerName = kubernetes.GWCMustHaveAcceptedConditionTrue(t, internetGatewaySuite.Client, internetGatewaySuite.TimeoutConfig, internetGatewaySuite.GatewayClassName)
 
+		timedTests := e2e.WrapConformanceTestsWithTiming(tests.MultipleGCTests[internetGatewaySuiteGatewayClassName], recorder)
 		tlog.Logf(t, "Running %d MultipleGC tests", len(tests.MultipleGCTests[internetGatewaySuiteGatewayClassName]))
 
-		err = internetGatewaySuite.Run(t, tests.MultipleGCTests[internetGatewaySuiteGatewayClassName])
+		err = internetGatewaySuite.Run(t, timedTests)
 		if err != nil {
 			t.Fatalf("Failed to run InternetGC tests: %v", err)
 		}
@@ -96,8 +101,9 @@ func TestMultipleGC(t *testing.T) {
 		privateGatewaySuite.Applier.GatewayClass = privateGatewaySuiteGatewayClassName
 		privateGatewaySuite.ControllerName = kubernetes.GWCMustHaveAcceptedConditionTrue(t, privateGatewaySuite.Client, privateGatewaySuite.TimeoutConfig, privateGatewaySuite.GatewayClassName)
 
+		timedTests := e2e.WrapConformanceTestsWithTiming(tests.MultipleGCTests[privateGatewaySuiteGatewayClassName], recorder)
 		tlog.Logf(t, "Running %d MultipleGC tests", len(tests.MultipleGCTests[privateGatewaySuiteGatewayClassName]))
-		err = privateGatewaySuite.Run(t, tests.MultipleGCTests[privateGatewaySuiteGatewayClassName])
+		err = privateGatewaySuite.Run(t, timedTests)
 		if err != nil {
 			t.Fatalf("Failed to run PrivateGC tests: %v", err)
 		}

--- a/test/e2e/timing.go
+++ b/test/e2e/timing.go
@@ -1,0 +1,123 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+)
+
+const (
+	e2eWarnDurationEnv    = "EG_E2E_WARN_DURATION"
+	defaultWarnDuration   = 1 * time.Minute
+	minDurationResolution = time.Millisecond
+)
+
+type timingRecord struct {
+	name     string
+	duration time.Duration
+	failed   bool
+	skipped  bool
+}
+
+// TimingRecorder stores per-test durations for reporting.
+type TimingRecorder struct {
+	mu      sync.Mutex
+	records []timingRecord
+}
+
+// NewTimingRecorder creates a new recorder for test durations.
+func NewTimingRecorder() *TimingRecorder {
+	return &TimingRecorder{}
+}
+
+// Report logs test durations sorted by time.
+func (r *TimingRecorder) Report(t *testing.T) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	records := make([]timingRecord, len(r.records))
+	copy(records, r.records)
+	r.mu.Unlock()
+
+	if len(records) == 0 {
+		return
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].duration > records[j].duration
+	})
+
+	tlog.Logf(t, "E2E timing report (sorted by duration)")
+	for _, rec := range records {
+		status := "PASS"
+		if rec.skipped {
+			status = "SKIP"
+		} else if rec.failed {
+			status = "FAIL"
+		}
+		tlog.Logf(t, "%s %s (%s)", status, rec.name, rec.duration)
+	}
+}
+
+// WrapConformanceTestsWithTiming logs per-test duration and warns for slow tests.
+func WrapConformanceTestsWithTiming(tests []suite.ConformanceTest, recorder *TimingRecorder) []suite.ConformanceTest {
+	warnAfter := parseWarnDuration()
+	wrapped := make([]suite.ConformanceTest, 0, len(tests))
+
+	for _, test := range tests {
+		original := test.Test
+		test.Test = func(t *testing.T, suite *suite.ConformanceTestSuite) {
+			start := time.Now()
+			defer func() {
+				duration := time.Since(start).Round(minDurationResolution)
+				tlog.Logf(t, "Test %s completed in %s", test.ShortName, duration)
+				if warnAfter > 0 && duration > warnAfter {
+					tlog.Logf(t, "WARNING: Test %s took %s (threshold %s)", test.ShortName, duration, warnAfter)
+				}
+				if recorder != nil {
+					recorder.mu.Lock()
+					recorder.records = append(recorder.records, timingRecord{
+						name:     test.ShortName,
+						duration: duration,
+						failed:   t.Failed(),
+						skipped:  t.Skipped(),
+					})
+					recorder.mu.Unlock()
+				}
+			}()
+			original(t, suite)
+		}
+		wrapped = append(wrapped, test)
+	}
+
+	return wrapped
+}
+
+func parseWarnDuration() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(e2eWarnDurationEnv))
+	if raw == "" {
+		return defaultWarnDuration
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return defaultWarnDuration
+	}
+	if d <= 0 {
+		return 0
+	}
+	return d
+}

--- a/test/e2e/upgrade/eg_upgrade_test.go
+++ b/test/e2e/upgrade/eg_upgrade_test.go
@@ -71,10 +71,15 @@ func TestEGUpgrade(t *testing.T) {
 		tests.EGUpgradeTest,
 	}
 
+	recorder := e2e.NewTimingRecorder()
+	t.Cleanup(func() {
+		recorder.Report(t)
+	})
+	timedTests := e2e.WrapConformanceTestsWithTiming(tests.UpgradeTests, recorder)
 	tlog.Logf(t, "Running %d Upgrade tests", len(tests.UpgradeTests))
-	cSuite.Setup(t, tests.UpgradeTests)
+	cSuite.Setup(t, timedTests)
 
-	err = cSuite.Run(t, tests.UpgradeTests)
+	err = cSuite.Run(t, timedTests)
 	if err != nil {
 		t.Fatalf("Failed to run tests: %v", err)
 	}


### PR DESCRIPTION
Related to: https://github.com/envoyproxy/gateway/issues/8098

sort e2e tests by time and warning for tests lasting more than 1 minute.

    timing.go:64: 2026-01-29T05:20:07.108568982Z: E2E timing report (sorted by duration)
    timing.go:72: 2026-01-29T05:20:07.108615729Z: PASS EnvoyShutdown (1m58.134s)
    timing.go:72: 2026-01-29T05:20:07.10863224Z: PASS EGUpgrade (1m12.769s)
    
    
    timing.go:64: 2026-01-29T05:15:57.99500591Z: E2E timing report (sorted by duration)
    timing.go:72: 2026-01-29T05:15:57.995041416Z: PASS BackendTLSSettings (1m3.351s)
    timing.go:72: 2026-01-29T05:15:57.995055372Z: PASS OIDC with BackendCluster (49.91s)
    timing.go:72: 2026-01-29T05:15:57.995066112Z: PASS EnvoyProxyCustomName (48.714s)
    timing.go:72: 2026-01-29T05:15:57.99507594Z: PASS OIDC (46.81s)
    timing.go:72: 2026-01-29T05:15:57.995087762Z: PASS LocalRateLimit (38.431s)
    timing.go:72: 2026-01-29T05:15:57.99509741Z: PASS BTPTracing (35.07s)
    timing.go:72: 2026-01-29T05:15:57.995107248Z: PASS ZipkinTracing (30.091s)
    timing.go:72: 2026-01-29T05:15:57.995116997Z: PASS DatadogTracing (29.089s)
    timing.go:72: 2026-01-29T05:15:57.995126354Z: PASS OpenTelemetryTracing (25.072s)
    timing.go:72: 2026-01-29T05:15:57.995135711Z: PASS BackendPanicThresholdHTTPTest (20.059s)
    timing.go:72: 2026-01-29T05:15:57.995144878Z: PASS LocalRateLimitDistinctCIDR (19.084s)
    timing.go:72: 2026-01-29T05:15:57.995154596Z: PASS ExtProc (15.151s)