### PR TITLE
fix(ratelimit): expose metrics port to ratelimit container spec

### DIFF
--- a/internal/infrastructure/kubernetes/ratelimit/resource.go
+++ b/internal/infrastructure/kubernetes/ratelimit/resource.go
@@ -149,6 +149,14 @@ func expectedRateLimitContainers(rateLimit *egv1a1.RateLimit, rateLimitDeploymen
 		},
 	}
 
+	if enablePrometheus(rateLimit) {
+		ports = append(ports, corev1.ContainerPort{
+			Name:          "metrics",
+			ContainerPort: PrometheusPort,
+			Protocol:      corev1.ProtocolTCP,
+		})
+	}
+
 	containers := []corev1.Container{
 		{
 			Name:            InfraName,

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/custom.yaml
@@ -101,6 +101,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default-env.yaml
@@ -101,6 +101,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
@@ -100,6 +100,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing-custom.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing-custom.yaml
@@ -115,6 +115,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing.yaml
@@ -115,6 +115,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/extension-env.yaml
@@ -105,6 +105,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-annotations.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-annotations.yaml
@@ -102,6 +102,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-labels.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-labels.yaml
@@ -102,6 +102,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/override-env.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/override-env.yaml
@@ -101,6 +101,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment-containers.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment-containers.yaml
@@ -102,6 +102,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment.yaml
@@ -100,6 +100,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/redis-tls-settings.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/redis-tls-settings.yaml
@@ -109,6 +109,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/tolerations.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/tolerations.yaml
@@ -109,6 +109,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/volumes.yaml
@@ -109,6 +109,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-node-selector.yaml
@@ -100,6 +100,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-topology-spread-constraints.yaml
@@ -100,6 +100,9 @@ spec:
         - containerPort: 8081
           name: grpc
           protocol: TCP
+        - containerPort: 19001
+          name: metrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -42,6 +42,7 @@ bug fixes: |
   Fixed route and policy status aggregation across multiple GatewayClasses managed by the same controller, so resources preserve status from all relevant parents and ancestors instead of being overwritten by the last processed GatewayClass.
   Made ConnectionLimit.Value optional so users can configure MaxConnectionDuration, MaxRequestsPerConnection, or MaxStreamDuration without setting a max connections value.
   Fixed endpoint hostname is not respected when doing active health check.
+  Fixed ratelimit deployment missing metrics container port (19001), which prevented PodMonitor/ServiceMonitor from targeting the metrics endpoint.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
**What type of PR is this?**
fix(ratelimit) expose metrics port to ratelimit container spec

**What this PR does / why we need it**:
The `ratelimit` deployment only declared the gRPC port (8081) on the container, omitting the Prometheus metrics port (19001). This prevented metrics scraping tools such as PodMonitor/ServiceMonitor from the Prometheus Operator from targeting the metrics endpoint, since they require ports to be explicitly defined in the pod spec.

**Which issue(s) this PR fixes**:
Fixes #8479 

Release Notes: Yes
