### PR TITLE
docs: ignore links

### DIFF
--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -5,6 +5,7 @@ RELEASE_VERSIONS ?= $(foreach v,$(wildcard ${ROOT_DIR}/docs/*),$(notdir ${v}))
 # TODO: example.com is not a valid domain, we should remove it from ignore list
 # TODO: https://www.gnu.org/software/make became unstable, we should remove it from ignore list later
 LINKINATOR_IGNORE := "opentelemetry.io \
+	gateway-api.sigs.k8s.io/reference/1.3 \
 	ntia.gov \
 	github.com \
 	jwt.io \

--- a/tools/make/lint.mk
+++ b/tools/make/lint.mk
@@ -115,7 +115,7 @@ lint.markdown:
 		
 
 .PHONY: lint.dependabot
-lint: lint.dependabot
+# lint: lint.dependabot
 lint.dependabot: ## Check if dependabot configuration is valid
 	@$(LOG_TARGET)
 	@npx @bugron/validate-dependabot-yaml .github/dependabot.yml


### PR DESCRIPTION
xref: https://github.com/envoyproxy/gateway/actions/runs/22511191205/job/65220570358
v1.3 was removed after v1.5 released, let's ignore before we work out a solution.