### PR TITLE
fix: restore failure-path metric recording for delete and HPA reconcile

### DIFF
--- a/internal/infrastructure/kubernetes/infra_resource.go
+++ b/internal/infrastructure/kubernetes/infra_resource.go
@@ -342,6 +342,7 @@ func (i *Infra) createOrUpdateHPA(ctx context.Context, r ResourceRender) (err er
 	)
 
 	if hpa, err = r.HorizontalPodAutoscaler(); err != nil {
+		resourceApplyTotal.WithFailure(metrics.ReasonError, labels...).Increment()
 		return err
 	}
 
@@ -476,6 +477,7 @@ func (i *Infra) deleteDeployment(ctx context.Context, r ResourceRender) (err err
 		Namespace:     ns,
 		LabelSelector: r.LabelSelector(),
 	}); err != nil {
+		resourceDeleteTotal.WithFailure(metrics.ReasonError, labels...).Increment()
 		return err
 	}
 	if len(deployList.Items) == 0 {
@@ -524,6 +526,7 @@ func (i *Infra) deleteDaemonSet(ctx context.Context, r ResourceRender) (err erro
 		Namespace:     ns,
 		LabelSelector: r.LabelSelector(),
 	}); err != nil {
+		resourceDeleteTotal.WithFailure(metrics.ReasonError, labels...).Increment()
 		return err
 	}
 	if len(dsList.Items) == 0 {
@@ -642,6 +645,7 @@ func (i *Infra) deleteHPA(ctx context.Context, r ResourceRender) (err error) {
 		Namespace:     ns,
 		LabelSelector: r.LabelSelector(),
 	}); err != nil {
+		resourceDeleteTotal.WithFailure(metrics.ReasonError, labels...).Increment()
 		return err
 	}
 	if len(hpaList.Items) == 0 {
@@ -690,6 +694,7 @@ func (i *Infra) deletePDB(ctx context.Context, r ResourceRender) (err error) {
 		Namespace:     ns,
 		LabelSelector: r.LabelSelector(),
 	}); err != nil {
+		resourceDeleteTotal.WithFailure(metrics.ReasonError, labels...).Increment()
 		return err
 	}
 	if len(pdbList.Items) == 0 {

--- a/internal/infrastructure/kubernetes/infra_resource_test.go
+++ b/internal/infrastructure/kubernetes/infra_resource_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/envoyproxy/gateway/internal/ir"
 )
 
+// errSimulatedListFailure is the sentinel error returned by newListFailingClient.
+var errSimulatedListFailure = fmt.Errorf("simulated list failure")
+
 // newDeleteTrackingClient builds a fake client whose interceptor counts
 // DeleteAllOf invocations per concrete Go type (e.g. "*v1.DaemonSet").
 func newDeleteTrackingClient(mu *sync.Mutex, counts map[string]int) client.Client {
@@ -284,4 +287,67 @@ func TestReconcileIdempotencyDaemonSetMode(t *testing.T) {
 		"HPA DeleteAllOf must never be called across multiple no-op reconciles")
 	assert.Equal(t, 0, counts["*v1.PodDisruptionBudget"],
 		"PDB DeleteAllOf must never be called across multiple no-op reconciles")
+}
+
+// newListFailingClient builds a fake client whose List interceptor returns an
+// error for the specified object list type (e.g. "*v1.DaemonSetList"), while
+// delegating all other List calls to the underlying client.
+func newListFailingClient(failType string) client.Client {
+	return fakeclient.NewClientBuilder().
+		WithScheme(envoygateway.GetScheme()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: interceptorFunc.Patch,
+			List: func(ctx context.Context, clnt client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if fmt.Sprintf("%T", list) == failType {
+					return errSimulatedListFailure
+				}
+				return clnt.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+}
+
+// TestDeleteListFailureReturnsError verifies that when the pre-delete List()
+// call fails (e.g. RBAC/API errors), the error propagates and the failure
+// metric recording path is exercised.
+func TestDeleteListFailureReturnsError(t *testing.T) {
+	tests := []struct {
+		name     string
+		failType string
+		infra    func() *ir.Infra
+	}{
+		{
+			name:     "DaemonSet List failure in Deployment mode",
+			failType: "*v1.DaemonSetList",
+			infra:    standardDeploymentInfra,
+		},
+		{
+			name:     "Deployment List failure in DaemonSet mode",
+			failType: "*v1.DeploymentList",
+			infra:    daemonSetModeInfra,
+		},
+		{
+			name:     "HPA List failure in Deployment mode",
+			failType: "*v2.HorizontalPodAutoscalerList",
+			infra:    standardDeploymentInfra,
+		},
+		{
+			name:     "PDB List failure in Deployment mode",
+			failType: "*v1.PodDisruptionBudgetList",
+			infra:    standardDeploymentInfra,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cli := newListFailingClient(tc.failType)
+			kube := newTestInfraWithClient(t, cli)
+			ctx := context.Background()
+			require.NoError(t, setupOwnerReferenceResources(ctx, kube.Client))
+
+			err := kube.CreateOrUpdateProxyInfra(ctx, tc.infra())
+			require.Error(t, err, "reconcile should fail when pre-delete List returns an error")
+			assert.ErrorIs(t, err, errSimulatedListFailure)
+		})
+	}
 }


### PR DESCRIPTION
## What type of PR is this?
  fix

  ## What this PR does / why we need it
  Follow-up to #8480 — restores failure-path observability that regressed when
  the no-op delete metric fix was introduced.

  **Problem**: Moving the metric-recording `defer` blocks to after existence checks
  fixed no-op metric inflation, but failures on the pre-defer paths stopped being
  recorded:

  - `createOrUpdateHPA()` returned on `r.HorizontalPodAutoscaler()` errors before
    the defer, so HPA render failures no longer incremented
    `resource_apply_total{result="failure"}`.
  - `deleteDeployment()`, `deleteDaemonSet()`, `deleteHPA()`, and `deletePDB()`
    returned on the pre-delete `List()` call before the defer, so list/RBAC/API
    failures no longer incremented `resource_delete_total{result="failure"}`.

  **Fix**: Add explicit failure metric recording on the early-return error paths,
  matching the pattern already used by `createOrUpdateDeployment`,
  `createOrUpdateDaemonSet`, and `createOrUpdatePodDisruptionBudget`.

  ## Changes
  - Add `resourceApplyTotal.WithFailure(...)` on the `r.HorizontalPodAutoscaler()`
    error path in `createOrUpdateHPA()`
  - Add `resourceDeleteTotal.WithFailure(...)` on the `List()` error paths in
    `deleteDeployment()`, `deleteDaemonSet()`, `deleteHPA()`, `deletePDB()`
  - Add `TestDeleteListFailureReturnsError` to verify error propagation when
    pre-delete `List()` calls fail

  ## Which issue(s) this PR fixes
  Fixes #8651

  ## Release Notes
  No