### PR TITLE
DFP: always add dynamic_forward_proxy for the dynamic forward cluster

### DIFF
--- a/internal/xds/translator/dynamic_forward_proxy.go
+++ b/internal/xds/translator/dynamic_forward_proxy.go
@@ -110,36 +110,30 @@ func (*dynamicForwardProxy) patchRoute(route *routev3.Route, irRoute *ir.HTTPRou
 		return errors.New("ir route is nil")
 	}
 
-	// Add per-route RBAC config to deny loopback addresses when DFP is used.
-	if irRoute.IsDynamicResolverRoute() {
-		hostFromLiteral := irRoute.URLRewrite != nil && irRoute.URLRewrite.Host != nil && irRoute.URLRewrite.Host.Name != nil
-		// We don't enforce check for host rewrite from literal since it's static and known at config time.
-		// The loopback check is mainly to prevent dynamic hostnames that may resolve to loopback addresses.
-		if !hostFromLiteral {
-			rbacPerRouteCfg, err := buildDFPLoopbackRBACPerRoute(irRoute)
-			if err != nil {
-				return err
-			}
-			rbacAny, err := anypb.New(rbacPerRouteCfg)
-			if err != nil {
-				return err
-			}
-			if route.TypedPerFilterConfig == nil {
-				route.TypedPerFilterConfig = make(map[string]*anypb.Any)
-			}
-			route.TypedPerFilterConfig[dfpLoopbackRBACFilterName] = rbacAny
-		}
-	}
-
 	if !routeRequireDFP(irRoute) {
 		return nil
 	}
 
-	perRouteCfg := buildDFPPerRouteConfig(irRoute)
-	if perRouteCfg == nil {
-		return nil
+	// Add per-route RBAC config to deny loopback addresses when DFP is used.
+	hostFromLiteral := irRoute.URLRewrite != nil && irRoute.URLRewrite.Host != nil && irRoute.URLRewrite.Host.Name != nil
+	// We don't enforce check for host rewrite from literal since it's static and known at config time.
+	// The loopback check is mainly to prevent dynamic hostnames that may resolve to loopback addresses.
+	if !hostFromLiteral {
+		rbacPerRouteCfg, err := buildDFPLoopbackRBACPerRoute(irRoute)
+		if err != nil {
+			return err
+		}
+		rbacAny, err := anypb.New(rbacPerRouteCfg)
+		if err != nil {
+			return err
+		}
+		if route.TypedPerFilterConfig == nil {
+			route.TypedPerFilterConfig = make(map[string]*anypb.Any)
+		}
+		route.TypedPerFilterConfig[dfpLoopbackRBACFilterName] = rbacAny
 	}
 
+	perRouteCfg := buildDFPPerRouteConfig(irRoute)
 	perRouteAny, err := anypb.New(perRouteCfg)
 	if err != nil {
 		return err
@@ -186,24 +180,13 @@ func listenerHasDynamicResolverRoute(listener *ir.HTTPListener) bool {
 }
 
 // routeRequireDFP check if a given route requires the dynamic forward proxy filter.
-// A dynamic forward proxy is required when:
-// * The route has a dynamic resolver backend.
-// * The route needs DFP to rewrite the host header based on a header or literal name.
+// A dynamic forward proxy is required for any dynamic resolver backend route.
 func routeRequireDFP(route *ir.HTTPRoute) bool {
 	if route == nil || route.Destination == nil {
 		return false
 	}
 
-	if !route.IsDynamicResolverRoute() {
-		return false
-	}
-
-	if route.URLRewrite != nil && route.URLRewrite.Host != nil &&
-		(route.URLRewrite.Host.Header != nil || route.URLRewrite.Host.Name != nil) {
-		return true
-	}
-
-	return false
+	return route.IsDynamicResolverRoute()
 }
 
 // dfpCacheConfigs builds a sorted list of unique DFP DNS cache configs needed by the given routes.
@@ -245,23 +228,20 @@ func dfpCacheConfigs(routes []*ir.HTTPRoute) []*commondfpv3.DnsCacheConfig {
 
 func buildDFPPerRouteConfig(irRoute *ir.HTTPRoute) *dfpv3.PerRouteConfig {
 	switch {
-	case irRoute.URLRewrite == nil || irRoute.URLRewrite.Host == nil:
-		return nil
-	case irRoute.URLRewrite.Host.Header != nil:
+	case irRoute.URLRewrite != nil && irRoute.URLRewrite.Host != nil && irRoute.URLRewrite.Host.Header != nil:
 		return &dfpv3.PerRouteConfig{
 			HostRewriteSpecifier: &dfpv3.PerRouteConfig_HostRewriteHeader{
 				HostRewriteHeader: *irRoute.URLRewrite.Host.Header,
 			},
 		}
-	case irRoute.URLRewrite.Host.Name != nil:
+	case irRoute.URLRewrite != nil && irRoute.URLRewrite.Host != nil && irRoute.URLRewrite.Host.Name != nil:
 		return &dfpv3.PerRouteConfig{
 			HostRewriteSpecifier: &dfpv3.PerRouteConfig_HostRewriteLiteral{
 				HostRewriteLiteral: *irRoute.URLRewrite.Host.Name,
 			},
 		}
 	default:
-		return nil
-
+		return &dfpv3.PerRouteConfig{}
 	}
 }
 

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-dynamic-resolver.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-dynamic-resolver.listeners.yaml
@@ -53,6 +53,14 @@
         - name: envoy.filters.http.rbac.dfp_loopback_deny
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+        - disabled: true
+          name: envoy.filters.http.dynamic_forward_proxy.envoy-gateway-dfp-cache-v4_preferred-30000ms-default
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
+            dnsCacheConfig:
+              dnsLookupFamily: V4_PREFERRED
+              dnsRefreshRate: 30s
+              name: envoy-gateway-dfp-cache-v4_preferred-30000ms-default
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-dynamic-resolver.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-dynamic-resolver.routes.yaml
@@ -28,6 +28,8 @@
         upgradeConfigs:
         - upgradeType: websocket
       typedPerFilterConfig:
+        envoy.filters.http.dynamic_forward_proxy.envoy-gateway-dfp-cache-v4_preferred-30000ms-default:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.PerRouteConfig
         envoy.filters.http.rbac.dfp_loopback_deny:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:


### PR DESCRIPTION
Ensure DynamicResolver HTTP routes always install the dynamic forward proxy filter, even when no host rewrite is configured.

Previously, the filter was only attached for host-rewrite routes, so routes without host rewrite could rely on the DFP cluster’s async host-resolution path.

With the DFP filter in the request path, Envoy pauses request processing until DNS resolution completes, so routing usually proceeds with a populated DFP cache instead of falling back to the DFP cluster’s async host-resolution path. This makes resolution behavior more consistent for HTTP requests, reduces dependence on the cluster’s async host-selection fallback, and lowers the risk of timing-sensitive edge cases during routing.