### PR TITLE
chore: log skipped xds

### DIFF
--- a/internal/xds/runner/runner.go
+++ b/internal/xds/runner/runner.go
@@ -320,7 +320,7 @@ func (r *Runner) translateFromSubscription(sub <-chan watchable.Snapshot[string,
 				result, err := t.Translate(val.XdsIR)
 				translateSpan.End()
 				if err != nil {
-					traceLogger.Error(err, "failed to translate xds ir")
+					traceLogger.Error(err, "skipped publishing xds resources: failed to translate xds ir")
 					errChan <- err
 				}
 
@@ -331,7 +331,8 @@ func (r *Runner) translateFromSubscription(sub <-chan watchable.Snapshot[string,
 					return
 				}
 
-				// Update snapshot cache
+				// Only update the snapshot cache when there are no errors, to avoid publishing partial resources.
+				// This allows Envoy to continue using the previous known-good snapshot until the next successful translation.
 				if err == nil {
 					if result.XdsResources != nil {
 						if r.cache == nil {


### PR DESCRIPTION
This was hard to debug because the XDS push was silently skipped.