### PR TITLE
fix(gatewayapi): allow same hostname on different protocols per port

### DIFF
--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-http-and-tlsroute-same-hostname-and-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-http-and-tlsroute-same-hostname-and-port.out.yaml
@@ -28,8 +28,8 @@ gateways:
     - attachedRoutes: 1
       conditions:
       - lastTransitionTime: null
-        message: All listeners for a given port must use a unique hostname
-        reason: HostnameConflict
+        message: All listeners for a given port must use a compatible protocol
+        reason: ProtocolConflict
         status: "True"
         type: Conflicted
       - lastTransitionTime: null
@@ -51,8 +51,8 @@ gateways:
     - attachedRoutes: 1
       conditions:
       - lastTransitionTime: null
-        message: All listeners for a given port must use a unique hostname
-        reason: HostnameConflict
+        message: All listeners for a given port must use a compatible protocol
+        reason: ProtocolConflict
         status: "True"
         type: Conflicted
       - lastTransitionTime: null

--- a/internal/gatewayapi/validate.go
+++ b/internal/gatewayapi/validate.go
@@ -738,7 +738,11 @@ func (t *Translator) validateConflictedLayer7Listeners(gateways []*GatewayContex
 				hostname = string(*listener.Hostname)
 			}
 
-			portListenerInfo[listener.Port].hostnames[hostname]++
+			// Track hostnames per actual protocol to allow same hostname on different protocols
+			// Use the actual protocol, not the grouped protocol, to distinguish HTTPS from TLS
+			actualProtocol := string(listener.Protocol)
+			protocolHostnameKey := fmt.Sprintf("%s:%s", actualProtocol, hostname)
+			portListenerInfo[listener.Port].hostnames[protocolHostnameKey]++
 		}
 
 		// Set Conflicted conditions for any listeners with conflicting specs.
@@ -758,7 +762,10 @@ func (t *Translator) validateConflictedLayer7Listeners(gateways []*GatewayContex
 					hostname = string(*listener.Hostname)
 				}
 
-				if info.hostnames[hostname] > 1 {
+				// Use actual protocol for hostname conflict detection
+				actualProtocol := string(listener.Protocol)
+				protocolHostnameKey := fmt.Sprintf("%s:%s", actualProtocol, hostname)
+				if info.hostnames[protocolHostnameKey] > 1 {
 					listener.SetCondition(
 						gwapiv1.ListenerConditionConflicted,
 						metav1.ConditionTrue,


### PR DESCRIPTION
## Description

Fixes #8524

Fixes validation to honor the stated capability that HTTPS and TLS listeners can co-exist on the same port with the same hostname.

## Problem

The code comment at line 729 in `internal/gatewayapi/validate.go` explicitly states "HTTPS and TLS can co-exist on the same port" and groups them for protocol compatibility checking. However, hostname validation was checking uniqueness per port only, which incorrectly rejected valid configurations like:

```yaml
listeners:
- name: https-terminate
  protocol: HTTPS
  port: 443
  hostname: "*.example.com"
  tls:
    mode: Terminate
    
- name: tls-passthrough
  protocol: TLS
  port: 443
  hostname: "*.example.com"
  tls:
    mode: Passthrough
```

This resulted in the error: `All listeners for a given port must use a unique hostname`

## Solution

According to Gateway API spec, listener identity is defined by the `(port, protocol, hostname)` tuple. These are distinct listeners and should be allowed.

The fix tracks hostnames per `(port, actual_protocol)` instead of just per port, using the concrete protocol (HTTPS, TLS, HTTP) rather than the grouped protocol used for compatibility checking.

This ensures:
- HTTPS and TLS can coexist with same hostname on same port (routed via SNI) ✅
- Duplicate listeners of the same protocol are still rejected ✅
- Validation logic matches the code's documented intent ✅

## Changes

- Modified `validateConflictedLayer7Listeners` to track hostnames per `(port, protocol)` tuple
- Updated test expectations to reflect correct behavior (HTTP + TLS now shows `ProtocolConflict` instead of incorrect `HostnameConflict`)

## Testing

- All unit tests pass
- Test data regenerated with `--override-testdata=true`
- Verified e2e rate limit tests pass locally with native Docker environment
