### PR TITLE
fix(translator): set Conflicted and SupportedVersion conditions on Gateway/GatewayClass status

### DIFF
--- a/internal/gatewayapi/status/gatewayclass.go
+++ b/internal/gatewayapi/status/gatewayclass.go
@@ -29,7 +29,10 @@ const (
 // SetGatewayClassAccepted inserts or updates the Accepted condition
 // for the provided GatewayClass.
 func SetGatewayClassAccepted(gc *gwapiv1.GatewayClass, accepted bool, reason, msg string) {
-	gc.Status.Conditions = MergeConditions(gc.Status.Conditions, computeGatewayClassAcceptedCondition(gc, accepted, reason, msg))
+	gc.Status.Conditions = MergeConditions(gc.Status.Conditions,
+		computeGatewayClassAcceptedCondition(gc, accepted, reason, msg),
+		computeGatewayClassSupportedVersionCondition(gc),
+	)
 	// Disable SupportedFeatures until the field moves from experimental to stable to avoid
 	// status failures due to changes in the datatype. This can occur because we cannot control
 	// how a CRD is installed in the cluster
@@ -58,5 +61,16 @@ func computeGatewayClassAcceptedCondition(gatewayClass *gwapiv1.GatewayClass,
 			Message:            msg,
 			ObservedGeneration: gatewayClass.Generation,
 		}
+	}
+}
+
+// computeGatewayClassSupportedVersionCondition computes the GatewayClass SupportedVersion status condition.
+func computeGatewayClassSupportedVersionCondition(gatewayClass *gwapiv1.GatewayClass) metav1.Condition {
+	return metav1.Condition{
+		Type:               string(gwapiv1.GatewayClassConditionStatusSupportedVersion),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(gwapiv1.GatewayClassReasonSupportedVersion),
+		Message:            "Gateway API CRD versions are supported",
+		ObservedGeneration: gatewayClass.Generation,
 	}
 }

--- a/internal/gatewayapi/testdata/accesslog-als-backend.out.yaml
+++ b/internal/gatewayapi/testdata/accesslog-als-backend.out.yaml
@@ -85,6 +85,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/accesslog-als-grpc.out.yaml
+++ b/internal/gatewayapi/testdata/accesslog-als-grpc.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/accesslog-types.out.yaml
+++ b/internal/gatewayapi/testdata/accesslog-types.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/accesslog.out.yaml
+++ b/internal/gatewayapi/testdata/accesslog.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backend-invalid-feature-disabled.out.yaml
+++ b/internal/gatewayapi/testdata/backend-invalid-feature-disabled.out.yaml
@@ -88,6 +88,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backend-tls-settings-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/backend-tls-settings-invalid.out.yaml
@@ -111,6 +111,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backend-tls-settings.out.yaml
+++ b/internal/gatewayapi/testdata/backend-tls-settings.out.yaml
@@ -291,6 +291,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backend-with-auto-san-sni.out.yaml
+++ b/internal/gatewayapi/testdata/backend-with-auto-san-sni.out.yaml
@@ -166,6 +166,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backend-with-endpoint-zones.out.yaml
+++ b/internal/gatewayapi/testdata/backend-with-endpoint-zones.out.yaml
@@ -69,6 +69,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backend-with-fallback.out.yaml
+++ b/internal/gatewayapi/testdata/backend-with-fallback.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backend-with-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/backend-with-hostname.out.yaml
@@ -70,6 +70,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backend-with-skip-tls-verify.out.yaml
+++ b/internal/gatewayapi/testdata/backend-with-skip-tls-verify.out.yaml
@@ -87,6 +87,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-across-ns.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-across-ns.out.yaml
@@ -53,6 +53,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-ca-clustertrustbundle.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-ca-clustertrustbundle.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-ca-only-secret.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-ca-only-secret.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-ca-only.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-ca-only.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-conflict.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-conflict.out.yaml
@@ -106,6 +106,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-default-ns-targetrefs.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-default-ns-targetrefs.out.yaml
@@ -105,6 +105,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -144,6 +149,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-default-ns.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-default-ns.out.yaml
@@ -156,6 +156,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-invalid-ca.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-invalid-ca.out.yaml
@@ -105,6 +105,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-multiple-targets.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-multiple-targets.out.yaml
@@ -72,6 +72,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-not-conflict-service.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-not-conflict-service.out.yaml
@@ -102,6 +102,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-not-conflict.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-not-conflict.out.yaml
@@ -103,6 +103,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
@@ -69,6 +69,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-status-conditions-truncated.out.yaml
@@ -563,6 +563,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -602,6 +607,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -641,6 +651,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -680,6 +695,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -719,6 +739,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -758,6 +783,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -797,6 +827,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -836,6 +871,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -875,6 +915,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -914,6 +959,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -953,6 +1003,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -992,6 +1047,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1031,6 +1091,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1070,6 +1135,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1109,6 +1179,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1148,6 +1223,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1187,6 +1267,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1226,6 +1311,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-subjectaltnames.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-subjectaltnames.out.yaml
@@ -73,6 +73,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtlspolicy-system-truststore.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-system-truststore.out.yaml
@@ -65,6 +65,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-buffer-limit-out-of-range-error.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-buffer-limit-out-of-range-error.out.yaml
@@ -100,6 +100,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -139,6 +144,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-buffer-limit-with-invalid-value.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-buffer-limit-with-invalid-value.out.yaml
@@ -100,6 +100,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -139,6 +144,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-buffer-limit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-buffer-limit.out.yaml
@@ -106,6 +106,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -145,6 +150,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compression-json-merge.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compression-json-merge.out.yaml
@@ -111,6 +111,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compression-strategic-merge.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compression-strategic-merge.out.yaml
@@ -187,6 +187,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compression.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compression.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-basic.disable.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-basic.disable.out.yaml
@@ -67,6 +67,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-basic.enable.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-basic.enable.out.yaml
@@ -70,6 +70,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-basic.min-content-length.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-basic.min-content-length.out.yaml
@@ -73,6 +73,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-json-merge-disable-all.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-json-merge-disable-all.out.yaml
@@ -115,6 +115,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-json-merge-enable-only-gzip.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-json-merge-enable-only-gzip.out.yaml
@@ -107,6 +107,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-json-merge-enable-only-zstd.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-json-merge-enable-only-zstd.out.yaml
@@ -107,6 +107,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-json-merge-switch-compression.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-json-merge-switch-compression.out.yaml
@@ -113,6 +113,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-json-merge.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-json-merge.out.yaml
@@ -113,6 +113,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-strategic-merge.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-compressor-strategic-merge.out.yaml
@@ -185,6 +185,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-connect-proxy.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-connect-proxy.out.yaml
@@ -65,6 +65,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-connect-terminate.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-connect-terminate.out.yaml
@@ -67,6 +67,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-dns-lookup-family.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-dns-lookup-family.out.yaml
@@ -159,6 +159,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-http-upgrade-spdy.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-http-upgrade-spdy.out.yaml
@@ -65,6 +65,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-http-upgrade-websocket.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-http-upgrade-websocket.out.yaml
@@ -66,6 +66,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-http2-keepalive.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-http2-keepalive.out.yaml
@@ -69,6 +69,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-invalid-no-section.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-invalid-no-section.out.yaml
@@ -94,6 +94,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-multiple-targets-targetselector.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-multiple-targets-targetselector.out.yaml
@@ -60,6 +60,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-override-replace.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-override-replace.out.yaml
@@ -140,6 +140,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-request-buffer-out-of-range-error.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-request-buffer-out-of-range-error.out.yaml
@@ -66,6 +66,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-request-buffer.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-request-buffer.out.yaml
@@ -96,6 +96,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -135,6 +140,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-section-name-override.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-section-name-override.out.yaml
@@ -191,6 +191,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -214,6 +219,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-section-name-with-not-backendref.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-section-name-with-not-backendref.out.yaml
@@ -59,6 +59,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions-truncated.out.yaml
@@ -768,6 +768,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -807,6 +812,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -846,6 +856,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -885,6 +900,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -924,6 +944,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -963,6 +988,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1002,6 +1032,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1041,6 +1076,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1080,6 +1120,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1119,6 +1164,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1158,6 +1208,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1197,6 +1252,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1236,6 +1296,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1275,6 +1340,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1314,6 +1384,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1353,6 +1428,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1392,6 +1472,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1431,6 +1516,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-status-conditions.out.yaml
@@ -224,6 +224,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -275,6 +280,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -316,6 +326,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -353,6 +368,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-status-fault-injection.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-status-fault-injection.out.yaml
@@ -146,6 +146,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -185,6 +190,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-global-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-global-ratelimit.out.yaml
@@ -163,6 +163,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -202,6 +207,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-local-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-local-ratelimit.out.yaml
@@ -161,6 +161,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -200,6 +205,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-only-gw-rl.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-only-gw-rl.out.yaml
@@ -158,6 +158,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -197,6 +202,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-only-httproute-rl.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-only-httproute-rl.out.yaml
@@ -158,6 +158,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -197,6 +202,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-section.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-section.out.yaml
@@ -307,6 +307,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -330,6 +335,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-with-multi-parents.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge-with-multi-parents.out.yaml
@@ -137,6 +137,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -176,6 +181,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-strategic-merge.out.yaml
@@ -157,6 +157,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-tracing.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-tracing.out.yaml
@@ -87,6 +87,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-use-client-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-use-client-protocol.out.yaml
@@ -63,6 +63,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-circuitbreakers-error.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-circuitbreakers-error.out.yaml
@@ -128,6 +128,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -167,6 +172,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-circuitbreakers.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-circuitbreakers.out.yaml
@@ -108,6 +108,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -147,6 +152,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-dns-settings.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-dns-settings.out.yaml
@@ -131,6 +131,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -170,6 +175,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer-multiple-mixed.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer-multiple-mixed.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer-single-header.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer-single-header.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-endpointoverride-loadbalancer.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-envoyproxy-endpoint-btp-service.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-envoyproxy-endpoint-btp-service.out.yaml
@@ -63,6 +63,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-envoyproxy-service-mixed-btp.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-envoyproxy-service-mixed-btp.out.yaml
@@ -63,6 +63,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-healthcheck-overrides.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-healthcheck-overrides.out.yaml
@@ -195,6 +195,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-healthcheck.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-healthcheck.out.yaml
@@ -432,6 +432,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -471,6 +476,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-http2.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-http2.out.yaml
@@ -102,6 +102,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -141,6 +146,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-httproute-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-httproute-timeout.out.yaml
@@ -106,6 +106,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-loadbalancer-invalid-consistent-hash-table-size.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-loadbalancer-invalid-consistent-hash-table-size.out.yaml
@@ -103,6 +103,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-loadbalancer-remove-headers.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-loadbalancer-remove-headers.out.yaml
@@ -62,6 +62,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-loadbalancer.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-loadbalancer.out.yaml
@@ -292,6 +292,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -331,6 +336,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-default-route-level-limit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-default-route-level-limit.out.yaml
@@ -86,6 +86,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-distinct-match-type.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-distinct-match-type.out.yaml
@@ -86,6 +86,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-invalid-limit-unit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-invalid-limit-unit.out.yaml
@@ -90,6 +90,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-invalid-multiple-route-level-limits.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-invalid-multiple-route-level-limits.out.yaml
@@ -93,6 +93,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-shadowmode.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit-shadowmode.out.yaml
@@ -91,6 +91,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-local-ratelimit.out.yaml
@@ -89,6 +89,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-panic-threshold.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-panic-threshold.out.yaml
@@ -128,6 +128,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -167,6 +172,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-preconnect.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-preconnect.out.yaml
@@ -100,6 +100,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -139,6 +144,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-proxyprotocol.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-proxyprotocol.out.yaml
@@ -96,6 +96,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -135,6 +140,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit-both-type.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit-both-type.out.yaml
@@ -84,6 +84,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit-invalid-distinct-invert.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit-invalid-distinct-invert.out.yaml
@@ -75,6 +75,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit-invalid-regex.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit-invalid-regex.out.yaml
@@ -77,6 +77,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit.out.yaml
@@ -179,6 +179,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -218,6 +223,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -257,6 +267,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-response-override-invalid-valueref.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-response-override-invalid-valueref.out.yaml
@@ -145,6 +145,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -184,6 +189,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-response-override-merged-diff-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-response-override-merged-diff-namespace.out.yaml
@@ -124,6 +124,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-response-override.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-response-override.out.yaml
@@ -231,6 +231,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -270,6 +275,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-retries.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-retries.out.yaml
@@ -187,6 +187,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -226,6 +231,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-endpoint.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-endpoint.out.yaml
@@ -63,6 +63,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-full-priority.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-full-priority.out.yaml
@@ -176,6 +176,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-gateway.out.yaml
@@ -63,6 +63,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-listener.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-listener.out.yaml
@@ -111,6 +111,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-override.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-override.out.yaml
@@ -99,6 +99,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-rule-override.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-rule-override.out.yaml
@@ -100,6 +100,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-selector.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-selector.out.yaml
@@ -59,6 +59,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-service.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-routing-type-service.out.yaml
@@ -63,6 +63,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-same-prefix-httproutes.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-same-prefix-httproutes.out.yaml
@@ -67,6 +67,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-shared-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-shared-ratelimit.out.yaml
@@ -129,6 +129,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -168,6 +173,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-stats.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-stats.out.yaml
@@ -137,6 +137,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -176,6 +181,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-gateway.out.yaml
@@ -116,6 +116,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: foo
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -137,6 +142,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: bar
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-route.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcp-udp-listeners-apply-on-route.out.yaml
@@ -193,6 +193,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: foo
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -214,6 +219,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: bar
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcpkeepalive.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-tcpkeepalive.out.yaml
@@ -100,6 +100,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -139,6 +144,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-timeout-error.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-timeout-error.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-timeout-targetrefs.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-timeout-targetrefs.out.yaml
@@ -79,6 +79,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -118,6 +123,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-timeout.out.yaml
@@ -109,6 +109,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -148,6 +153,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-weighted-zones.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-weighted-zones.out.yaml
@@ -73,6 +73,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit-with-format-error.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit-with-format-error.out.yaml
@@ -103,6 +103,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -126,6 +131,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit-with-out-of-range-error.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit-with-out-of-range-error.out.yaml
@@ -104,6 +104,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -127,6 +132,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-buffer-limit.out.yaml
@@ -109,6 +109,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -132,6 +137,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-client-ip-detection.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-client-ip-detection.out.yaml
@@ -140,6 +140,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -163,6 +168,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -186,6 +196,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -209,6 +224,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-4
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-connection-limit-error.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-connection-limit-error.out.yaml
@@ -105,6 +105,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -128,6 +133,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-connection-limit.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-connection-limit.out.yaml
@@ -179,6 +179,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -202,6 +207,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -225,6 +235,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-connection-max-accept-per-socket-event.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-connection-max-accept-per-socket-event.out.yaml
@@ -137,6 +137,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -160,6 +165,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -183,6 +193,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-for-tcp-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-for-tcp-listeners.out.yaml
@@ -99,6 +99,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -122,6 +127,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-grpc-web-filter-disable.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-grpc-web-filter-disable.out.yaml
@@ -59,6 +59,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-grpc-web-filter.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-grpc-web-filter.out.yaml
@@ -59,6 +59,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-headers-add-if-absent.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-headers-add-if-absent.out.yaml
@@ -79,6 +79,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-headers-error.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-headers-error.out.yaml
@@ -130,6 +130,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-headers.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-headers.out.yaml
@@ -122,6 +122,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -145,6 +150,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-http-health-check.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-http-health-check.out.yaml
@@ -64,6 +64,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-http10.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-http10.out.yaml
@@ -204,6 +204,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -227,6 +232,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -250,6 +260,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -273,6 +288,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-4
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -296,6 +316,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-5
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-http2-keepalive.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-http2-keepalive.out.yaml
@@ -65,6 +65,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-http2.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-http2.out.yaml
@@ -103,6 +103,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -126,6 +131,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-http3.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-http3.out.yaml
@@ -91,6 +91,11 @@ gateways:
         status: "True"
         type: ResolvedRefs
       - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: null
         message: The hostname *.example.com overlaps with the hostname bar.example.com
           in listener https-bar. ALPN will default to HTTP/1.1 to prevent HTTP/2 connection
           coalescing, unless explicitly configured via ClientTrafficPolicy
@@ -121,6 +126,11 @@ gateways:
         status: "True"
         type: ResolvedRefs
       - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: null
         message: The hostname foo.example.com overlaps with the hostname *.example.com
           in listener https-wildcard. ALPN will default to HTTP/1.1 to prevent HTTP/2
           connection coalescing, unless explicitly configured via ClientTrafficPolicy
@@ -150,6 +160,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       - lastTransitionTime: null
         message: The hostname bar.example.com overlaps with the hostname *.example.com
           in listener https-wildcard. ALPN will default to HTTP/1.1 to prevent HTTP/2

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-idle-timeout-with-error.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-idle-timeout-with-error.out.yaml
@@ -65,6 +65,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-idle-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-idle-timeout.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -91,6 +96,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-invalid-settings.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-invalid-settings.out.yaml
@@ -254,6 +254,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -277,6 +282,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -300,6 +310,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -323,6 +338,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -388,6 +408,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -411,6 +436,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -434,6 +464,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -457,6 +492,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -522,6 +562,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -545,6 +590,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -568,6 +618,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -591,6 +646,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -633,6 +693,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -677,6 +742,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-cert-bundle-both-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-cert-bundle-both-invalid.out.yaml
@@ -75,6 +75,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-cert-bundle-both-valid.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-cert-bundle-both-valid.out.yaml
@@ -73,6 +73,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-cert-bundle.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-cert-bundle.out.yaml
@@ -73,6 +73,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-client-verification-expired-crl.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-client-verification-expired-crl.out.yaml
@@ -221,6 +221,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -244,6 +249,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -288,6 +298,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -343,6 +358,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -366,6 +386,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-client-verification.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-client-verification.out.yaml
@@ -303,6 +303,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -326,6 +331,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -370,6 +380,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -425,6 +440,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -448,6 +468,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -492,6 +517,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -536,6 +566,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -580,6 +615,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-clustertrustbundle.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-clustertrustbundle.out.yaml
@@ -245,6 +245,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -268,6 +273,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -312,6 +322,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -356,6 +371,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -400,6 +420,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -444,6 +469,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert-custom-data.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert-custom-data.out.yaml
@@ -249,6 +249,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -272,6 +277,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -316,6 +326,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -360,6 +375,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -404,6 +424,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -448,6 +473,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls-forward-client-cert.out.yaml
@@ -236,6 +236,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -259,6 +264,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -303,6 +313,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -347,6 +362,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -391,6 +411,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -435,6 +460,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-mtls.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-mtls.out.yaml
@@ -113,6 +113,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -136,6 +141,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -180,6 +190,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-path-settings.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-path-settings.out.yaml
@@ -71,6 +71,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -94,6 +99,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-preserve-case-multiple-targets.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-preserve-case-multiple-targets.out.yaml
@@ -77,6 +77,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -122,6 +127,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -145,6 +155,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-preserve-case.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-preserve-case.out.yaml
@@ -71,6 +71,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -94,6 +99,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-proxyprotocol-legacy-mixed.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-proxyprotocol-legacy-mixed.out.yaml
@@ -128,6 +128,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -167,6 +172,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -204,6 +214,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-proxyprotocol.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-proxyprotocol.out.yaml
@@ -67,6 +67,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -90,6 +95,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-ratelimitheaders.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-ratelimitheaders.out.yaml
@@ -71,6 +71,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -94,6 +99,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-scheme.out.yaml
@@ -63,6 +63,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions-truncated.out.yaml
@@ -571,6 +571,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -610,6 +615,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -649,6 +659,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -688,6 +703,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -727,6 +747,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -766,6 +791,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -805,6 +835,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -844,6 +879,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -883,6 +923,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -922,6 +967,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -961,6 +1011,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1000,6 +1055,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1039,6 +1099,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1078,6 +1143,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1117,6 +1187,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1156,6 +1231,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1195,6 +1275,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1234,6 +1319,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-status-conditions.out.yaml
@@ -251,6 +251,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -302,6 +307,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -343,6 +353,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -380,6 +395,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: bar-foo
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -419,6 +439,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-stream-idle-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-stream-idle-timeout.out.yaml
@@ -69,6 +69,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -92,6 +97,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-tcp-keepalive.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-tcp-keepalive.out.yaml
@@ -105,6 +105,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -128,6 +133,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-timeout-with-error.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-timeout-with-error.out.yaml
@@ -65,6 +65,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-timeout.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -91,6 +96,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-tls-invalid-cipher.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-tls-invalid-cipher.out.yaml
@@ -70,6 +70,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: https
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-tls-settings.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-tls-settings.out.yaml
@@ -148,6 +148,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -171,6 +176,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -215,6 +225,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -259,6 +274,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-trailers.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-trailers.out.yaml
@@ -70,6 +70,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -93,6 +98,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/conflicting-policies.out.yaml
+++ b/internal/gatewayapi/testdata/conflicting-policies.out.yaml
@@ -67,6 +67,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -104,6 +109,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/custom-filter-order.out.yaml
+++ b/internal/gatewayapi/testdata/custom-filter-order.out.yaml
@@ -83,6 +83,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/disable-accesslog.out.yaml
+++ b/internal/gatewayapi/testdata/disable-accesslog.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-failopen.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-failopen.out.yaml
@@ -296,6 +296,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-invalid-cross-ns-ref.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-invalid-cross-ns-ref.out.yaml
@@ -49,6 +49,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-invalid-no-section.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-invalid-no-section.out.yaml
@@ -94,6 +94,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-lua-feature-disabled.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-lua-feature-disabled.out.yaml
@@ -149,6 +149,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-override-replace.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-override-replace.out.yaml
@@ -136,6 +136,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-section-name-override.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-section-name-override.out.yaml
@@ -194,6 +194,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -217,6 +222,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions-truncated.out.yaml
@@ -768,6 +768,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -807,6 +812,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -846,6 +856,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -885,6 +900,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -924,6 +944,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -963,6 +988,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1002,6 +1032,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1041,6 +1076,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1080,6 +1120,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1119,6 +1164,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1158,6 +1208,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1197,6 +1252,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1236,6 +1296,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1275,6 +1340,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1314,6 +1384,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1353,6 +1428,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1392,6 +1472,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -1431,6 +1516,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-status-conditions.out.yaml
@@ -224,6 +224,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -275,6 +280,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -316,6 +326,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -353,6 +368,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-dynamicmodule.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-dynamicmodule.out.yaml
@@ -119,6 +119,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-matching-port.out.yaml
@@ -66,6 +66,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-port.out.yaml
@@ -66,6 +66,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-reference-grant.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-reference-grant.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-invalid-no-service.out.yaml
@@ -190,6 +190,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-backendtlspolicy.out.yaml
@@ -201,6 +201,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-mixed-backendrefs.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-mixed-backendrefs.out.yaml
@@ -108,6 +108,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-multiple-backendrefs.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-multiple-backendrefs.out.yaml
@@ -186,6 +186,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-retries.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-retries.out.yaml
@@ -226,6 +226,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-traffic-features.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-extproc-with-traffic-features.out.yaml
@@ -213,6 +213,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-invalid-dynamicmodule.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-invalid-dynamicmodule.out.yaml
@@ -73,6 +73,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-invalid-lua-validation-disabled.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-invalid-lua-validation-disabled.out.yaml
@@ -72,6 +72,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-invalid-lua-validation-syntax.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-invalid-lua-validation-syntax.out.yaml
@@ -125,6 +125,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-invalid-lua.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-invalid-lua.out.yaml
@@ -125,6 +125,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-lua-configmap.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-lua-configmap.out.yaml
@@ -184,6 +184,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-lua.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-lua.out.yaml
@@ -113,6 +113,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-wasm-env-vars.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-wasm-env-vars.out.yaml
@@ -139,6 +139,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-wasm-invalid-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-wasm-invalid-configuration.out.yaml
@@ -295,6 +295,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -334,6 +339,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -373,6 +383,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-wasm-targetrefs.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-wasm-targetrefs.out.yaml
@@ -100,6 +100,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyextensionpolicy-with-wasm.out.yaml
+++ b/internal/gatewayapi/testdata/envoyextensionpolicy-with-wasm.out.yaml
@@ -141,6 +141,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoypatchpolicy-cross-ns-target.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-cross-ns-target.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoypatchpolicy-invalid-feature-disabled.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-invalid-feature-disabled.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoypatchpolicy-invalid-merge-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-invalid-merge-gateways.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoypatchpolicy-invalid-target-kind-merge-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-invalid-target-kind-merge-gateways.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoypatchpolicy-invalid-target-kind.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-invalid-target-kind.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoypatchpolicy-invalid-target-name.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-invalid-target-name.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoypatchpolicy-valid-merge-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-valid-merge-gateways.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoypatchpolicy-valid.out.yaml
+++ b/internal/gatewayapi/testdata/envoypatchpolicy-valid.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-als-json.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-als-json.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-backend-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-backend-invalid.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-backend.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-backend.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-cel-with-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-cel-with-invalid.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-cel.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-cel.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json-no-format.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json-no-format.out.yaml
@@ -17,6 +17,11 @@ gatewayClass:
       reason: Accepted
       status: "True"
       type: Accepted
+    - lastTransitionTime: null
+      message: Gateway API CRD versions are supported
+      reason: SupportedVersion
+      status: "True"
+      type: SupportedVersion
 gateways:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: Gateway
@@ -51,6 +56,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-file-json.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-otel-notype.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-otel-notype.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-otel-text-attrs.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-otel-text-attrs.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-types.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-types.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-with-bad-sinks.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-with-bad-sinks.out.yaml
@@ -19,6 +19,11 @@ gatewayClass:
       reason: InvalidParameters
       status: "False"
       type: Accepted
+    - lastTransitionTime: null
+      message: Gateway API CRD versions are supported
+      reason: SupportedVersion
+      status: "True"
+      type: SupportedVersion
 gateways:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: Gateway

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-with-traffic.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-with-traffic.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-without-format.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-without-format.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-endpoint-routing-for-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-endpoint-routing-for-gateway.out.yaml
@@ -37,6 +37,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-endpoint-routing.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-endpoint-routing.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-for-gatewayclass.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-for-gatewayclass.out.yaml
@@ -19,6 +19,11 @@ gatewayClass:
       reason: InvalidParameters
       status: "False"
       type: Accepted
+    - lastTransitionTime: null
+      message: Gateway API CRD versions are supported
+      reason: SupportedVersion
+      status: "True"
+      type: SupportedVersion
 gateways:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: Gateway
@@ -58,6 +63,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-metric-backend-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-metric-backend-invalid.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-metric-backend.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-metric-backend.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-metric-enabled-backend.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-metric-enabled-backend.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-otel-backend-custom-ca.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-otel-backend-custom-ca.out.yaml
@@ -55,6 +55,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-otel-backend-tls.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-otel-backend-tls.out.yaml
@@ -52,6 +52,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-preserve-route-order.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-preserve-route-order.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-preserve-order
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-priority-backend.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-priority-backend.out.yaml
@@ -187,6 +187,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-service-routing-for-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-service-routing-for-gateway.out.yaml
@@ -37,6 +37,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-service-routing.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-service-routing.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid-ns.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid-ns.out.yaml
@@ -77,6 +77,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: ""
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -100,6 +105,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: ""
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tls-settings-invalid.out.yaml
@@ -77,6 +77,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: ""
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -100,6 +105,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: ""
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-tls-settings.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tls-settings.out.yaml
@@ -77,6 +77,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: ""
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -100,6 +105,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: ""
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-tracing-backend-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tracing-backend-invalid.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-tracing-backend-uds.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tracing-backend-uds.out.yaml
@@ -50,6 +50,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-tracing-backend.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tracing-backend.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-valid.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-valid.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/envoyproxy-with-statname.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-with-statname.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/extensionpolicy-tcp-listener.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/extensionpolicy-tcp-listener.out.yaml
@@ -91,6 +91,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -112,6 +117,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/extensionpolicy-udp-listener.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/extensionpolicy-udp-listener.out.yaml
@@ -91,6 +91,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -112,6 +117,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/extensionpolicy-with-invalid-target.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/extensionpolicy-with-invalid-target.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -61,6 +66,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/extensionpolicy-with-valid-target-array.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/extensionpolicy-with-valid-target-array.out.yaml
@@ -73,6 +73,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -112,6 +117,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/extensionpolicy-with-valid-target.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/extensionpolicy-with-valid-target.out.yaml
@@ -91,6 +91,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -114,6 +119,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/grpcroute-with-valid-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/grpcroute-with-valid-extension-filter.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-invalid-apiversion.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-invalid-apiversion.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-invalid-group.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-invalid-group.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-invalid.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-mixed-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-mixed-multiple.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-mixed.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-mixed.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-multiple.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-not-found.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend-not-found.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-custom-backend.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/httproute-with-non-matching-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-non-matching-extension-filter.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/httproute-with-unsupported-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-unsupported-extension-filter.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
+++ b/internal/gatewayapi/testdata/extensions/httproute-with-valid-extension-filter.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-allowed-httproute.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-allows-same-namespace-with-disallowed-httproute.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-http-listener-with-hostname-intersection.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-http-listener-with-hostname-intersection.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: empty-hostname
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -62,6 +67,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: wildcard-example-com
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-infrastructure.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-infrastructure.out.yaml
@@ -43,6 +43,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: https
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-namespace-mode-infra-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-namespace-mode-infra-httproute.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -110,6 +120,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-addresses-with-ipaddress.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-addresses-with-ipaddress.out.yaml
@@ -36,6 +36,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-attached-routes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-attached-routes.out.yaml
@@ -34,6 +34,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - kind: HTTPRoute
@@ -73,6 +78,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - kind: HTTPRoute

--- a/internal/gatewayapi/testdata/gateway-with-infrastructure-parametersref.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-infrastructure-parametersref.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-invalid-infrastructure-parametersref-does-not-exist.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-invalid-infrastructure-parametersref-does-not-exist.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-invalid-infrastructure-parametersref-fallback.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-invalid-infrastructure-parametersref-fallback.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-mismatch-port-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-mismatch-port-protocol.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-backends.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-backends.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tcproute-with-multiple-rules.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-configuration-sni-san-mismatch-allowed.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-configuration-sni-san-mismatch-allowed.out.yaml
@@ -37,6 +37,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-secret-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -37,6 +37,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
@@ -46,6 +46,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls-passthrough
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -67,6 +72,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls-terminate
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-tls-fingerprint.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-tls-fingerprint.out.yaml
@@ -80,6 +80,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls-passthrough
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -101,6 +106,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls-terminate
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-mismatch-port-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-mismatch-port-protocol.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-backends.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-backends.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-udproute-with-multiple-rules.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-tcproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-tcproute.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-udproute.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-unmatched-udproute.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration-with-same-algorithm-different-fqdn.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration-with-same-algorithm-different-fqdn.out.yaml
@@ -37,6 +37,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-multiple-tls-configuration.out.yaml
@@ -37,6 +37,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-valid-tls-configuration.out.yaml
@@ -36,6 +36,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-certs.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-certs.out.yaml
@@ -60,6 +60,11 @@ gateways:
         status: "True"
         type: ResolvedRefs
       - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: null
         message: The certificate SAN *.example.com overlaps with the certificate SAN
           bar.example.com in listener https-2. ALPN will default to HTTP/1.1 to prevent
           HTTP/2 connection coalescing, unless explicitly configured via ClientTrafficPolicy
@@ -90,6 +95,11 @@ gateways:
         status: "True"
         type: ResolvedRefs
       - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: null
         message: The certificate SAN bar.example.com overlaps with the certificate
           SAN *.example.com in listener https-1. ALPN will default to HTTP/1.1 to
           prevent HTTP/2 connection coalescing, unless explicitly configured via ClientTrafficPolicy
@@ -119,6 +129,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: https-3
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames-and-certs-merged-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames-and-certs-merged-gateways.out.yaml
@@ -38,6 +38,11 @@ gateways:
         status: "True"
         type: ResolvedRefs
       - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: null
         message: The certificate SAN *.example.com overlaps with the certificate SAN
           bar.example.com in listener https-1 of gateway gateway-2. ALPN will default
           to HTTP/1.1 to prevent HTTP/2 connection coalescing, unless explicitly configured
@@ -89,6 +94,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       - lastTransitionTime: null
         message: The certificate SAN bar.example.com overlaps with the certificate
           SAN *.example.com in listener https-1 of gateway gateway-1. ALPN will default

--- a/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames-and-certs.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames-and-certs.out.yaml
@@ -49,6 +49,11 @@ gateways:
         status: "True"
         type: ResolvedRefs
       - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: null
         message: The certificate SAN *.example.com overlaps with the certificate SAN
           bar.example.com in listener https-2. ALPN will default to HTTP/1.1 to prevent
           HTTP/2 connection coalescing, unless explicitly configured via ClientTrafficPolicy
@@ -78,6 +83,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       - lastTransitionTime: null
         message: The certificate SAN bar.example.com overlaps with the certificate
           SAN *.example.com in listener https-1. ALPN will default to HTTP/1.1 to

--- a/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames-merged-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames-merged-gateways.out.yaml
@@ -38,6 +38,11 @@ gateways:
         status: "True"
         type: ResolvedRefs
       - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: null
         message: The hostname foo.example.com overlaps with the hostname *.example.com
           in listener https-1 of gateway gateway-2. ALPN will default to HTTP/1.1
           to prevent HTTP/2 connection coalescing, unless explicitly configured via
@@ -101,6 +106,11 @@ gateways:
         status: "True"
         type: ResolvedRefs
       - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: null
         message: The hostname *.example.com overlaps with the hostname foo.example.com
           in listener https-1 of gateway gateway-1. ALPN will default to HTTP/1.1
           to prevent HTTP/2 connection coalescing, unless explicitly configured via
@@ -131,6 +141,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: https-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames.out.yaml
@@ -60,6 +60,11 @@ gateways:
         status: "True"
         type: ResolvedRefs
       - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: null
         message: The hostname foo.example.com overlaps with the hostname *.example.com
           in listener https-2. ALPN will default to HTTP/1.1 to prevent HTTP/2 connection
           coalescing, unless explicitly configured via ClientTrafficPolicy
@@ -90,6 +95,11 @@ gateways:
         status: "True"
         type: ResolvedRefs
       - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: null
         message: The hostname *.example.com overlaps with the hostname foo.example.com
           in listener https-1. ALPN will default to HTTP/1.1 to prevent HTTP/2 connection
           coalescing, unless explicitly configured via ClientTrafficPolicy
@@ -119,6 +129,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: https-3
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-preexisting-status-condition.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-preexisting-status-condition.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-udproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-udproutes.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-stale-status-condition.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-stale-status-condition.out.yaml
@@ -36,6 +36,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: https
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-or-tls-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-tcp-or-tls-port.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-udp-port.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-on-same-udp-port.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-multiple-httproutes.out.yaml
@@ -40,6 +40,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -63,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-tcp-protocol.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -62,6 +67,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-same-port-http-udp-protocol.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -62,6 +67,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-with-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-with-sectionname.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -59,6 +64,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -59,6 +64,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-with-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-with-sectionname.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -59,6 +64,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-without-sectionname.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -59,6 +64,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-mixed-with-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-mixed-with-httproute.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-with-backend.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-backend.out.yaml
@@ -50,6 +50,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-with-conflicting-filters.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-conflicting-filters.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-with-empty-backends.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-empty-backends.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-with-header-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-header-match.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-with-method-and-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-method-and-service-match.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-with-method-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-method-match.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-with-mirror.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-mirror.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-with-mixed-invalid-and-valid-backend-refs.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-mixed-invalid-and-valid-backend-refs.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-with-mixed-invalid-and-valid-rules.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-mixed-invalid-and-valid-rules.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-with-request-header-modifier.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-request-header-modifier.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
+++ b/internal/gatewayapi/testdata/grpcroute-with-service-match.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-and-backendtrafficpolicy-with-timeout-error.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-and-backendtrafficpolicy-with-timeout-error.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-and-backendtrafficpolicy-with-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-and-backendtrafficpolicy-with-timeout.out.yaml
@@ -103,6 +103,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -142,6 +147,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-different-listeners.out.yaml
@@ -82,6 +82,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -105,6 +110,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -128,6 +138,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -151,6 +166,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-4
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -174,6 +194,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-5
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -197,6 +222,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-6
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -220,6 +250,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-7
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -243,6 +278,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-8
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-more-listeners.out.yaml
@@ -82,6 +82,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -105,6 +110,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -128,6 +138,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -151,6 +166,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-4
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -174,6 +194,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-5
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -197,6 +222,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-6
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -220,6 +250,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-7
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -243,6 +278,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-8
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners-with-different-ports.out.yaml
@@ -42,6 +42,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -65,6 +70,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway-with-two-listeners.out.yaml
@@ -40,6 +40,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -63,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-gateway.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-matching-port.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-on-gateway-with-two-listeners.out.yaml
@@ -40,6 +40,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -63,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-and-core-backendrefs.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-and-core-backendrefs.out.yaml
@@ -83,6 +83,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref-host-infra.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref-host-infra.out.yaml
@@ -117,6 +117,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref-mixed-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref-mixed-address-type.out.yaml
@@ -111,6 +111,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-backend-backendref.out.yaml
@@ -119,6 +119,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-backend-backendrefs-diff-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-backend-backendrefs-diff-address-type.out.yaml
@@ -83,6 +83,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-backend-backendrefs-same-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-backend-backendrefs-same-address-type.out.yaml
@@ -133,6 +133,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-serviceimport-backendrefs-diff-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-serviceimport-backendrefs-diff-address-type.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-serviceimport-backendrefs-same-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-multiple-serviceimport-backendrefs-same-address-type.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref-fqdn-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref-fqdn-address-type.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref-mixed-address-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref-mixed-address-type.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener-with-serviceimport-backendref.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-attaching-to-listener.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-backend-request-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-backend-request-timeout.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-default-order-by-creation-date-and-route-name.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-default-order-by-creation-date-and-route-name.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-dynamic-resolver-host-rewriting.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-dynamic-resolver-host-rewriting.out.yaml
@@ -97,6 +97,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-dynamic-resolver-with-mutliple-backends.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-dynamic-resolver-with-mutliple-backends.out.yaml
@@ -64,6 +64,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-dynamic-resolver.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-dynamic-resolver.out.yaml
@@ -70,6 +70,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-filter-match-matrix.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-filter-match-matrix.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-not-attaching-to-listener-non-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-not-attaching-to-listener-non-matching-port.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-order-by-creation-date.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-order-by-creation-date.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-request-timeout.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-request-timeout.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-retry.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-retry.out.yaml
@@ -116,6 +116,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -155,6 +160,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-rule-with-empty-backends-and-no-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-empty-backends-and-no-filters.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-no-weights.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-multiple-backends-and-weights.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-rule-with-non-service-backends-and-app-protocols.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-non-service-backends-and-app-protocols.out.yaml
@@ -71,6 +71,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-rule-with-non-service-backends-and-weights.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-non-service-backends-and-weights.out.yaml
@@ -67,6 +67,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-api-key-auth-duplicated-api-key.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-api-key-auth-duplicated-api-key.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-backendref-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-add-multiple-filters.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-backendref-no-endpoints.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-no-endpoints.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-backendref-serviceimport-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-serviceimport-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-backendref-urlrewrite-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-backendref-urlrewrite-filter.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-conflicting-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-conflicting-filters.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-cors-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-cors-filter.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-credential-injection.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-credential-injection.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-direct-response.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-direct-response.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-empty-matches.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-enable-zone-discovery.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-enable-zone-discovery.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-adds.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-duplicate-removes.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-header-values.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-empty-headers.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-header-values.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-invalid-headers.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-headers.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-no-valid-headers.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-filter-remove.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-match-diff-number.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-match-diff-number.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-match-diff-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-match-diff-type.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-header-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-header-match.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-headless-service-endpoint-routing.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-headless-service-endpoint-routing.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-headless-service-service-routing.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-headless-service-service-routing.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-bad-port.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-group.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-kind.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-mixed-kind.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-invalid-mixed-kind.out.yaml
@@ -50,6 +50,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-port.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.import.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.import.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-no-service.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-unsupported-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backend-ref-unsupported-filter.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-in-other-namespace.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-invalid-regex.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-regex.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-metadata.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-metadata.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-duplicates.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-multiple.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-percentage-mirroring.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-percentage-mirroring.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-no-port.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter-service-not-found.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mirror-filter.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-missing-protocol-backends.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-missing-protocol-backends.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-mixed-invalid-and-valid-backend-refs.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-mixed-invalid-and-valid-backend-refs.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-multi-gateways-notmatch.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-multi-gateways-notmatch.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-multi-gateways-with-same-name.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-multi-gateways-with-same-name.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-multiple-gateways-from-different-ns.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-multiple-gateways-from-different-ns.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: default
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -73,6 +78,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: default
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-multiple-gateways-from-same-ns.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-multiple-gateways-from-same-ns.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: default
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -73,6 +78,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: default
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-multiple-invalid-rules.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-multiple-invalid-rules.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-non-matching-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-query-match-diff-number.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-query-match-diff-number.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-query-match-diff-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-query-match-diff-type.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-full-path-replace-https.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-hostname.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-filter-type.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-scheme.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-invalid-status.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-redirect-filter-prefix-replace-with-port-http.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-adds.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-add-multiple-filters.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-adds.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-remove-multiple-filters.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-duplicate-removes.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-header-values.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-empty-headers.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-invalid-header-values.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-invalid-header-values.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-invalid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-invalid-headers.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-headers.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-valid-headers.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-no-valid-headers.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-response-header-filter-remove.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-exact-path-match.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-http-method-match.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-multiple-rules.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-single-rule-with-path-prefix-and-exact-header-matches.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-some-invalid-backend-refs-no-service.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-specific-hostname-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-tls-and-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-tls-and-http.out.yaml
@@ -91,6 +91,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-two-specific-hostnames-attaching-to-gateway-with-wildcard-hostname.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-full-path-replace-http.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname-prefix-replace.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-hostname.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-filter-type.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-hostname.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-multiple-filters.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-multiple-filters.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path-type.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path-type.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-invalid-path.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-missing-path.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-missing-path.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-prefix-replace-http.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-regex-match-replace-http.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-regex-match-replace-http.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-regex-match-replace-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-filter-regex-match-replace-invalid.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-hostname-filter-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-hostname-filter-invalid.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-urlrewrite-hostname-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-urlrewrite-hostname-filter.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-wildcard-hostname-attaching-to-gateway-with-unset-hostname.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
+++ b/internal/gatewayapi/testdata/httproutes-with-multiple-matches.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/listenerset-conflict-listeners.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-conflict-listeners.out.yaml
@@ -45,6 +45,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: core-http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/listenerset-cross-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-cross-namespace.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: core-http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/listenerset-grpcroute.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-grpcroute.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: core-grpc
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/listenerset-httproute.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-httproute.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: core-http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/listenerset-https-tls-misuses-gateway-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-https-tls-misuses-gateway-namespace.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: core-http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/listenerset-https-tls-same-namespace.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-https-tls-same-namespace.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: core-http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/listenerset-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-invalid.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: core-http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/listenerset-no-maching-listener.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-no-maching-listener.out.yaml
@@ -45,6 +45,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: core-http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -68,6 +73,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: conflict-listener
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/listenerset-tcproute.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-tcproute.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: core-http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/listenerset-tlsroute.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-tlsroute.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: core-http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/listenerset-udproute.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-udproute.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: core-http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/merge-invalid-multiple-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/merge-invalid-multiple-gateways.out.yaml
@@ -29,6 +29,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -91,6 +96,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/merge-valid-multiple-gateways-multiple-listeners-same-ports.out.yaml
+++ b/internal/gatewayapi/testdata/merge-valid-multiple-gateways-multiple-listeners-same-ports.out.yaml
@@ -36,6 +36,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -59,6 +64,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -102,6 +112,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -125,6 +140,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-4
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/merge-valid-multiple-gateways-multiple-routes.out.yaml
+++ b/internal/gatewayapi/testdata/merge-valid-multiple-gateways-multiple-routes.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -76,6 +81,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -99,6 +109,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/merge-valid-multiple-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/merge-valid-multiple-gateways.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -75,6 +80,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -98,6 +108,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/merge-with-isolated-policies-2.out.yaml
+++ b/internal/gatewayapi/testdata/merge-with-isolated-policies-2.out.yaml
@@ -137,6 +137,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -160,6 +165,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -207,6 +217,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -230,6 +245,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/merge-with-isolated-policies.out.yaml
+++ b/internal/gatewayapi/testdata/merge-with-isolated-policies.out.yaml
@@ -99,6 +99,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -138,6 +143,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/request-id-extension.out.yaml
+++ b/internal/gatewayapi/testdata/request-id-extension.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-invalid-cross-ns-ref.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-invalid-cross-ns-ref.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-invalid-no-section-name-listener.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-invalid-no-section-name-listener.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-invalid-no-section-name-route-rule.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-invalid-no-section-name-route-rule.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-mixed-managed-unmanaged-route-parents.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-mixed-managed-unmanaged-route-parents.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-override-replace.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-override-replace.out.yaml
@@ -40,6 +40,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-1
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -63,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-2
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-status-conditions-route-rule.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-status-conditions-route-rule.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: listener-1
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-status-conditions-truncated.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -110,6 +120,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -149,6 +164,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -188,6 +208,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -227,6 +252,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -266,6 +296,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -305,6 +340,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -344,6 +384,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -383,6 +428,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -422,6 +472,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -461,6 +516,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -500,6 +560,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -539,6 +604,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -578,6 +648,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -617,6 +692,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -656,6 +736,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -695,6 +780,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-status-conditions.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-status-conditions.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -83,6 +88,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -124,6 +134,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip-invalid-no-client-ip-detection.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip-invalid-no-client-ip-detection.out.yaml
@@ -17,6 +17,11 @@ gatewayClass:
       reason: Accepted
       status: "True"
       type: Accepted
+    - lastTransitionTime: null
+      message: Gateway API CRD versions are supported
+      reason: SupportedVersion
+      status: "True"
+      type: SupportedVersion
 gateways:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: Gateway
@@ -51,6 +56,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip-invalid-no-provider.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip-invalid-no-provider.out.yaml
@@ -46,6 +46,11 @@ gatewayClass:
       reason: Accepted
       status: "True"
       type: Accepted
+    - lastTransitionTime: null
+      message: Gateway API CRD versions are supported
+      reason: SupportedVersion
+      status: "True"
+      type: SupportedVersion
 gateways:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: Gateway
@@ -80,6 +85,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip-invalid-trusted-cidrs.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip-invalid-trusted-cidrs.out.yaml
@@ -46,6 +46,11 @@ gatewayClass:
       reason: Accepted
       status: "True"
       type: Accepted
+    - lastTransitionTime: null
+      message: Gateway API CRD versions are supported
+      reason: SupportedVersion
+      status: "True"
+      type: SupportedVersion
 gateways:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: Gateway
@@ -80,6 +85,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip-mixed-valid-invalid-route-target.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip-mixed-valid-invalid-route-target.out.yaml
@@ -48,6 +48,11 @@ gatewayClass:
       reason: Accepted
       status: "True"
       type: Accepted
+    - lastTransitionTime: null
+      message: Gateway API CRD versions are supported
+      reason: SupportedVersion
+      status: "True"
+      type: SupportedVersion
 gateways:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: Gateway
@@ -88,6 +93,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-valid
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -111,6 +121,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-invalid
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip-mixed-valid-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip-mixed-valid-invalid.out.yaml
@@ -48,6 +48,11 @@ gatewayClass:
       reason: Accepted
       status: "True"
       type: Accepted
+    - lastTransitionTime: null
+      message: Gateway API CRD versions are supported
+      reason: SupportedVersion
+      status: "True"
+      type: SupportedVersion
 gateways:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: Gateway
@@ -88,6 +93,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-valid
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -111,6 +121,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-invalid
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-authorization-geoip.out.yaml
@@ -46,6 +46,11 @@ gatewayClass:
       reason: Accepted
       status: "True"
       type: Accepted
+    - lastTransitionTime: null
+      message: Gateway API CRD versions are supported
+      reason: SupportedVersion
+      status: "True"
+      type: SupportedVersion
 gateways:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: Gateway
@@ -80,6 +85,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-authoriztion-client-cidr.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-authoriztion-client-cidr.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-authoriztion-headers-and-methods.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-authoriztion-headers-and-methods.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-authoriztion-jwt-claim.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-authoriztion-jwt-claim.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-basic-auth.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-basic-auth.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors-targetrefs.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors-targetrefs.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -110,6 +120,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -110,6 +120,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-backend.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-backend.out.yaml
@@ -66,6 +66,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-backendref.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-backendref.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-backendrefs.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-backendrefs.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-body.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-body.out.yaml
@@ -50,6 +50,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-matching-port.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-matching-port.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-port.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-port.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-reference-grant.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-reference-grant.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-service.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-service.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -110,6 +120,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-serviceimport-port.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-serviceimport-port.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-serviceimport.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-invalid-no-serviceimport.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-recomputation.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-recomputation.out.yaml
@@ -50,6 +50,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-serviceimport-retry.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-serviceimport-retry.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-serviceimport.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-serviceimport.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-weighted-backendrefs.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-weighted-backendrefs.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth-with-backendtlspolicy.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth-with-backendtlspolicy.out.yaml
@@ -105,6 +105,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-extauth.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-extauth.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-and-invalid-oidc.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-and-invalid-oidc.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-backendcluster.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-backendcluster.out.yaml
@@ -86,6 +86,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-backendsettings.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-backendsettings.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-local-jwks.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-local-jwks.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-optional.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-optional.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-serviceimport.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-serviceimport.out.yaml
@@ -69,6 +69,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt-with-custom-extractor.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt-with-custom-extractor.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-jwt.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-jwt.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-merge-jwt-cors.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-merge-jwt-cors.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-merge-multi-gateway-same-listener.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-merge-multi-gateway-same-listener.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-merge-multi-listener.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-merge-multi-listener.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-a
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -61,6 +66,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-b
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-merge-tcp-invalid.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-merge-tcp-invalid.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-merge.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-merge.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-and-jwt-passthrough.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-and-jwt-passthrough.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-backendcluster.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-backendcluster.out.yaml
@@ -86,6 +86,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-backendrefs.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-backendrefs.out.yaml
@@ -67,6 +67,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-backendsettings.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-backendsettings.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-custom-cookies-samesite.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-custom-cookies-samesite.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-custom-cookies.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-custom-cookies.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-deny-redirect.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-deny-redirect.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-issuer.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-secretref.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-invalid-secretref.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -110,6 +120,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc-serviceimport.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc-serviceimport.out.yaml
@@ -69,6 +69,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/securitypolicy-with-oidc.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-oidc.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tcproute-attaching-to-gateway-with-listener-tls-terminate.out.yaml
+++ b/internal/gatewayapi/testdata/tcproute-attaching-to-gateway-with-listener-tls-terminate.out.yaml
@@ -51,6 +51,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -74,6 +79,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls-hostname
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tcproute-rule-with-multiple-backends-and-zero-weights.out.yaml
+++ b/internal/gatewayapi/testdata/tcproute-rule-with-multiple-backends-and-zero-weights.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tcproute-securitypolicy-with-authorization-client-cidr.out.yaml
+++ b/internal/gatewayapi/testdata/tcproute-securitypolicy-with-authorization-client-cidr.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: foo
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -59,6 +64,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: bar
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -102,6 +112,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -125,6 +140,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: foo
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tcproute-with-backend.out.yaml
+++ b/internal/gatewayapi/testdata/tcproute-with-backend.out.yaml
@@ -50,6 +50,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tcproute-with-backendtlspolicy.out.yaml
+++ b/internal/gatewayapi/testdata/tcproute-with-backendtlspolicy.out.yaml
@@ -68,6 +68,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tcp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
@@ -35,6 +35,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-hostname-intersection.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-hostname-intersection.out.yaml
@@ -35,6 +35,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -75,6 +80,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-invalid-no-matching-listener.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-invalid-no-matching-listener.out.yaml
@@ -34,6 +34,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls-passthrough
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -71,6 +76,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -150,6 +160,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: https
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -194,6 +209,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - kind: TLSRoute
@@ -236,6 +256,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-invalid-reference-grant.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-invalid-reference-grant.out.yaml
@@ -37,6 +37,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: https
       supportedKinds:
       - kind: TLSRoute

--- a/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
@@ -34,6 +34,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-with-backend.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-backend.out.yaml
@@ -53,6 +53,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -35,6 +35,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
@@ -34,6 +34,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
@@ -34,6 +34,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-with-tls-terminate-hostname-match.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-tls-terminate-hostname-match.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-with-tls-terminate-invalid-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-tls-terminate-invalid-hostname.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-with-tls-terminate-multiple-routes.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-tls-terminate-multiple-routes.out.yaml
@@ -39,6 +39,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tlsroute-with-tls-terminate.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-tls-terminate.out.yaml
@@ -38,6 +38,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: tls
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tracing-merged-multiple-routes.out.yaml
+++ b/internal/gatewayapi/testdata/tracing-merged-multiple-routes.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -76,6 +81,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -99,6 +109,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tracing-multiple-routes.out.yaml
+++ b/internal/gatewayapi/testdata/tracing-multiple-routes.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -76,6 +81,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -99,6 +109,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tracing-sampling-fraction.out.yaml
+++ b/internal/gatewayapi/testdata/tracing-sampling-fraction.out.yaml
@@ -33,6 +33,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -76,6 +81,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -99,6 +109,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/tracing-span-name.out.yaml
+++ b/internal/gatewayapi/testdata/tracing-span-name.out.yaml
@@ -64,6 +64,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -107,6 +112,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-2
       supportedKinds:
       - group: gateway.networking.k8s.io
@@ -130,6 +140,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: http-3
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/udproute-rule-with-multiple-backends-and-zero-weights.out.yaml
+++ b/internal/gatewayapi/testdata/udproute-rule-with-multiple-backends-and-zero-weights.out.yaml
@@ -32,6 +32,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/testdata/udproute-with-backend.out.yaml
+++ b/internal/gatewayapi/testdata/udproute-with-backend.out.yaml
@@ -50,6 +50,11 @@ gateways:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
       name: udp
       supportedKinds:
       - group: gateway.networking.k8s.io

--- a/internal/gatewayapi/validate.go
+++ b/internal/gatewayapi/validate.go
@@ -283,10 +283,8 @@ func (t *Translator) validateListenerConditions(listener *ListenerContext) {
 			"Listener has been successfully translated")
 		listener.SetCondition(gwapiv1.ListenerConditionResolvedRefs, metav1.ConditionTrue, gwapiv1.ListenerReasonResolvedRefs,
 			"Listener references have been resolved")
-		if listener.isFromListenerSet() {
-			listener.SetCondition(gwapiv1.ListenerConditionConflicted, metav1.ConditionFalse, gwapiv1.ListenerReasonNoConflicts,
-				"No conflicts detected")
-		}
+		listener.SetCondition(gwapiv1.ListenerConditionConflicted, metav1.ConditionFalse, gwapiv1.ListenerReasonNoConflicts,
+			"No conflicts detected")
 		return
 	}
 

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -59,6 +59,7 @@ bug fixes: |
   Fixed BackendTrafficPolicy `requestBuffer` coexisting with route upgrades by disabling the default WebSocket upgrade on buffered routes and rejecting explicit `requestBuffer` + `httpUpgrade` combinations.
   Fixed per-endpoint hostname override not working because the auto-generated wildcard hostname.
   Fixed Basic Authentication failing when htpasswd secrets use CRLF line endings by normalizing to LF before passing to Envoy.
+  Fixed Gateway listeners missing the Conflicted condition when no conflict exists, and GatewayClass missing the SupportedVersion condition.
 
 
 # Enhancements that improve performance.


### PR DESCRIPTION
**What type of PR is this?**

fix

**What this PR does / why we need it**:

Gateway listeners were missing the `Conflicted` condition when no conflict existed. In `validate.go`, the `Conflicted: False` condition was only set for ListenerSet-sourced listeners. This change sets it on all listeners when no conflict is detected, aligning with the Gateway API spec which defines `Conflicted` as a standard listener condition.

GatewayClass was also missing the `SupportedVersion` condition in its status. This change adds `SupportedVersion: True` when the GatewayClass is accepted.

Both conditions are part of the Gateway API spec and their absence causes monitoring tools (e.g. Gloo Mesh Platform) to flag healthy resources as unhealthy.

**Changes:**
- `internal/gatewayapi/validate.go`: Removed the `isFromListenerSet()` guard around `Conflicted: False` so it applies to all listeners
- `internal/gatewayapi/status/gatewayclass.go`: Added `SupportedVersion: True` condition when GatewayClass is accepted
- `release-notes/current.yaml`: Added bug fix entry
- Updated all affected test data `.out.yaml` files

**Which issue(s) this PR fixes**:

Fixes #8624

Release Notes: Yes