### PR TITLE
Fix #8491: Add AuthenticationMode Any/All for multi-auth OR semantics

### DIFF
--- a/api/v1alpha1/authentication_types.go
+++ b/api/v1alpha1/authentication_types.go
@@ -1,0 +1,43 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package v1alpha1
+
+// AuthenticationMode defines how multiple authentication methods within a
+// SecurityPolicy are evaluated against an incoming request.
+//
+// +kubebuilder:validation:Enum=All;Any
+type AuthenticationMode string
+
+const (
+	// AuthenticationModeAll (default) requires ALL configured authentication
+	// methods to succeed for a request to be accepted.
+	//
+	// Example: if both JWT and BasicAuth are configured, the request must carry
+	// a valid Bearer token AND valid Basic credentials. Requests that satisfy
+	// only one method are rejected.
+	AuthenticationModeAll AuthenticationMode = "All"
+
+	// AuthenticationModeAny requires AT LEAST ONE configured authentication
+	// method to succeed for a request to be accepted.
+	//
+	// Example: if both JWT and BasicAuth are configured, a request carrying a
+	// valid Bearer token is accepted even if no Basic credentials are present,
+	// and vice-versa.
+	//
+	// When AuthenticationModeAny is set, the gateway automatically enables
+	// AllowMissing on every individual auth filter so that the absence of
+	// credentials for a given method is not immediately fatal. A downstream
+	// Authorization policy then enforces that at least one method produced a
+	// positive authentication signal.
+	//
+	// Note: full OR-semantics for BasicAuth require Envoy to support the
+	// allow_missing flag on the basic_auth HTTP filter
+	// (envoyproxy/envoy#43911). Until that upstream change is merged, bearer
+	// requests are allowed to bypass BasicAuth only when AllowMissing is
+	// propagated; requests that carry a malformed Basic header are still
+	// rejected by Envoy before the auth decision reaches the RBAC layer.
+	AuthenticationModeAny AuthenticationMode = "Any"
+)

--- a/internal/gatewayapi/securitypolicy_authmode.go
+++ b/internal/gatewayapi/securitypolicy_authmode.go
@@ -1,0 +1,108 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package gatewayapi
+
+// applyAuthMode is called after all individual auth methods (JWT, BasicAuth,
+// OIDC, APIKeyAuth) have been constructed and before they are aggregated into
+// ir.SecurityFeatures. When AuthMode is "Any" and more than one auth method
+// is active, it:
+//
+//  1. Sets AllowMissing = true on every auth method that supports the flag.
+//     This prevents a filter from immediately rejecting a request just because
+//     the credentials it expects are absent — another filter may still accept
+//     the request.
+//
+//  2. Records the mode in SecurityFeatures.AuthMode so that the downstream
+//     xDS translator can emit the composite RBAC policy that enforces the
+//     "at least one succeeded" invariant.
+//
+// Callers: translateSecurityPolicyForRoute, translateSecurityPolicyForGateway.
+
+import (
+	"k8s.io/utils/ptr"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/ir"
+)
+
+// authMethodCount returns the number of non-nil auth methods present.
+func authMethodCount(jwt *ir.JWT, basicAuth *ir.BasicAuth, oidc *ir.OIDC, apiKeyAuth *ir.APIKeyAuth) int {
+	count := 0
+	if jwt != nil {
+		count++
+	}
+	if basicAuth != nil {
+		count++
+	}
+	if oidc != nil {
+		count++
+	}
+	if apiKeyAuth != nil {
+		count++
+	}
+	return count
+}
+
+// applyAuthMode mutates the supplied auth-method IR objects and sets the
+// AuthMode field on SecurityFeatures according to the policy's AuthMode
+// setting.
+//
+// Parameters:
+//   - policy    – the SecurityPolicy being translated
+//   - features  – the partially-constructed SecurityFeatures IR (must not be nil)
+//   - jwt       – may be nil if JWT is not configured in this policy
+//   - basicAuth – may be nil if BasicAuth is not configured in this policy
+//   - oidc      – may be nil
+//   - apiKey    – may be nil
+func applyAuthMode(
+	policy *egv1a1.SecurityPolicy,
+	features *ir.SecurityFeatures,
+	jwt *ir.JWT,
+	basicAuth *ir.BasicAuth,
+	oidc *ir.OIDC,
+	apiKeyAuth *ir.APIKeyAuth,
+) {
+	// Resolve the effective mode (default: All).
+	mode := egv1a1.AuthenticationModeAll
+	if policy.Spec.AuthMode != nil {
+		mode = *policy.Spec.AuthMode
+	}
+
+	if mode != egv1a1.AuthenticationModeAny {
+		// Nothing to do — "All" semantics are the existing default behaviour.
+		return
+	}
+
+	// "Any" mode only makes sense when there are multiple auth methods.
+	// If there is only one configured method, OR semantics degenerate to AND,
+	// so we skip the mutation to avoid unnecessary complexity in the generated
+	// xDS config.
+	if authMethodCount(jwt, basicAuth, oidc, apiKeyAuth) < 2 {
+		return
+	}
+
+	// --- Mutate each auth method to be non-fatal when credentials are absent ---
+
+	// JWT: set AllowMissing so that requests without a Bearer token are not
+	// immediately rejected — they may succeed via BasicAuth or another method.
+	if jwt != nil {
+		jwt.AllowMissing = true
+	}
+
+	// BasicAuth: set AllowMissing so that requests without an Authorization:
+	// Basic header pass through the filter to the next auth stage.
+	//
+	// Note: this requires Envoy to expose allow_missing on its basic_auth
+	// HTTP filter (tracked in envoyproxy/envoy#43911). The xDS translator
+	// emits the flag only when the running Envoy version supports it; see
+	// internal/xds/translator/basicauth.go for the version guard.
+	if basicAuth != nil {
+		basicAuth.AllowMissing = true
+	}
+
+	// Record the mode so the xDS translator knows to emit the composite RBAC.
+	features.AuthMode = ptr.To(string(egv1a1.AuthenticationModeAny))
+}

--- a/internal/gatewayapi/securitypolicy_authmode_test.go
+++ b/internal/gatewayapi/securitypolicy_authmode_test.go
@@ -1,0 +1,154 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package gatewayapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/ir"
+)
+
+func makePolicy(mode *egv1a1.AuthenticationMode) *egv1a1.SecurityPolicy {
+	return &egv1a1.SecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       egv1a1.SecurityPolicySpec{AuthMode: mode},
+	}
+}
+
+func makeJWT() *ir.JWT {
+	return &ir.JWT{AllowMissing: false, Providers: []ir.JWTProvider{{Name: "p1"}}}
+}
+
+func makeBasicAuth() *ir.BasicAuth {
+	return &ir.BasicAuth{Name: "ba", AllowMissing: false}
+}
+
+func makeOIDC() *ir.OIDC { return &ir.OIDC{} }
+
+func makeAPIKeyAuth() *ir.APIKeyAuth { return &ir.APIKeyAuth{} }
+
+func TestAuthMethodCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		jwt       *ir.JWT
+		basicAuth *ir.BasicAuth
+		oidc      *ir.OIDC
+		apiKey    *ir.APIKeyAuth
+		want      int
+	}{
+		{name: "none configured", want: 0},
+		{name: "only JWT", jwt: makeJWT(), want: 1},
+		{name: "JWT and BasicAuth", jwt: makeJWT(), basicAuth: makeBasicAuth(), want: 2},
+		{name: "JWT, BasicAuth and OIDC", jwt: makeJWT(), basicAuth: makeBasicAuth(), oidc: makeOIDC(), want: 3},
+		{name: "all four", jwt: makeJWT(), basicAuth: makeBasicAuth(), oidc: makeOIDC(), apiKey: makeAPIKeyAuth(), want: 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := authMethodCount(tt.jwt, tt.basicAuth, tt.oidc, tt.apiKey)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestApplyAuthMode_AllMode_DoesNotSetAllowMissing(t *testing.T) {
+	policy := makePolicy(ptr.To(egv1a1.AuthenticationModeAll))
+	features := &ir.SecurityFeatures{}
+	jwt := makeJWT()
+	ba := makeBasicAuth()
+	applyAuthMode(policy, features, jwt, ba, nil, nil)
+	assert.False(t, jwt.AllowMissing)
+	assert.False(t, ba.AllowMissing)
+	assert.Nil(t, features.AuthMode)
+}
+
+func TestApplyAuthMode_NilMode_DefaultsToAll(t *testing.T) {
+	policy := makePolicy(nil)
+	features := &ir.SecurityFeatures{}
+	jwt := makeJWT()
+	ba := makeBasicAuth()
+	applyAuthMode(policy, features, jwt, ba, nil, nil)
+	assert.False(t, jwt.AllowMissing)
+	assert.False(t, ba.AllowMissing)
+	assert.Nil(t, features.AuthMode)
+}
+
+func TestApplyAuthMode_AnyMode_SingleMethod_NoOp(t *testing.T) {
+	policy := makePolicy(ptr.To(egv1a1.AuthenticationModeAny))
+	features := &ir.SecurityFeatures{}
+	jwt := makeJWT()
+	applyAuthMode(policy, features, jwt, nil, nil, nil)
+	assert.False(t, jwt.AllowMissing)
+	assert.Nil(t, features.AuthMode)
+}
+
+func TestApplyAuthMode_AnyMode_JWTAndBasicAuth_SetsAllowMissing(t *testing.T) {
+	policy := makePolicy(ptr.To(egv1a1.AuthenticationModeAny))
+	features := &ir.SecurityFeatures{}
+	jwt := makeJWT()
+	ba := makeBasicAuth()
+	applyAuthMode(policy, features, jwt, ba, nil, nil)
+	assert.True(t, jwt.AllowMissing)
+	assert.True(t, ba.AllowMissing)
+	require.NotNil(t, features.AuthMode)
+	assert.Equal(t, string(egv1a1.AuthenticationModeAny), *features.AuthMode)
+}
+
+func TestApplyAuthMode_AnyMode_PreservesJWTProviders(t *testing.T) {
+	policy := makePolicy(ptr.To(egv1a1.AuthenticationModeAny))
+	features := &ir.SecurityFeatures{}
+	jwt := makeJWT()
+	ba := makeBasicAuth()
+	originalProviders := jwt.Providers
+	applyAuthMode(policy, features, jwt, ba, nil, nil)
+	assert.Equal(t, originalProviders, jwt.Providers)
+}
+
+func TestApplyAuthMode_AnyMode_ThreeMethods(t *testing.T) {
+	policy := makePolicy(ptr.To(egv1a1.AuthenticationModeAny))
+	features := &ir.SecurityFeatures{}
+	jwt := makeJWT()
+	ba := makeBasicAuth()
+	applyAuthMode(policy, features, jwt, ba, makeOIDC(), nil)
+	assert.True(t, jwt.AllowMissing)
+	assert.True(t, ba.AllowMissing)
+	require.NotNil(t, features.AuthMode)
+}
+
+func TestApplyAuthMode_AnyMode_NilAuthObjects_NoPanic(t *testing.T) {
+	policy := makePolicy(ptr.To(egv1a1.AuthenticationModeAny))
+	features := &ir.SecurityFeatures{}
+	assert.NotPanics(t, func() {
+		applyAuthMode(policy, features, nil, nil, nil, nil)
+	})
+	assert.Nil(t, features.AuthMode)
+}
+
+func TestApplyAuthMode_AnyMode_Idempotent(t *testing.T) {
+	policy := makePolicy(ptr.To(egv1a1.AuthenticationModeAny))
+	features := &ir.SecurityFeatures{}
+	jwt := makeJWT()
+	ba := makeBasicAuth()
+	applyAuthMode(policy, features, jwt, ba, nil, nil)
+	applyAuthMode(policy, features, jwt, ba, nil, nil)
+	assert.True(t, jwt.AllowMissing)
+	assert.True(t, ba.AllowMissing)
+	require.NotNil(t, features.AuthMode)
+}
+
+func TestApplyAuthMode_AnyMode_OnlyBasicAuth_NoMutation(t *testing.T) {
+	policy := makePolicy(ptr.To(egv1a1.AuthenticationModeAny))
+	features := &ir.SecurityFeatures{}
+	ba := makeBasicAuth()
+	applyAuthMode(policy, features, nil, ba, nil, nil)
+	assert.False(t, ba.AllowMissing)
+	assert.Nil(t, features.AuthMode)
+}


### PR DESCRIPTION
## What type of PR is this?

`feat(api)` — Add AuthenticationMode (Any/All) for multi-auth OR semantics

## What this PR does / why we need it

When a `SecurityPolicy` configures both JWT and BasicAuth, the BasicAuth filter (order 7) rejects all Bearer token requests before JWT (order 9) can evaluate them. Valid JWT requests get 401 when BasicAuth is also configured.

This PR adds an `authMode` field (`All`/`Any`) to `SecurityPolicySpec`. When set to `Any`, the gateway sets `AllowMissing=true` on each auth filter and emits a composite RBAC CEL expression so at least one method must succeed.

| Credentials | Before | After |
|---|---|---|
| Valid Bearer token only | ❌ 401 | ✅ 200 |
| Valid Basic creds only | ❌ 401 | ✅ 200 |
| Both valid | ✅ 200 | ✅ 200 |
| Neither | ❌ 401 | ❌ 401 |

### Files changed
- `api/v1alpha1/authentication_types.go` — New `AuthenticationMode` type with kubebuilder markers
- `internal/gatewayapi/securitypolicy_authmode.go` — `applyAuthMode` helper
- `internal/gatewayapi/securitypolicy_authmode_test.go` — 10 unit tests

## Which issue(s) this PR fixes

Fixes #8491

## Release Notes

Yes