### PR TITLE
monitoring: update CustomResourceStateMetrics to v1 and fix metric naming conventions

### DIFF
--- a/charts/gateway-addons-helm/values.yaml
+++ b/charts/gateway-addons-helm/values.yaml
@@ -57,7 +57,7 @@ prometheus:
   prometheus-pushgateway:
     enabled: false
   kube-state-metrics:
-    enabled: true
+    enabled: false
     customResourceState:
       enabled: true
       # Add (Cluster)Role permissions to list/watch the customResources defined in the config to rbac.extraRules

--- a/charts/gateway-addons-helm/values.yaml
+++ b/charts/gateway-addons-helm/values.yaml
@@ -57,7 +57,7 @@ prometheus:
   prometheus-pushgateway:
     enabled: false
   kube-state-metrics:
-    enabled: false
+    enabled: true
     customResourceState:
       enabled: true
       # Add (Cluster)Role permissions to list/watch the customResources defined in the config to rbac.extraRules
@@ -85,7 +85,7 @@ prometheus:
                     info:
                       labelsFromPath:
                         gatewayclass_name: [ spec, gatewayClassName ]
-                - name: "labels"
+                - name: "labels_info"
                   help: "Kubernetes labels converted to Prometheus labels."
                   each:
                     type: Info
@@ -105,6 +105,7 @@ prometheus:
                     type: Gauge
                     gauge:
                       path: [ metadata, deletionTimestamp ]
+                      nilIsZero: true
                 - name: "listener_info"
                   help: "Gateway listener information"
                   each:
@@ -162,7 +163,7 @@ prometheus:
                     info:
                       labelsFromPath:
                         controller_name: [ spec, controllerName ]
-                - name: "labels"
+                - name: "labels_info"
                   help: "Kubernetes labels converted to Prometheus labels."
                   each:
                     type: Info
@@ -182,6 +183,7 @@ prometheus:
                     type: Gauge
                     gauge:
                       path: [ metadata, deletionTimestamp ]
+                      nilIsZero: true
                 - name: "status"
                   help: "status condition"
                   each:
@@ -212,7 +214,7 @@ prometheus:
                   - metadata
                   - namespace
               metrics:
-                - name: "labels"
+                - name: "labels_info"
                   help: "Kubernetes labels converted to Prometheus labels."
                   each:
                     type: Info
@@ -232,6 +234,7 @@ prometheus:
                     type: Gauge
                     gauge:
                       path: [ metadata, deletionTimestamp ]
+                      nilIsZero: true
                 - name: "hostname_info"
                   help: "Hostname information"
                   each:
@@ -280,7 +283,7 @@ prometheus:
                   - metadata
                   - namespace
               metrics:
-                - name: "labels"
+                - name: "labels_info"
                   help: "Kubernetes labels converted to Prometheus labels."
                   each:
                     type: Info
@@ -300,6 +303,7 @@ prometheus:
                     type: Gauge
                     gauge:
                       path: [ metadata, deletionTimestamp ]
+                      nilIsZero: true
                 - name: "hostname_info"
                   help: "Hostname information"
                   each:
@@ -338,7 +342,7 @@ prometheus:
             - groupVersionKind:
                 group: gateway.networking.k8s.io
                 kind: "TCPRoute"
-                version: "v1alpha2"
+                version: "v1"
               metricNamePrefix: gatewayapi_tcproute
               labelsFromPath:
                 name:
@@ -348,7 +352,7 @@ prometheus:
                   - metadata
                   - namespace
               metrics:
-                - name: "labels"
+                - name: "labels_info"
                   help: "Kubernetes labels converted to Prometheus labels."
                   each:
                     type: Info
@@ -368,6 +372,7 @@ prometheus:
                     type: Gauge
                     gauge:
                       path: [ metadata, deletionTimestamp ]
+                      nilIsZero: true
                 - name: "parent_info"
                   help: "Parent references that the tcproute wants to be attached to"
                   each:
@@ -398,7 +403,7 @@ prometheus:
             - groupVersionKind:
                 group: gateway.networking.k8s.io
                 kind: "TLSRoute"
-                version: "v1alpha2"
+                version: "v1"
               metricNamePrefix: gatewayapi_tlsroute
               labelsFromPath:
                 name:
@@ -408,7 +413,7 @@ prometheus:
                   - metadata
                   - namespace
               metrics:
-                - name: "labels"
+                - name: "labels_info"
                   help: "Kubernetes labels converted to Prometheus labels."
                   each:
                     type: Info
@@ -428,6 +433,7 @@ prometheus:
                     type: Gauge
                     gauge:
                       path: [ metadata, deletionTimestamp ]
+                      nilIsZero: true
                 - name: "hostname_info"
                   help: "Hostname information"
                   each:
@@ -466,7 +472,7 @@ prometheus:
             - groupVersionKind:
                 group: gateway.networking.k8s.io
                 kind: "UDPRoute"
-                version: "v1alpha2"
+                version: "v1"
               metricNamePrefix: gatewayapi_udproute
               labelsFromPath:
                 name:
@@ -476,7 +482,7 @@ prometheus:
                   - metadata
                   - namespace
               metrics:
-                - name: "labels"
+                - name: "labels_info"
                   help: "Kubernetes labels converted to Prometheus labels."
                   each:
                     type: Info
@@ -496,6 +502,7 @@ prometheus:
                     type: Gauge
                     gauge:
                       path: [ metadata, deletionTimestamp ]
+                      nilIsZero: true
                 - name: "parent_info"
                   help: "Parent references that the udproute wants to be attached to"
                   each:
@@ -526,7 +533,7 @@ prometheus:
             - groupVersionKind:
                 group: gateway.networking.k8s.io
                 kind: "BackendTLSPolicy"
-                version: "v1alpha3"
+                version: "v1"
               metricNamePrefix: gatewayapi_backendtlspolicy
               labelsFromPath:
                 name:
@@ -536,7 +543,7 @@ prometheus:
                   - metadata
                   - namespace
               metrics:
-                - name: "labels"
+                - name: "labels_info"
                   help: "Kubernetes labels converted to Prometheus labels."
                   each:
                     type: Info
@@ -556,6 +563,7 @@ prometheus:
                     type: Gauge
                     gauge:
                       path: [ metadata, deletionTimestamp ]
+                      nilIsZero: true
                 - name: "target_info"
                   help: "Target references that the backendtlspolicy wants to be attached to"
                   each:


### PR DESCRIPTION
**What type of PR is this?**

fix(monitoring): update CustomResourceStateMetrics to v1 and align metric naming

---

**What this PR does / why we need it**:

This PR updates the `CustomResourceStateMetrics` configuration in the `gateway-addons` chart to align with the current Gateway API `v1` resources and kube-state-metrics naming conventions.

Specifically, this change:

- Updates all `groupVersionKind.version` fields from deprecated `v1alpha*` versions to `v1` for:
  - Gateway
  - GatewayClass
  - HTTPRoute
  - GRPCRoute
  - TCPRoute
  - TLSRoute
  - UDPRoute
  - BackendTLSPolicy

- Adds `nilIsZero: true` to all `deletionTimestamp` gauge metrics to prevent nil resolution warnings such as:
  "got nil while resolving path"

- Renames Info metrics from `labels` to `labels_info` to comply with the kube-state-metrics `_info` suffix requirement and eliminate warnings like:
  "Info metric does not have _info suffix"

These updates remove deprecated API warnings (e.g. BackendTLSPolicy v1alpha3 deprecation warnings), prevent noisy log errors for deleted resources, and ensure compatibility with the current Gateway API and kube-state-metrics behavior.

This change only affects monitoring configuration. No API changes or behavioral changes to Gateway functionality are introduced.

---

**Which issue(s) this PR fixes**:

Fixes #8284

---

Release Notes: Yes

<img width="713" height="157" alt="Screenshot 2026-02-17 at 3 07 09 PM" src="https://github.com/user-attachments/assets/6ebbe753-8ef8-480d-834a-592777bf2397" />
