### PR TITLE
e2e: reduce consistent hash flaky

### DIFF
--- a/internal/troubleshoot/collect.go
+++ b/internal/troubleshoot/collect.go
@@ -29,6 +29,7 @@ const (
 
 type CollectOptions struct {
 	namespaces []string
+	selector   []string
 	bundlePath string
 	// enableSDS indicates whether to remove the SDS section from the config dump
 	// to avoid collecting sensitive information.
@@ -49,6 +50,12 @@ func WithBundlePath(path string) CollectOption {
 func WithCollectedNamespaces(ns []string) CollectOption {
 	return func(opts *CollectOptions) {
 		opts.namespaces = ns
+	}
+}
+
+func WithSelector(selector ...string) CollectOption {
+	return func(opts *CollectOptions) {
+		opts.selector = selector
 	}
 }
 
@@ -120,6 +127,7 @@ func CollectResult(ctx context.Context, restConfig *rest.Config, opts ...Collect
 					Collector: &troubleshootv1b2.Logs{
 						Name:      "pod-logs",
 						Namespace: ns,
+						Selector:  collectorOpts.selector,
 					},
 					ClientConfig: restConfig,
 					BundlePath:   bundlePath,

--- a/test/e2e/base/manifests.yaml
+++ b/test/e2e/base/manifests.yaml
@@ -273,102 +273,6 @@ metadata:
     gateway-conformance: backend
 ---
 apiVersion: v1
-kind: Service
-metadata:
-  name: app-backend-v1
-  namespace: gateway-conformance-app-backend
-spec:
-  selector:
-    app: app-backend-v1
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: app-backend-v1
-  namespace: gateway-conformance-app-backend
-  labels:
-    app: app-backend-v1
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: app-backend-v1
-  template:
-    metadata:
-      labels:
-        app: app-backend-v1
-    spec:
-      containers:
-        - name: app-backend-v1
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: SERVICE_NAME
-              value: app-backend-v1
-          resources:
-            requests:
-              cpu: 10m
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: app-backend-v2
-  namespace: gateway-conformance-app-backend
-spec:
-  selector:
-    app: app-backend-v2
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: app-backend-v2
-  namespace: gateway-conformance-app-backend
-  labels:
-    app: app-backend-v2
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: app-backend-v2
-  template:
-    metadata:
-      labels:
-        app: app-backend-v2
-    spec:
-      containers:
-        - name: app-backend-v2
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: SERVICE_NAME
-              value: app-backend-v2
-          resources:
-            requests:
-              cpu: 10m
----
-apiVersion: v1
 kind: Namespace
 metadata:
   name: gateway-conformance-web-backend
@@ -379,7 +283,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: web-backend
-  namespace: gateway-conformance-web-backend
+  namespace: gateway-conformance-infra
 spec:
   selector:
     app: web-backend
@@ -392,11 +296,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web-backend
-  namespace: gateway-conformance-web-backend
+  namespace: gateway-conformance-infra
   labels:
     app: web-backend
 spec:
-  replicas: 2
+  replicas: 4
   selector:
     matchLabels:
       app: web-backend

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -41,7 +41,6 @@ func TestE2E(t *testing.T) {
 
 	skipTests := []string{
 		tests.GatewayInfraResourceTest.ShortName, // https://github.com/envoyproxy/gateway/issues/3191
-		tests.ConsistentHashQueryParamsLoadBalancingTest.ShortName,
 	}
 
 	// Skip test only work on DualStack cluster

--- a/test/e2e/testdata/load_balancing_consistent_hash_cookie.yaml
+++ b/test/e2e/testdata/load_balancing_consistent_hash_cookie.yaml
@@ -1,52 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: lb-backend-cookie
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: lb-backend-cookie
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lb-backend-cookie
-  namespace: gateway-conformance-infra
-  labels:
-    app: lb-backend-cookie
-spec:
-  replicas: 4
-  selector:
-    matchLabels:
-      app: lb-backend-cookie
-  template:
-    metadata:
-      labels:
-        app: lb-backend-cookie
-    spec:
-      containers:
-        - name: backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: SERVICE_NAME
-              value: lb-backend-cookie
-          resources:
-            requests:
-              cpu: 10m
----
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -81,5 +32,5 @@ spec:
             type: PathPrefix
             value: /cookie
       backendRefs:
-        - name: lb-backend-cookie
+        - name: web-backend
           port: 8080

--- a/test/e2e/testdata/load_balancing_consistent_hash_header.yaml
+++ b/test/e2e/testdata/load_balancing_consistent_hash_header.yaml
@@ -1,51 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: lb-backend-header
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: lb-backend-header
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lb-backend-header
-  namespace: gateway-conformance-infra
-  labels:
-    app: lb-backend-header
-spec:
-  replicas: 4
-  selector:
-    matchLabels:
-      app: lb-backend-header
-  template:
-    metadata:
-      labels:
-        app: lb-backend-header
-    spec:
-      containers:
-        - name: backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: SERVICE_NAME
-              value: lb-backend-header
-          resources:
-            requests:
-              cpu: 10m
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
@@ -78,5 +30,5 @@ spec:
             type: PathPrefix
             value: /header
       backendRefs:
-        - name: lb-backend-header
+        - name: web-backend
           port: 8080

--- a/test/e2e/testdata/load_balancing_consistent_hash_multi_header.yaml
+++ b/test/e2e/testdata/load_balancing_consistent_hash_multi_header.yaml
@@ -1,51 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: lb-backend-header
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: lb-backend-header
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lb-backend-header
-  namespace: gateway-conformance-infra
-  labels:
-    app: lb-backend-header
-spec:
-  replicas: 4
-  selector:
-    matchLabels:
-      app: lb-backend-header
-  template:
-    metadata:
-      labels:
-        app: lb-backend-header
-    spec:
-      containers:
-        - name: backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: SERVICE_NAME
-              value: lb-backend-header
-          resources:
-            requests:
-              cpu: 10m
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
@@ -79,5 +31,5 @@ spec:
             type: PathPrefix
             value: /header
       backendRefs:
-        - name: lb-backend-header
+        - name: web-backend
           port: 8080

--- a/test/e2e/testdata/load_balancing_consistent_hash_query_parameter.yaml
+++ b/test/e2e/testdata/load_balancing_consistent_hash_query_parameter.yaml
@@ -1,51 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: lb-backend-query-parameter
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: lb-backend-query-parameter
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lb-backend-query-parameter
-  namespace: gateway-conformance-infra
-  labels:
-    app: lb-backend-query-parameter
-spec:
-  replicas: 4
-  selector:
-    matchLabels:
-      app: lb-backend-query-parameter
-  template:
-    metadata:
-      labels:
-        app: lb-backend-query-parameter
-    spec:
-      containers:
-        - name: backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: SERVICE_NAME
-              value: lb-backend-query-parameter
-          resources:
-            requests:
-              cpu: 10m
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
@@ -79,5 +31,5 @@ spec:
             type: PathPrefix
             value: /query-parameter
       backendRefs:
-        - name: lb-backend-query-parameter
+        - name: web-backend
           port: 8080

--- a/test/e2e/testdata/load_balancing_consistent_hash_source_ip.yaml
+++ b/test/e2e/testdata/load_balancing_consistent_hash_source_ip.yaml
@@ -1,52 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: lb-backend-sourceip
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: lb-backend-sourceip
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lb-backend-sourceip
-  namespace: gateway-conformance-infra
-  labels:
-    app: lb-backend-sourceip
-spec:
-  replicas: 4
-  selector:
-    matchLabels:
-      app: lb-backend-sourceip
-  template:
-    metadata:
-      labels:
-        app: lb-backend-sourceip
-    spec:
-      containers:
-        - name: backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: SERVICE_NAME
-              value: lb-backend-sourceip
-          resources:
-            requests:
-              cpu: 10m
----
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -76,5 +27,5 @@ spec:
             type: PathPrefix
             value: /source
       backendRefs:
-        - name: lb-backend-sourceip
+        - name: web-backend
           port: 8080

--- a/test/e2e/testdata/load_balancing_endpoint_override.yaml
+++ b/test/e2e/testdata/load_balancing_endpoint_override.yaml
@@ -1,56 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: lb-backend-endpointoverride
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: lb-backend-endpointoverride
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lb-backend-endpointoverride
-  namespace: gateway-conformance-infra
-  labels:
-    app: lb-backend-endpointoverride
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: lb-backend-endpointoverride
-  template:
-    metadata:
-      labels:
-        app: lb-backend-endpointoverride
-    spec:
-      containers:
-        - name: backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: SERVICE_NAME
-              value: lb-backend-endpointoverride
-          resources:
-            requests:
-              cpu: 10m
----
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -81,6 +28,6 @@ spec:
             type: PathPrefix
             value: /endpoint-override-header
       backendRefs:
-        - name: lb-backend-endpointoverride
+        - name: web-backend
           port: 8080
 

--- a/test/e2e/testdata/load_balancing_round_robin.yaml
+++ b/test/e2e/testdata/load_balancing_round_robin.yaml
@@ -1,51 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: lb-backend-roundrobin
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: lb-backend-roundrobin
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lb-backend-roundrobin
-  namespace: gateway-conformance-infra
-  labels:
-    app: lb-backend-roundrobin
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: lb-backend-roundrobin
-  template:
-    metadata:
-      labels:
-        app: lb-backend-roundrobin
-    spec:
-      containers:
-        - name: backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: SERVICE_NAME
-              value: lb-backend-roundrobin
-          resources:
-            requests:
-              cpu: 10m
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
@@ -74,5 +26,5 @@ spec:
             type: PathPrefix
             value: /round
       backendRefs:
-        - name: lb-backend-roundrobin
+        - name: web-backend
           port: 8080

--- a/test/e2e/tests/load_balancing.go
+++ b/test/e2e/tests/load_balancing.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -38,30 +39,33 @@ import (
 
 func init() {
 	ConformanceTests = append(ConformanceTests,
-		RoundRobinLoadBalancingTest,
-		ConsistentHashSourceIPLoadBalancingTest,
-		ConsistentHashHeaderLoadBalancingTest,
-		ConsistentHashCookieLoadBalancingTest,
-		EndpointOverrideLoadBalancingTest,
-		MultiHeaderConsistentHashHeaderLoadBalancingTest,
-		ConsistentHashQueryParamsLoadBalancingTest,
+		RoundRobinLoadBalancing,
+		SourceIPBasedConsistentHashLoadBalancing,
+		HeaderBasedConsistentHashLoadBalancing,
+		CookieBasedConsistentHashLoadBalancing,
+		EndpointOverrideLoadBalancing,
+		MultiHeaderConsistentHashHeaderLoadBalancing,
+		QueryParamsBasedConsistentHashLoadBalancing,
 	)
 }
 
-var RoundRobinLoadBalancingTest = suite.ConformanceTest{
+var RoundRobinLoadBalancing = suite.ConformanceTest{
 	ShortName:   "RoundRobinLoadBalancing",
 	Description: "Test for round robin load balancing type",
-	Manifests:   []string{"testdata/load_balancing_round_robin.yaml"},
+	Manifests: []string{
+		"testdata/load_balancing_round_robin.yaml",
+	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		const (
-			sendRequests = 100
-			replicas     = 3
+			// The replicas of the deployment gateway-conformance-infra/web-backend.
+			replicas     = 4
+			sendRequests = replicas * 50
 			offset       = 5
 		)
 
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "round-robin-lb-route", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwNN := types.NamespacedName{Name: SameNamespaceGateway.Name, Namespace: ns}
 
 		ancestorRef := gwapiv1.ParentReference{
 			Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
@@ -70,8 +74,6 @@ var RoundRobinLoadBalancingTest = suite.ConformanceTest{
 			Name:      gwapiv1.ObjectName(gwNN.Name),
 		}
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "round-robin-lb-policy", Namespace: ns}, suite.ControllerName, ancestorRef)
-		WaitForPods(t, suite.Client, ns, map[string]string{"app": "lb-backend-roundrobin"}, corev1.PodRunning, &PodReady)
-
 		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
 
 		t.Run("traffic should be split evenly", func(t *testing.T) {
@@ -97,7 +99,7 @@ var RoundRobinLoadBalancingTest = suite.ConformanceTest{
 				return true
 			}
 
-			if err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 30*time.Second, true, func(_ context.Context) (bool, error) {
+			if err := wait.PollUntilContextTimeout(t.Context(), time.Second, 30*time.Second, true, func(_ context.Context) (bool, error) {
 				return runTrafficTest(t, suite, &req, &expectedResponse, sendRequests, compareFunc), nil
 			}); err != nil {
 				tlog.Errorf(t, "failed to run round robin load balancing test: %v", err)
@@ -113,27 +115,33 @@ func runTrafficTest(t *testing.T, suite *suite.ConformanceTestSuite,
 	totalRequestCount int, compareFunc TrafficCompareFunc,
 ) bool {
 	if req == nil {
+		// this should never happen, just a sanity check for the caller
 		t.Fatalf("request cannot be nil")
+		return false
 	}
 	if expectedResponse == nil {
+		// this should never happen, just a sanity check for the caller
 		t.Fatalf("expected response cannot be nil")
+		return false
 	}
 	trafficMap := make(map[string]int)
-	for i := 0; i < totalRequestCount; i++ {
+	for range totalRequestCount {
 		request := *req
 		cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(request)
 		if err != nil {
-			t.Errorf("failed to get expected response: %v", err)
+			tlog.Logf(t, "failed to get expected response: %v", err)
+			continue
 		}
 
 		if err := http.CompareRoundTrip(t, &request, cReq, cResp, *expectedResponse); err != nil {
-			t.Errorf("failed to compare request and response: %v", err)
+			tlog.Logf(t, "failed to get expected response: %v", err)
+			continue
 		}
 
 		podName := cReq.Pod
 		if len(podName) == 0 {
 			// it shouldn't be missing here
-			tlog.Errorf(t, "failed to get pod header in response: %v", err)
+			tlog.Logf(t, "failed to get pod header in response: %v", err)
 		} else {
 			trafficMap[podName]++
 		}
@@ -142,19 +150,25 @@ func runTrafficTest(t *testing.T, suite *suite.ConformanceTestSuite,
 	ret := compareFunc(trafficMap)
 	if !ret {
 		tlog.Logf(t, "traffic map: %v", trafficMap)
+		// wait for a while to let envoy flush all the logs.
+		time.Sleep(6 * time.Second)
+		consistentHashDump(t, suite.RestConfig)
+		t.FailNow()
 	}
 
 	return ret
 }
 
-var ConsistentHashSourceIPLoadBalancingTest = suite.ConformanceTest{
+var SourceIPBasedConsistentHashLoadBalancing = suite.ConformanceTest{
 	ShortName:   "SourceIPBasedConsistentHashLoadBalancing",
 	Description: "Test for source IP based consistent hash load balancing type",
-	Manifests:   []string{"testdata/load_balancing_consistent_hash_source_ip.yaml"},
+	Manifests: []string{
+		"testdata/load_balancing_consistent_hash_source_ip.yaml",
+	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "source-ip-lb-route", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwNN := types.NamespacedName{Name: SameNamespaceGateway.Name, Namespace: ns}
 
 		ancestorRef := gwapiv1.ParentReference{
 			Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
@@ -163,8 +177,6 @@ var ConsistentHashSourceIPLoadBalancingTest = suite.ConformanceTest{
 			Name:      gwapiv1.ObjectName(gwNN.Name),
 		}
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "source-ip-lb-policy", Namespace: ns}, suite.ControllerName, ancestorRef)
-		WaitForPods(t, suite.Client, ns, map[string]string{"app": "lb-backend-sourceip"}, corev1.PodRunning, &PodReady)
-
 		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
 
 		t.Run("all traffics route to the same backend with same source ip", func(t *testing.T) {
@@ -184,14 +196,16 @@ var ConsistentHashSourceIPLoadBalancingTest = suite.ConformanceTest{
 	},
 }
 
-var ConsistentHashHeaderLoadBalancingTest = suite.ConformanceTest{
+var HeaderBasedConsistentHashLoadBalancing = suite.ConformanceTest{
 	ShortName:   "HeaderBasedConsistentHashLoadBalancing",
 	Description: "Test for header based consistent hash load balancing type",
-	Manifests:   []string{"testdata/load_balancing_consistent_hash_header.yaml"},
+	Manifests: []string{
+		"testdata/load_balancing_consistent_hash_header.yaml",
+	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "header-lb-route", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwNN := types.NamespacedName{Name: SameNamespaceGateway.Name, Namespace: ns}
 
 		ancestorRef := gwapiv1.ParentReference{
 			Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
@@ -200,10 +214,7 @@ var ConsistentHashHeaderLoadBalancingTest = suite.ConformanceTest{
 			Name:      gwapiv1.ObjectName(gwNN.Name),
 		}
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "header-lb-policy", Namespace: ns}, suite.ControllerName, ancestorRef)
-		WaitForPods(t, suite.Client, ns, map[string]string{"app": "lb-backend-header"}, corev1.PodRunning, &PodReady)
-
 		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
-
 		expectedResponse := &http.ExpectedResponse{
 			Request: http.Request{
 				Path: "/header",
@@ -225,14 +236,16 @@ var ConsistentHashHeaderLoadBalancingTest = suite.ConformanceTest{
 	},
 }
 
-var MultiHeaderConsistentHashHeaderLoadBalancingTest = suite.ConformanceTest{
+var MultiHeaderConsistentHashHeaderLoadBalancing = suite.ConformanceTest{
 	ShortName:   "MultiHeaderBasedConsistentHashLoadBalancing",
 	Description: "Test for multiple header based consistent hash load balancing type",
-	Manifests:   []string{"testdata/load_balancing_consistent_hash_multi_header.yaml"},
+	Manifests: []string{
+		"testdata/load_balancing_consistent_hash_multi_header.yaml",
+	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "header-lb-route", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwNN := types.NamespacedName{Name: SameNamespaceGateway.Name, Namespace: ns}
 
 		ancestorRef := gwapiv1.ParentReference{
 			Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
@@ -241,8 +254,6 @@ var MultiHeaderConsistentHashHeaderLoadBalancingTest = suite.ConformanceTest{
 			Name:      gwapiv1.ObjectName(gwNN.Name),
 		}
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "header-lb-policy", Namespace: ns}, suite.ControllerName, ancestorRef)
-		WaitForPods(t, suite.Client, ns, map[string]string{"app": "lb-backend-header"}, corev1.PodRunning, &PodReady)
-
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		expectedResponse := &http.ExpectedResponse{
@@ -282,9 +293,9 @@ var MultiHeaderConsistentHashHeaderLoadBalancingTest = suite.ConformanceTest{
 }
 
 func runConsistentHashLoadBalancingTest(t *testing.T, suite *suite.ConformanceTestSuite, req *roundtripper.Request, expectedResponse *http.ExpectedResponse) {
-	if err := wait.PollUntilContextTimeout(t.Context(), time.Second, 30*time.Second, true, func(_ context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(t.Context(), time.Second, time.Minute, true, func(_ context.Context) (bool, error) {
 		got := runTrafficTest(t, suite, req, expectedResponse, sendRequests, func(trafficMap map[string]int) bool {
-			// All traffic with the same header combination should route to the same pod
+			// All traffic with the same hash combination should route to the same pod
 			return len(trafficMap) == 1
 		})
 		return got, nil
@@ -293,16 +304,18 @@ func runConsistentHashLoadBalancingTest(t *testing.T, suite *suite.ConformanceTe
 	}
 }
 
-var ConsistentHashCookieLoadBalancingTest = suite.ConformanceTest{
+var CookieBasedConsistentHashLoadBalancing = suite.ConformanceTest{
 	ShortName:   "CookieBasedConsistentHashLoadBalancing",
 	Description: "Test for cookie based consistent hash load balancing type",
-	Manifests:   []string{"testdata/load_balancing_consistent_hash_cookie.yaml"},
+	Manifests: []string{
+		"testdata/load_balancing_consistent_hash_cookie.yaml",
+	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		const sendRequests = 10
 
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "cookie-lb-route", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwNN := types.NamespacedName{Name: SameNamespaceGateway.Name, Namespace: ns}
 
 		ancestorRef := gwapiv1.ParentReference{
 			Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
@@ -311,7 +324,6 @@ var ConsistentHashCookieLoadBalancingTest = suite.ConformanceTest{
 			Name:      gwapiv1.ObjectName(gwNN.Name),
 		}
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "cookie-lb-policy", Namespace: ns}, suite.ControllerName, ancestorRef)
-		WaitForPods(t, suite.Client, ns, map[string]string{"app": "lb-backend-cookie"}, corev1.PodRunning, &PodReady)
 
 		gwHost := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
 		gwAddr := net.JoinHostPort(gwHost, "80")
@@ -325,6 +337,7 @@ var ConsistentHashCookieLoadBalancingTest = suite.ConformanceTest{
 			client := &nethttp.Client{
 				Jar:       cookieJar,
 				Transport: nethttp.DefaultTransport,
+				Timeout:   suite.TimeoutConfig.RequestTimeout,
 			}
 			req, err := nethttp.NewRequest(nethttp.MethodGet, fmt.Sprintf("http://%s/cookie", gwAddr), nil)
 			require.NoError(t, err)
@@ -344,12 +357,16 @@ var ConsistentHashCookieLoadBalancingTest = suite.ConformanceTest{
 				for range sendRequests {
 					resp, err := client.Do(req)
 					if err != nil {
-						t.Errorf("failed to get response: %v", err)
+						t.Logf("failed to get response: %v", err)
+						continue
 					}
 
 					body, err := io.ReadAll(resp.Body)
 					require.NoError(t, err)
-					require.Equal(t, nethttp.StatusOK, resp.StatusCode)
+					if resp.StatusCode != nethttp.StatusOK {
+						t.Logf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+						continue
+					}
 
 					// Parse response body.
 					cReq := &roundtripper.CapturedRequest{}
@@ -363,7 +380,7 @@ var ConsistentHashCookieLoadBalancingTest = suite.ConformanceTest{
 					podName := cReq.Pod
 					if len(podName) == 0 {
 						// it shouldn't be missing here
-						t.Errorf("failed to get pod header in response: %v", err)
+						t.Logf("failed to get pod header in response: %v", err)
 					} else {
 						if len(expectPodName) == 0 {
 							expectPodName = podName
@@ -386,6 +403,7 @@ var ConsistentHashCookieLoadBalancingTest = suite.ConformanceTest{
 			client := &nethttp.Client{
 				Jar:       cookieJar,
 				Transport: nethttp.DefaultTransport,
+				Timeout:   suite.TimeoutConfig.RequestTimeout,
 			}
 			req, err := nethttp.NewRequest(nethttp.MethodGet, fmt.Sprintf("http://%s/cookie", gwAddr), nil)
 			require.NoError(t, err)
@@ -401,11 +419,12 @@ var ConsistentHashCookieLoadBalancingTest = suite.ConformanceTest{
 			waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 60*time.Second, true, func(_ context.Context) (bool, error) {
 				resp, err := client.Do(req)
 				if err != nil {
-					t.Errorf("failed to get response: %v", err)
+					tlog.Logf(t, "failed to get response: %v", err)
 					return false, err
 				}
 
 				if resp.StatusCode != nethttp.StatusOK {
+					tlog.Logf(t, "unexpected status code: %d", resp.StatusCode)
 					return false, nil
 				}
 
@@ -423,14 +442,16 @@ var ConsistentHashCookieLoadBalancingTest = suite.ConformanceTest{
 	},
 }
 
-var ConsistentHashQueryParamsLoadBalancingTest = suite.ConformanceTest{
+var QueryParamsBasedConsistentHashLoadBalancing = suite.ConformanceTest{
 	ShortName:   "QueryParamsBasedConsistentHashLoadBalancing",
 	Description: "Test for multiple query parameter based consistent hash load balancing type",
-	Manifests:   []string{"testdata/load_balancing_consistent_hash_query_parameter.yaml"},
+	Manifests: []string{
+		"testdata/load_balancing_consistent_hash_query_parameter.yaml",
+	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "query-parameter-lb-route", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwNN := types.NamespacedName{Name: SameNamespaceGateway.Name, Namespace: ns}
 
 		ancestorRef := gwapiv1.ParentReference{
 			Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
@@ -439,8 +460,6 @@ var ConsistentHashQueryParamsLoadBalancingTest = suite.ConformanceTest{
 			Name:      gwapiv1.ObjectName(gwNN.Name),
 		}
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "query-parameter-lb-policy", Namespace: ns}, suite.ControllerName, ancestorRef)
-		WaitForPods(t, suite.Client, ns, map[string]string{"app": "lb-backend-query-parameter"}, corev1.PodRunning, &PodReady)
-
 		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
 		// Test with different combinations of multiple queries
 		queryCombinations := []struct {
@@ -466,23 +485,24 @@ var ConsistentHashQueryParamsLoadBalancingTest = suite.ConformanceTest{
 					Namespace: ns,
 				}
 				req := http.MakeRequest(t, expectedResponse, gwAddr, "HTTP", "http")
-
 				runConsistentHashLoadBalancingTest(t, suite, &req, expectedResponse)
 			})
 		}
 	},
 }
 
-var EndpointOverrideLoadBalancingTest = suite.ConformanceTest{
+var EndpointOverrideLoadBalancing = suite.ConformanceTest{
 	ShortName:   "EndpointOverrideLoadBalancing",
 	Description: "Test for endpoint override load balancing functionality",
-	Manifests:   []string{"testdata/load_balancing_endpoint_override.yaml"},
+	Manifests: []string{
+		"testdata/load_balancing_endpoint_override.yaml",
+	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		const sendRequests = 10
 
 		ns := "gateway-conformance-infra"
 		headerRouteNN := types.NamespacedName{Name: "endpoint-override-header-lb-route", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwNN := types.NamespacedName{Name: SameNamespaceGateway.Name, Namespace: ns}
 
 		ancestorRef := gwapiv1.ParentReference{
 			Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
@@ -491,19 +511,16 @@ var EndpointOverrideLoadBalancingTest = suite.ConformanceTest{
 			Name:      gwapiv1.ObjectName(gwNN.Name),
 		}
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "endpoint-override-header-lb-policy", Namespace: ns}, suite.ControllerName, ancestorRef)
-		WaitForPods(t, suite.Client, ns, map[string]string{"app": "lb-backend-endpointoverride"}, corev1.PodRunning, &PodReady)
-
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), headerRouteNN)
-
 		// Get pods associated with the service to find valid pod IPs and names
-		ctx, cancel := context.WithTimeout(context.Background(), suite.TimeoutConfig.GetTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), suite.TimeoutConfig.GetTimeout)
 		defer cancel()
 
 		// Get pods by label selector
 		podList := &corev1.PodList{}
 		err := suite.Client.List(ctx, podList, &client.ListOptions{
 			Namespace:     ns,
-			LabelSelector: labels.SelectorFromSet(map[string]string{"app": "lb-backend-endpointoverride"}),
+			LabelSelector: labels.SelectorFromSet(map[string]string{"app": "web-backend"}),
 		})
 		require.NoError(t, err, "failed to list pods")
 		require.NotEmpty(t, podList.Items, "should have pods")
@@ -521,21 +538,57 @@ var EndpointOverrideLoadBalancingTest = suite.ConformanceTest{
 
 		// Get service port
 		svc := &corev1.Service{}
-		err = suite.Client.Get(ctx, types.NamespacedName{Name: "lb-backend-endpointoverride", Namespace: ns}, svc)
+		err = suite.Client.Get(ctx, types.NamespacedName{Name: "web-backend", Namespace: ns}, svc)
 		require.NoError(t, err, "failed to get service")
 		require.NotEmpty(t, svc.Spec.Ports, "service should have ports")
 		servicePort := svc.Spec.Ports[0].TargetPort.IntValue()
 
 		t.Logf("Found %d valid pods: %v, service port: %d", len(validPodIPs), podIPToName, servicePort)
 
+		t.Run("header-based endpoint override with invalid pod IP should fallback to load balancer policy", func(t *testing.T) {
+			// Use an invalid pod IP that's not in the service endpoints
+			invalidOverrideHost := "192.168.99.99:8080"
+
+			t.Logf("Testing endpoint override with invalid pod IP: %s (should fallback to load balancer policy)", invalidOverrideHost)
+
+			expectedResponse := http.ExpectedResponse{
+				Request: http.Request{
+					Path: "/endpoint-override-header",
+					Headers: map[string]string{
+						"x-custom-host": invalidOverrideHost,
+					},
+				},
+				Response: http.Response{
+					StatusCodes: []int{200},
+				},
+				Namespace: ns,
+			}
+
+			runEndpointOverrideTest(t, suite, gwAddr, podIPToName, &expectedResponse)
+
+			t.Logf("All %d requests with invalid override host %s got 200 response (fallback working)", sendRequests, invalidOverrideHost)
+		})
+
+		t.Run("header-based endpoint override without header should fallback to load balancer policy", func(t *testing.T) {
+			expectedResponse := http.ExpectedResponse{
+				Request: http.Request{
+					Path: "/endpoint-override-header",
+					// No x-custom-host header
+				},
+				Response: http.Response{
+					StatusCodes: []int{200},
+				},
+				Namespace: ns,
+			}
+			runEndpointOverrideTest(t, suite, gwAddr, podIPToName, &expectedResponse)
+
+			t.Logf("All %d requests without override header got 200 response (fallback working)", sendRequests)
+		})
+
 		t.Run("header-based endpoint override with valid pod IP should route to specific pod", func(t *testing.T) {
 			// Use the first valid pod IP as override host
 			targetPodIP := validPodIPs[0]
-			format := "%s:%d"
-			if IPFamily == "ipv6" {
-				format = "[%s]:%d"
-			}
-			overrideHost := fmt.Sprintf(format, targetPodIP, servicePort)
+			overrideHost := net.JoinHostPort(targetPodIP, fmt.Sprintf("%d", servicePort))
 
 			// Get the expected pod name from our mapping
 			expectPodName := podIPToName[targetPodIP]
@@ -559,7 +612,7 @@ var EndpointOverrideLoadBalancingTest = suite.ConformanceTest{
 			req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
 
 			// Test that all requests go to the expected pod
-			for i := 0; i < sendRequests; i++ {
+			for i := range sendRequests {
 				cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
 				require.NoError(t, err, "failed to get expected response")
 				require.NoError(t, http.CompareRoundTrip(t, &req, cReq, cResp, expectedResponse), "failed to compare request and response")
@@ -570,65 +623,30 @@ var EndpointOverrideLoadBalancingTest = suite.ConformanceTest{
 
 			t.Logf("All %d requests with valid override host %s routed to expected pod: %s", sendRequests, overrideHost, expectPodName)
 		})
-		t.Run("header-based endpoint override with invalid pod IP should fallback to load balancer policy", func(t *testing.T) {
-			// Use an invalid pod IP that's not in the service endpoints
-			invalidOverrideHost := "192.168.99.99:8080"
-
-			t.Logf("Testing endpoint override with invalid pod IP: %s (should fallback to load balancer policy)", invalidOverrideHost)
-
-			expectedResponse := http.ExpectedResponse{
-				Request: http.Request{
-					Path: "/endpoint-override-header",
-					Headers: map[string]string{
-						"x-custom-host": invalidOverrideHost,
-					},
-				},
-				Response: http.Response{
-					StatusCodes: []int{200},
-				},
-				Namespace: ns,
-			}
-
-			req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
-
-			// Make multiple requests and verify fallback behavior (just check 200 response)
-			for i := 0; i < sendRequests; i++ {
-				cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
-				require.NoError(t, err, "failed to get expected response")
-				require.NoError(t, http.CompareRoundTrip(t, &req, cReq, cResp, expectedResponse), "failed to compare request and response")
-
-				// For invalid override host, we just verify the response is 200 (fallback works)
-				// No need to check specific pod routing since it should use fallback policy
-			}
-
-			t.Logf("All %d requests with invalid override host %s got 200 response (fallback working)", sendRequests, invalidOverrideHost)
-		})
-
-		t.Run("header-based endpoint override without header should fallback to load balancer policy", func(t *testing.T) {
-			expectedResponse := http.ExpectedResponse{
-				Request: http.Request{
-					Path: "/endpoint-override-header",
-					// No x-custom-host header
-				},
-				Response: http.Response{
-					StatusCodes: []int{200},
-				},
-				Namespace: ns,
-			}
-
-			req := http.MakeRequest(t, &expectedResponse, gwAddr, "HTTP", "http")
-
-			// Make multiple requests and verify fallback behavior (just check 200 response)
-			for i := 0; i < sendRequests; i++ {
-				cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
-				require.NoError(t, err, "failed to get expected response")
-				require.NoError(t, http.CompareRoundTrip(t, &req, cReq, cResp, expectedResponse), "failed to compare request and response")
-
-				// For missing header, we just verify the response is 200 (fallback works)
-				// No need to check specific pod routing since it should use fallback policy
-			}
-
-			t.Logf("All %d requests without override header got 200 response (fallback working)", sendRequests)
-		})
 	},
+}
+
+func runEndpointOverrideTest(t *testing.T, suite *suite.ConformanceTestSuite, gwAddr string, podIPToName map[string]string, expectedResponse *http.ExpectedResponse) {
+	req := http.MakeRequest(t, expectedResponse, gwAddr, "HTTP", "http")
+
+	allPodNames := sets.NewString()
+	for _, podName := range podIPToName {
+		allPodNames.Insert(podName)
+	}
+
+	tlog.Logf(t, "all pods: %v", allPodNames.List())
+
+	// Make multiple requests and verify fallback behavior (just check 200 response)
+	for range sendRequests {
+		cReq, cResp, err := suite.RoundTripper.CaptureRoundTrip(req)
+		require.NoError(t, err, "failed to get expected response")
+		require.NoError(t, http.CompareRoundTrip(t, &req, cReq, cResp, *expectedResponse), "failed to compare request and response")
+
+		// For invalid override host, we just verify the response is 200 (fallback works)
+		// and the request can hit any of the valid pods since it should use fallback policy
+		tlog.Logf(t, "received response from pod: %s", cReq.Pod)
+		allPodNames.Delete(cReq.Pod)
+	}
+
+	require.Emptyf(t, allPodNames, "all the valid pods should be removed.")
 }

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -119,6 +119,7 @@ func WaitForPods(t *testing.T, cl client.Client, namespace string, selectors map
 
 			for _, c := range p.Status.Conditions {
 				if c.Type == condition.Type && c.Status == condition.Status {
+					tlog.Logf(t, "pod %s/%s matches the status: %v ip: %v", p.Namespace, p.Name, condition.Status, p.Status.PodIPs)
 					continue checkPods // pod is ready, check next pod
 				}
 			}
@@ -682,21 +683,34 @@ func CollectAndDump(t *testing.T, rest *rest.Config) {
 		tlog.Logf(t, "Skipping collecting and dumping cluster data, set ACTIONS_STEP_DEBUG=true to enable it")
 		return
 	}
-
 	dumpedNamespaces := []string{"envoy-gateway-system"}
 	if IsGatewayNamespaceMode() {
 		dumpedNamespaces = append(dumpedNamespaces, ConformanceInfraNamespace)
 	}
 
-	opts := []tb.CollectOption{
-		tb.WithCollectedNamespaces(dumpedNamespaces),
-	}
+	runCollectAndDump(t, rest, tb.WithCollectedNamespaces(dumpedNamespaces))
+}
 
+func runCollectAndDump(t *testing.T, rest *rest.Config, opts ...tb.CollectOption) {
 	result, _ := tb.CollectResult(t.Context(), rest, opts...)
 	for r, data := range result {
 		tlog.Logf(t, "\nfilename: %s", r)
-		tlog.Logf(t, "\ndata: \n%s", data)
+		tlog.Logf(t, "\ndata: \n%s\n", data)
 	}
+}
+
+func consistentHashDump(t *testing.T, rest *rest.Config) {
+	dumpedNamespaces := []string{"envoy-gateway-system"}
+	if IsGatewayNamespaceMode() {
+		dumpedNamespaces = append(dumpedNamespaces, ConformanceInfraNamespace)
+	}
+
+	runCollectAndDump(t, rest,
+		tb.WithCollectedNamespaces(dumpedNamespaces),
+		tb.DisableCollector(tb.CollectorTypeEnvoyGatewayResource),
+		tb.DisableCollector(tb.CollectorTypePrometheusMetrics),
+		tb.WithSelector("gateway.envoyproxy.io/owning-gateway-name=lb-backend-gateway"),
+	)
 }
 
 func GetService(c client.Client, nn types.NamespacedName) (*corev1.Service, error) {


### PR DESCRIPTION
I spent a lot of time on this issue this week, but still haven't found the root cause.
During the debugging process, I found that when the maglev hash was not updated, the same requests were assigned to different upstream hosts. It's not r eproducible with pure envoy image. 
Maybe there's something with the github CI.

~~This patch will ensure all the backends is ready before running consistent hash tests to reduce flakiness.~~


This's more like a resource issue on github CI, I changed the tests to use the `app-webbackend`.