### PR TITLE
docs: rename Contributions section to Community

### DIFF
--- a/site/content/en/contributions/_index.md
+++ b/site/content/en/contributions/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Get Involved"
-description = "This section includes contents related to Contributions"
+description = "This section includes contents related to the Community"
 linktitle = "Get Involved"
 
 [[cascade]]

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -213,7 +213,7 @@ enable = true
 
 [menu]
   [[menu.main]]
-    name = "Contributions"
+    name = "Community"
     weight = -98
     url = "/contributions"
   [[menu.main]]


### PR DESCRIPTION
Resolves #6229

Renames the "Contributions" navigation menu item to "Community" to better reflect the broader scope of the section, which includes maintainers, code of conduct, adopters, and the open source ecosystem — not just contribution guidelines.

Changes:
- `site/hugo.toml`: renamed menu item from "Contributions" to "Community"
- `site/content/en/contributions/_index.md`: updated description text