### PR TITLE
fix: continue processing the remaining xDS with invalid EnvoyPatchPolicies

### DIFF
--- a/internal/xds/runner/runner.go
+++ b/internal/xds/runner/runner.go
@@ -333,8 +333,9 @@ func (r *Runner) translateFromSubscription(sub <-chan watchable.Snapshot[string,
 					return
 				}
 
-				// Only update the snapshot cache when there are no errors, to avoid publishing partial resources.
+				// Only update the snapshot cache when there are no system-level errors, to avoid publishing partial resources.
 				// This allows Envoy to continue using the previous known-good snapshot until the next successful translation.
+				// Note: invalid EnvoyPatchPolicies are considered user-level errors and will not prevent the snapshot from being updated.
 				if err == nil {
 					if result.XdsResources != nil {
 						if r.cache == nil {

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.clusters.yaml
@@ -1,0 +1,24 @@
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: first-route-dest
+  perConnectionBufferLimitBytes: 32768
+  type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.endpoints.yaml
@@ -1,0 +1,11 @@
+- clusterName: first-route-dest
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 1.2.3.4
+            portValue: 50000
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.listeners.yaml
@@ -1,0 +1,54 @@
+- address:
+    socketAddress:
+      address: '::'
+      portValue: 10080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        commonHttpProtocolOptions:
+          headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            suppressEnvoyHeaders: true
+        mergeSlashes: true
+        normalizePath: true
+        pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: first-listener
+        serverHeaderTransformation: PASS_THROUGH
+        statPrefix: https-10080
+        useRemoteAddress: true
+    name: first-listener
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - h2
+          - http/1.1
+          tlsCertificateSdsSecretConfigs:
+          - name: secret-1
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+          - name: secret-2
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        disableStatefulSessionResumption: true
+        disableStatelessSessionResumption: true
+  maxConnectionsToAcceptPerSocketEvent: 1
+  name: first-listener
+  perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.routes.yaml
@@ -1,0 +1,18 @@
+- ignorePortInHostMatching: true
+  name: first-listener
+  virtualHosts:
+  - domains:
+    - '*'
+    name: first-listener/*
+    routes:
+    - match:
+        headers:
+        - name: user
+          stringMatch:
+            exact: jason
+        prefix: /
+      name: first-route
+      route:
+        cluster: first-route-dest
+        upgradeConfigs:
+        - upgradeType: websocket

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.secrets.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.secrets.yaml
@@ -1,0 +1,12 @@
+- name: secret-1
+  tlsCertificate:
+    certificateChain:
+      inlineBytes: Y2VydC1kYXRh
+    privateKey:
+      inlineBytes: a2V5LWRhdGE=
+- name: secret-2
+  tlsCertificate:
+    certificateChain:
+      inlineBytes: Y2VydC1kYXRh
+    privateKey:
+      inlineBytes: a2V5LWRhdGE=

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.clusters.yaml
@@ -1,0 +1,24 @@
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: first-route-dest
+  perConnectionBufferLimitBytes: 32768
+  type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.endpoints.yaml
@@ -1,0 +1,11 @@
+- clusterName: first-route-dest
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 1.2.3.4
+            portValue: 50000
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.listeners.yaml
@@ -1,0 +1,65 @@
+- address:
+    socketAddress:
+      address: '::'
+      portValue: 10080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        commonHttpProtocolOptions:
+          headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
+        httpFilters:
+        - name: envoy.filters.http.ratelimit
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
+            domain: eg-ratelimit
+            failureModeDeny: true
+            rateLimitService:
+              grpcService:
+                envoyGrpc:
+                  clusterName: rate-limit-cluster
+              transportApiVersion: V3
+            timeout: 1s
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            suppressEnvoyHeaders: true
+        mergeSlashes: true
+        normalizePath: true
+        pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: first-listener
+        serverHeaderTransformation: PASS_THROUGH
+        statPrefix: https-10080
+        useRemoteAddress: true
+    name: first-listener
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - h2
+          - http/1.1
+          tlsCertificateSdsSecretConfigs:
+          - name: secret-1
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+          - name: secret-2
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        disableStatefulSessionResumption: true
+        disableStatelessSessionResumption: true
+  maxConnectionsToAcceptPerSocketEvent: 1
+  name: first-listener
+  perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.routes.yaml
@@ -1,0 +1,18 @@
+- ignorePortInHostMatching: true
+  name: first-listener
+  virtualHosts:
+  - domains:
+    - '*'
+    name: first-listener/*
+    routes:
+    - match:
+        headers:
+        - name: user
+          stringMatch:
+            exact: jason
+        prefix: /
+      name: first-route
+      route:
+        cluster: first-route-dest
+        upgradeConfigs:
+        - upgradeType: websocket

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.secrets.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.secrets.yaml
@@ -1,0 +1,12 @@
+- name: secret-1
+  tlsCertificate:
+    certificateChain:
+      inlineBytes: Y2VydC1kYXRh
+    privateKey:
+      inlineBytes: a2V5LWRhdGE=
+- name: secret-2
+  tlsCertificate:
+    certificateChain:
+      inlineBytes: Y2VydC1kYXRh
+    privateKey:
+      inlineBytes: a2V5LWRhdGE=

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.clusters.yaml
@@ -1,0 +1,24 @@
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: first-route-dest
+  perConnectionBufferLimitBytes: 32768
+  type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.endpoints.yaml
@@ -1,0 +1,11 @@
+- clusterName: first-route-dest
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 1.2.3.4
+            portValue: 50000
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.listeners.yaml
@@ -1,0 +1,35 @@
+- address:
+    socketAddress:
+      address: '::'
+      portValue: 10080
+  defaultFilterChain:
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        commonHttpProtocolOptions:
+          headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            suppressEnvoyHeaders: true
+        mergeSlashes: true
+        normalizePath: true
+        pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: first-listener
+        serverHeaderTransformation: PASS_THROUGH
+        statPrefix: http-10080
+        useRemoteAddress: true
+    name: first-listener
+  maxConnectionsToAcceptPerSocketEvent: 1
+  name: first-listener
+  perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.routes.yaml
@@ -1,0 +1,18 @@
+- ignorePortInHostMatching: true
+  name: first-listener
+  virtualHosts:
+  - domains:
+    - '*'
+    name: first-listener/*
+    routes:
+    - match:
+        headers:
+        - name: user
+          stringMatch:
+            exact: jason
+        prefix: /
+      name: first-route
+      route:
+        cluster: first-route-dest
+        upgradeConfigs:
+        - upgradeType: websocket

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.clusters.yaml
@@ -1,0 +1,24 @@
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: first-route-dest
+  perConnectionBufferLimitBytes: 32768
+  type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.endpoints.yaml
@@ -1,0 +1,11 @@
+- clusterName: first-route-dest
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 1.2.3.4
+            portValue: 50000
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.listeners.yaml
@@ -1,0 +1,65 @@
+- address:
+    socketAddress:
+      address: '::'
+      portValue: 10080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        commonHttpProtocolOptions:
+          headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
+        httpFilters:
+        - name: envoy.filters.http.ratelimit
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
+            domain: eg-ratelimit
+            failureModeDeny: true
+            rateLimitService:
+              grpcService:
+                envoyGrpc:
+                  clusterName: rate-limit-cluster
+              transportApiVersion: V3
+            timeout: 1s
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            suppressEnvoyHeaders: true
+        mergeSlashes: true
+        normalizePath: true
+        pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: first-listener
+        serverHeaderTransformation: PASS_THROUGH
+        statPrefix: https-10080
+        useRemoteAddress: true
+    name: first-listener
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - h2
+          - http/1.1
+          tlsCertificateSdsSecretConfigs:
+          - name: secret-1
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+          - name: secret-2
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        disableStatefulSessionResumption: true
+        disableStatelessSessionResumption: true
+  maxConnectionsToAcceptPerSocketEvent: 1
+  name: first-listener
+  perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.routes.yaml
@@ -1,0 +1,18 @@
+- ignorePortInHostMatching: true
+  name: first-listener
+  virtualHosts:
+  - domains:
+    - '*'
+    name: first-listener/*
+    routes:
+    - match:
+        headers:
+        - name: user
+          stringMatch:
+            exact: jason
+        prefix: /
+      name: first-route
+      route:
+        cluster: first-route-dest
+        upgradeConfigs:
+        - upgradeType: websocket

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.secrets.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.secrets.yaml
@@ -1,0 +1,12 @@
+- name: secret-1
+  tlsCertificate:
+    certificateChain:
+      inlineBytes: Y2VydC1kYXRh
+    privateKey:
+      inlineBytes: a2V5LWRhdGE=
+- name: secret-2
+  tlsCertificate:
+    certificateChain:
+      inlineBytes: Y2VydC1kYXRh
+    privateKey:
+      inlineBytes: a2V5LWRhdGE=

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.clusters.yaml
@@ -1,0 +1,48 @@
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: first-route-dest
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: second-route-dest
+  ignoreHealthOnHostRemoval: true
+  lbPolicy: LEAST_REQUEST
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: second-route-dest
+  perConnectionBufferLimitBytes: 32768
+  type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.endpoints.yaml
@@ -1,0 +1,24 @@
+- clusterName: first-route-dest
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 1.2.3.4
+            portValue: 50000
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: first-route-dest/backend/0
+- clusterName: second-route-dest
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 4.5.6.7
+            portValue: 60000
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: second-route-dest/backend/0

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.listeners.yaml
@@ -1,0 +1,54 @@
+- address:
+    socketAddress:
+      address: '::'
+      portValue: 10080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        commonHttpProtocolOptions:
+          headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            suppressEnvoyHeaders: true
+        mergeSlashes: true
+        normalizePath: true
+        pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: first-listener
+        serverHeaderTransformation: PASS_THROUGH
+        statPrefix: https-10080
+        useRemoteAddress: true
+    name: first-listener
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - h2
+          - http/1.1
+          tlsCertificateSdsSecretConfigs:
+          - name: secret-1
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+          - name: secret-2
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        disableStatefulSessionResumption: true
+        disableStatelessSessionResumption: true
+  maxConnectionsToAcceptPerSocketEvent: 1
+  name: first-listener
+  perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.routes.yaml
@@ -1,0 +1,32 @@
+- ignorePortInHostMatching: true
+  name: first-listener
+  virtualHosts:
+  - domains:
+    - '*'
+    name: first-listener/*
+    routes:
+    - match:
+        headers:
+        - name: user
+          stringMatch:
+            exact: jason
+        prefix: /
+      name: first-route
+      route:
+        cluster: first-route-dest
+        upgradeConfigs:
+        - upgradeType: websocket
+    - match:
+        headers:
+        - name: user
+          stringMatch:
+            exact: james
+        - name: country
+          stringMatch:
+            exact: US
+        prefix: /
+      name: second-route
+      route:
+        cluster: second-route-dest
+        upgradeConfigs:
+        - upgradeType: websocket

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.secrets.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.secrets.yaml
@@ -1,0 +1,12 @@
+- name: secret-1
+  tlsCertificate:
+    certificateChain:
+      inlineBytes: Y2VydC1kYXRh
+    privateKey:
+      inlineBytes: a2V5LWRhdGE=
+- name: secret-2
+  tlsCertificate:
+    certificateChain:
+      inlineBytes: Y2VydC1kYXRh
+    privateKey:
+      inlineBytes: a2V5LWRhdGE=

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -155,7 +155,9 @@ func (t *Translator) Translate(xdsIR *ir.Xds) (*types.ResourceVersionTable, erro
 
 	// All XDS resources is ready, let's do the patch.
 	if err := processJSONPatches(tCtx, xdsIR.EnvoyPatchPolicies); err != nil {
-		errs = errors.Join(errs, err)
+		// Since JSONPatch error is user-triggered, we don't fail the entire xDS translation so that the remaining
+		// valid xDS resources can be sent to the proxy.
+		t.Logger.Error(err, "Failed to process JSON patches")
 	}
 
 	// Check if an extension want to inject any clusters/secrets

--- a/internal/xds/translator/translator_test.go
+++ b/internal/xds/translator/translator_test.go
@@ -71,26 +71,21 @@ func TestTranslateXds(t *testing.T) {
 		},
 		"jsonpatch-with-jsonpath-invalid": {
 			requireEnvoyPatchPolicies: true,
-			errMsg:                    "no jsonPointers were found while evaluating the jsonPath",
 		},
 		"jsonpatch-add-op-empty-jsonpath": {
 			requireEnvoyPatchPolicies: true,
-			errMsg:                    "a patch operation must specify a path or jsonPath",
 		},
 		"jsonpatch-missing-resource": {
 			requireEnvoyPatchPolicies: true,
 		},
 		"jsonpatch-invalid-patch": {
 			requireEnvoyPatchPolicies: true,
-			errMsg:                    "unable to unmarshal xds resource",
 		},
 		"jsonpatch-add-op-without-value": {
 			requireEnvoyPatchPolicies: true,
-			errMsg:                    "the add operation requires a value",
 		},
 		"jsonpatch-move-op-with-value": {
 			requireEnvoyPatchPolicies: true,
-			errMsg:                    "value and from can't be specified with the remove operation",
 		},
 		"http-route-invalid": {
 			errMsg: "validation failed for xds resource",


### PR DESCRIPTION
fix: #8151

This PR ignores the invalid `EnvoyPatchPolicy` in the xDS translator and continue pushing the xDS for unrelated resources to the Envoy fleet.

Errors from the invalid `EnvoyPatchPolicy` are logged in the Envoy Gateway logs, and surfaced in the `Programmed` condition of the `EnvoyPatchPolicy`'s status.