### PR TITLE
fix json report

### DIFF
--- a/test/benchmark/suite/json.go
+++ b/test/benchmark/suite/json.go
@@ -10,6 +10,8 @@ package suite
 import (
 	"encoding/json"
 	"math"
+
+	"github.com/envoyproxy/gateway/test/benchmark/proto"
 )
 
 func ToJSON(report *BenchmarkSuiteReport) []byte {
@@ -53,25 +55,7 @@ func convertCaseReport(report *BenchmarkCaseReport) *JSONTestResult {
 			latency.Max = stat.GetMax().AsDuration().Seconds() * 1000
 			latency.Min = stat.GetMin().AsDuration().Seconds() * 1000
 			latency.Mean = stat.GetMean().AsDuration().Seconds() * 1000
-			latency.Percentiles = Percentiles{}
-			for _, p := range stat.Percentiles {
-				switch p.Percentile {
-				case 0.5:
-					latency.Percentiles.P50 = p.GetDuration().AsDuration().Seconds() * 1000
-				case 0.75:
-					latency.Percentiles.P75 = p.GetDuration().AsDuration().Seconds() * 1000
-				case 0.8:
-					latency.Percentiles.P80 = p.GetDuration().AsDuration().Seconds() * 1000
-				case 0.9:
-					latency.Percentiles.P90 = p.GetDuration().AsDuration().Seconds() * 1000
-				case 0.95:
-					latency.Percentiles.P95 = p.GetDuration().AsDuration().Seconds() * 1000
-				case 0.99:
-					latency.Percentiles.P99 = p.GetDuration().AsDuration().Seconds() * 1000
-				case 0.999:
-					latency.Percentiles.P999 = p.GetDuration().AsDuration().Seconds() * 1000
-				}
-			}
+			latency.Percentiles = getLatencyPercentiles(stat.Percentiles)
 		}
 	}
 
@@ -157,4 +141,29 @@ func getResourceUsage(metrics []float64) *ResourceUsage {
 		Min:  minVal,
 		Max:  maxVal,
 	}
+}
+
+func getLatencyPercentiles(percentiles []*proto.Percentile) Percentiles {
+	return Percentiles{
+		P50:  getPercentileDurationMs(percentiles, 0.5),
+		P75:  getPercentileDurationMs(percentiles, 0.75),
+		P80:  getPercentileDurationMs(percentiles, 0.8),
+		P90:  getPercentileDurationMs(percentiles, 0.9),
+		P95:  getPercentileDurationMs(percentiles, 0.95),
+		P99:  getPercentileDurationMs(percentiles, 0.99),
+		P999: getPercentileDurationMs(percentiles, 0.999),
+	}
+}
+
+func getPercentileDurationMs(percentiles []*proto.Percentile, target float64) float64 {
+	lastPercentile := float64(-1)
+	for _, percentile := range percentiles {
+		current := percentile.GetPercentile()
+		if current >= target && lastPercentile < current {
+			return percentile.GetDuration().AsDuration().Seconds() * 1000
+		}
+		lastPercentile = current
+	}
+
+	return 0
 }

--- a/test/benchmark/suite/json_test.go
+++ b/test/benchmark/suite/json_test.go
@@ -1,0 +1,30 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+//go:build benchmark
+
+package suite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLatencyPercentiles(t *testing.T) {
+	result := fakeCaseResult()
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Statistics)
+
+	percentiles := getLatencyPercentiles(result.Statistics[1].Percentiles)
+
+	require.InDelta(t, 0.438127, percentiles.P50, 1e-9)
+	require.InDelta(t, 0.546047, percentiles.P75, 1e-9)
+	require.InDelta(t, 0.584511, percentiles.P80, 1e-9)
+	require.InDelta(t, 0.751775, percentiles.P90, 1e-9)
+	require.InDelta(t, 1.100415, percentiles.P95, 1e-9)
+	require.InDelta(t, 55.601151, percentiles.P99, 1e-9)
+	require.InDelta(t, 60.461055, percentiles.P999, 1e-9)
+}


### PR DESCRIPTION
Nighthawk emits nearby histogram percentiles instead of exact decimal values, for example the benchmark testdata shows values like:

```
  Percentile  Count   Value
  0.500000    17999   478.255µs
  0.750000    27001   494.671µs
  0.800000    28801   500.831µs
  0.900000    32398   524.479µs
  0.950000    34199   565.567µs
  0.990625    35660   1.174719ms
  0.999023    35962   4.073215ms
```

The current Json file will output 0 for P99.

```
        "percentiles": {
          "p50": 0.47825500000000004,
          "p75": 0.494671,
          "p80": 0.500831,
          "p90": 0.524479,
          "p95": 0.565567,
          "p99": 0,
          "p999": 0
        }
```