### PR TITLE
feat: support locality weighted consistent hashing

### DIFF
--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -427,6 +427,13 @@ func buildXdsCluster(args *xdsClusterArgs) (*buildClusterResult, error) {
 	case args.loadBalancer.ConsistentHash != nil:
 		cluster.LbPolicy = clusterv3.Cluster_MAGLEV
 		consistentHash := &maglevv3.Maglev{}
+		// Maglev only supports LocalityWeightedLbConfig, not the full LocalityLbConfig
+		// Extract it if the config is using weighted locality (which is the default)
+		if localityLbConfig != nil {
+			if weightedConfig, ok := localityLbConfig.LocalityConfigSpecifier.(*commonv3.LocalityLbConfig_LocalityWeightedLbConfig_); ok {
+				consistentHash.LocalityWeightedLbConfig = weightedConfig.LocalityWeightedLbConfig
+			}
+		}
 		if args.loadBalancer.ConsistentHash.TableSize != nil {
 			consistentHash.TableSize = wrapperspb.UInt64(*args.loadBalancer.ConsistentHash.TableSize)
 		}

--- a/internal/xds/translator/cluster_test.go
+++ b/internal/xds/translator/cluster_test.go
@@ -12,6 +12,7 @@ import (
 	bootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	maglevv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/load_balancing_policies/maglev/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -221,4 +222,88 @@ func TestBuildXdsOutlierDetection(t *testing.T) {
 
 func requireCmpNoDiff(t *testing.T, expected, actual interface{}) {
 	require.Empty(t, cmp.Diff(expected, actual, protocmp.Transform()))
+}
+
+func TestBuildXdsClusterWithConsistentHashAndLocalityWeighted(t *testing.T) {
+	tests := []struct {
+		name              string
+		loadBalancer      *ir.LoadBalancer
+		expectLocalityLb  bool
+		expectTableSize   bool
+		expectedTableSize uint64
+	}{
+		{
+			name: "consistent hash with locality weighted lb config",
+			loadBalancer: &ir.LoadBalancer{
+				ConsistentHash: &ir.ConsistentHash{},
+			},
+			expectLocalityLb: true,
+			expectTableSize:  false,
+		},
+		{
+			name: "consistent hash with table size and locality weighted lb config",
+			loadBalancer: &ir.LoadBalancer{
+				ConsistentHash: &ir.ConsistentHash{
+					TableSize: ptr.To(uint64(524287)),
+				},
+			},
+			expectLocalityLb:  true,
+			expectTableSize:   true,
+			expectedTableSize: 524287,
+		},
+		{
+			name: "consistent hash with preferLocal should not have locality weighted config",
+			loadBalancer: &ir.LoadBalancer{
+				ConsistentHash: &ir.ConsistentHash{},
+				PreferLocal: &ir.PreferLocalZone{
+					MinEndpointsThreshold: ptr.To(uint64(3)),
+				},
+			},
+			expectLocalityLb: false,
+			expectTableSize:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := &xdsClusterArgs{
+				name:         "test-cluster",
+				endpointType: EndpointTypeStatic,
+				loadBalancer: tc.loadBalancer,
+			}
+
+			result, err := buildXdsCluster(args)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.NotNil(t, result.cluster)
+
+			cluster := result.cluster
+			require.Equal(t, clusterv3.Cluster_MAGLEV, cluster.LbPolicy)
+			require.NotNil(t, cluster.LoadBalancingPolicy)
+			require.Len(t, cluster.LoadBalancingPolicy.Policies, 1)
+
+			policy := cluster.LoadBalancingPolicy.Policies[0]
+			require.Equal(t, "envoy.load_balancing_policies.maglev", policy.TypedExtensionConfig.Name)
+
+			// Unmarshal the Maglev config
+			maglev := &maglevv3.Maglev{}
+			err = policy.TypedExtensionConfig.TypedConfig.UnmarshalTo(maglev)
+			require.NoError(t, err)
+
+			// Check locality weighted LB config
+			if tc.expectLocalityLb {
+				require.NotNil(t, maglev.LocalityWeightedLbConfig, "expected LocalityWeightedLbConfig to be set")
+			} else {
+				require.Nil(t, maglev.LocalityWeightedLbConfig, "expected LocalityWeightedLbConfig to be nil when preferLocal is set")
+			}
+
+			// Check table size
+			if tc.expectTableSize {
+				require.NotNil(t, maglev.TableSize)
+				require.Equal(t, tc.expectedTableSize, maglev.TableSize.Value)
+			} else {
+				require.Nil(t, maglev.TableSize)
+			}
+		})
+	}
 }

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.clusters.yaml
@@ -72,6 +72,7 @@
         name: envoy.load_balancing_policies.maglev
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.maglev.v3.Maglev
+          localityWeightedLbConfig: {}
   name: securitypolicy/default/policy-for-route/jwt/0
   outlierDetection:
     baseEjectionTime: 160s

--- a/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
@@ -88,6 +88,7 @@
         name: envoy.load_balancing_policies.maglev
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.maglev.v3.Maglev
+          localityWeightedLbConfig: {}
   name: fourth-route-dest
   perConnectionBufferLimitBytes: 32768
   type: EDS
@@ -161,6 +162,7 @@
         name: envoy.load_balancing_policies.maglev
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.maglev.v3.Maglev
+          localityWeightedLbConfig: {}
   name: seventh-route-dest
   perConnectionBufferLimitBytes: 32768
   type: EDS
@@ -183,6 +185,7 @@
         name: envoy.load_balancing_policies.maglev
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.maglev.v3.Maglev
+          localityWeightedLbConfig: {}
           tableSize: "524287"
   name: eighth-route-dest
   perConnectionBufferLimitBytes: 32768
@@ -206,6 +209,7 @@
         name: envoy.load_balancing_policies.maglev
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.maglev.v3.Maglev
+          localityWeightedLbConfig: {}
   name: ninth-route-dest
   perConnectionBufferLimitBytes: 32768
   type: EDS
@@ -228,6 +232,7 @@
         name: envoy.load_balancing_policies.maglev
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.maglev.v3.Maglev
+          localityWeightedLbConfig: {}
   name: tenth-route-dest
   perConnectionBufferLimitBytes: 32768
   type: EDS
@@ -340,6 +345,7 @@
         name: envoy.load_balancing_policies.maglev
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.maglev.v3.Maglev
+          localityWeightedLbConfig: {}
   name: fourteenth-route-dest
   perConnectionBufferLimitBytes: 32768
   type: EDS
@@ -362,6 +368,7 @@
         name: envoy.load_balancing_policies.maglev
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.maglev.v3.Maglev
+          localityWeightedLbConfig: {}
   name: fifteenth-route-dest
   perConnectionBufferLimitBytes: 32768
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.clusters.yaml
@@ -72,6 +72,7 @@
         name: envoy.load_balancing_policies.maglev
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.maglev.v3.Maglev
+          localityWeightedLbConfig: {}
   name: securitypolicy/envoy-gateway/policy-for-gateway/0
   outlierDetection:
     baseEjectionTime: 160s

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-provider-traffic-features.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-provider-traffic-features.clusters.yaml
@@ -75,6 +75,7 @@
         name: envoy.load_balancing_policies.maglev
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.maglev.v3.Maglev
+          localityWeightedLbConfig: {}
   name: oauth_foo_com_443
   outlierDetection:
     baseEjectionTime: 160s

--- a/test/e2e/testdata/load_balancing_locality_weighted_consistent_hash.yaml
+++ b/test/e2e/testdata/load_balancing_locality_weighted_consistent_hash.yaml
@@ -1,0 +1,143 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: lb-backend-locality-weighted-v1
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: lb-backend-locality-weighted
+    version: v1
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lb-backend-locality-weighted-v2
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: lb-backend-locality-weighted
+    version: v2
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lb-backend-locality-weighted-v1
+  namespace: gateway-conformance-infra
+  labels:
+    app: lb-backend-locality-weighted
+    version: v1
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: lb-backend-locality-weighted
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: lb-backend-locality-weighted
+        version: v1
+    spec:
+      containers:
+        - name: backend
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE_NAME
+              value: lb-backend-locality-weighted-v1
+          resources:
+            requests:
+              cpu: 10m
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lb-backend-locality-weighted-v2
+  namespace: gateway-conformance-infra
+  labels:
+    app: lb-backend-locality-weighted
+    version: v2
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: lb-backend-locality-weighted
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: lb-backend-locality-weighted
+        version: v2
+    spec:
+      containers:
+        - name: backend
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE_NAME
+              value: lb-backend-locality-weighted-v2
+          resources:
+            requests:
+              cpu: 10m
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: locality-weighted-lb-policy
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: locality-weighted-lb-route
+  loadBalancer:
+    type: ConsistentHash
+    consistentHash:
+      type: Header
+      header:
+        name: X-Hash-Key
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: locality-weighted-lb-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /locality-weighted
+      backendRefs:
+        - name: lb-backend-locality-weighted-v1
+          port: 8080
+          weight: 60
+        - name: lb-backend-locality-weighted-v2
+          port: 8080
+          weight: 40

--- a/test/e2e/testdata/load_balancing_locality_weighted_consistent_hash.yaml
+++ b/test/e2e/testdata/load_balancing_locality_weighted_consistent_hash.yaml
@@ -1,109 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: lb-backend-locality-weighted-v1
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: lb-backend-locality-weighted
-    version: v1
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 3000
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: lb-backend-locality-weighted-v2
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: lb-backend-locality-weighted
-    version: v2
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lb-backend-locality-weighted-v1
-  namespace: gateway-conformance-infra
-  labels:
-    app: lb-backend-locality-weighted
-    version: v1
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: lb-backend-locality-weighted
-      version: v1
-  template:
-    metadata:
-      labels:
-        app: lb-backend-locality-weighted
-        version: v1
-    spec:
-      containers:
-        - name: backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: SERVICE_NAME
-              value: lb-backend-locality-weighted-v1
-          resources:
-            requests:
-              cpu: 10m
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lb-backend-locality-weighted-v2
-  namespace: gateway-conformance-infra
-  labels:
-    app: lb-backend-locality-weighted
-    version: v2
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: lb-backend-locality-weighted
-      version: v2
-  template:
-    metadata:
-      labels:
-        app: lb-backend-locality-weighted
-        version: v2
-    spec:
-      containers:
-        - name: backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: SERVICE_NAME
-              value: lb-backend-locality-weighted-v2
-          resources:
-            requests:
-              cpu: 10m
----
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -135,9 +29,9 @@ spec:
             type: PathPrefix
             value: /locality-weighted
       backendRefs:
-        - name: lb-backend-locality-weighted-v1
+        - name: infra-backend-v1
           port: 8080
           weight: 60
-        - name: lb-backend-locality-weighted-v2
+        - name: infra-backend-v2
           port: 8080
           weight: 40

--- a/test/e2e/tests/load_balancing.go
+++ b/test/e2e/tests/load_balancing.go
@@ -636,7 +636,7 @@ var EndpointOverrideLoadBalancingTest = suite.ConformanceTest{
 
 var LocalityWeightedConsistentHashLoadBalancingTest = suite.ConformanceTest{
 	ShortName:   "LocalityWeightedConsistentHashLoadBalancing",
-	Description: "Test for locality weighted consistent hash load balancing type",
+	Description: "Test for locality weighted consistent hash load balancing across multiple backend refs",
 	Manifests:   []string{"testdata/load_balancing_locality_weighted_consistent_hash.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		const sendRequests = 10
@@ -652,11 +652,10 @@ var LocalityWeightedConsistentHashLoadBalancingTest = suite.ConformanceTest{
 			Name:      gwapiv1.ObjectName(gwNN.Name),
 		}
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "locality-weighted-lb-policy", Namespace: ns}, suite.ControllerName, ancestorRef)
-		WaitForPods(t, suite.Client, ns, map[string]string{"app": "lb-backend-locality-weighted"}, corev1.PodRunning, &PodReady)
 
 		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
 
-		t.Run("same hash key routes to same pod consistently", func(t *testing.T) {
+		t.Run("same hash key routes to same backend consistently", func(t *testing.T) {
 			expectedResponse := http.ExpectedResponse{
 				Request: http.Request{
 					Path: "/locality-weighted",
@@ -667,7 +666,7 @@ var LocalityWeightedConsistentHashLoadBalancingTest = suite.ConformanceTest{
 				Namespace: ns,
 			}
 
-			// Test multiple hash keys - each should stick to one pod
+			// Test multiple hash keys - each should consistently route to the same backend ref
 			hashKeys := []string{"user-1", "user-2", "user-3", "user-4", "user-5"}
 
 			for _, hashKey := range hashKeys {
@@ -687,7 +686,7 @@ var LocalityWeightedConsistentHashLoadBalancingTest = suite.ConformanceTest{
 			}
 		})
 
-		t.Run("different hash keys can distribute to different pods", func(t *testing.T) {
+		t.Run("different hash keys distribute across both backends", func(t *testing.T) {
 			expectedResponse := http.ExpectedResponse{
 				Request: http.Request{
 					Path: "/locality-weighted",
@@ -698,45 +697,48 @@ var LocalityWeightedConsistentHashLoadBalancingTest = suite.ConformanceTest{
 				Namespace: ns,
 			}
 
-			// Map to track which pod each hash key routes to
-			hashKeyToPod := make(map[string]string)
-			hashKeys := []string{"key-1", "key-2", "key-3", "key-4", "key-5", "key-6", "key-7", "key-8", "key-9", "key-10"}
+			if err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 30*time.Second, true, func(_ context.Context) (bool, error) {
+				// Map to track which backend each hash key routes to
+				hashKeyToBackend := make(map[string]string)
+				hashKeys := []string{"key-1", "key-2", "key-3", "key-4", "key-5", "key-6", "key-7", "key-8", "key-9", "key-10"}
 
-			for _, hashKey := range hashKeys {
-				req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
-				req.Headers["X-Hash-Key"] = []string{hashKey}
+				for _, hashKey := range hashKeys {
+					req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
+					req.Headers["X-Hash-Key"] = []string{hashKey}
 
-				cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
-				if err != nil {
-					t.Errorf("failed to get expected response: %v", err)
-					continue
+					cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
+					if err != nil {
+						return false, nil
+					}
+
+					if err := http.CompareRoundTrip(t, &req, cReq, cResp, expectedResponse); err != nil {
+						return false, nil
+					}
+
+					podName := cReq.Pod
+					if len(podName) == 0 {
+						return false, nil
+					}
+					// Extract backend name from pod name (e.g., "infra-backend-v1-xxx" -> "infra-backend-v1")
+					backend := strings.Join(strings.Split(podName, "-")[:3], "-")
+					hashKeyToBackend[hashKey] = backend
 				}
 
-				if err := http.CompareRoundTrip(t, &req, cReq, cResp, expectedResponse); err != nil {
-					t.Errorf("failed to compare request and response: %v", err)
-					continue
+				// Count unique backends that received traffic
+				uniqueBackends := make(map[string]bool)
+				for _, backend := range hashKeyToBackend {
+					uniqueBackends[backend] = true
 				}
 
-				podName := cReq.Pod
-				if len(podName) == 0 {
-					t.Errorf("failed to get pod header in response")
-				} else {
-					hashKeyToPod[hashKey] = podName
+				// Different hash keys should distribute across both backend refs
+				if len(uniqueBackends) < 2 {
+					tlog.Logf(t, "only reached %d backends so far, retrying: %v", len(uniqueBackends), hashKeyToBackend)
+					return false, nil
 				}
-			}
-
-			// Count unique pods that received traffic
-			uniquePods := make(map[string]bool)
-			for _, pod := range hashKeyToPod {
-				uniquePods[pod] = true
-			}
-
-			// Different hash keys should distribute across multiple pods (at least 2)
-			// This verifies both consistent hashing distribution and locality weighting
-			if len(uniquePods) < 2 {
-				t.Errorf("expected different hash keys to distribute across at least 2 pods, but got %d pods: %v", len(uniquePods), hashKeyToPod)
-			} else {
-				tlog.Logf(t, "different hash keys distributed across %d pods: %v", len(uniquePods), hashKeyToPod)
+				tlog.Logf(t, "different hash keys distributed across %d backends: %v", len(uniqueBackends), hashKeyToBackend)
+				return true, nil
+			}); err != nil {
+				t.Errorf("failed: different hash keys did not distribute across both backends: %v", err)
 			}
 		})
 	},

--- a/test/e2e/tests/load_balancing.go
+++ b/test/e2e/tests/load_balancing.go
@@ -45,6 +45,7 @@ func init() {
 		EndpointOverrideLoadBalancingTest,
 		MultiHeaderConsistentHashHeaderLoadBalancingTest,
 		ConsistentHashQueryParamsLoadBalancingTest,
+		LocalityWeightedConsistentHashLoadBalancingTest,
 	)
 }
 
@@ -629,6 +630,114 @@ var EndpointOverrideLoadBalancingTest = suite.ConformanceTest{
 			}
 
 			t.Logf("All %d requests without override header got 200 response (fallback working)", sendRequests)
+		})
+	},
+}
+
+var LocalityWeightedConsistentHashLoadBalancingTest = suite.ConformanceTest{
+	ShortName:   "LocalityWeightedConsistentHashLoadBalancing",
+	Description: "Test for locality weighted consistent hash load balancing type",
+	Manifests:   []string{"testdata/load_balancing_locality_weighted_consistent_hash.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		const sendRequests = 10
+
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "locality-weighted-lb-route", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+
+		ancestorRef := gwapiv1.ParentReference{
+			Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+			Kind:      gatewayapi.KindPtr(resource.KindGateway),
+			Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
+			Name:      gwapiv1.ObjectName(gwNN.Name),
+		}
+		BackendTrafficPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "locality-weighted-lb-policy", Namespace: ns}, suite.ControllerName, ancestorRef)
+		WaitForPods(t, suite.Client, ns, map[string]string{"app": "lb-backend-locality-weighted"}, corev1.PodRunning, &PodReady)
+
+		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+
+		t.Run("same hash key routes to same pod consistently", func(t *testing.T) {
+			expectedResponse := http.ExpectedResponse{
+				Request: http.Request{
+					Path: "/locality-weighted",
+				},
+				Response: http.Response{
+					StatusCodes: []int{200},
+				},
+				Namespace: ns,
+			}
+
+			// Test multiple hash keys - each should stick to one pod
+			hashKeys := []string{"user-1", "user-2", "user-3", "user-4", "user-5"}
+
+			for _, hashKey := range hashKeys {
+				req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
+				req.Headers["X-Hash-Key"] = []string{hashKey}
+
+				// All requests with the same hash key should go to the same pod
+				compareFunc := func(trafficMap map[string]int) bool {
+					return len(trafficMap) == 1
+				}
+
+				if err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 30*time.Second, true, func(_ context.Context) (bool, error) {
+					return runTrafficTest(t, suite, &req, &expectedResponse, sendRequests, compareFunc), nil
+				}); err != nil {
+					tlog.Errorf(t, "failed: hash key %s did not consistently route to same pod: %v", hashKey, err)
+				}
+			}
+		})
+
+		t.Run("different hash keys can distribute to different pods", func(t *testing.T) {
+			expectedResponse := http.ExpectedResponse{
+				Request: http.Request{
+					Path: "/locality-weighted",
+				},
+				Response: http.Response{
+					StatusCodes: []int{200},
+				},
+				Namespace: ns,
+			}
+
+			// Map to track which pod each hash key routes to
+			hashKeyToPod := make(map[string]string)
+			hashKeys := []string{"key-1", "key-2", "key-3", "key-4", "key-5", "key-6", "key-7", "key-8", "key-9", "key-10"}
+
+			for _, hashKey := range hashKeys {
+				req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
+				req.Headers["X-Hash-Key"] = []string{hashKey}
+
+				cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
+				if err != nil {
+					t.Errorf("failed to get expected response: %v", err)
+					continue
+				}
+
+				if err := http.CompareRoundTrip(t, &req, cReq, cResp, expectedResponse); err != nil {
+					t.Errorf("failed to compare request and response: %v", err)
+					continue
+				}
+
+				podName := cReq.Pod
+				if len(podName) == 0 {
+					t.Errorf("failed to get pod header in response")
+				} else {
+					hashKeyToPod[hashKey] = podName
+				}
+			}
+
+			// Count unique pods that received traffic
+			uniquePods := make(map[string]bool)
+			for _, pod := range hashKeyToPod {
+				uniquePods[pod] = true
+			}
+
+			// Different hash keys should distribute across multiple pods (at least 2)
+			// This verifies both consistent hashing distribution and locality weighting
+			if len(uniquePods) < 2 {
+				t.Errorf("expected different hash keys to distribute across at least 2 pods, but got %d pods: %v", len(uniquePods), hashKeyToPod)
+			} else {
+				tlog.Logf(t, "different hash keys distributed across %d pods: %v", len(uniquePods), hashKeyToPod)
+			}
 		})
 	},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable locality_weighted_lb_config for ConsistentHash load balancer type (Maglev/RingHash) in Envoy Gateway, which is already supported by upstream Envoy but not exposed in Envoy Gateway's API.

**Which issue(s) this PR fixes**:
Fixes #8146 

Release Notes: Yes
Enable locality_weighted_lb_config for ConsistentHash load balancer type
