### PR TITLE
chore: Fix JA Fingerprint ipv6 e2e

### DIFF
--- a/test/e2e/tests/ja_fingerprint.go
+++ b/test/e2e/tests/ja_fingerprint.go
@@ -8,7 +8,8 @@
 package tests
 
 import (
-	"fmt"
+	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -60,7 +61,7 @@ func testJAFingerprint(t *testing.T, suite *suite.ConformanceTestSuite, routeNam
 		t.Fatalf("unexpected error finding TLS secret: %v", err)
 	}
 
-	req := http.MakeRequest(t, &expected, fmt.Sprintf("%s:%d", gwAddr, port), "HTTPS", "https")
+	req := http.MakeRequest(t, &expected, net.JoinHostPort(gwAddr, strconv.Itoa(port)), "HTTPS", "https")
 	req.Server = serverName
 	// Use the certificate and key for TLS setup, CA cert for validation (self-signed cert)
 	req.CertPem = certPem


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/contributions/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

The IPv6 e2e never succeeds for the JA Fingerprint test due to incorrect address formatting and this changes uses net.JoinHostPort to properly bracket the ipv6 address.

Current code: https://github.com/envoyproxy/gateway/blob/e56785c4cccc989a9f82264a848b3f9973ca4839/test/e2e/tests/ja_fingerprint.go#L63

The port is absorbed into the IPv6 address. This also failed in the initial PR - https://github.com/envoyproxy/gateway/actions/runs/22037592915/job/63675657398

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
