### PR TITLE
chore: add make target for benchmark dashboard

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -15,7 +15,9 @@ assignees: ''
 - [ ] push tag
     - [ ] Push tag https://github.com/envoyproxy/gateway/releases/tag/v1.x.x
     - [ ] wait for release CI
-- [ ] update benchmark report
+- [ ] update benchmark dashboard
+    - [ ] `make sync-benchmark-dashboard VERSION=v1.x.x`
+    - [ ] open and merge PR with generated `site/tools/benchmark-dashboard/src/data/**` and `site/static/**` changes
 - [ ] verify quickstart
 - [ ] update doc
 - [ ] update release [announcement](https://github.com/envoyproxy/gateway/releases/tag/v1.x.x)

--- a/site/content/en/contributions/RELEASING.md
+++ b/site/content/en/contributions/RELEASING.md
@@ -237,14 +237,13 @@ export GITHUB_REMOTE=origin
 11. Confirm that the [release workflow][] completed successfully.
 12. Confirm that the Envoy Gateway [image][] with the correct release tag was published to Docker Hub.
 13. Confirm that the [release][] was created.
-14. Update the benchmark explorer data for the new release:
+14. Update the benchmark dashboard data for the new release:
 
     ```shell
-    cd tools
-    ./src/benchmark-dashboard-sync/sync.sh --version v${MAJOR_VERSION}.${MINOR_VERSION}.0
+    make sync-benchmark-dashboard VERSION=v${MAJOR_VERSION}.${MINOR_VERSION}.0
     ```
 
-    Commit the generated benchmark dashboard changes, including the updated files under `site/static/`, open a PR against `main`, and merge it so the docs workflow publishes the new benchmark explorer entry.
+    Commit the generated benchmark dashboard changes, including the updated files under `site/static/`, open a PR against `main`, and merge it so the docs workflow publishes the new benchmark dashboard entry.
 
 15. Confirm that the steps in the [Quickstart][] work as expected.
 16. [Generate][] the GitHub changelog and include the following text at the beginning of the release page:
@@ -393,14 +392,13 @@ export GITHUB_REMOTE=origin
 12. Confirm that the [release workflow][] completed successfully.
 13. Confirm that the Envoy Gateway [image][] with the correct release tag was published to Docker Hub.
 14. Confirm that the [release][] was created.
-15. Update the benchmark explorer data for the new release:
+15. Update the benchmark dashboard data for the new release:
 
     ```shell
-    cd tools
-    ./src/benchmark-dashboard-sync/sync.sh --version v${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}
+    make sync-benchmark-dashboard VERSION=v${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}
     ```
 
-    Commit the generated benchmark dashboard changes, including the updated files under `site/static/`, open a PR against `main`, and merge it so the docs workflow publishes the new benchmark explorer entry.
+    Commit the generated benchmark dashboard changes, including the updated files under `site/static/`, open a PR against `main`, and merge it so the docs workflow publishes the new benchmark dashboard entry.
 
 16. Confirm that the steps in the [Quickstart][] work as expected.
 17. [Generate][] the GitHub changelog and include the following text at the beginning of the release page:

--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -49,6 +49,11 @@ docs-gen: docs.clean helm-readme-gen docs-api copy-current-release-docs docs-syn
 .PHONY: docs
 docs: docs-gen docs-check ## Generate docs and verify no changes are needed
 
+.PHONY: sync-benchmark-dashboard
+sync-benchmark-dashboard: ## Sync release benchmark dashboard data and rebuild tracked static assets. Requires VERSION=vX.Y.Z.
+	@test -n "$(VERSION)" || (echo "VERSION is required, e.g. make sync-benchmark-dashboard VERSION=v1.7.1" && exit 1)
+	@./tools/src/benchmark-dashboard-sync/sync.sh --version "$(VERSION)" --force
+
 .PHONY: copy-current-release-docs
 copy-current-release-docs:  ## Copy the current release docs to the docs folder
 	@$(LOG_TARGET)


### PR DESCRIPTION
Adding a make target for benchmark dashboard to simplify the releasing process.

Follow up of https://github.com/envoyproxy/gateway/pull/8617.