### PR TITLE
chore: lower the qps to mitigate flaky upgrade test

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -239,10 +239,10 @@ jobs:
         KUBE_DEPLOY_PROFILE: ${{ matrix.target.profile }}
         E2E_TIMEOUT: 1h
         NUM_WORKERS: 2
-        # QPS more than 3000 may cause e2e flaky test.
+        # QPS more than 2000 may cause e2e flaky test.
         # This is not the limit of Envoy Gateway,
         # but the limit of running e2e tests in github CI.
-        E2E_BACKEND_UPGRADE_QPS: "3000"
+        E2E_BACKEND_UPGRADE_QPS: "2000"
         # Cluster trust bundle reach beta in v1.33, so we can enable it for v1.33 and later.
         ENABLE_CLUSTER_TRUST_BUNDLE: ${{ startsWith(matrix.target.version, 'v1.33') }}
       run: make e2e


### PR DESCRIPTION
Hopefully this helps mitigate #8414, which might be caused by small Github runner getting overloaded.