### PR TITLE
fix(certgen): trigger rolling restart of Rate Limit on cert rotation

### DIFF
--- a/internal/cmd/certgen.go
+++ b/internal/cmd/certgen.go
@@ -12,10 +12,14 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"time"
 
 	"github.com/spf13/cobra"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clicfg "sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -25,6 +29,7 @@ import (
 	"github.com/envoyproxy/gateway/internal/envoygateway"
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/infrastructure/host"
+	"github.com/envoyproxy/gateway/internal/infrastructure/kubernetes/ratelimit"
 	"github.com/envoyproxy/gateway/internal/provider/kubernetes"
 	"github.com/envoyproxy/gateway/internal/utils/file"
 )
@@ -90,6 +95,11 @@ func certGen(ctx context.Context, logOut io.Writer, local bool, configHome strin
 		if err = patchTopologyInjectorWebhook(ctx, cli, cfg); err != nil {
 			return fmt.Errorf("failed to patch webhook: %w", err)
 		}
+		if overwriteControlPlaneCerts {
+			if err = rolloutRestartRateLimitDeployment(ctx, cli, cfg); err != nil {
+				return fmt.Errorf("failed to restart rate limit deployment: %w", err)
+			}
+		}
 	} else {
 		// Use provided configHome or default
 		hostCfg := &egv1a1.EnvoyGatewayHostInfrastructureProvider{}
@@ -133,6 +143,53 @@ func outputCertsForKubernetes(ctx context.Context, cli client.Client, cfg *confi
 		log.Info("created secret", "namespace", s.Namespace, "name", s.Name)
 	}
 
+	return nil
+}
+
+// rolloutRestartRateLimitDeployment triggers a rolling restart of the Rate Limit
+// deployment by patching its pod-template annotation. This is necessary because
+// the Rate Limit process loads its CA certificate once at startup and does not
+// watch the mounted secret for changes. After a cert rotation the kubelet will
+// update the secret volume on disk, but the running process continues to verify
+// client certs against the old CA in memory, causing mTLS failures for any Envoy
+// pod that has already reloaded its new leaf cert via SDS.
+//
+// A rolling restart ensures every Rate Limit pod starts fresh with the updated
+// CA bundle. The restart respects any PodDisruptionBudget the operator has
+// configured and uses the deployment's existing RollingUpdate strategy, so no
+// replica is terminated until a replacement is healthy.
+//
+// If the Rate Limit deployment does not exist (Rate Limit is not enabled) the
+// function returns nil without error.
+func rolloutRestartRateLimitDeployment(ctx context.Context, cli client.Client, cfg *config.Server) error {
+	log := cfg.Logger
+
+	deployment := &appsv1.Deployment{}
+	key := types.NamespacedName{
+		Namespace: cfg.ControllerNamespace,
+		Name:      ratelimit.InfraName,
+	}
+	if err := cli.Get(ctx, key, deployment); err != nil {
+		if kerrors.IsNotFound(err) {
+			// Rate Limit is not deployed; nothing to restart.
+			log.Info("rate limit deployment not found, skipping restart")
+			return nil
+		}
+		return fmt.Errorf("failed to get rate limit deployment %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	patched := deployment.DeepCopy()
+	if patched.Spec.Template.Annotations == nil {
+		patched.Spec.Template.Annotations = make(map[string]string)
+	}
+	patched.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = metav1.Now().UTC().Format(time.RFC3339)
+
+	if err := cli.Patch(ctx, patched, client.MergeFrom(deployment)); err != nil {
+		return fmt.Errorf("failed to patch rate limit deployment %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	log.Info("triggered rolling restart of rate limit deployment",
+		"namespace", key.Namespace, "name", key.Name)
 	return nil
 }
 

--- a/internal/provider/kubernetes/secrets.go
+++ b/internal/provider/kubernetes/secrets.go
@@ -6,10 +6,15 @@
 package kubernetes
 
 import (
+	"bytes"
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -114,7 +119,21 @@ func CreateOrUpdateSecrets(ctx context.Context, client client.Client, secrets []
 				existingSecrets = append(existingSecrets, fmt.Sprintf("%s/%s", secret.Namespace, secret.Name))
 				continue
 			}
-			fmt.Println()
+
+			// Bundle the old CA with the new CA for backwards-compatible rotation.
+			// Pods pick up updated secrets at different times, so during the rotation
+			// window some pods may still present leaf certs signed by the old CA.
+			// Keeping both CAs in the trust bundle prevents mTLS failures while all
+			// components converge to the new certificates.
+			if oldCA := current.Data[caCertificateKey]; len(oldCA) > 0 {
+				if newCA := secret.Data[caCertificateKey]; len(newCA) > 0 {
+					if bundled := bundleCACerts(newCA, oldCA); !bytes.Equal(bundled, newCA) {
+						newData := maps.Clone(secret.Data)
+						newData[caCertificateKey] = bundled
+						secret.Data = newData
+					}
+				}
+			}
 
 			if !reflect.DeepEqual(secret.Data, current.Data) {
 				if err := client.Update(ctx, &secret); err != nil {
@@ -132,4 +151,59 @@ func CreateOrUpdateSecrets(ctx context.Context, client client.Client, secrets []
 	}
 
 	return tidySecrets, nil
+}
+
+// bundleCACerts returns a PEM bundle containing all certificates from newCA
+// followed by any non-expired, non-duplicate certificates from oldCA. This
+// allows components that haven't yet reloaded to continue trusting leaf certs
+// signed by the previous CA while simultaneously trusting the new CA.
+func bundleCACerts(newCA, oldCA []byte) []byte {
+	if bytes.Equal(newCA, oldCA) {
+		return newCA
+	}
+
+	// Index the certs already present in newCA by their raw DER bytes.
+	existing := make(map[string]struct{})
+	for rest := newCA; ; {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+				existing[string(cert.Raw)] = struct{}{}
+			}
+		}
+	}
+
+	// Append only the first non-expired, non-duplicate cert from oldCA.
+	// This is always the CA that was active at the last rotation. Carrying
+	// forward only one previous CA keeps the bundle at a maximum of two
+	// entries regardless of rotation frequency: by the time a second rotation
+	// occurs all components should have converged on the previous rotation's
+	// certs, so earlier CAs are no longer needed.
+	result := make([]byte, len(newCA))
+	copy(result, newCA)
+	now := time.Now()
+	for rest := oldCA; ; {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil || cert.NotAfter.Before(now) {
+			continue
+		}
+		if _, dup := existing[string(cert.Raw)]; dup {
+			continue
+		}
+		result = append(result, pem.EncodeToMemory(block)...)
+		break // only carry forward one previous CA
+	}
+	return result
 }

--- a/internal/provider/kubernetes/secrets_test.go
+++ b/internal/provider/kubernetes/secrets_test.go
@@ -7,8 +7,16 @@ package kubernetes
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,4 +102,140 @@ func TestCreateSecretsWhenUpgrade(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, created, 4)
 	})
+}
+
+// TestCreateOrUpdateSecretsBundlesCA verifies that when rotating certificates the
+// old CA is bundled with the new CA so that components that haven't reloaded yet
+// continue to be trusted during the transition window.
+func TestCreateOrUpdateSecretsBundlesCA(t *testing.T) {
+	now := time.Now()
+	ca1 := makeTestCAPEM(t, now.Add(365*24*time.Hour))
+	ca2 := makeTestCAPEM(t, now.Add(365*24*time.Hour))
+	require.NotEqual(t, ca1, ca2)
+
+	// Seed the cluster with a secret carrying the old CA.
+	existing := newSecret(corev1.SecretTypeTLS, "envoy-gateway", "test-ns", map[string][]byte{
+		caCertificateKey:        ca1,
+		corev1.TLSCertKey:       []byte("old-cert"),
+		corev1.TLSPrivateKeyKey: []byte("old-key"),
+	})
+	cli := fakeclient.NewClientBuilder().WithObjects(&existing).Build()
+
+	// Rotate: present a new secret carrying  the new CA.
+	rotated := newSecret(corev1.SecretTypeTLS, "envoy-gateway", "test-ns", map[string][]byte{
+		caCertificateKey:        ca2,
+		corev1.TLSCertKey:       []byte("new-cert"),
+		corev1.TLSPrivateKeyKey: []byte("new-key"),
+	})
+	updated, err := CreateOrUpdateSecrets(context.Background(), cli, []corev1.Secret{rotated}, true)
+	require.NoError(t, err)
+	require.Len(t, updated, 1)
+
+	bundle := updated[0].Data[caCertificateKey]
+
+	// The bundle must be valid PEM accepted by x509.
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(bundle), "bundle must be valid PEM")
+
+	certs := decodePEMCerts(t, bundle)
+	require.Len(t, certs, 2, "bundle must contain exactly 2 certs: new CA + old CA")
+	assert.Equal(t, decodePEMCerts(t, ca2)[0].Raw, certs[0].Raw, "first cert in bundle must be the new CA")
+	assert.Equal(t, decodePEMCerts(t, ca1)[0].Raw, certs[1].Raw, "second cert in bundle must be the old CA")
+}
+
+// TestBundleCACerts covers the bundleCACerts helper directly.
+func TestBundleCACerts(t *testing.T) {
+	now := time.Now()
+	ca1 := makeTestCAPEM(t, now.Add(365*24*time.Hour))
+	ca2 := makeTestCAPEM(t, now.Add(365*24*time.Hour))
+	expired := makeTestCAPEM(t, now.Add(-time.Second)) // already expired
+
+	t.Run("identical CAs return the original bytes unchanged", func(t *testing.T) {
+		result := bundleCACerts(ca1, ca1)
+		assert.Equal(t, ca1, result)
+	})
+
+	t.Run("different CAs are concatenated new-first", func(t *testing.T) {
+		result := bundleCACerts(ca2, ca1)
+		certs := decodePEMCerts(t, result)
+		require.Len(t, certs, 2)
+		assert.Equal(t, decodePEMCerts(t, ca2)[0].Raw, certs[0].Raw, "new CA must be first")
+		assert.Equal(t, decodePEMCerts(t, ca1)[0].Raw, certs[1].Raw, "old CA must be second")
+	})
+
+	t.Run("cert already present in newCA is not duplicated", func(t *testing.T) {
+		// Bundle containing ca2+ca1; applying bundleCACerts(ca2, bundle) must
+		// not add ca2 again.
+		bundle := bundleCACerts(ca2, ca1)
+		result := bundleCACerts(ca2, bundle)
+		certs := decodePEMCerts(t, result)
+		require.Len(t, certs, 2, "ca2 that is already in newCA must not be re-appended")
+	})
+
+	t.Run("expired cert from old bundle is excluded", func(t *testing.T) {
+		result := bundleCACerts(ca1, expired)
+		certs := decodePEMCerts(t, result)
+		require.Len(t, certs, 1, "expired cert must not be included in the bundle")
+	})
+
+	t.Run("bundle never exceeds two CAs across multiple rotations", func(t *testing.T) {
+		ca3 := makeTestCAPEM(t, now.Add(365*24*time.Hour))
+
+		// Rotation 1: CA1 -> CA2
+		after1 := bundleCACerts(ca2, ca1)
+		require.Len(t, decodePEMCerts(t, after1), 2)
+
+		// Rotation 2: CA2 -> CA3 (oldCA is the after1 bundle: CA2+CA1)
+		// Only CA2 (the head of after1) should be carried forward; CA1 is dropped.
+		after2 := bundleCACerts(ca3, after1)
+		certs := decodePEMCerts(t, after2)
+		require.Len(t, certs, 2, "bundle must not grow beyond 2 CAs after a second rotation")
+		assert.Equal(t, decodePEMCerts(t, ca3)[0].Raw, certs[0].Raw, "new CA must be first")
+		assert.Equal(t, decodePEMCerts(t, ca2)[0].Raw, certs[1].Raw, "only the immediately-previous CA is carried forward")
+	})
+}
+
+// makeTestCAPEM generates a minimal self-signed CA certificate with the given
+// validity window and returns it as a PEM-encoded CERTIFICATE block.
+func makeTestCAPEM(t *testing.T, notAfter time.Time) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	now := time.Now()
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              notAfter,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}
+
+// decodePEMCerts returns all x509 certificates decoded from a PEM bundle.
+func decodePEMCerts(t *testing.T, data []byte) []*x509.Certificate {
+	t.Helper()
+	var certs []*x509.Certificate
+	for rest := data; len(rest) > 0; {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		require.NoError(t, err)
+		certs = append(certs, cert)
+	}
+	return certs
 }


### PR DESCRIPTION
## Summary

> ⚠️ **Depends on #8534** — that PR must be merged first. The diff here includes those changes; the net-new change in this PR is solely in `internal/cmd/certgen.go`.

Completes the fix for #4891.

### Problem

Rate Limit loads its CA certificate once at startup and does not watch the mounted Secret volume for changes. After `certgen --overwrite` rotates certificates:

1. The kubelet updates the `/certs` volume on disk for the Rate Limit pod.
2. The running Rate Limit process continues verifying incoming client certs against the **old CA in memory**.
3. Any Envoy pod that has already reloaded its new leaf cert via SDS is subsequently rejected by Rate Limit, causing mTLS failures.

Unlike Envoy (which uses SDS path-based reload) or Envoy Gateway (which uses `GetConfigForClient` to re-read certs per-connection), Rate Limit has no equivalent hot-reload path for its CA.

This is the root cause of the incident described in #4891: the failure was observed after a **weekend rotation** — pods had been running long enough that no natural restart had occurred since the previous cert write.

### Fix

After writing rotated Secrets (`--overwrite`), patch the Rate Limit Deployment's pod-template annotation with the current timestamp. This is identical to what `kubectl rollout restart` does:

```go
patched.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = metav1.Now().UTC().Format(time.RFC3339)
```

Kubernetes performs a rolling replacement of Rate Limit pods using the Deployment's existing `RollingUpdate` strategy. By default this keeps at least 75% of replicas available at all times and respects any `PodDisruptionBudget` the operator has configured.

The restart is **gated on `--overwrite`** so it does not fire on the initial install, where Rate Limit has just started with the correct certs. If the Rate Limit Deployment does not exist (Rate Limit not enabled), the function is a no-op.

### Why this depends on #8534

During the rolling restart, old and new Rate Limit pods run concurrently for a brief overlap period. The CA bundle written by #8534 (`[newCA, previousCA]`) ensures Envoy can authenticate against both old and new Rate Limit pods throughout that window. Without the bundle, the rolling restart itself would cause a brief mTLS failure as new Rate Limit pods come up with new leaf certs before Envoy has reloaded the new CA.

### Note on single-replica deployments

If Rate Limit has 1 replica and no PodDisruptionBudget, there will be a brief gap between the old pod terminating and the new pod becoming ready. This is a pre-existing limitation of single-replica deployments and is not introduced by this change. Users with availability requirements should configure at least 2 replicas or a PDB with `minAvailable: 1`.