### PR TITLE
chore: update stale action settings to clean up stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,10 +21,10 @@ jobs:
       uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f  # v10.2.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        # Different amounts of days for issues/PRs are not currently supported but there is a PR
-        # open for it: https://github.com/actions/stale/issues/214
-        days-before-stale: 30
-        days-before-close: -1
+        days-before-pr-stale: 30
+        days-before-pr-close: 7
+        days-before-issue-stale: 30
+        days-before-issue-close: -1
         stale-issue-message: >
           This issue has been automatically marked as stale because it has not had activity in the
           last 30 days.


### PR DESCRIPTION
New [actions](https://github.com/actions/stale/pull/224/changes) available to have different settings for issues and PRs. Will help prioritizing PRs for reviews.