### PR TITLE
ci: remove codecov workaround

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -85,7 +85,7 @@ jobs:
         files: ./coverage.xml
         name: codecov-envoy-gateway
         verbose: true
-        use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+        use_oidc: true
 
   go-benchmark-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the `use_oidc` workaround since [codecov/codecov-action#1594](https://github.com/codecov/codecov-action/issues/1594) has been fixed.

**Which issue(s) this PR fixes**:

Fixes #

Release Notes: No
