### PR TITLE
ci: fix ACTIONS_STEP_DEBUG not working

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -16,11 +16,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # set ACTIONS_STEP_DEBUG to true if context runner.debug is '1',
-  # which means to dump the current state when there's a case failed.
-  ACTIONS_STEP_DEBUG: ${{ runner.debug == '1' }}
-
 jobs:
   # Check if there are changes that require running the test jobs
   changes:
@@ -187,6 +182,9 @@ jobs:
         IP_FAMILY: ${{ matrix.target.ipFamily }}
         KUBE_DEPLOY_PROFILE: ${{ matrix.target.profile }}
         E2E_GATEWAY_API_CHANNEL: ${{ matrix.target.gwapiChannel }}
+        # set ACTIONS_STEP_DEBUG to true if context runner.debug is '1',
+        # which means to dump the current state when there's a case failed.
+        ACTIONS_STEP_DEBUG: ${{ runner.debug == '1' }}
       run: make conformance
 
   e2e-test:
@@ -250,6 +248,9 @@ jobs:
         E2E_BACKEND_UPGRADE_QPS: "2000"
         # Cluster trust bundle reach beta in v1.33, so we can enable it for v1.33 and later.
         ENABLE_CLUSTER_TRUST_BUNDLE: ${{ startsWith(matrix.target.version, 'v1.33') }}
+        # set ACTIONS_STEP_DEBUG to true if context runner.debug is '1',
+        # which means to dump the current state when there's a case failed.
+        ACTIONS_STEP_DEBUG: ${{ runner.debug == '1' }}
       run: make e2e
 
   benchmark-test:


### PR DESCRIPTION
xref: https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging?search-overlay-input=jobs#enabling-step-debug-logging

```
You can also use the runner.debug context to conditionally run steps only when debug logging is enabled. For more information
```

set `ACTIONS_STEP_DEBUG` env if `runner.debug` is `1`