### PR TITLE
feat(helm): add eg.fullname support for resources names (#8156)

### DIFF
--- a/charts/gateway-helm/README.md
+++ b/charts/gateway-helm/README.md
@@ -33,7 +33,7 @@ Please refer to Helm's [documentation](https://helm.sh/docs) to get started.
 Once Helm has been set up correctly, install the chart from dockerhub:
 
 ``` shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace
 ```
 You can find all helm chart release in [Dockerhub](https://hub.docker.com/r/envoyproxy/gateway-helm/tags)
 
@@ -52,7 +52,7 @@ make kube-deploy TAG=latest
 You can install the eg chart along without Gateway API CRDs and Envoy Gateway CRDs, make sure CRDs exist in Cluster first if you want to skip to install them, otherwise EG may fail to start:
 
 ``` shell
-helm install eg --create-namespace oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --skip-crds
+helm install envoy-gateway --create-namespace oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --skip-crds
 ```
 
 To uninstall the chart:

--- a/charts/gateway-helm/templates/_helpers.tpl
+++ b/charts/gateway-helm/templates/_helpers.tpl
@@ -9,7 +9,7 @@ Allow the release namespace to be overridden.
 Expand the name of the chart.
 */}}
 {{- define "eg.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Values.nameOverride "envoy-gateway" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -21,7 +21,7 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := default .Values.nameOverride "envoy-gateway" }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}

--- a/charts/gateway-helm/templates/certgen-rbac.yaml
+++ b/charts/gateway-helm/templates/certgen-rbac.yaml
@@ -96,7 +96,7 @@ rules:
     resources:
       - mutatingwebhookconfigurations
     resourceNames:
-      - 'envoy-gateway-topology-injector.{{ include "eg.namespace" . }}'
+      - '{{ include "eg.fullname" . }}-topology-injector.{{ include "eg.namespace" . }}'
     verbs:
       - update
       - patch

--- a/charts/gateway-helm/templates/certgen.yaml
+++ b/charts/gateway-helm/templates/certgen.yaml
@@ -52,7 +52,7 @@ spec:
           value: {{ .Values.kubernetesClusterDomain }}
         image: {{ include "eg.image" . }}
         imagePullPolicy: {{ include "eg.image.pullPolicy" . }}
-        name: envoy-gateway-certgen
+        name: {{ include "eg.fullname" . }}-certgen
         {{- with .Values.certgen.job.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/gateway-helm/templates/envoy-gateway-config.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: envoy-gateway-config
+  name: {{ include "eg.fullname" . }}-config
   namespace: {{ include "eg.namespace" . }}
   labels:
   {{- include "eg.labels" . | nindent 4 }}

--- a/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
@@ -1,14 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: envoy-gateway
+  name: {{ include "eg.fullname" . }}
   namespace: {{ include "eg.namespace" . }}
   {{- with .Values.deployment.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    control-plane: envoy-gateway
+    control-plane: {{ include "eg.fullname" . }}
   {{- include "eg.labels" . | nindent 4 }}
 spec:
 {{- if not .Values.hpa.enabled }}
@@ -16,7 +16,7 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      control-plane: envoy-gateway
+      control-plane: {{ include "eg.fullname" . }}
     {{- include "eg.selectorLabels" . | nindent 6 }}
   template:
     metadata:
@@ -25,7 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        control-plane: envoy-gateway
+        control-plane: {{ include "eg.fullname" . }}
       {{- include "eg.selectorLabels" . | nindent 8 }}
       {{- with .Values.deployment.pod.labels }}
         {{- toYaml . | nindent 8 }}
@@ -67,7 +67,7 @@ spec:
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
-        name: envoy-gateway
+        name: {{ include "eg.fullname" . }}
         ports:
         {{- range .Values.deployment.ports }}
         - containerPort: {{ .port }}
@@ -98,13 +98,13 @@ spec:
       {{- with .Values.deployment.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
-      serviceAccountName: envoy-gateway
+      serviceAccountName: {{ include "eg.fullname" . }}
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:
           defaultMode: 420
-          name: envoy-gateway-config
+          name: {{ include "eg.fullname" . }}-config
         name: envoy-gateway-config
       - name: certs
         secret:
-          secretName: envoy-gateway
+          secretName: {{ include "eg.fullname" . }}

--- a/charts/gateway-helm/templates/envoy-gateway-hpa.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-hpa.yaml
@@ -2,13 +2,13 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: envoy-gateway
+  name: {{ include "eg.fullname" . }}
   namespace: {{ include "eg.namespace" $ }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: envoy-gateway
+    name: {{ include "eg.fullname" . }}
   {{- if .Values.hpa.minReplicas }}
   minReplicas: {{ .Values.hpa.minReplicas }}
   {{- end }}

--- a/charts/gateway-helm/templates/envoy-gateway-poddisruptionbudget.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: envoy-gateway
+  name: {{ include "eg.fullname" . }}
   namespace: {{ include "eg.namespace" . }}
 spec:
   {{- if and .Values.podDisruptionBudget.minAvailable }}
@@ -13,6 +13,6 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      control-plane: envoy-gateway
+      control-plane: {{ include "eg.fullname" . }}
     {{- include "eg.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/gateway-helm/templates/envoy-gateway-rbac.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-rbac.yaml
@@ -32,7 +32,7 @@ roleRef:
   name: {{ include "eg.fullname" $ }}-envoy-gateway-role
 subjects:
 - kind: ServiceAccount
-  name: 'envoy-gateway'
+  name: {{ include "eg.fullname" $ }}
   namespace: {{ include "eg.namespace" $ }}
 {{ end }}
 ---
@@ -54,7 +54,7 @@ roleRef:
   name: {{ include "eg.fullname" . }}-envoy-gateway-role
 subjects:
 - kind: ServiceAccount
-  name: 'envoy-gateway'
+  name: '{{ include "eg.fullname" . }}'
   namespace: {{ include "eg.namespace" . }}
 {{ else }}
 ---
@@ -77,6 +77,6 @@ roleRef:
   name: {{ include "eg.fullname" . }}-envoy-gateway-role
 subjects:
 - kind: ServiceAccount
-  name: 'envoy-gateway'
+  name: '{{ include "eg.fullname" . }}'
   namespace: {{ include "eg.namespace" . }}
 {{ end }}

--- a/charts/gateway-helm/templates/envoy-gateway-service.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-service.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: envoy-gateway
+  name: {{ include "eg.fullname" . }}
   namespace: {{ include "eg.namespace" . }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    control-plane: envoy-gateway
+    control-plane: {{ include "eg.fullname" . }}
   {{- include "eg.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
@@ -16,7 +16,7 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   selector:
-    control-plane: envoy-gateway
+    control-plane: {{ include "eg.fullname" . }}
   {{- include "eg.selectorLabels" . | nindent 4 }}
   ports:
   {{- .Values.deployment.ports | toYaml | nindent 2 -}}

--- a/charts/gateway-helm/templates/envoy-gateway-serviceaccount.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: envoy-gateway
+  name: {{ include "eg.fullname" . }}
   namespace: {{ include "eg.namespace" . }}
   labels:
   {{- include "eg.labels" . | nindent 4 }}

--- a/charts/gateway-helm/templates/envoy-proxy-topology-injector-webhook.yaml
+++ b/charts/gateway-helm/templates/envoy-proxy-topology-injector-webhook.yaml
@@ -17,7 +17,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: 'envoy-gateway-topology-injector.{{ include "eg.namespace" . }}'
+  name: '{{ include "eg.fullname" . }}-topology-injector.{{ include "eg.namespace" . }}'
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-weight": "-1"
@@ -33,7 +33,7 @@ webhooks:
     sideEffects: None
     clientConfig:
       service:
-        name: envoy-gateway
+        name: {{ include "eg.fullname" . }}
         namespace: {{ include "eg.namespace" . }}
         path: "/inject-pod-topology"
         port: 9443

--- a/charts/gateway-helm/templates/infra-manager-rbac.yaml
+++ b/charts/gateway-helm/templates/infra-manager-rbac.yaml
@@ -28,7 +28,7 @@ roleRef:
   name: '{{ include "eg.fullname" $ }}-cluster-infra-manager'
 subjects:
 - kind: ServiceAccount
-  name: 'envoy-gateway'
+  name: {{ include "eg.fullname" $ }}
   namespace: {{ include "eg.namespace" $ }}
 ---
 {{ end }}
@@ -56,5 +56,5 @@ roleRef:
   name: '{{ include "eg.fullname" . }}-infra-manager'
 subjects:
 - kind: ServiceAccount
-  name: 'envoy-gateway'
+  name: '{{ include "eg.fullname" . }}'
   namespace: {{ include "eg.namespace" . }}

--- a/charts/gateway-helm/templates/leader-election-rbac.yaml
+++ b/charts/gateway-helm/templates/leader-election-rbac.yaml
@@ -51,5 +51,5 @@ roleRef:
   name: '{{ include "eg.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: 'envoy-gateway'
+  name: '{{ include "eg.fullname" . }}'
   namespace: {{ include "eg.namespace" . }}

--- a/charts/gateway-helm/templates/namespaced-infra-manager-rbac.yaml
+++ b/charts/gateway-helm/templates/namespaced-infra-manager-rbac.yaml
@@ -24,7 +24,7 @@ roleRef:
   name: '{{ include "eg.fullname" $ }}-infra-manager-tokenreview'
 subjects:
 - kind: ServiceAccount
-  name: 'envoy-gateway'
+  name: {{ include "eg.fullname" $ }}
   namespace: {{ include "eg.namespace" $ }}
 {{ if $kube.watch.namespaces }}
 {{ if gt (len $kube.watch.namespaces) 0 }}
@@ -59,7 +59,7 @@ roleRef:
   name: '{{ include "eg.fullname" $ }}-namespaced-infra-manager'
 subjects:
 - kind: ServiceAccount
-  name: 'envoy-gateway'
+  name: {{ include "eg.fullname" $ }}
   namespace: {{ include "eg.namespace" $ }}
 ---
 {{- end }}

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -1,3 +1,8 @@
+# -- Override the name of the chart
+nameOverride: ""
+# -- Override the full name of resources
+fullnameOverride: ""
+
 # Global settings
 global:
   # If set, these take highest precedence and change both envoyGateway and ratelimit's container registry and pull secrets.

--- a/site/content/en/latest/boilerplates/prerequisites.md
+++ b/site/content/en/latest/boilerplates/prerequisites.md
@@ -10,7 +10,7 @@ proceeding, you should be able to query the example backend using HTTP.
 1. Install the Gateway API CRDs and Envoy Gateway using Helm:
 
    ```shell
-   helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
+   helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
    ```
 
 2. Install the GatewayClass, Gateway, HTTPRoute and example app:

--- a/site/content/en/latest/install/install-helm.md
+++ b/site/content/en/latest/install/install-helm.md
@@ -30,7 +30,7 @@ You can visit [Envoy Gateway Helm Chart](https://hub.docker.com/r/envoyproxy/gat
 Install the Gateway API CRDs and Envoy Gateway:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
 ```
 
 Wait for Envoy Gateway to become available:
@@ -85,7 +85,7 @@ related to large CRDs in the `templates/` directory.
 Once the CRDs are installed, you can install the main Envoy Gateway Helm chart without re-applying CRDs by using the `--skip-crds` flag:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm \
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm \
   --version {{< helm-version >}} \
   -n envoy-gateway-system \
   --create-namespace \
@@ -113,7 +113,7 @@ If you want to know all the available fields inside the values.yaml file, please
 The Backend API is not enabled by default. Enable it via Helm values:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set config.envoyGateway.extensionApis.enableBackend=true
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set config.envoyGateway.extensionApis.enableBackend=true
 ```
 
 Or with a `values.yaml` file:
@@ -128,13 +128,13 @@ config:
 Then install using the file:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace -f values.yaml
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace -f values.yaml
 ```
 
 ### Increase the replicas
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set deployment.replicas=2
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set deployment.replicas=2
 ```
 
 ### Change the kubernetesClusterDomain name
@@ -142,7 +142,7 @@ helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-versi
 If you have installed your cluster with different domain name you can use below command.
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set kubernetesClusterDomain=<domain name>
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set kubernetesClusterDomain=<domain name>
 ```
 
 **Note**: Above are some of the ways we can directly use for customization of our installation. But if you are looking for more complex changes [values.yaml](https://helm.sh/docs/chart_template_guide/values_files/) comes to rescue.
@@ -179,7 +179,7 @@ Here we have made three changes to our values.yaml file. Increase the resources 
 You can use the below command to install the envoy gateway using values.yaml file.
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace -f values.yaml
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace -f values.yaml
 ```
 
 {{< boilerplate open-ports >}}

--- a/site/content/en/latest/tasks/quickstart.md
+++ b/site/content/en/latest/tasks/quickstart.md
@@ -20,7 +20,7 @@ so the `Gateway` resource has an Address associated with it. We recommend using 
 Install the Gateway API CRDs and Envoy Gateway:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
 ```
 
 Wait for Envoy Gateway to become available:

--- a/site/content/en/latest/tasks/traffic/multicluster-service.md
+++ b/site/content/en/latest/tasks/traffic/multicluster-service.md
@@ -39,7 +39,7 @@ Once the above steps are done and all the pods are up in both the clusters. We a
 Install the Gateway API CRDs and Envoy Gateway in cluster1:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --kubeconfig output/kubeconfigs/kind-config-cluster1
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --kubeconfig output/kubeconfigs/kind-config-cluster1
 ```
 
 Wait for Envoy Gateway to become available:

--- a/site/content/en/v1.7/boilerplates/o11y_prerequisites.md
+++ b/site/content/en/v1.7/boilerplates/o11y_prerequisites.md
@@ -14,12 +14,12 @@ The documentation for the add-ons chart can be found
 Follow the instructions below to install the add-ons Helm chart.
 
 ```shell
-helm install eg-addons oci://docker.io/envoyproxy/gateway-addons-helm --version {{< helm-version >}} -n monitoring --create-namespace
+helm install envoy-gateway-addons oci://docker.io/envoyproxy/gateway-addons-helm --version {{< helm-version >}} -n monitoring --create-namespace
 ```
 
 By default, the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) is **disabled.**
 To install add-ons with OpenTelemetry Collector enabled, use the following command.
 
 ```shell
-helm install eg-addons oci://docker.io/envoyproxy/gateway-addons-helm --version {{< helm-version >}} --set opentelemetry-collector.enabled=true -n monitoring --create-namespace
+helm install envoy-gateway-addons oci://docker.io/envoyproxy/gateway-addons-helm --version {{< helm-version >}} --set opentelemetry-collector.enabled=true -n monitoring --create-namespace
 ```

--- a/site/content/en/v1.7/boilerplates/prerequisites.md
+++ b/site/content/en/v1.7/boilerplates/prerequisites.md
@@ -10,7 +10,7 @@ proceeding, you should be able to query the example backend using HTTP.
 1. Install the Gateway API CRDs and Envoy Gateway using Helm:
 
    ```shell
-   helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
+   helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
    ```
 
 2. Install the GatewayClass, Gateway, HTTPRoute and example app:

--- a/site/content/en/v1.7/install/install-helm.md
+++ b/site/content/en/v1.7/install/install-helm.md
@@ -30,7 +30,7 @@ You can visit [Envoy Gateway Helm Chart](https://hub.docker.com/r/envoyproxy/gat
 Install the Gateway API CRDs and Envoy Gateway:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
 ```
 
 Wait for Envoy Gateway to become available:
@@ -85,7 +85,7 @@ related to large CRDs in the `templates/` directory.
 Once the CRDs are installed, you can install the main Envoy Gateway Helm chart without re-applying CRDs by using the `--skip-crds` flag:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm \
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm \
   --version {{< helm-version >}} \
   -n envoy-gateway-system \
   --create-namespace \
@@ -113,7 +113,7 @@ If you want to know all the available fields inside the values.yaml file, please
 The Backend API is not enabled by default. Enable it via Helm values:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set config.envoyGateway.extensionApis.enableBackend=true
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set config.envoyGateway.extensionApis.enableBackend=true
 ```
 
 Or with a `values.yaml` file:
@@ -128,13 +128,13 @@ config:
 Then install using the file:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace -f values.yaml
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace -f values.yaml
 ```
 
 ### Increase the replicas
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set deployment.replicas=2
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set deployment.replicas=2
 ```
 
 ### Change the kubernetesClusterDomain name
@@ -142,7 +142,7 @@ helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-versi
 If you have installed your cluster with different domain name you can use below command.
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set kubernetesClusterDomain=<domain name>
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --set kubernetesClusterDomain=<domain name>
 ```
 
 **Note**: Above are some of the ways we can directly use for customization of our installation. But if you are looking for more complex changes [values.yaml](https://helm.sh/docs/chart_template_guide/values_files/) comes to rescue.
@@ -179,7 +179,7 @@ Here we have made three changes to our values.yaml file. Increase the resources 
 You can use the below command to install the envoy gateway using values.yaml file.
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace -f values.yaml
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace -f values.yaml
 ```
 
 {{< boilerplate open-ports >}}

--- a/site/content/en/v1.7/tasks/quickstart.md
+++ b/site/content/en/v1.7/tasks/quickstart.md
@@ -20,7 +20,7 @@ so the `Gateway` resource has an Address associated with it. We recommend using 
 Install the Gateway API CRDs and Envoy Gateway:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace
 ```
 
 Wait for Envoy Gateway to become available:

--- a/site/content/en/v1.7/tasks/traffic/multicluster-service.md
+++ b/site/content/en/v1.7/tasks/traffic/multicluster-service.md
@@ -39,7 +39,7 @@ Once the above steps are done and all the pods are up in both the clusters. We a
 Install the Gateway API CRDs and Envoy Gateway in cluster1:
 
 ```shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --kubeconfig output/kubeconfigs/kind-config-cluster1
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version {{< helm-version >}} -n envoy-gateway-system --create-namespace --kubeconfig output/kubeconfigs/kind-config-cluster1
 ```
 
 Wait for Envoy Gateway to become available:

--- a/tools/helm-docs/readme.gateway-addons-helm.gotmpl
+++ b/tools/helm-docs/readme.gateway-addons-helm.gotmpl
@@ -25,7 +25,7 @@ The Envoy Gateway must be installed before installing this chart.
 Once Helm has been set up correctly, install the chart from dockerhub:
 
 ``` shell
-helm install eg-addons oci://docker.io/envoyproxy/gateway-addons-helm --version v0.0.0-latest -n monitoring --create-namespace
+helm install envoy-gateway-addons oci://docker.io/envoyproxy/gateway-addons-helm --version v0.0.0-latest -n monitoring --create-namespace
 ```
 
 You can find all helm chart release in [Dockerhub](https://hub.docker.com/r/envoyproxy/gateway-addons-helm/tags)

--- a/tools/helm-docs/readme.gateway-helm.gotmpl
+++ b/tools/helm-docs/readme.gateway-helm.gotmpl
@@ -23,7 +23,7 @@ Please refer to Helm's [documentation](https://helm.sh/docs) to get started.
 Once Helm has been set up correctly, install the chart from dockerhub:
 
 ``` shell
-helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace
 ```
 You can find all helm chart release in [Dockerhub](https://hub.docker.com/r/envoyproxy/gateway-helm/tags)
 
@@ -42,7 +42,7 @@ make kube-deploy TAG=latest
 You can install the eg chart along without Gateway API CRDs and Envoy Gateway CRDs, make sure CRDs exist in Cluster first if you want to skip to install them, otherwise EG may fail to start:
 
 ``` shell
-helm install eg --create-namespace oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --skip-crds
+helm install envoy-gateway --create-namespace oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --skip-crds
 ```
 
 To uninstall the chart:

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -183,7 +183,7 @@ ifeq ($(E2E_GATEWAY_API_CHANNEL),standard)
 		-f $(ROOT_DIR)/test/helm/gateway-crds-helm/e2e.in.yaml \
 		| kubectl apply -f - --server-side
 	# Install EG with --skip-crds since CRDs are already installed.
-	$(GO_TOOL) helm install eg charts/gateway-helm \
+	$(GO_TOOL) helm install envoy-gateway charts/gateway-helm \
 		--set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) \
 		--skip-crds \
 		-n envoy-gateway-system --create-namespace \
@@ -191,7 +191,7 @@ ifeq ($(E2E_GATEWAY_API_CHANNEL),standard)
 		--wait --wait-for-jobs \
 		-f $(KUBE_DEPLOY_HELM_VALUES_FILE)
 else
-	$(GO_TOOL) helm install eg charts/gateway-helm \
+	$(GO_TOOL) helm install envoy-gateway charts/gateway-helm \
 		--set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) \
 		-n envoy-gateway-system --create-namespace \
 		--debug --timeout='$(WAIT_TIMEOUT)' \
@@ -202,13 +202,13 @@ endif
 .PHONY: kube-deploy-for-benchmark-test
 kube-deploy-for-benchmark-test: manifests helm-generate ## Install Envoy Gateway and prometheus-server for benchmark test purpose only.
 	@$(LOG_TARGET)
-	$(GO_TOOL) helm install eg charts/gateway-helm --set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) \
+	$(GO_TOOL) helm install envoy-gateway charts/gateway-helm --set deployment.envoyGateway.imagePullPolicy=$(IMAGE_PULL_POLICY) \
 		--set deployment.envoyGateway.resources.limits.cpu=$(BENCHMARK_CPU_LIMITS) \
 		--set deployment.envoyGateway.resources.limits.memory=$(BENCHMARK_MEMORY_LIMITS) \
 		--set config.envoyGateway.admin.enablePprof=true \
 		-n envoy-gateway-system --create-namespace --debug --timeout='$(WAIT_TIMEOUT)' --wait --wait-for-jobs
 	# Install Prometheus-server only
-	$(GO_TOOL) helm install eg-addons charts/gateway-addons-helm --set loki.enabled=false \
+	$(GO_TOOL) helm install envoy-gateway-addons charts/gateway-addons-helm --set loki.enabled=false \
 		--set tempo.enabled=false \
 		--set grafana.enabled=false \
 		--set fluent-bit.enabled=false \


### PR DESCRIPTION
**What type of PR is this?**

feat: add eg.fullname support for resources names (#8156)

**What this PR does / why we need it**:

Fixed hardcoded resources names in Helm chart (#8156)

**Which issue(s) this PR fixes**:

Fixes #8156

Release Notes:

BREAKING CHANGES: 

It will change resources labels:

app.kubernetes.io/name: gateway-helm -> envoy-gateway

And names for some resources:

ClusterRole, ClusterRoleBinding, Role, RoleBinding, ServiceAccount