### PR TITLE
Add missing BackendTLSPolicy indexer to wasm test

### DIFF
--- a/internal/provider/kubernetes/wasm_tls_indexers_test.go
+++ b/internal/provider/kubernetes/wasm_tls_indexers_test.go
@@ -358,7 +358,8 @@ func TestWasmTLSIndexers(t *testing.T) {
 				WithScheme(envoygateway.GetScheme()).
 				WithIndex(&egv1a1.EnvoyExtensionPolicy{}, secretEnvoyExtensionPolicyIndex, secretEnvoyExtensionPolicyIndexFunc).
 				WithIndex(&egv1a1.EnvoyExtensionPolicy{}, configMapEepIndex, configMapEepIndexFunc).
-				WithIndex(&egv1a1.EnvoyExtensionPolicy{}, clusterTrustBundleEepIndex, clusterTrustBundleEepIndexFunc)
+				WithIndex(&egv1a1.EnvoyExtensionPolicy{}, clusterTrustBundleEepIndex, clusterTrustBundleEepIndexFunc).
+				WithIndex(&gwapiv1.BackendTLSPolicy{}, configMapBtlsIndex, configMapBtlsIndexFunc)
 
 			for _, obj := range objs {
 				clientBuilder = clientBuilder.WithObjects(obj)


### PR DESCRIPTION
**What type of PR is this?**

Test fix

**What this PR does / why we need it**:

TestWasmTLSIndexers was failing because the BackendTLSPolicy indexer wasn't being registered in the test setup. Added the missing index call.

**Which issue(s) this PR fixes**:

Fixes #8381

Release Notes: No