### PR TITLE
refactor/perf: use LuaPerRoute instead of FilterConfig

### DIFF
--- a/internal/xds/translator/lua.go
+++ b/internal/xds/translator/lua.go
@@ -7,6 +7,7 @@ package translator
 
 import (
 	"errors"
+	"fmt"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -27,8 +28,9 @@ type lua struct{}
 
 var _ httpFilter = &lua{}
 
-// patchHCM builds and appends the lua Filters to the HTTP Connection Manager
-// Lua filters are created in disabled mode.
+// patchHCM builds and appends disabled Lua filters to the HTTP Connection Manager.
+// One filter is added per distinct Lua name (across all routes). Each has empty default source code;
+// the actual script is supplied per-route via LuaPerRoute.
 func (*lua) patchHCM(mgr *hcmv3.HttpConnectionManager, irListener *ir.HTTPListener) error {
 	if mgr == nil {
 		return errors.New("hcm is nil")
@@ -54,11 +56,11 @@ func (*lua) patchHCM(mgr *hcmv3.HttpConnectionManager, irListener *ir.HTTPListen
 			mgr.HttpFilters = append(mgr.HttpFilters, filter)
 		}
 	}
-
 	return errs
 }
 
-// buildHCMLuaFilter returns a Lua filter for HCM.
+// buildHCMLuaFilter returns a disabled Lua filter for HCM with empty default source code.
+// The actual Lua script for each route is provided via LuaPerRoute in the route's TypedPerFilterConfig.
 func buildHCMLuaFilter(lua ir.Lua) (*hcmv3.HttpFilter, error) {
 	var (
 		luaProto *luafilterv3.Lua
@@ -68,7 +70,7 @@ func buildHCMLuaFilter(lua ir.Lua) (*hcmv3.HttpFilter, error) {
 	luaProto = &luafilterv3.Lua{
 		DefaultSourceCode: &corev3.DataSource{
 			Specifier: &corev3.DataSource_InlineString{
-				InlineString: *lua.Code,
+				InlineString: "",
 			},
 		},
 	}
@@ -88,16 +90,16 @@ func buildHCMLuaFilter(lua ir.Lua) (*hcmv3.HttpFilter, error) {
 	}, nil
 }
 
+// luaFilterName returns the filter name for the given Lua (policy-based naming).
 func luaFilterName(lua ir.Lua) string {
 	return perRouteFilterName(egv1a1.EnvoyFilterLua, lua.Name)
 }
 
-// routeContainsLua returns true if Luas exists for the provided route.
+// routeContainsLua returns true if the route has any Lua extensions.
 func routeContainsLua(irRoute *ir.HTTPRoute) bool {
 	if irRoute == nil {
 		return false
 	}
-
 	return irRoute.EnvoyExtensions != nil && len(irRoute.EnvoyExtensions.Luas) > 0
 }
 
@@ -106,7 +108,7 @@ func (*lua) patchResources(_ *types.ResourceVersionTable, _ []*ir.HTTPRoute) err
 	return nil
 }
 
-// patchRoute patches the provided route so Lua filters are enabled if applicable.
+// patchRoute patches the provided route with LuaPerRoute so the Lua filter runs with the route's script.
 func (*lua) patchRoute(route *routev3.Route, irRoute *ir.HTTPRoute, _ *ir.HTTPListener) error {
 	if route == nil {
 		return errors.New("xds route is nil")
@@ -120,11 +122,26 @@ func (*lua) patchRoute(route *routev3.Route, irRoute *ir.HTTPRoute, _ *ir.HTTPLi
 
 	for _, ep := range irRoute.EnvoyExtensions.Luas {
 		filterName := luaFilterName(ep)
-		if err := enableFilterOnRoute(route, filterName, &routev3.FilterConfig{
-			Config: &anypb.Any{},
-		}); err != nil {
+		luaPerRoute := &luafilterv3.LuaPerRoute{
+			Override: &luafilterv3.LuaPerRoute_SourceCode{
+				SourceCode: &corev3.DataSource{
+					Specifier: &corev3.DataSource_InlineString{
+						InlineString: *ep.Code,
+					},
+				},
+			},
+		}
+		luaPerRouteAny, err := anypb.New(luaPerRoute)
+		if err != nil {
 			return err
 		}
+		if route.TypedPerFilterConfig == nil {
+			route.TypedPerFilterConfig = make(map[string]*anypb.Any)
+		}
+		if _, exists := route.TypedPerFilterConfig[filterName]; exists {
+			return fmt.Errorf("route already has Lua per-route config for %s", filterName)
+		}
+		route.TypedPerFilterConfig[filterName] = luaPerRouteAny
 	}
 	return nil
 }

--- a/internal/xds/translator/testdata/out/xds-ir/lua.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/lua.listeners.yaml
@@ -19,22 +19,19 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
             defaultSourceCode:
-              inlineString: function envoy_on_request(request_handle) request_handle:logInfo('Goodbye.')
-                end
+              inlineString: ""
         - disabled: true
           name: envoy.filters.http.lua/envoyextensionpolicy/envoy-gateway/policy-for-gateway/lua/0
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
             defaultSourceCode:
-              inlineString: function envoy_on_response(response_handle) response_handle:logWarn('Goodbye.')
-                end
+              inlineString: ""
         - disabled: true
           name: envoy.filters.http.lua/envoyextensionpolicy/envoy-gateway/policy-for-gateway/lua/1
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
             defaultSourceCode:
-              inlineString: function envoy_on_response(response_handle) response_handle:logError('Hello.')
-                end
+              inlineString: ""
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/lua.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/lua.routes.yaml
@@ -14,8 +14,10 @@
         - upgradeType: websocket
       typedPerFilterConfig:
         envoy.filters.http.lua/envoyextensionpolicy/default/policy-for-http-route/lua/0:
-          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-          config: {}
+          '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
+          sourceCode:
+            inlineString: function envoy_on_request(request_handle) request_handle:logInfo('Goodbye.')
+              end
     - match:
         pathSeparatedPrefix: /bar
       name: httproute/default/httproute-2/rule/0/match/0/www_example_com
@@ -25,8 +27,12 @@
         - upgradeType: websocket
       typedPerFilterConfig:
         envoy.filters.http.lua/envoyextensionpolicy/envoy-gateway/policy-for-gateway/lua/0:
-          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-          config: {}
+          '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
+          sourceCode:
+            inlineString: function envoy_on_response(response_handle) response_handle:logWarn('Goodbye.')
+              end
         envoy.filters.http.lua/envoyextensionpolicy/envoy-gateway/policy-for-gateway/lua/1:
-          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
-          config: {}
+          '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
+          sourceCode:
+            inlineString: function envoy_on_response(response_handle) response_handle:logError('Hello.')
+              end

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -42,6 +42,7 @@ bug fixes: |
 
 # Enhancements that improve performance.
 performance improvements: |
+  Reduce chances of listener drain due to Lua policy updates by migrating to LuaPerRoute.
 
 # Deprecated features or APIs.
 deprecations: |


### PR DESCRIPTION
**What type of PR is this?**
refactor/perf: use LuaPerRoute instead of FilterConfig

**What this PR does / why we need it**:

Helps reduce listener drain due to Lua policy churn as they are applied at routes now. Lua E2E and tests are already in place.

Fixes #7839 

Release Notes: Yes
