### PR TITLE
docs: fix typo in page for http-request-headers

### DIFF
--- a/site/content/en/v1.5/tasks/traffic/http-request-headers.md
+++ b/site/content/en/v1.5/tasks/traffic/http-request-headers.md
@@ -96,7 +96,7 @@ spec:
 {{< /tabpane >}}
 
 
-The `HTTPRoute]` status should indicate that it has been accepted and is bound to the example `Gateway`.
+The `HTTPRoute` status should indicate that it has been accepted and is bound to the example `Gateway`.
 
 ```shell
 kubectl get httproute/http-headers -o yaml

--- a/site/content/en/v1.6/tasks/traffic/http-request-headers.md
+++ b/site/content/en/v1.6/tasks/traffic/http-request-headers.md
@@ -96,7 +96,7 @@ spec:
 {{< /tabpane >}}
 
 
-The `HTTPRoute]` status should indicate that it has been accepted and is bound to the example `Gateway`.
+The `HTTPRoute` status should indicate that it has been accepted and is bound to the example `Gateway`.
 
 ```shell
 kubectl get httproute/http-headers -o yaml

--- a/site/content/en/v1.7/tasks/traffic/http-request-headers.md
+++ b/site/content/en/v1.7/tasks/traffic/http-request-headers.md
@@ -96,7 +96,7 @@ spec:
 {{< /tabpane >}}
 
 
-The `HTTPRoute]` status should indicate that it has been accepted and is bound to the example `Gateway`.
+The `HTTPRoute` status should indicate that it has been accepted and is bound to the example `Gateway`.
 
 ```shell
 kubectl get httproute/http-headers -o yaml


### PR DESCRIPTION
doc fix for wrongly placed `]`-char in the page for [`HTTP Request Headers`](https://gateway.envoyproxy.io/docs/tasks/traffic/http-request-headers/#adding-request-headers), in doc-pages for v1.5, v1.6, v1.7