### PR TITLE
feat: invalid listener should not block IR

### DIFF
--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -103,10 +103,7 @@ func (t *Translator) ProcessListeners(gateways []*GatewayContext, xdsIR resource
 			t.validateHostName(listener)
 
 			// Process conditions and check if the listener is ready
-			isReady := t.validateListenerConditions(listener)
-			if !isReady {
-				continue
-			}
+			t.validateListenerConditions(listener)
 
 			address := netutils.IPv4ListenerAddress
 			ipFamily := getEnvoyIPFamily(gateway.envoyProxy)

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions.out.yaml
@@ -508,6 +508,12 @@ infraIR:
           name: http-80
           protocol: HTTP
           servicePort: 80
+      - name: envoy-gateway/gateway-2/https
+        ports:
+        - containerPort: 10443
+          name: https-443
+          protocol: HTTPS
+          servicePort: 443
       - name: envoy-gateway/gateway-2/tcp
         ports:
         - containerPort: 10053
@@ -729,6 +735,21 @@ xdsIR:
             namespace: envoy-gateway
         name: grpcroute/envoy-gateway/grpcroute-1/rule/0/match/0/*
         traffic: {}
+    - address: 0.0.0.0
+      externalPort: 443
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+        sectionName: https
+      name: envoy-gateway/gateway-2/https
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10443
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions.out.yaml
@@ -453,6 +453,12 @@ infraIR:
           name: http-80
           protocol: HTTP
           servicePort: 80
+      - name: envoy-gateway/gateway-2/https
+        ports:
+        - containerPort: 10443
+          name: https-443
+          protocol: HTTPS
+          servicePort: 443
       - name: envoy-gateway/gateway-2/tcp
         ports:
         - containerPort: 10053
@@ -592,6 +598,21 @@ xdsIR:
         escapedSlashesAction: UnescapeAndRedirect
         mergeSlashes: true
       port: 10080
+    - address: 0.0.0.0
+      externalPort: 443
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+        sectionName: https
+      name: envoy-gateway/gateway-2/https
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10443
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions.out.yaml
@@ -508,6 +508,12 @@ infraIR:
           name: http-80
           protocol: HTTP
           servicePort: 80
+      - name: envoy-gateway/gateway-2/https
+        ports:
+        - containerPort: 10443
+          name: https-443
+          protocol: HTTPS
+          servicePort: 443
       - name: envoy-gateway/gateway-2/tcp
         ports:
         - containerPort: 10053
@@ -721,6 +727,21 @@ xdsIR:
           name: grpcroute-1
           namespace: envoy-gateway
         name: grpcroute/envoy-gateway/grpcroute-1/rule/0/match/0/*
+    - address: 0.0.0.0
+      externalPort: 443
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+        sectionName: https
+      name: envoy-gateway/gateway-2/https
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10443
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-attached-routes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-attached-routes.out.yaml
@@ -326,6 +326,13 @@ infraIR:
       namespace: envoy-gateway-system
   envoy-gateway/unresolved-gateway-with-one-attached-unresolved-route:
     proxy:
+      listeners:
+      - name: envoy-gateway/unresolved-gateway-with-one-attached-unresolved-route/tls
+        ports:
+        - containerPort: 10443
+          name: https-443
+          protocol: HTTPS
+          servicePort: 443
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: unresolved-gateway-with-one-attached-unresolved-route
@@ -482,6 +489,22 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/unresolved-gateway-with-one-attached-unresolved-route
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 443
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: unresolved-gateway-with-one-attached-unresolved-route
+        namespace: envoy-gateway
+        sectionName: tls
+      name: envoy-gateway/unresolved-gateway-with-one-attached-unresolved-route/tls
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10443
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-namespaces-selector.out.yaml
@@ -78,6 +78,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -113,6 +120,22 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-group.out.yaml
@@ -69,6 +69,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -104,6 +111,22 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind-and-supported.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind-and-supported.out.yaml
@@ -71,6 +71,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -106,6 +113,22 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-routes-kind.out.yaml
@@ -69,6 +69,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -104,6 +111,22 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-tls-route-kind.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-allowed-tls-route-kind.out.yaml
@@ -38,6 +38,13 @@ gateways:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/tls
+        ports:
+        - containerPort: 10080
+          name: tls-80
+          protocol: TLS
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -109,3 +116,13 @@ xdsIR:
       ipFamily: IPv4
       path: /ready
       port: 19003
+    tcp:
+    - address: 0.0.0.0
+      externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
+      name: envoy-gateway/gateway-1/tls
+      port: 10080

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-multiple-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-multiple-tls-configuration.out.yaml
@@ -158,6 +158,12 @@ infraIR:
           name: https-8443
           protocol: HTTPS
           servicePort: 8443
+      - name: envoy-gateway/gateway-1/tls-all-invalid-cert
+        ports:
+        - containerPort: 8444
+          name: https-8444
+          protocol: HTTPS
+          servicePort: 8444
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -298,6 +304,21 @@ xdsIR:
         - certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJ2VENDQVVTZ0F3SUJBZ0lVU2l2SkdURHdva1M3aGVZLzJjc1JzejR2SkIwd0NnWUlLb1pJemowRUF3SXcKRmpFVU1CSUdBMVVFQXd3TFptOXZMbUpoY2k1amIyMHdIaGNOTWpRd01qSTVNRGt6TURFd1doY05NelF3TWpJMgpNRGt6TURFd1dqQVdNUlF3RWdZRFZRUUREQXRtYjI4dVltRnlMbU52YlRCMk1CQUdCeXFHU000OUFnRUdCU3VCCkJBQWlBMklBQkZ2cnZSZWJhYVd1UzZNQUVJZDZ3WmZPS3Z1Q1R5VU1PbFpKcUZDRjlUa3pNWWw4Q2lvZnluT3QKQ3JzMHZ2YTlrZC9QMkpNR0JKcWdZZXZid290clJpMTJxTG5IMDQvam9HSWpqVE9LbzNJb2ZyK0ZrOHdMdkFlMwpPMVpLdFI5c3pxTlRNRkV3SFFZRFZSME9CQllFRklLczFRRm5vRHQ5K3Fva1I0T0RXYk16MWYrUE1COEdBMVVkCkl3UVlNQmFBRklLczFRRm5vRHQ5K3Fva1I0T0RXYk16MWYrUE1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0NnWUkKS29aSXpqMEVBd0lEWndBd1pBSXdIMzF0SHlmVVAwNFhIcGJXR2UxWjFJYUJaQndJdGg1NURVNGhqZlB1OG0rSgpXdjdiVzh6VFNnd0xpcW9yZmN1bkFqQTBnaE5KQkExWDJYdElLRG1sM3M3L1Z4OEZKY1MwNHZwQ2hoK2xBYkxTCnZlYWEyOFIzVExFWTNVK1FUWEkvd0lrPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
           name: envoy-gateway/tls-secret-ecdsa-2
           privateKey: '[redacted]'
+    - address: 0.0.0.0
+      externalPort: 8444
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls-all-invalid-cert
+      name: envoy-gateway/gateway-1/tls-all-invalid-cert
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8444
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-invalid-mode.out.yaml
@@ -75,6 +75,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/tls
+        ports:
+        - containerPort: 10443
+          name: https-443
+          protocol: HTTPS
+          servicePort: 443
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -110,6 +117,22 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 443
+      hostnames:
+      - foo.com
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
+      name: envoy-gateway/gateway-1/tls
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10443
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-no-certificate-refs.out.yaml
@@ -72,6 +72,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/tls
+        ports:
+        - containerPort: 10443
+          name: https-443
+          protocol: HTTPS
+          servicePort: 443
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -107,6 +114,22 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 443
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
+      name: envoy-gateway/gateway-1/tls
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10443
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-does-not-exist.out.yaml
@@ -75,6 +75,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/tls
+        ports:
+        - containerPort: 10443
+          name: https-443
+          protocol: HTTPS
+          servicePort: 443
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -110,6 +117,22 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 443
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
+      name: envoy-gateway/gateway-1/tls
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10443
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-in-other-namespace.out.yaml
@@ -76,6 +76,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/tls
+        ports:
+        - containerPort: 10443
+          name: https-443
+          protocol: HTTPS
+          servicePort: 443
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -111,6 +118,22 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 443
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
+      name: envoy-gateway/gateway-1/tls
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10443
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-invalid-tls-configuration-secret-is-not-valid.out.yaml
@@ -75,6 +75,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/tls
+        ports:
+        - containerPort: 10443
+          name: https-443
+          protocol: HTTPS
+          servicePort: 443
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -110,6 +117,22 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 443
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
+      name: envoy-gateway/gateway-1/tls
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10443
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-missing-allowed-namespaces-selector.out.yaml
@@ -71,6 +71,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -106,6 +113,22 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcp-with-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcp-with-hostname.out.yaml
@@ -35,6 +35,13 @@ gateways:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/tcp
+        ports:
+        - containerPort: 10080
+          name: tcp-80
+          protocol: TCP
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -75,3 +82,13 @@ xdsIR:
       ipFamily: IPv4
       path: /ready
       port: 19003
+    tcp:
+    - address: 0.0.0.0
+      externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp
+      name: envoy-gateway/gateway-1/tcp
+      port: 10080

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udp-with-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udp-with-hostname.out.yaml
@@ -35,6 +35,13 @@ gateways:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/udp
+        ports:
+        - containerPort: 10080
+          name: udp-80
+          protocol: UDP
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -75,3 +82,13 @@ xdsIR:
       ipFamily: IPv4
       path: /ready
       port: 19003
+    udp:
+    - address: 0.0.0.0
+      externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp
+      name: envoy-gateway/gateway-1/udp
+      port: 10080

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unsupported-protocol.out.yaml
@@ -71,6 +71,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/unsupported
+        ports:
+        - containerPort: 10080
+          name: "-80"
+          protocol: ""
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-or-tls-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-or-tls-port.out.yaml
@@ -70,6 +70,12 @@ infraIR:
           name: tcp-162
           protocol: TCP
           servicePort: 162
+      - name: envoy-gateway/gateway-1/tcp2
+        ports:
+        - containerPort: 10162
+          name: tls-162
+          protocol: TLS
+          servicePort: 162
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -176,3 +182,12 @@ xdsIR:
           name: tcproute-1
           namespace: default
         name: tcproute/default/tcproute-1
+    - address: 0.0.0.0
+      externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tcp2
+      name: envoy-gateway/gateway-1/tcp2
+      port: 10162

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-udp-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-udp-port.out.yaml
@@ -175,3 +175,12 @@ xdsIR:
             protocol: UDP
             weight: 1
         name: udproute/default/udproute-1
+    - address: 0.0.0.0
+      externalPort: 162
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: udp2
+      name: envoy-gateway/gateway-1/udp2
+      port: 10162

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-http-and-tlsroute-same-hostname-and-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-http-and-tlsroute-same-hostname-and-port.out.yaml
@@ -106,6 +106,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/http-1
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -172,8 +179,34 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - foo.com
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http-1
+      name: envoy-gateway/gateway-1/http-1
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4
       path: /ready
       port: 19003
+    tcp:
+    - address: 0.0.0.0
+      externalPort: 80
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls-1
+      name: envoy-gateway/gateway-1/tls-1
+      port: 10080

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-hostname.out.yaml
@@ -106,6 +106,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/http-1
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -141,6 +148,37 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - foo.com
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http-1
+      name: envoy-gateway/gateway-1/http-1
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - foo.com
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http-2
+      name: envoy-gateway/gateway-1/http-2
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-and-incompatible-protocol.out.yaml
@@ -106,6 +106,13 @@ httpRoutes:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/http-1
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -141,6 +148,37 @@ xdsIR:
             sectionName: "8080"
           name: envoy-gateway/gateway-1
           protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - foo.com
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http-1
+      name: envoy-gateway/gateway-1/http-1
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - bar.com
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http-2
+      name: envoy-gateway/gateway-1/http-2
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/listenerset-conflict-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-conflict-listeners.out.yaml
@@ -84,6 +84,18 @@ infraIR:
           name: http-80
           protocol: HTTP
           servicePort: 80
+      - name: gateway-xls/composite-gateway/conflict-listener
+        ports:
+        - containerPort: 8888
+          name: http-8888
+          protocol: HTTP
+          servicePort: 8888
+      - name: gateway-xls/composite-gateway/gateway-xls/conflict-listener-from-same-xls/conflict-listener-1
+        ports:
+        - containerPort: 8089
+          name: http-8089
+          protocol: HTTP
+          servicePort: 8089
       - name: gateway-xls/composite-gateway/gateway-xls/conflict-listener-from-two-xlss/good-listener
         ports:
         - containerPort: 8090
@@ -399,6 +411,66 @@ xdsIR:
         mergeSlashes: true
       port: 10080
     - address: 0.0.0.0
+      externalPort: 8888
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: composite-gateway
+        namespace: gateway-xls
+        sectionName: conflict-listener
+      name: gateway-xls/composite-gateway/conflict-listener
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8888
+    - address: 0.0.0.0
+      externalPort: 8089
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: composite-gateway
+        namespace: gateway-xls
+        sectionName: conflict-listener-1
+      name: gateway-xls/composite-gateway/gateway-xls/conflict-listener-from-same-xls/conflict-listener-1
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8089
+    - address: 0.0.0.0
+      externalPort: 8089
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: composite-gateway
+        namespace: gateway-xls
+        sectionName: conflict-listener-2
+      name: gateway-xls/composite-gateway/gateway-xls/conflict-listener-from-same-xls/conflict-listener-2
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8089
+    - address: 0.0.0.0
+      externalPort: 8089
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: composite-gateway
+        namespace: gateway-xls
+        sectionName: conflict-listener
+      name: gateway-xls/composite-gateway/gateway-xls/conflict-listener-from-two-xlss/conflict-listener
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8089
+    - address: 0.0.0.0
       externalPort: 8090
       hostnames:
       - '*'
@@ -413,6 +485,21 @@ xdsIR:
         escapedSlashesAction: UnescapeAndRedirect
         mergeSlashes: true
       port: 8090
+    - address: 0.0.0.0
+      externalPort: 8888
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: composite-gateway
+        namespace: gateway-xls
+        sectionName: conflict-listener
+      name: gateway-xls/composite-gateway/gateway-xls/listener-conflict-with-gateway/conflict-listener
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8888
     - address: 0.0.0.0
       externalPort: 8091
       hostnames:

--- a/internal/gatewayapi/testdata/listenerset-https-tls-misuses-gateway-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-https-tls-misuses-gateway-namespace.out.yaml
@@ -92,6 +92,12 @@ infraIR:
           name: http-80
           protocol: HTTP
           servicePort: 80
+      - name: gateway/composite-gateway/xls/https-xls/extra-https-same-ns
+        ports:
+        - containerPort: 8443
+          name: https-8443
+          protocol: HTTPS
+          servicePort: 8443
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: composite-gateway
@@ -199,6 +205,21 @@ xdsIR:
         escapedSlashesAction: UnescapeAndRedirect
         mergeSlashes: true
       port: 10080
+    - address: 0.0.0.0
+      externalPort: 8443
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: composite-gateway
+        namespace: gateway
+        sectionName: extra-https-same-ns
+      name: gateway/composite-gateway/xls/https-xls/extra-https-same-ns
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8443
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/listenerset-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-invalid.out.yaml
@@ -200,12 +200,30 @@ infraIR:
           name: http-80
           protocol: HTTP
           servicePort: 80
+      - name: gateway-xls/composite-gateway/gateway-xls/same-namespace-invalid/invalid-one
+        ports:
+        - containerPort: 8085
+          name: "-8085"
+          protocol: ""
+          servicePort: 8085
+      - name: gateway-xls/composite-gateway/gateway-xls/same-namespace-invalid/invalid-two
+        ports:
+        - containerPort: 8086
+          name: "-8086"
+          protocol: ""
+          servicePort: 8086
       - name: gateway-xls/composite-gateway/gateway-xls/same-namespace-mixed/mixed-valid
         ports:
         - containerPort: 8087
           name: http-8087
           protocol: HTTP
           servicePort: 8087
+      - name: gateway-xls/composite-gateway/gateway-xls/same-namespace-mixed/mixed-invalid
+        ports:
+        - containerPort: 8088
+          name: "-8088"
+          protocol: ""
+          servicePort: 8088
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: composite-gateway

--- a/internal/gatewayapi/testdata/merge-invalid-multiple-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/merge-invalid-multiple-gateways.out.yaml
@@ -171,6 +171,21 @@ xdsIR:
         escapedSlashesAction: UnescapeAndRedirect
         mergeSlashes: true
       port: 10080
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-2/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/securitypolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-status-conditions.out.yaml
@@ -228,6 +228,12 @@ infraIR:
           name: http-80
           protocol: HTTP
           servicePort: 80
+      - name: envoy-gateway/gateway-2/https
+        ports:
+        - containerPort: 10443
+          name: https-443
+          protocol: HTTPS
+          servicePort: 443
       - name: envoy-gateway/gateway-2/tcp
         ports:
         - containerPort: 10053
@@ -544,6 +550,21 @@ xdsIR:
               name: ""
               safeRegex: http://.*\.example\.com
             maxAge: 16m40s
+    - address: 0.0.0.0
+      externalPort: 443
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: gateway-2
+        namespace: envoy-gateway
+        sectionName: https
+      name: envoy-gateway/gateway-2/https
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10443
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/tlsroute-invalid-no-matching-listener.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-invalid-no-matching-listener.out.yaml
@@ -315,6 +315,13 @@ infraIR:
       namespace: envoy-gateway-system
   envoy-gateway/gateway-tlsroute-tcproute-only:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-tlsroute-tcproute-only/tls-passthrough
+        ports:
+        - containerPort: 10443
+          name: tls-443
+          protocol: TLS
+          servicePort: 443
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-tlsroute-tcproute-only
@@ -738,6 +745,16 @@ xdsIR:
       ipFamily: IPv4
       path: /ready
       port: 19003
+    tcp:
+    - address: 0.0.0.0
+      externalPort: 443
+      metadata:
+        kind: Gateway
+        name: gateway-tlsroute-tcproute-only
+        namespace: envoy-gateway
+        sectionName: tls-passthrough
+      name: envoy-gateway/gateway-tlsroute-tcproute-only/tls-passthrough
+      port: 10443
   envoy-gateway/gateway-tlsroute-tls-passthrough-only:
     accessLog:
       json:

--- a/internal/gatewayapi/testdata/tlsroute-not-attaching-to-gateway-with-no-mode.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-not-attaching-to-gateway-with-no-mode.out.yaml
@@ -36,6 +36,13 @@ gateways:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/tls
+        ports:
+        - containerPort: 10090
+          name: tls-90
+          protocol: TLS
+          servicePort: 90
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -107,3 +114,13 @@ xdsIR:
       ipFamily: IPv4
       path: /ready
       port: 19003
+    tcp:
+    - address: 0.0.0.0
+      externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
+      name: envoy-gateway/gateway-1/tls
+      port: 10090

--- a/internal/gatewayapi/testdata/tlsroute-with-listener-both-passthrough-and-cert-data.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-listener-both-passthrough-and-cert-data.out.yaml
@@ -39,6 +39,13 @@ gateways:
 infraIR:
   envoy-gateway/gateway-1:
     proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/tls
+        ports:
+        - containerPort: 10090
+          name: tls-90
+          protocol: TLS
+          servicePort: 90
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: gateway-1
@@ -110,3 +117,13 @@ xdsIR:
       ipFamily: IPv4
       path: /ready
       port: 19003
+    tcp:
+    - address: 0.0.0.0
+      externalPort: 90
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: tls
+      name: envoy-gateway/gateway-1/tls
+      port: 10090

--- a/test/conformance/suite.go
+++ b/test/conformance/suite.go
@@ -20,7 +20,6 @@ func SkipTests(gatewayNamespaceMode bool) []suite.ConformanceTest {
 		tests.ListenerSetHostnameConflict,
 		tests.ListenerSetProtocolConflict,
 		tests.TLSRouteHostnameIntersection,
-		tests.TLSRouteInvalidNoMatchingListener,
 		tests.TLSRouteMixedTerminationSameNamespace,
 		tests.GatewayInvalidTLSBackendConfiguration,
 		tests.GatewayWithAttachedRoutes,


### PR DESCRIPTION
xref: https://github.com/envoyproxy/gateway/issues/3673
Find this when debugging [TLSRouteInvalidNoMatchingListener](https://github.com/kubernetes-sigs/gateway-api/blob/6f1fc073610759753577ad55d5cd8536cc16815f/conformance/tests/tlsroute-invalid-no-matching-listener.go#L36), also this should be part of https://github.com/kubernetes-sigs/gateway-api/issues/4425