### PR TITLE
feat: JSON log encoder uses abbreviated field keys

### DIFF
--- a/internal/logging/log.go
+++ b/internal/logging/log.go
@@ -135,7 +135,7 @@ func (l Logger) Sugar() *zap.SugaredLogger {
 
 func initZapLogger(w io.Writer, logging *egv1a1.EnvoyGatewayLogging, level egv1a1.LogLevel) *zap.Logger {
 	parseLevel, _ := zapcore.ParseLevel(string(logging.DefaultEnvoyGatewayLoggingLevel(level)))
-	cfg := zap.NewDevelopmentEncoderConfig()
+	cfg := zap.NewProductionEncoderConfig()
 	var encoder zapcore.Encoder
 	logEncoder := egv1a1.EnvoyGatewayLogEncoderText
 	if logging != nil && logging.Encoder != nil {

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -5,6 +5,7 @@ breaking changes: |
   The DirectResponse body in HTTPFilter now supports Envoy command operators for dynamic content. Existing configurations including the template syntax (%) will be interpolated.
   The `0s` timeout in SecurityPolicy is now treated as infinite timeout instead of immediate timeout.
   `SamplingFraction` behavior changed from raw fraction to percentage ratio. This will lead to 100x more sampling than before. E.g. `numerator: 100` used to result in 1% sampling rate, now will result in 100% sampling.
+  The controller now uses production logging encoder config by default, which provides better output when using JSON encoder.
 
 # Updates addressing vulnerabilities, security flaws, or compliance requirements.
 security updates: |


### PR DESCRIPTION
fixes: https://github.com/envoyproxy/gateway/issues/8552

the output as following:

```console
{"level":"info","ts":1773900658.0818536,"logger":"provider","caller":"kubernetes/controller.go:1202","msg":"processing OIDC HMAC Secret","runner":"provider","namespace":"envoy-gateway-system","name":"envoy-oidc-hmac"}
{"level":"info","ts":1773900658.0818622,"logger":"provider","caller":"kubernetes/controller.go:1224","msg":"processing Envoy TLS Secret","runner":"provider","namespace":"envoy-gateway-system","name":"envoy"}
{"level":"info","ts":1773900658.0820184,"logger":"provider","caller":"kubernetes/controller.go:557","msg":"No gateways found for accepted GatewayClass","runner":"provider","trace_id":"b30673449e19b35ed56c38140f7f882e","span_id":"168c82967f8a79f9","GatewayClass":"internet"}
{"level":"info","ts":1773900658.0822415,"logger":"provider","caller":"kubernetes/controller.go:600","msg":"reconciled gateways successfully","runner":"provider","trace_id":"b30673449e19b35ed56c38140f7f882e","span_id":"168c82967f8a79f9"}
```