### PR TITLE
chore: fix ExtAuthTimeout flaky

### DIFF
--- a/test/e2e/testdata/ext-auth-grpc-securitypolicy.yaml
+++ b/test/e2e/testdata/ext-auth-grpc-securitypolicy.yaml
@@ -55,7 +55,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
-  name: envoy-ext-auth-btls
+  name: grpc-ext-auth-btls
   namespace: gateway-conformance-infra
 spec:
   targetRefs:

--- a/test/e2e/testdata/ext-auth-grpc-timeout-securitypolicy.yaml
+++ b/test/e2e/testdata/ext-auth-grpc-timeout-securitypolicy.yaml
@@ -56,7 +56,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
-  name: envoy-ext-auth-btls
+  name: grpc-ext-auth-btls
   namespace: gateway-conformance-infra
 spec:
   targetRefs:


### PR DESCRIPTION
xref: https://github.com/envoyproxy/gateway/actions/runs/21911079069/job/63267152635
```
apply.go:275: 2026-02-11T15:59:29.000006118Z: Creating http-with-http-ext-auth HTTPRoute
    apply.go:275: 2026-02-11T15:59:29.023642378Z: Creating http-ext-auth SecurityPolicy
    apply.go:294: 2026-02-11T15:59:29.043423724Z: Updating envoy-ext-auth-btls BackendTLSPolicy
    apply.go:308: 
        	Error Trace:	/home/runner/go/pkg/mod/sigs.k8s.io/gateway-api@v1.4.1/conformance/utils/kubernetes/apply.go:308
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/gateway-api@v1.4.1/conformance/utils/suite/conformance.go:71
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/gateway-api@v1.4.1/conformance/utils/suite/suite.go:487
        	Error:      	Received unexpected error:
        	            	Operation cannot be fulfilled on backendtlspolicies.gateway.networking.k8s.io "envoy-ext-auth-btls": the object has been modified; please apply your changes to the latest version and try again
        	Test:       	TestE2E/ExtAuthTimeout
        	Messages:   	error updating resource
```