### PR TITLE
fix: per-endpoint hostname override blocked by auto-generated wildcad host

### DIFF
--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -1003,7 +1003,8 @@ func getHealthCheckOverridesHostname(hc *ir.HealthCheck, ep *ir.DestinationEndpo
 	// If Active Health Check has an explicit hostname override, it will be used on Cluster.
 	// Otherwise, if the endpoint has a hostname, set the hostname on the EndpointHealthCheckConfig
 	// so that Envoy can use it for health checking.
-	if hc.Active.HTTP != nil && hc.Active.HTTP.Host != "" {
+	// Note: The "*" wildcard is not an explicit user-provided hostname
+	if hc.Active.HTTP != nil && hc.Active.HTTP.Host != "" && hc.Active.HTTP.Host != "*" {
 		return ""
 	}
 	if ep == nil || ep.Hostname == nil {

--- a/internal/xds/translator/cluster_test.go
+++ b/internal/xds/translator/cluster_test.go
@@ -222,3 +222,173 @@ func TestBuildXdsOutlierDetection(t *testing.T) {
 func requireCmpNoDiff(t *testing.T, expected, actual interface{}) {
 	require.Empty(t, cmp.Diff(expected, actual, protocmp.Transform()))
 }
+
+func TestGetHealthCheckOverridesHostname(t *testing.T) {
+	tests := []struct {
+		name        string
+		healthCheck *ir.HealthCheck
+		endpoint    *ir.DestinationEndpoint
+		expected    string
+	}{
+		{
+			name: "nil HTTP health checker",
+			healthCheck: &ir.HealthCheck{
+				Active: &ir.ActiveHealthCheck{
+					HealthyThreshold: ptr.To[uint32](3),
+				},
+			},
+			endpoint: &ir.DestinationEndpoint{
+				Host:     "example.com",
+				Port:     8080,
+				Hostname: ptr.To("backend.example.com"),
+			},
+			expected: "backend.example.com",
+		},
+		{
+			name: "HTTP health checker with empty host and endpoint has hostname",
+			healthCheck: &ir.HealthCheck{
+				Active: &ir.ActiveHealthCheck{
+					HTTP: &ir.HTTPHealthChecker{
+						Host: "",
+						Path: "/health",
+					},
+				},
+			},
+			endpoint: &ir.DestinationEndpoint{
+				Host:     "example.com",
+				Port:     8080,
+				Hostname: ptr.To("backend.example.com"),
+			},
+			expected: "backend.example.com",
+		},
+		{
+			name: "HTTP health checker with wildcard host and endpoint has hostname",
+			healthCheck: &ir.HealthCheck{
+				Active: &ir.ActiveHealthCheck{
+					HTTP: &ir.HTTPHealthChecker{
+						Host: "*",
+						Path: "/health",
+					},
+				},
+			},
+			endpoint: &ir.DestinationEndpoint{
+				Host:     "example.com",
+				Port:     8080,
+				Hostname: ptr.To("backend.example.com"),
+			},
+			expected: "backend.example.com",
+		},
+		{
+			name: "HTTP health checker with explicit host",
+			healthCheck: &ir.HealthCheck{
+				Active: &ir.ActiveHealthCheck{
+					HTTP: &ir.HTTPHealthChecker{
+						Host: "health.example.com",
+						Path: "/health",
+					},
+				},
+			},
+			endpoint: &ir.DestinationEndpoint{
+				Host:     "example.com",
+				Port:     8080,
+				Hostname: ptr.To("backend.example.com"),
+			},
+			expected: "",
+		},
+		{
+			name: "HTTP health checker with empty host but nil endpoint",
+			healthCheck: &ir.HealthCheck{
+				Active: &ir.ActiveHealthCheck{
+					HTTP: &ir.HTTPHealthChecker{
+						Host: "",
+						Path: "/health",
+					},
+				},
+			},
+			endpoint: nil,
+			expected: "",
+		},
+		{
+			name: "HTTP health checker with empty host but endpoint has nil hostname",
+			healthCheck: &ir.HealthCheck{
+				Active: &ir.ActiveHealthCheck{
+					HTTP: &ir.HTTPHealthChecker{
+						Host: "",
+						Path: "/health",
+					},
+				},
+			},
+			endpoint: &ir.DestinationEndpoint{
+				Host:     "example.com",
+				Port:     8080,
+				Hostname: nil,
+			},
+			expected: "",
+		},
+		{
+			name: "HTTP health checker with wildcard host but nil endpoint",
+			healthCheck: &ir.HealthCheck{
+				Active: &ir.ActiveHealthCheck{
+					HTTP: &ir.HTTPHealthChecker{
+						Host: "*",
+						Path: "/health",
+					},
+				},
+			},
+			endpoint: nil,
+			expected: "",
+		},
+		{
+			name: "HTTP health checker with wildcard host but endpoint has nil hostname",
+			healthCheck: &ir.HealthCheck{
+				Active: &ir.ActiveHealthCheck{
+					HTTP: &ir.HTTPHealthChecker{
+						Host: "*",
+						Path: "/health",
+					},
+				},
+			},
+			endpoint: &ir.DestinationEndpoint{
+				Host:     "example.com",
+				Port:     8080,
+				Hostname: nil,
+			},
+			expected: "",
+		},
+		{
+			name: "TCP health checker with endpoint hostname",
+			healthCheck: &ir.HealthCheck{
+				Active: &ir.ActiveHealthCheck{
+					TCP: &ir.TCPHealthChecker{},
+				},
+			},
+			endpoint: &ir.DestinationEndpoint{
+				Host:     "example.com",
+				Port:     8080,
+				Hostname: ptr.To("backend.example.com"),
+			},
+			expected: "backend.example.com",
+		},
+		{
+			name: "GRPC health checker with endpoint hostname",
+			healthCheck: &ir.HealthCheck{
+				Active: &ir.ActiveHealthCheck{
+					GRPC: &ir.GRPCHealthChecker{},
+				},
+			},
+			endpoint: &ir.DestinationEndpoint{
+				Host:     "example.com",
+				Port:     8080,
+				Hostname: ptr.To("backend.example.com"),
+			},
+			expected: "backend.example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getHealthCheckOverridesHostname(tc.healthCheck, tc.endpoint)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/xds/translator/testdata/in/xds-ir/health-check.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/health-check.yaml
@@ -73,6 +73,7 @@ http:
       settings:
       - endpoints:
         - host: "1.2.3.4"
+          hostname: example.com
           port: 50000
         name: "second-route-dest/backend/0"
   - name: "third-route"

--- a/internal/xds/translator/testdata/out/xds-ir/health-check.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check.endpoints.yaml
@@ -18,6 +18,9 @@
           socketAddress:
             address: 1.2.3.4
             portValue: 50000
+        healthCheckConfig:
+          hostname: example.com
+        hostname: example.com
       loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -49,6 +49,7 @@ bug fixes: |
   Made ConnectionLimit.Value optional so users can configure MaxConnectionDuration, MaxRequestsPerConnection, or MaxStreamDuration without setting a max connections value.
   Fixed endpoint hostname is not respected when doing active health check.
   Fixed ratelimit deployment missing metrics container port (19001), which prevented PodMonitor/ServiceMonitor from targeting the metrics endpoint.
+  Fixed per-endpoint hostname override not working because the auto-generated wildcard hostname.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
Fixes: https://github.com/envoyproxy/gateway/issues/8564