### PR TITLE
ci: remove continue-on-error from go-benchmark-test

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -99,7 +99,6 @@ jobs:
         fetch-depth: 0  # Need main branch access for benchmark comparison
     - uses: ./tools/github-actions/setup-deps
     - name: Run Benchmark Comparison
-      continue-on-error: true
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           ./tools/hack/go-benchmark-compare.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up of #8663 

**Which issue(s) this PR fixes**:
N/A

Release Notes: No
