### PR TITLE
docs: clarify supported HTTP redirect status codes

### DIFF
--- a/site/content/en/latest/tasks/traffic/http-redirect.md
+++ b/site/content/en/latest/tasks/traffic/http-redirect.md
@@ -69,10 +69,6 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-__Note:__ Currently, Envoy Gateway supports only `301` (default) and `302`
-redirect status codes. Support for additional status codes such as
-`303`, `307`, and `308` is planned for a future release (targeted for v1.8).
-
 The HTTPRoute status should indicate that it has been accepted and is bound to the example Gateway.
 
 ```shell


### PR DESCRIPTION
Fixes #8561

Update the HTTP redirect documentation to clarify that Envoy Gateway
currently supports only status codes 301 and 302.

Also mention planned support for additional status codes
(303, 307, 308) in a future release.