### PR TITLE
fix: XListenerSet allows route from same namespace

### DIFF
--- a/internal/gatewayapi/contexts.go
+++ b/internal/gatewayapi/contexts.go
@@ -170,7 +170,7 @@ func (l *ListenerContext) AllowsNamespace(namespace *corev1.Namespace) bool {
 	}
 
 	if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil || l.AllowedRoutes.Namespaces.From == nil {
-		return l.gateway.Namespace == namespace.Name
+		return l.GetNamespace() == namespace.Name
 	}
 
 	switch *l.AllowedRoutes.Namespaces.From {
@@ -183,7 +183,7 @@ func (l *ListenerContext) AllowsNamespace(namespace *corev1.Namespace) bool {
 		return l.namespaceSelector.Matches(labels.Set(namespace.Labels))
 	default:
 		// NamespacesFromSame is the default
-		return l.gateway.Namespace == namespace.Name
+		return l.GetNamespace() == namespace.Name
 	}
 }
 

--- a/internal/gatewayapi/testdata/xlistenerset-cross-namespace.in.yaml
+++ b/internal/gatewayapi/testdata/xlistenerset-cross-namespace.in.yaml
@@ -56,6 +56,22 @@ xListenerSets:
 - apiVersion: gateway.networking.x-k8s.io/v1alpha1
   kind: XListenerSet
   metadata:
+    namespace: cross-allowed
+    name: cross-namespace-same
+  spec:
+    parentRef:
+      namespace: gateway-xls
+      name: composite-gateway
+    listeners:
+    - name: cross-http-same
+      protocol: HTTP
+      port: 8085
+      allowedRoutes:
+        namespaces:
+          from: Same
+- apiVersion: gateway.networking.x-k8s.io/v1alpha1
+  kind: XListenerSet
+  metadata:
     namespace: cross-denied
     name: cross-namespace-denied
   spec:
@@ -89,6 +105,23 @@ httpRoutes:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: HTTPRoute
   metadata:
+    namespace: cross-allowed
+    name: route-same-namespace
+  spec:
+    parentRefs:
+    - group: gateway.networking.x-k8s.io
+      kind: XListenerSet
+      namespace: cross-allowed
+      name: cross-namespace-same
+      sectionName: cross-http-same
+    rules:
+    - backendRefs:
+      - name: service-1
+        namespace: default
+        port: 8080
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
     namespace: default
     name: route-cross-http-denied
   spec:
@@ -102,3 +135,17 @@ httpRoutes:
     - backendRefs:
       - name: service-1
         port: 8080
+referenceGrants:
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: ReferenceGrant
+  metadata:
+    namespace: default
+    name: allow-cross-allowed
+  spec:
+    from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: cross-allowed
+    to:
+    - group: ""
+      kind: Service

--- a/internal/gatewayapi/testdata/xlistenerset-cross-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/xlistenerset-cross-namespace.out.yaml
@@ -81,6 +81,43 @@ httpRoutes:
         name: cross-namespace-allowed
         namespace: cross-allowed
         sectionName: cross-http-allowed
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: route-same-namespace
+    namespace: cross-allowed
+  spec:
+    parentRefs:
+    - group: gateway.networking.x-k8s.io
+      kind: XListenerSet
+      name: cross-namespace-same
+      namespace: cross-allowed
+      sectionName: cross-http-same
+    rules:
+    - backendRefs:
+      - name: service-1
+        namespace: default
+        port: 8080
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        group: gateway.networking.x-k8s.io
+        kind: XListenerSet
+        name: cross-namespace-same
+        namespace: cross-allowed
+        sectionName: cross-http-same
 infraIR:
   gateway-xls/composite-gateway:
     proxy:
@@ -99,6 +136,13 @@ infraIR:
           name: http-8083
           protocol: HTTP
           servicePort: 8083
+      - address: null
+        name: gateway-xls/composite-gateway/cross-allowed/cross-namespace-same/cross-http-same
+        ports:
+        - containerPort: 8085
+          name: http-8085
+          protocol: HTTP
+          servicePort: 8085
       metadata:
         labels:
           gateway.envoyproxy.io/owning-gateway-name: composite-gateway
@@ -159,6 +203,61 @@ xListenerSets:
         type: ResolvedRefs
       name: cross-http-allowed
       port: 8083
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.x-k8s.io/v1alpha1
+  kind: XListenerSet
+  metadata:
+    name: cross-namespace-same
+    namespace: cross-allowed
+  spec:
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: cross-http-same
+      port: 8085
+      protocol: HTTP
+    parentRef:
+      group: null
+      kind: null
+      name: composite-gateway
+      namespace: gateway-xls
+  status:
+    conditions:
+    - lastTransitionTime: null
+      message: All listeners are valid
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: null
+      message: All listeners are valid
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: cross-http-same
+      port: 8085
       supportedKinds:
       - group: gateway.networking.k8s.io
         kind: HTTPRoute
@@ -279,6 +378,48 @@ xdsIR:
           name: route-cross-http-allowed
           namespace: default
         name: httproute/default/route-cross-http-allowed/rule/0/match/-1/*
+    - address: 0.0.0.0
+      externalPort: 8085
+      hostnames:
+      - '*'
+      isHTTP2: false
+      metadata:
+        kind: Gateway
+        name: composite-gateway
+        namespace: gateway-xls
+        sectionName: cross-http-same
+      name: gateway-xls/composite-gateway/cross-allowed/cross-namespace-same/cross-http-same
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8085
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: route-same-namespace
+            namespace: cross-allowed
+          name: httproute/cross-allowed/route-same-namespace/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/cross-allowed/route-same-namespace/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: route-same-namespace
+          namespace: cross-allowed
+        name: httproute/cross-allowed/route-same-namespace/rule/0/match/-1/*
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -13,6 +13,7 @@ new features: |
 bug fixes: |
   Rejected ClientTrafficPolicy if invalid TLS cipher suites are configured.
   Fixed validation of XListenerSet certificateRefs
+  Fixed XListenerSet not allowing xRoutes from the same namespace when configured to allow them
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, using allowedRoutes/Same for an XListenerSet with an xRoute in the same namespace would return an error. Now it properly allows xRoutes from the same namespace.

All of the previous tests I saw for this included `allowedRoutes .. All`, so the bug wasn't clear.

This is the last reference to the listener's gateway's namespace that I found that isn't gated by an isFromXListenerSet() check, so maybe the end of this category of bug.

fixes: #8230

Release Notes: Yes
