### PR TITLE
chore: pin example Dockerfiles digests and simplify dynamic module bump workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directories:
       - /tools/docker/envoy-gateway/
       - /site
+      - "/examples/*"
     schedule:
       interval: weekly
   - package-ecosystem: github-actions

--- a/examples/backend-utilization/Dockerfile
+++ b/examples/backend-utilization/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.1@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1 AS builder
 
 ARG GO_LDFLAGS=""
 
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
     GOARCH=${TARGETARCH} \
     go build -o /bin/backend-utilization -ldflags "${GO_LDFLAGS}" .
 
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian11@sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /bin/backend-utilization /
 

--- a/examples/dynamic-module-test/Dockerfile
+++ b/examples/dynamic-module-test/Dockerfile
@@ -1,8 +1,4 @@
-# ENVOY_VERSION must match the SDK version in go.mod to ensure ABI compatibility.
-# Update both together when changing the target Envoy version.
-ARG ENVOY_VERSION=dev
-
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.1@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1 AS builder
 
 WORKDIR /build
 COPY go.mod go.sum ./
@@ -13,6 +9,6 @@ COPY . ./
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=1 go build -buildmode=c-shared -o /build/libheader_mutation.so .
 
-ARG ENVOY_VERSION
-FROM docker.io/envoyproxy/envoy:distroless-${ENVOY_VERSION}
+# Envoy image tag and digest are updated by tools/hack/bump-envoy-dynamic-modules.sh during releases.
+FROM docker.io/envoyproxy/envoy:distroless-dev@sha256:1679d1bb44c7f90aca4a0f5e33f7c7c5723e96a90b38f9ad5a5b158ed4c95a40
 COPY --from=builder /build/libheader_mutation.so /usr/local/lib/libheader_mutation.so

--- a/examples/dynamic-module-test/Makefile
+++ b/examples/dynamic-module-test/Makefile
@@ -2,8 +2,7 @@
 IMAGE_PREFIX ?= envoyproxy/gateway-
 APP_NAME ?= dynamic-module-test
 TAG ?= latest
-ENVOY_VERSION ?= dev
 
 .PHONY: docker-buildx
 docker-buildx:
-	docker buildx build . --build-arg ENVOY_VERSION=$(ENVOY_VERSION) -t $(IMAGE_PREFIX)$(APP_NAME):$(TAG) --load
+	docker buildx build . -t $(IMAGE_PREFIX)$(APP_NAME):$(TAG) --load

--- a/examples/envoy-ext-auth/Dockerfile
+++ b/examples/envoy-ext-auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.1@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1 AS builder
 
 ARG GO_LDFLAGS=""
 
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
     go build -o /bin/envoy-ext-auth -ldflags "${GO_LDFLAGS}" .
 
 # Make our production image
-FROM gcr.io/distroless/static-debian11:nonroot
+FROM gcr.io/distroless/static-debian11:nonroot@sha256:63ebe035fbdd056ed682e6a87b286d07d3f05f12cb46f26b2b44fc10fc4a59ed
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /bin/envoy-ext-auth /
 

--- a/examples/grpc-ext-proc/Dockerfile
+++ b/examples/grpc-ext-proc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.1@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1 AS builder
 
 ARG GO_LDFLAGS=""
 
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
     go build -o /bin/grpc-ext-proc -ldflags "${GO_LDFLAGS}" .
 
 # Need root user for UDS
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian11@sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /bin/grpc-ext-proc /
 

--- a/examples/preserve-case-backend/Dockerfile
+++ b/examples/preserve-case-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.1@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1 AS builder
 
 ARG GO_LDFLAGS=""
 
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
     go build -o /bin/preserve-case-backend -ldflags "${GO_LDFLAGS}" .
 
 # Need root user for UDS
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian11@sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /bin/preserve-case-backend /
 

--- a/examples/simple-extension-server/Dockerfile
+++ b/examples/simple-extension-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.1@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1 AS builder
 
 ARG GO_LDFLAGS=""
 
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
     go build -o /bin/simple-extension-server -ldflags "${GO_LDFLAGS}" .
 
 # Need root user for UDS
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian11@sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /bin/simple-extension-server /
 

--- a/examples/static-file-server/Dockerfile
+++ b/examples/static-file-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.1@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1 AS builder
 
 ARG GO_LDFLAGS=""
 
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
     go build -o /bin/static-file-server -ldflags "${GO_LDFLAGS}" .
 
 # Need root user for UDS
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian11@sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /bin/static-file-server /
 COPY files/ files/

--- a/site/content/en/contributions/RELEASING.md
+++ b/site/content/en/contributions/RELEASING.md
@@ -69,7 +69,7 @@ export GITHUB_REMOTE=origin
     (+v1.8.x only) After updating the Envoy proxy image tag, update the dynamic module SDK and example dependencies:
 
    ```shell
-   make update-dynamic-module-deps ENVOY_VERSION=v${ENVOY_PROXY_VERSION}
+   make update-dynamic-module-deps
    ```
 
 10. Sign, commit, and push your changes to your fork.

--- a/tools/hack/bump-envoy-dynamic-modules.sh
+++ b/tools/hack/bump-envoy-dynamic-modules.sh
@@ -4,7 +4,16 @@
 
 set -euo pipefail
 
-ENVOY_VERSION="${1:?Usage: $0 <envoy-version, e.g. v1.37.0>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Read envoy version from DefaultEnvoyProxyImage in source code.
+# On main this is "distroless-dev" (no version), on release branches it's "distroless-vX.Y.Z".
+ENVOY_VERSION=$(grep 'DefaultEnvoyProxyImage' "${ROOT_DIR}/api/v1alpha1/shared_types.go" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || true)
+if [ -z "${ENVOY_VERSION}" ]; then
+    echo "No envoy release version found in DefaultEnvoyProxyImage (dev image?) — skipping." >&2
+    exit 0
+fi
 
 # Extract major.minor from version (e.g., v1.37.0 -> 1.37)
 MAJOR_MINOR=$(echo "${ENVOY_VERSION}" | sed 's/^v//' | cut -d. -f1,2)
@@ -26,28 +35,28 @@ echo "Resolved ${ENVOY_VERSION} (release/v${MAJOR_MINOR}) to commit ${COMMIT_SHA
 GNU_SED=$(sed --version >/dev/null 2>&1 && echo "yes" || echo "no")
 
 # Find all dynamic module example directories
-DYNAMIC_MODULE_DIRS=$(find examples -name "go.mod" \
+DYNAMIC_MODULE_DIRS=$(find "${ROOT_DIR}/examples" -name "go.mod" \
     -exec grep -l "envoy/source/extensions/dynamic_modules" {} \; \
     | xargs -I{} dirname {})
 
 for dir in $DYNAMIC_MODULE_DIRS; do
     echo "Updating ${dir}..."
 
-    # Update Dockerfile ARG ENVOY_VERSION
+    # Update Dockerfile envoy image FROM line
     if [ -f "${dir}/Dockerfile" ]; then
-        if [ "$GNU_SED" = "yes" ]; then
-            sed -i'' "s/^ARG ENVOY_VERSION=.*/ARG ENVOY_VERSION=${ENVOY_VERSION}/" "${dir}/Dockerfile"
-        else
-            sed -i '' "s/^ARG ENVOY_VERSION=.*/ARG ENVOY_VERSION=${ENVOY_VERSION}/" "${dir}/Dockerfile"
+        ENVOY_IMAGE="docker.io/envoyproxy/envoy:distroless-${ENVOY_VERSION}"
+        ENVOY_DIGEST=$(docker buildx imagetools inspect "${ENVOY_IMAGE}" 2>/dev/null | grep -m1 'Digest:' | awk '{print $2}')
+        if [ -z "${ENVOY_DIGEST}" ]; then
+            echo "Error: Could not resolve digest for ${ENVOY_IMAGE}" >&2
+            exit 1
         fi
-    fi
 
-    # Update Makefile ENVOY_VERSION
-    if [ -f "${dir}/Makefile" ]; then
+        NEW_FROM="FROM ${ENVOY_IMAGE}@${ENVOY_DIGEST}"
+
         if [ "$GNU_SED" = "yes" ]; then
-            sed -i'' "s/^ENVOY_VERSION ?=.*/ENVOY_VERSION ?= ${ENVOY_VERSION}/" "${dir}/Makefile"
+            sed -i'' "s|^FROM docker.io/envoyproxy/envoy:distroless.*|${NEW_FROM}|" "${dir}/Dockerfile"
         else
-            sed -i '' "s/^ENVOY_VERSION ?=.*/ENVOY_VERSION ?= ${ENVOY_VERSION}/" "${dir}/Makefile"
+            sed -i '' "s|^FROM docker.io/envoyproxy/envoy:distroless.*|${NEW_FROM}|" "${dir}/Dockerfile"
         fi
     fi
 

--- a/tools/make/examples.mk
+++ b/tools/make/examples.mk
@@ -2,10 +2,6 @@ EXAMPLE_APPS := simple-extension-server extension-server envoy-ext-auth grpc-ext
 EXAMPLE_IMAGE_PREFIX ?= envoyproxy/gateway-
 EXAMPLE_TAG ?= latest
 
-# Extract envoy proxy version from DefaultEnvoyProxyImage (e.g., "distroless-v1.37.0" -> "v1.37.0").
-# Empty on main branch where the image is "distroless-dev".
-ENVOY_PROXY_VERSION := $(shell grep 'DefaultEnvoyProxyImage' api/v1alpha1/shared_types.go | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
-
 kube-generate-examples:
 	@$(LOG_TARGET)
 	@pushd $(ROOT_DIR)/examples/extension-server; \
@@ -17,11 +13,7 @@ kube-build-examples-image:
 	@$(LOG_TARGET)
 	@for app in $(EXAMPLE_APPS); do \
 		pushd $(ROOT_DIR)/examples/$$app; \
-		if [ -n "$(ENVOY_PROXY_VERSION)" ]; then \
-			make docker-buildx ENVOY_VERSION=$(ENVOY_PROXY_VERSION); \
-		else \
-			make docker-buildx; \
-		fi; \
+		make docker-buildx; \
 		popd; \
 	done
 
@@ -44,4 +36,4 @@ go.mod.tidy.examples:
 .PHONY: update-dynamic-module-deps
 update-dynamic-module-deps: ## Update dynamic module SDK and envoy version in examples
 	@$(LOG_TARGET)
-	@tools/hack/bump-envoy-dynamic-modules.sh $(ENVOY_VERSION)
+	@tools/hack/bump-envoy-dynamic-modules.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor the dynamic module dependency bump process and pin all example
Dockerfile images by digest.

- **Dynamic module bump simplification**: Rework `bump-envoy-dynamic-modules.sh`
  to read the envoy version directly from `DefaultEnvoyProxyImage` in
  `api/v1alpha1/shared_types.go` instead of requiring a CLI argument. On main
  (where the image is `distroless-dev`) the script exits cleanly; on release
  branches it extracts the version automatically. This eliminates the need to
  pass `ENVOY_VERSION` through the Makefile, build-args, and Dockerfile ARGs.
  - Remove `ARG ENVOY_VERSION` / `ARG ENVOY_IMAGE_DIGEST` from the dynamic
    module Dockerfile; use direct `FROM` lines with digest pins instead.
  - Remove `ENVOY_VERSION` variable from `examples/dynamic-module-test/Makefile`
    and `--build-arg` passthrough.
  - Remove `ENVOY_PROXY_VERSION` parsing from `tools/make/examples.mk` and
    simplify the `update-dynamic-module-deps` target.
  - Update `RELEASING.md` to reflect the simplified
    `make update-dynamic-module-deps` command (no argument needed).
- **Dockerfile digest pinning**: Pin all images in example Dockerfiles with
  SHA256 digests to improve reproducibility and supply-chain security.
- **Dependabot**: Add `"/examples/*"` to the Docker package ecosystem in
  `dependabot.yml` so digest pins are kept up to date automatically.

**Which issue(s) this PR fixes**:
N/A

Release Notes: No