### PR TITLE
[gatewayapi] skip unused BTP routing index work

### DIFF
--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -54,6 +54,16 @@ type BTPRoutingTypeIndex struct {
 // BuildBTPRoutingTypeIndex builds a pre-computed index of RoutingType values
 // from BackendTrafficPolicies, organized by priority-level.
 // BTPs are pre-sorted by the provider layer, so first-write-wins respects priority.
+func hasBTPRoutingType(btps []*egv1a1.BackendTrafficPolicy) bool {
+	for _, btp := range btps {
+		if btp.Spec.RoutingType != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
 func BuildBTPRoutingTypeIndex(
 	btps []*egv1a1.BackendTrafficPolicy,
 	routes []client.Object,

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -252,11 +252,14 @@ func (t *Translator) Translate(resources *resource.Resources) (*TranslateResult,
 	xdsIR, infraIR := t.InitIRs(acceptedGateways, failedGateways)
 
 	// Build pre-computed BTP RoutingType index for O(1) lookups in processDestination.
-	t.BTPRoutingTypeIndex = BuildBTPRoutingTypeIndex(
-		resources.BackendTrafficPolicies,
-		routesToObjects(resources),
-		acceptedGateways,
-	)
+	t.BTPRoutingTypeIndex = nil
+	if hasBTPRoutingType(resources.BackendTrafficPolicies) {
+		t.BTPRoutingTypeIndex = BuildBTPRoutingTypeIndex(
+			resources.BackendTrafficPolicies,
+			routesToObjects(resources),
+			acceptedGateways,
+		)
+	}
 
 	// Process ListenerSets and attach them to the relevant Gateways
 	t.ProcessListenerSets(resources.ListenerSets, acceptedGateways)


### PR DESCRIPTION
Only build the BTP routing type index when BackendTrafficPolicies actually set routingType. This avoids the extra route boxing and index setup, reducing GC pressure when the feature is unused.
