### PR TITLE
feat(cors): Add wildcard port matching for CORS allowOrigins

### DIFF
--- a/api/v1alpha1/cors_types.go
+++ b/api/v1alpha1/cors_types.go
@@ -10,7 +10,8 @@ import gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 // Origin is defined by the scheme (protocol), hostname (domain), and port of
 // the URL used to access it. The hostname can be "precise" which is just the
 // domain name or "wildcard" which is a domain name prefixed with a single
-// wildcard label such as "*.example.com".
+// wildcard label such as "*.example.com". The optional port can be a wildcard
+// as well to allow all ports.
 // In addition to that a single wildcard (with or without scheme) can be
 // configured to match any origin.
 //
@@ -19,11 +20,12 @@ import gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 // - https://*.example.com
 // - http://foo.example.com:8080
 // - http://*.example.com:8080
+// - https://localhost:*
 // - https://*
 //
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$`
+// +kubebuilder:validation:Pattern=`^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:(\*|\d{1,5}))?)$`
 type Origin string
 
 // CORS defines the configuration for Cross-Origin Resource Sharing (CORS).

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -587,7 +587,8 @@ spec:
                         Origin is defined by the scheme (protocol), hostname (domain), and port of
                         the URL used to access it. The hostname can be "precise" which is just the
                         domain name or "wildcard" which is a domain name prefixed with a single
-                        wildcard label such as "*.example.com".
+                        wildcard label such as "*.example.com". The optional port can be a wildcard
+                        as well to allow all ports.
                         In addition to that a single wildcard (with or without scheme) can be
                         configured to match any origin.
 
@@ -596,10 +597,11 @@ spec:
                         - https://*.example.com
                         - http://foo.example.com:8080
                         - http://*.example.com:8080
+                        - https://localhost:*
                         - https://*
                       maxLength: 253
                       minLength: 1
-                      pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$
+                      pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:(\*|\d{1,5}))?)$
                       type: string
                     type: array
                   exposeHeaders:

--- a/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -586,7 +586,8 @@ spec:
                         Origin is defined by the scheme (protocol), hostname (domain), and port of
                         the URL used to access it. The hostname can be "precise" which is just the
                         domain name or "wildcard" which is a domain name prefixed with a single
-                        wildcard label such as "*.example.com".
+                        wildcard label such as "*.example.com". The optional port can be a wildcard
+                        as well to allow all ports.
                         In addition to that a single wildcard (with or without scheme) can be
                         configured to match any origin.
 
@@ -595,10 +596,11 @@ spec:
                         - https://*.example.com
                         - http://foo.example.com:8080
                         - http://*.example.com:8080
+                        - https://localhost:*
                         - https://*
                       maxLength: 253
                       minLength: 1
-                      pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$
+                      pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:(\*|\d{1,5}))?)$
                       type: string
                     type: array
                   exposeHeaders:

--- a/internal/gatewayapi/securitypolicy_test.go
+++ b/internal/gatewayapi/securitypolicy_test.go
@@ -95,6 +95,30 @@ func Test_wildcard2regex(t *testing.T) {
 			origin:   "http://foo.example.com",
 			want:     1,
 		},
+		{
+			name:     "test11",
+			wildcard: "http://*.example.com:*",
+			origin:   "http://foo.example.com:8080",
+			want:     1,
+		},
+		{
+			name:     "test12",
+			wildcard: "http://*.example.com:*",
+			origin:   "http://foo.example.com",
+			want:     0,
+		},
+		{
+			name:     "test13",
+			wildcard: "http://localhost:*",
+			origin:   "http://localhost:1234",
+			want:     1,
+		},
+		{
+			name:     "test14",
+			wildcard: "http://localhost:*",
+			origin:   "http://localhost",
+			want:     0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/gatewayapi/securitypolicy_test.go
+++ b/internal/gatewayapi/securitypolicy_test.go
@@ -94,6 +94,30 @@ func Test_wildcard2regex(t *testing.T) {
 			origin:   "http://foo.example.com",
 			want:     1,
 		},
+		{
+			name:     "test11",
+			wildcard: "http://*.example.com:*",
+			origin:   "http://foo.example.com:8080",
+			want:     1,
+		},
+		{
+			name:     "test12",
+			wildcard: "http://*.example.com:*",
+			origin:   "http://foo.example.com",
+			want:     0,
+		},
+		{
+			name:     "test13",
+			wildcard: "http://localhost:*",
+			origin:   "http://localhost:1234",
+			want:     1,
+		},
+		{
+			name:     "test14",
+			wildcard: "http://localhost:*",
+			origin:   "http://localhost",
+			want:     0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -4215,7 +4215,8 @@ _Underlying type:_ _string_
 Origin is defined by the scheme (protocol), hostname (domain), and port of
 the URL used to access it. The hostname can be "precise" which is just the
 domain name or "wildcard" which is a domain name prefixed with a single
-wildcard label such as "*.example.com".
+wildcard label such as "*.example.com". The optional port can be a wildcard
+as well to allow all ports.
 In addition to that a single wildcard (with or without scheme) can be
 configured to match any origin.
 
@@ -4224,6 +4225,7 @@ For example, the following are valid origins:
 - https://*.example.com
 - http://foo.example.com:8080
 - http://*.example.com:8080
+- https://localhost:*
 - https://*
 
 _Appears in:_

--- a/test/cel-validation/securitypolicy_test.go
+++ b/test/cel-validation/securitypolicy_test.go
@@ -406,7 +406,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 				}
 			},
 			wantErrors: []string{
-				"spec.cors.allowOrigins[0]: Invalid value: \"https://foo.*.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:\\d{1,5})?)$'",
+				"spec.cors.allowOrigins[0]: Invalid value: \"https://foo.*.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:(\\*|\\d{1,5}))?)$'",
 			},
 		},
 		{
@@ -430,7 +430,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 				}
 			},
 			wantErrors: []string{
-				"spec.cors.allowOrigins[0]: Invalid value: \"foo.bar.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:\\d{1,5})?)$'",
+				"spec.cors.allowOrigins[0]: Invalid value: \"foo.bar.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:(\\*|\\d{1,5}))?)$'",
 			},
 		},
 		{
@@ -454,7 +454,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 				}
 			},
 			wantErrors: []string{
-				"spec.cors.allowOrigins[0]: Invalid value: \"grpc://foo.bar.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:\\d{1,5})?)$'",
+				"spec.cors.allowOrigins[0]: Invalid value: \"grpc://foo.bar.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:(\\*|\\d{1,5}))?)$'",
 			},
 		},
 

--- a/test/cel-validation/securitypolicy_test.go
+++ b/test/cel-validation/securitypolicy_test.go
@@ -405,7 +405,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 				}
 			},
 			wantErrors: []string{
-				"spec.cors.allowOrigins[0]: Invalid value: \"https://foo.*.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:\\d{1,5})?)$'",
+				"spec.cors.allowOrigins[0]: Invalid value: \"https://foo.*.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:(\\*|\\d{1,5}))?)$'",
 			},
 		},
 		{
@@ -429,7 +429,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 				}
 			},
 			wantErrors: []string{
-				"spec.cors.allowOrigins[0]: Invalid value: \"foo.bar.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:\\d{1,5})?)$'",
+				"spec.cors.allowOrigins[0]: Invalid value: \"foo.bar.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:(\\*|\\d{1,5}))?)$'",
 			},
 		},
 		{
@@ -453,7 +453,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 				}
 			},
 			wantErrors: []string{
-				"spec.cors.allowOrigins[0]: Invalid value: \"grpc://foo.bar.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:\\d{1,5})?)$'",
+				"spec.cors.allowOrigins[0]: Invalid value: \"grpc://foo.bar.com\": spec.cors.allowOrigins[0] in body should match '^(\\*|https?:\\/\\/(\\*|(\\*\\.)?(([\\w-]+\\.?)+)?[\\w-]+)(:(\\*|\\d{1,5}))?)$'",
 			},
 		},
 

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -49982,7 +49982,8 @@ spec:
                         Origin is defined by the scheme (protocol), hostname (domain), and port of
                         the URL used to access it. The hostname can be "precise" which is just the
                         domain name or "wildcard" which is a domain name prefixed with a single
-                        wildcard label such as "*.example.com".
+                        wildcard label such as "*.example.com". The optional port can be a wildcard
+                        as well to allow all ports.
                         In addition to that a single wildcard (with or without scheme) can be
                         configured to match any origin.
 
@@ -49991,10 +49992,11 @@ spec:
                         - https://*.example.com
                         - http://foo.example.com:8080
                         - http://*.example.com:8080
+                        - https://localhost:*
                         - https://*
                       maxLength: 253
                       minLength: 1
-                      pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$
+                      pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:(\*|\d{1,5}))?)$
                       type: string
                     type: array
                   exposeHeaders:

--- a/test/helm/gateway-crds-helm/e2e.out.yaml
+++ b/test/helm/gateway-crds-helm/e2e.out.yaml
@@ -27955,7 +27955,8 @@ spec:
                         Origin is defined by the scheme (protocol), hostname (domain), and port of
                         the URL used to access it. The hostname can be "precise" which is just the
                         domain name or "wildcard" which is a domain name prefixed with a single
-                        wildcard label such as "*.example.com".
+                        wildcard label such as "*.example.com". The optional port can be a wildcard
+                        as well to allow all ports.
                         In addition to that a single wildcard (with or without scheme) can be
                         configured to match any origin.
 
@@ -27964,10 +27965,11 @@ spec:
                         - https://*.example.com
                         - http://foo.example.com:8080
                         - http://*.example.com:8080
+                        - https://localhost:*
                         - https://*
                       maxLength: 253
                       minLength: 1
-                      pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$
+                      pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:(\*|\d{1,5}))?)$
                       type: string
                     type: array
                   exposeHeaders:

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -27955,7 +27955,8 @@ spec:
                         Origin is defined by the scheme (protocol), hostname (domain), and port of
                         the URL used to access it. The hostname can be "precise" which is just the
                         domain name or "wildcard" which is a domain name prefixed with a single
-                        wildcard label such as "*.example.com".
+                        wildcard label such as "*.example.com". The optional port can be a wildcard
+                        as well to allow all ports.
                         In addition to that a single wildcard (with or without scheme) can be
                         configured to match any origin.
 
@@ -27964,10 +27965,11 @@ spec:
                         - https://*.example.com
                         - http://foo.example.com:8080
                         - http://*.example.com:8080
+                        - https://localhost:*
                         - https://*
                       maxLength: 253
                       minLength: 1
-                      pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$
+                      pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:(\*|\d{1,5}))?)$
                       type: string
                     type: array
                   exposeHeaders:


### PR DESCRIPTION
**What type of PR is this?**

feat(cors)

**What this PR does**:

Re-adds wildcard port matching (`*`) for CORS `allowOrigins`, reverting the removal in commit [81dce3e](github.com/envoyproxy/gateway/pull/2453/changes/81dce3e4499fb01cc3d7dd85bc56621857664fd2) (upstream PR [#2453](github.com/envoyproxy/gateway/pull/2453)).

The `wildcard2regex` runtime function already handles port wildcards correctly; This PR relaxes the kubebuilder CRD validation regex to accept `*` in the port position.

**Why we need it**:

The current `SecurityPolicy` CRD validation rejects wildcard ports, requiring every port to be enumerated explicitly. This creates friction in several scenarios:

1. **Local development with arbitrary ports**: Tools like webpack dev servers run on several ports chosen by the developers. Arbitrary client applications can also use multiple ports. Explicitly listing these ports is no manageable.

2. Using a general wildcard is not suitable in development environments that require stricter controls to prevent unwanted CORS access.

3. **Parallel agent workflows**: Multiple AI coding agents working in separate worktrees each need their own dev server on a unique port. Hardcoding ports prevents this.

Wildcard port matching (e.g., `https://host.com:*`) allows a single origin entry to cover all ports for a given host, eliminating the need to enumerate and maintain an ever-growing list of port numbers or compromise on security by using the general wildcard option.

### What Changed

- `api/v1alpha1/cors_types.go`: Relaxed the kubebuilder validation regex on `Origin` from `(:\d{1,5})?` to `(:(\*|\d{1,5}))?`
- Regenerated CRD manifests via `make manifests`
- Added wildcard port test cases to `internal/gatewayapi/securitypolicy_test.go`
- Updated CEL validation test expectations in `test/cel-validation/securitypolicy_test.go`

### Test plan

- [x] `make manifests` regenerates CRDs with the new regex
- [x] `go test ./internal/gatewayapi/... -run Test_wildcard2regex` passes with new port wildcard cases
- [x] CEL validation tests pass: `go test ./test/cel-validation/... -run TestSecurityPolicyTarget`
- [x] Origins like `https://example.com:*` are accepted by the CRD
- [x] Origins like `https://examplecom:5173` still work (no regression)

**Which issue(s) this PR fixes**:
N.A 