### PR TITLE
fix(xds): preserve original host metadata for DFP rewrites

### DIFF
--- a/internal/xds/translator/dynamic_forward_proxy.go
+++ b/internal/xds/translator/dynamic_forward_proxy.go
@@ -151,13 +151,6 @@ func (*dynamicForwardProxy) patchRoute(route *routev3.Route, irRoute *ir.HTTPRou
 	filterName := dfpFilterName(dfpCacheName(determineIPFamily(irRoute.Destination.Settings), routeDNS(irRoute)))
 	route.TypedPerFilterConfig[filterName] = perRouteAny
 
-	// Clear out any existing host rewrite specifier to avoid conflicts.
-	routeAction := route.GetRoute()
-	if routeAction != nil {
-		routeAction.HostRewriteSpecifier = nil
-		routeAction.AppendXForwardedHost = false
-	}
-
 	return nil
 }
 

--- a/internal/xds/translator/dynamic_forward_proxy_test.go
+++ b/internal/xds/translator/dynamic_forward_proxy_test.go
@@ -1,0 +1,109 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"testing"
+
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/gateway/internal/ir"
+)
+
+func TestDynamicForwardProxyPatchRoutePreservesHostRewriteMetadata(t *testing.T) {
+	tests := []struct {
+		name         string
+		buildIRRoute func() *ir.HTTPRoute
+		buildAction  func() *routev3.RouteAction
+		assertSpec   func(t *testing.T, action *routev3.RouteAction)
+	}{
+		{
+			name: "header rewrite",
+			buildIRRoute: func() *ir.HTTPRoute {
+				header := "x-dynamic-host"
+				return &ir.HTTPRoute{
+					URLRewrite: &ir.URLRewrite{
+						Host: &ir.HTTPHostModifier{
+							Header: &header,
+						},
+					},
+					Destination: &ir.RouteDestination{
+						Settings: []*ir.DestinationSetting{
+							{IsDynamicResolver: true},
+						},
+					},
+				}
+			},
+			buildAction: func() *routev3.RouteAction {
+				return &routev3.RouteAction{
+					HostRewriteSpecifier: &routev3.RouteAction_HostRewriteHeader{
+						HostRewriteHeader: "x-dynamic-host",
+					},
+					AppendXForwardedHost: true,
+				}
+			},
+			assertSpec: func(t *testing.T, action *routev3.RouteAction) {
+				t.Helper()
+				spec, ok := action.HostRewriteSpecifier.(*routev3.RouteAction_HostRewriteHeader)
+				require.True(t, ok)
+				require.Equal(t, "x-dynamic-host", spec.HostRewriteHeader)
+			},
+		},
+		{
+			name: "literal rewrite",
+			buildIRRoute: func() *ir.HTTPRoute {
+				host := "www.google.com"
+				return &ir.HTTPRoute{
+					URLRewrite: &ir.URLRewrite{
+						Host: &ir.HTTPHostModifier{
+							Name: &host,
+						},
+					},
+					Destination: &ir.RouteDestination{
+						Settings: []*ir.DestinationSetting{
+							{IsDynamicResolver: true},
+						},
+					},
+				}
+			},
+			buildAction: func() *routev3.RouteAction {
+				return &routev3.RouteAction{
+					HostRewriteSpecifier: &routev3.RouteAction_HostRewriteLiteral{
+						HostRewriteLiteral: "www.google.com",
+					},
+					AppendXForwardedHost: true,
+				}
+			},
+			assertSpec: func(t *testing.T, action *routev3.RouteAction) {
+				t.Helper()
+				spec, ok := action.HostRewriteSpecifier.(*routev3.RouteAction_HostRewriteLiteral)
+				require.True(t, ok)
+				require.Equal(t, "www.google.com", spec.HostRewriteLiteral)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			irRoute := tt.buildIRRoute()
+			routeAction := tt.buildAction()
+			route := &routev3.Route{
+				Action: &routev3.Route_Route{
+					Route: routeAction,
+				},
+			}
+
+			err := (&dynamicForwardProxy{}).patchRoute(route, irRoute, nil)
+			require.NoError(t, err)
+
+			filterName := dfpFilterName(dfpCacheName(determineIPFamily(irRoute.Destination.Settings), routeDNS(irRoute)))
+			require.Contains(t, route.TypedPerFilterConfig, filterName)
+			require.True(t, route.GetRoute().AppendXForwardedHost)
+			tt.assertSpec(t, route.GetRoute())
+		})
+	}
+}

--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -578,24 +578,21 @@ func buildXdsURLRewriteAction(route *ir.HTTPRoute, urlRewrite *ir.URLRewrite, pa
 	}
 
 	if urlRewrite.Host != nil {
-		// For DFP use cases, route-level host literal/header rewrites are not used, and instead DFP per-filter config is used, see here:
-		// https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/dynamic_forward_proxy/v3/dynamic_forward_proxy.proto#envoy-v3-api-msg-extensions-filters-http-dynamic-forward-proxy-v3-perrouteconfig
-		// Auto Host rewrites are only supported for strict/logical DNS clusters, so not relevant for DFP, see here:
-		// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-auto-host-rewrite
-		if !route.IsDynamicResolverRoute() {
-			switch {
-			case urlRewrite.Host.Name != nil:
-				routeAction.HostRewriteSpecifier = &routev3.RouteAction_HostRewriteLiteral{
-					HostRewriteLiteral: *urlRewrite.Host.Name,
-				}
-			case urlRewrite.Host.Header != nil:
-				routeAction.HostRewriteSpecifier = &routev3.RouteAction_HostRewriteHeader{
-					HostRewriteHeader: *urlRewrite.Host.Header,
-				}
-			case urlRewrite.Host.Backend != nil:
-				routeAction.HostRewriteSpecifier = &routev3.RouteAction_AutoHostRewrite{
-					AutoHostRewrite: wrapperspb.Bool(true),
-				}
+		// Dynamic forward proxy routes still need the route-level host rewrite metadata so the router filter
+		// preserves the original host in envoy-added headers. DFP per-route config is still used separately
+		// to ensure DNS resolution follows the rewritten host.
+		switch {
+		case urlRewrite.Host.Name != nil:
+			routeAction.HostRewriteSpecifier = &routev3.RouteAction_HostRewriteLiteral{
+				HostRewriteLiteral: *urlRewrite.Host.Name,
+			}
+		case urlRewrite.Host.Header != nil:
+			routeAction.HostRewriteSpecifier = &routev3.RouteAction_HostRewriteHeader{
+				HostRewriteHeader: *urlRewrite.Host.Header,
+			}
+		case urlRewrite.Host.Backend != nil:
+			routeAction.HostRewriteSpecifier = &routev3.RouteAction_AutoHostRewrite{
+				AutoHostRewrite: wrapperspb.Bool(true),
 			}
 		}
 

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-dynamic-resolver-with-host-rewriting.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-dynamic-resolver-with-host-rewriting.routes.yaml
@@ -24,7 +24,9 @@
               namespace: default
       name: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
       route:
+        appendXForwardedHost: true
         cluster: httproute/default/httproute-1/rule/0
+        hostRewriteHeader: x-dynamic-host-header-1
         upgradeConfigs:
         - upgradeType: websocket
       typedPerFilterConfig:
@@ -134,7 +136,9 @@
               namespace: default
       name: httproute/default/httproute-1/rule/1/match/0/gateway_envoyproxy_io
       route:
+        appendXForwardedHost: true
         cluster: httproute/default/httproute-1/rule/1
+        hostRewriteHeader: x-dynamic-host-header-2
         upgradeConfigs:
         - upgradeType: websocket
       typedPerFilterConfig:
@@ -244,7 +248,9 @@
               namespace: default
       name: httproute/default/httproute-2/rule/0/match/0/gateway_envoyproxy_io
       route:
+        appendXForwardedHost: true
         cluster: httproute/default/httproute-2/rule/0
+        hostRewriteHeader: x-dynamic-host-header-3
         upgradeConfigs:
         - upgradeType: websocket
       typedPerFilterConfig:
@@ -382,7 +388,9 @@
               namespace: default
       name: httproute/default/httproute-2/rule/1/match/0/gateway_envoyproxy_io
       route:
+        appendXForwardedHost: true
         cluster: httproute/default/httproute-2/rule/1
+        hostRewriteLiteral: rewrite.com
         upgradeConfigs:
         - upgradeType: websocket
       typedPerFilterConfig:

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -56,6 +56,7 @@ bug fixes: |
   Fixed GRPCRoute not detecting conflicting RequestMirror and DirectResponse filters, which caused the mirror to be silently dropped.
   Fixed BackendTrafficPolicy `requestBuffer` coexisting with route upgrades by disabling the default WebSocket upgrade on buffered routes and rejecting explicit `requestBuffer` + `httpUpgrade` combinations.
   Fixed per-endpoint hostname override not working because the auto-generated wildcard hostname.
+  Fixed dynamic resolver host rewrites dropping the original host metadata needed for `X-ENVOY-ORIGINAL-HOST`.
   Fixed Basic Authentication failing when htpasswd secrets use CRLF line endings by normalizing to LF before passing to Envoy.
 
 


### PR DESCRIPTION
**What type of PR is this?**
fix(xds): preserve original host metadata for DFP rewrites

**What this PR does / why we need it**:
Dynamic forward proxy host rewrites were clearing the route-level host rewrite metadata after the per-route DFP config was added. That left Envoy without the router-level information it uses to emit `X-ENVOY-ORIGINAL-HOST`, even though the rewritten host still drove DNS resolution. This change keeps the route host rewrite metadata in place, adds a focused regression test for both header and literal rewrites, and updates the translator golden output accordingly.

**Which issue(s) this PR fixes**:
Fixes #8353

Release Notes: Yes
