### PR TITLE
docs: ignore blog.envoyproxy.io

### DIFF
--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -5,6 +5,7 @@ RELEASE_VERSIONS ?= $(foreach v,$(wildcard ${ROOT_DIR}/docs/*),$(notdir ${v}))
 # TODO: example.com is not a valid domain, we should remove it from ignore list
 # TODO: https://www.gnu.org/software/make became unstable, we should remove it from ignore list later
 LINKINATOR_IGNORE := "opentelemetry.io \
+	blog.envoyproxy.io \
 	gateway-api.sigs.k8s.io/reference/1.3 \
 	ntia.gov \
 	github.com \


### PR DESCRIPTION
xref: https://github.com/envoyproxy/gateway/actions/runs/23425732761/job/68140064144

Seems Medium change the policy for https://github.com/envoyproxy/gateway/actions/runs/23425732761/job/68140064144