### PR TITLE
Revert "api: add sourceCIDRs field in SecurityPolicy for L4 IP filtering"

### DIFF
--- a/api/v1alpha1/authorization_types.go
+++ b/api/v1alpha1/authorization_types.go
@@ -111,24 +111,6 @@ type Principal struct {
 	// +kubebuilder:validation:MaxItems=256
 	Headers []AuthorizationHeaderMatch `json:"headers,omitempty"`
 
-	// SourceCIDRs are the IP CIDR ranges of the source (L4 peer IP).
-	// Valid examples are "192.168.1.0/24" or "2001:db8::/64"
-	//
-	// If multiple CIDR ranges are specified, one of the CIDR ranges must match
-	// the source IP for the rule to match.
-	//
-	// The source IP is the IP address of the peer that connected to Envoy.
-	// This IP is obtained from the TCP connection's peer address and is not
-	// affected by X-Forwarded-For or other IP detection headers.
-	// If intermediaries (load balancers, NAT) terminate or proxy TCP,
-	// the original client IP will only be available if the intermediary
-	// preserves the source address (for example by enabling the PROXY protocol
-	// or avoiding SNAT).
-	// +optional
-	// +kubebuilder:validation:MinItems=1
-	// +notImplementedHide
-	SourceCIDRs []CIDR `json:"sourceCIDRs,omitempty"`
-
 	// ClientIPGeoLocations authorizes the request based on geolocation metadata derived from the client IP.
 	// If multiple entries are specified,  one of the ClientIPGeoLocation entries must match for the rule to match.
 	//

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -6072,11 +6072,6 @@ func (in *Principal) DeepCopyInto(out *Principal) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.SourceCIDRs != nil {
-		in, out := &in.SourceCIDRs, &out.SourceCIDRs
-		*out = make([]CIDR, len(*in))
-		copy(*out, *in)
-	}
 	if in.ClientIPGeoLocations != nil {
 		in, out := &in.ClientIPGeoLocations, &out.ClientIPGeoLocations
 		*out = make([]ClientIPGeoLocation, len(*in))

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -468,29 +468,6 @@ spec:
                               - message: at least one of claims or scopes must be
                                   specified
                                 rule: (has(self.claims) || has(self.scopes))
-                            sourceCIDRs:
-                              description: |-
-                                SourceCIDRs are the IP CIDR ranges of the source (L4 peer IP).
-                                Valid examples are "192.168.1.0/24" or "2001:db8::/64"
-
-                                If multiple CIDR ranges are specified, one of the CIDR ranges must match
-                                the source IP for the rule to match.
-
-                                The source IP is the IP address of the peer that connected to Envoy.
-                                This IP is obtained from the TCP connection's peer address and is not
-                                affected by X-Forwarded-For or other IP detection headers.
-                                If intermediaries (load balancers, NAT) terminate or proxy TCP,
-                                the original client IP will only be available if the intermediary
-                                preserves the source address (for example by enabling the PROXY protocol
-                                or avoiding SNAT).
-                              items:
-                                description: |-
-                                  CIDR defines a CIDR Address range.
-                                  A CIDR can be an IPv4 address range such as "192.168.1.0/24" or an IPv6 address range such as "2001:0db8:11a3:09d7::/64".
-                                pattern: ((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]+))|((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/([0-9]+))
-                                type: string
-                              minItems: 1
-                              type: array
                           type: object
                           x-kubernetes-validations:
                           - message: at least one of clientCIDRs, jwt, headers, or

--- a/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -467,29 +467,6 @@ spec:
                               - message: at least one of claims or scopes must be
                                   specified
                                 rule: (has(self.claims) || has(self.scopes))
-                            sourceCIDRs:
-                              description: |-
-                                SourceCIDRs are the IP CIDR ranges of the source (L4 peer IP).
-                                Valid examples are "192.168.1.0/24" or "2001:db8::/64"
-
-                                If multiple CIDR ranges are specified, one of the CIDR ranges must match
-                                the source IP for the rule to match.
-
-                                The source IP is the IP address of the peer that connected to Envoy.
-                                This IP is obtained from the TCP connection's peer address and is not
-                                affected by X-Forwarded-For or other IP detection headers.
-                                If intermediaries (load balancers, NAT) terminate or proxy TCP,
-                                the original client IP will only be available if the intermediary
-                                preserves the source address (for example by enabling the PROXY protocol
-                                or avoiding SNAT).
-                              items:
-                                description: |-
-                                  CIDR defines a CIDR Address range.
-                                  A CIDR can be an IPv4 address range such as "192.168.1.0/24" or an IPv6 address range such as "2001:0db8:11a3:09d7::/64".
-                                pattern: ((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]+))|((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/([0-9]+))
-                                type: string
-                              minItems: 1
-                              type: array
                           type: object
                           x-kubernetes-validations:
                           - message: at least one of clientCIDRs, jwt, headers, or

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -48499,29 +48499,6 @@ spec:
                               - message: at least one of claims or scopes must be
                                   specified
                                 rule: (has(self.claims) || has(self.scopes))
-                            sourceCIDRs:
-                              description: |-
-                                SourceCIDRs are the IP CIDR ranges of the source (L4 peer IP).
-                                Valid examples are "192.168.1.0/24" or "2001:db8::/64"
-
-                                If multiple CIDR ranges are specified, one of the CIDR ranges must match
-                                the source IP for the rule to match.
-
-                                The source IP is the IP address of the peer that connected to Envoy.
-                                This IP is obtained from the TCP connection's peer address and is not
-                                affected by X-Forwarded-For or other IP detection headers.
-                                If intermediaries (load balancers, NAT) terminate or proxy TCP,
-                                the original client IP will only be available if the intermediary
-                                preserves the source address (for example by enabling the PROXY protocol
-                                or avoiding SNAT).
-                              items:
-                                description: |-
-                                  CIDR defines a CIDR Address range.
-                                  A CIDR can be an IPv4 address range such as "192.168.1.0/24" or an IPv6 address range such as "2001:0db8:11a3:09d7::/64".
-                                pattern: ((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]+))|((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/([0-9]+))
-                                type: string
-                              minItems: 1
-                              type: array
                           type: object
                           x-kubernetes-validations:
                           - message: at least one of clientCIDRs, jwt, headers, or

--- a/test/helm/gateway-crds-helm/e2e.out.yaml
+++ b/test/helm/gateway-crds-helm/e2e.out.yaml
@@ -26480,29 +26480,6 @@ spec:
                               - message: at least one of claims or scopes must be
                                   specified
                                 rule: (has(self.claims) || has(self.scopes))
-                            sourceCIDRs:
-                              description: |-
-                                SourceCIDRs are the IP CIDR ranges of the source (L4 peer IP).
-                                Valid examples are "192.168.1.0/24" or "2001:db8::/64"
-
-                                If multiple CIDR ranges are specified, one of the CIDR ranges must match
-                                the source IP for the rule to match.
-
-                                The source IP is the IP address of the peer that connected to Envoy.
-                                This IP is obtained from the TCP connection's peer address and is not
-                                affected by X-Forwarded-For or other IP detection headers.
-                                If intermediaries (load balancers, NAT) terminate or proxy TCP,
-                                the original client IP will only be available if the intermediary
-                                preserves the source address (for example by enabling the PROXY protocol
-                                or avoiding SNAT).
-                              items:
-                                description: |-
-                                  CIDR defines a CIDR Address range.
-                                  A CIDR can be an IPv4 address range such as "192.168.1.0/24" or an IPv6 address range such as "2001:0db8:11a3:09d7::/64".
-                                pattern: ((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]+))|((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/([0-9]+))
-                                type: string
-                              minItems: 1
-                              type: array
                           type: object
                           x-kubernetes-validations:
                           - message: at least one of clientCIDRs, jwt, headers, or

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -26480,29 +26480,6 @@ spec:
                               - message: at least one of claims or scopes must be
                                   specified
                                 rule: (has(self.claims) || has(self.scopes))
-                            sourceCIDRs:
-                              description: |-
-                                SourceCIDRs are the IP CIDR ranges of the source (L4 peer IP).
-                                Valid examples are "192.168.1.0/24" or "2001:db8::/64"
-
-                                If multiple CIDR ranges are specified, one of the CIDR ranges must match
-                                the source IP for the rule to match.
-
-                                The source IP is the IP address of the peer that connected to Envoy.
-                                This IP is obtained from the TCP connection's peer address and is not
-                                affected by X-Forwarded-For or other IP detection headers.
-                                If intermediaries (load balancers, NAT) terminate or proxy TCP,
-                                the original client IP will only be available if the intermediary
-                                preserves the source address (for example by enabling the PROXY protocol
-                                or avoiding SNAT).
-                              items:
-                                description: |-
-                                  CIDR defines a CIDR Address range.
-                                  A CIDR can be an IPv4 address range such as "192.168.1.0/24" or an IPv6 address range such as "2001:0db8:11a3:09d7::/64".
-                                pattern: ((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]+))|((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/([0-9]+))
-                                type: string
-                              minItems: 1
-                              type: array
                           type: object
                           x-kubernetes-validations:
                           - message: at least one of clientCIDRs, jwt, headers, or


### PR DESCRIPTION
Revert "api: add sourceCIDRs field in SecurityPolicy for L4 IP filtering" (#8009)

This reverts commit a97d57a0cc218c957c9a4ea10c10712e2b6dd811.

Release Notes: No - the `SourceCIDRs` was marked as `notImplementedHide`, so no user-visible change.

Why this API should be reverted: the issue with putting this in SP instead of CTP is that SP can be applied per-route. That makes L4 IP filtering tricky, since different routes could end up with SecurityPolicies with/without/different SourceCIDRs.

Background: 
https://github.com/envoyproxy/gateway/issues/7825#issuecomment-4009048465
https://github.com/envoyproxy/gateway/issues/7825#issuecomment-4023724521
