### PR TITLE
chore: add lint check to enforce ubuntu-latest in workflow runs-on

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -39,7 +39,7 @@ jobs:
             - ".github/workflows/build_and_test.yaml"
 
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
     - uses: ./tools/github-actions/setup-deps
@@ -50,7 +50,7 @@ jobs:
     - run: make -k lint
 
   gen-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
     - uses: ./tools/github-actions/setup-deps

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-latest'
     timeout-minutes: 360
     permissions:
       actions: read

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -17,7 +17,7 @@ jobs:
          && github.actor != 'dependabot[bot]'
       }}
     name: Retest
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       actions: write

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   docs-lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Check out code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   scan:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       id-token: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
     name: Prune Stale
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     # do not run it in forked repos
     if: github.repository == 'envoyproxy/gateway'
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
     name: Image Scan
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1

--- a/tools/hack/check-workflows-runs-on.sh
+++ b/tools/hack/check-workflows-runs-on.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Ensure all GitHub Actions workflow jobs use 'ubuntu-latest' for runs-on.
+# Pinning to a specific version (e.g. ubuntu-latest) causes jobs to fall behind
+# and should be avoided.
+
+set -euo pipefail
+
+if matches=$(
+  grep -rn --include="*.yml" --include="*.yaml" \
+    'runs-on:' .github/workflows \
+  | grep -Ev "runs-on:[[:space:]]*['\"]?ubuntu-latest['\"]?$"
+); then
+  echo "ERROR: found workflows not using 'ubuntu-latest':"
+  echo "$matches"
+  exit 1
+fi
+
+echo "OK: all workflow jobs use 'ubuntu-latest'"

--- a/tools/make/lint.mk
+++ b/tools/make/lint.mk
@@ -125,3 +125,9 @@ lint: lint.release-notes-filenames
 lint.release-notes-filenames: ## Check if release notes filenames follow naming conventions
 	@$(LOG_TARGET)
 	@tools/hack/check-release-notes-filenames.sh
+
+.PHONY: lint.workflows-runs-on
+lint: lint.workflows-runs-on
+lint.workflows-runs-on: ## Check all workflow jobs use ubuntu-latest
+	@$(LOG_TARGET)
+	@tools/hack/check-workflows-runs-on.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

Aligns the remaining workflows that use `ubuntu-22.04` with the majority that already use `ubuntu-latest`.

This PR:
1. Replaces all `ubuntu-22.04` occurrences with `ubuntu-latest` across 8 workflow files
2. Adds a new `lint.workflows-runs-on` Make target (and backing script `tools/hack/check-workflows-runs-on.sh`) that fails CI if any workflow uses a pinned Ubuntu version instead of `ubuntu-latest`

Before this fix, `make lint.workflows-runs-on` reported:
```
ERROR: found workflows not using 'ubuntu-latest':
.github/workflows/docs.yaml:21:    runs-on: ubuntu-22.04
.github/workflows/license-scan.yml:16:    runs-on: ubuntu-22.04
.github/workflows/build_and_test.yaml:42:    runs-on: ubuntu-22.04
.github/workflows/build_and_test.yaml:53:    runs-on: ubuntu-22.04
.github/workflows/codeql.yml:20:    runs-on: 'ubuntu-22.04'
.github/workflows/trivy.yml:18:    runs-on: ubuntu-22.04
.github/workflows/stale.yml:15:    runs-on: ubuntu-22.04
.github/workflows/command.yaml:20:    runs-on: ubuntu-22.04
.github/workflows/scorecard.yml:17:    runs-on: ubuntu-22.04
```

**Which issue(s) this PR fixes**:

Fixes #

Release Notes: No
