### PR TITLE
ci: pin checkout action

### DIFF
--- a/.github/workflows/monthly-release-issue.yaml
+++ b/.github/workflows/monthly-release-issue.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Calculate current release month and versions
         id: release_info


### PR DESCRIPTION
**What this PR does / why we need it**:
Pinned checkout action in `Create Monthly Release Issue` workflow.
I recommend to check `Require actions to be pinned to a full-length commit SHA` in repo `Settings` -> `Actions` -> `General` to make workflows fail in such cases. Tested it in my fork:
<img width="869" height="484" alt="image" src="https://github.com/user-attachments/assets/98f62692-9434-4310-8bd8-b47cdd327528" />

**Which issue(s) this PR fixes**:
N/A

Release Notes: No
