### PR TITLE
docs: add note on case-insensitivity of header names

### DIFF
--- a/site/content/en/latest/tasks/traffic/http-request-headers.md
+++ b/site/content/en/latest/tasks/traffic/http-request-headers.md
@@ -13,7 +13,7 @@ request is sent from Envoy to the upstream service and will not affect response 
 client. Header values support Envoy [format strings][envoy-format-strings], enabling dynamic values sourced from the
 request and connection metadata.
 
-Header names are case-insensitive, so each header only needs to be listed once (for example, `x-forwarded-for` also matches `X-Forwarded-For`).
+According to [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1) and [RFC 7230](https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2), header names are case-insensitive, so each header only needs to be listed once (for example, `x-forwarded-for` also matches `X-Forwarded-For`).
 
 ## Prerequisites
 


### PR DESCRIPTION
Clarified that header names are case-insensitive and provided an example.

Release Notes: No
