### PR TITLE
fix: skip_test_workflow doesn't exist

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -274,7 +274,7 @@ jobs:
 
   resilience-test:
     runs-on: ubuntu-latest
-    if: ${{ ! (startsWith(github.event_name, 'push') && needs.changes.outputs.skip_test_workflow != 'true') }}
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_test_workflow == 'true' }}
     needs:
     - build
     - changes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,9 +60,11 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "release_tag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
-          echo "without_v_release_tag=$(echo ${GITHUB_REF##*/v})" >> $GITHUB_ENV
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          {
+            echo "release_tag=${GITHUB_REF##*/}"
+            echo "without_v_release_tag=${GITHUB_REF##*/v}"
+            echo "sha_short=$(git rev-parse --short HEAD)"
+          } >> "$GITHUB_ENV"
 
       - name: Login to DockerHub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0


### PR DESCRIPTION
The changes job only outputs run_test_workflow, not skip_test_workflow.
This also uses grouped redirects to satisfy shellcheck SC2129.
