### PR TITLE
ci: optimize binary builds in build_and_test workflow

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -205,6 +205,7 @@ jobs:
         # set ACTIONS_STEP_DEBUG to true if context runner.debug is '1',
         # which means to dump the current state when there's a case failed.
         ACTIONS_STEP_DEBUG: ${{ runner.debug == '1' }}
+        SKIP_GO_BUILD: "true"
       run: make conformance
 
   e2e-test:
@@ -269,6 +270,7 @@ jobs:
         # set ACTIONS_STEP_DEBUG to true if context runner.debug is '1',
         # which means to dump the current state when there's a case failed.
         ACTIONS_STEP_DEBUG: ${{ runner.debug == '1' }}
+        SKIP_GO_BUILD: "true"
       run: make e2e
 
   benchmark-test:
@@ -304,6 +306,7 @@ jobs:
         BENCHMARK_MEMORY_LIMITS: 2000Mi
         BENCHMARK_REPORT_DIR: benchmark_report
         BENCHMARK_RENDER_PNG: "false"
+        SKIP_GO_BUILD: "true"
       run: make benchmark
 
     - name: Upload Benchmark report
@@ -335,6 +338,7 @@ jobs:
       env:
         IMAGE_PULL_POLICY: IfNotPresent
         CUSTOM_CNI: "true"
+        SKIP_GO_BUILD: "true"
       run: make resilience
 
   publish:

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -124,14 +124,27 @@ jobs:
         filter: ${{ github.ref == 'refs/heads/main' && 'tree:0' || '' }}
     - uses: ./tools/github-actions/setup-deps
 
-    - name: Build EG Multiarch Binaries
-      run: make build-multiarch PLATFORMS="linux_amd64 linux_arm64"
+    # Build both linux/amd64 and linux/arm64 on main (needed for multi-arch image publish),
+    # and only linux/amd64 on PRs and release branches.
+    - name: Build EG Binaries
+      run: make build-multiarch BINS="envoy-gateway" PLATFORMS="${{ github.ref == 'refs/heads/main' && 'linux_amd64 linux_arm64' || 'linux_amd64' }}"
 
     - name: Upload EG Binaries
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: envoy-gateway
         path: bin/
+
+  build-egctl:
+    runs-on: ubuntu-latest
+    needs: [changes, lint, gen-check, license-check, coverage-test]
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.run_test_workflow == 'true' }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - uses: ./tools/github-actions/setup-deps
+
+    - name: Build egctl Binary
+      run: make build BINS="egctl" PLATFORM="linux_amd64"
 
   conformance-test:
     runs-on: ubuntu-latest
@@ -179,9 +192,7 @@ jobs:
         path: bin/
 
     - name: Give Privileges To EG Binaries
-      run: |
-        chmod +x bin/linux/amd64/envoy-gateway
-        chmod +x bin/linux/arm64/envoy-gateway
+      run: chmod +x bin/linux/*/envoy-gateway
 
     # conformance
     - name: Run Standard Conformance Tests
@@ -238,9 +249,7 @@ jobs:
         path: bin/
 
     - name: Give Privileges To EG Binaries
-      run: |
-        chmod +x bin/linux/amd64/envoy-gateway
-        chmod +x bin/linux/arm64/envoy-gateway
+      run: chmod +x bin/linux/*/envoy-gateway
 
     # E2E
     - name: Run E2E Tests
@@ -274,6 +283,14 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: ./tools/github-actions/setup-deps
 
+    - name: Download EG Binaries
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      with:
+        name: envoy-gateway
+        path: bin/
+
+    - name: Give Privileges To EG Binaries
+      run: chmod +x bin/linux/*/envoy-gateway
 
     # Benchmark
     - name: Run Benchmark tests
@@ -304,6 +321,16 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: ./tools/github-actions/setup-deps
+
+    - name: Download EG Binaries
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      with:
+        name: envoy-gateway
+        path: bin/
+
+    - name: Give Privileges To EG Binaries
+      run: chmod +x bin/linux/*/envoy-gateway
+
     - name: Resilience Test
       env:
         IMAGE_PULL_POLICY: IfNotPresent
@@ -325,9 +352,7 @@ jobs:
         path: bin/
 
     - name: Give Privileges To EG Binaries
-      run: |
-        chmod +x bin/linux/amd64/envoy-gateway
-        chmod +x bin/linux/arm64/envoy-gateway
+      run: chmod +x bin/linux/*/envoy-gateway
 
     # build and push image
     - name: Login to DockerHub
@@ -363,6 +388,7 @@ jobs:
     - license-check
     - coverage-test
     - build
+    - build-egctl
     - conformance-test
     - e2e-test
     - benchmark-test

--- a/tools/make/golang.mk
+++ b/tools/make/golang.mk
@@ -18,12 +18,18 @@ endif
 
 GO_VERSION = $(shell grep -oE "^go [[:digit:]]*\.[[:digit:]]*" go.mod | cut -d' ' -f2)
 
+# Set SKIP_GO_BUILD=true to skip go compilation (e.g. when using pre-built binaries from CI artifacts).
+SKIP_GO_BUILD ?= false
+
 # Build the target binary in target platform.
 # The pattern of build.% is `build.{Platform}.{Command}`.
 # If we want to build envoy-gateway in linux amd64 platform,
 # just execute make go.build.linux_amd64.envoy-gateway.
 .PHONY: go.build.%
 go.build.%:
+ifeq ($(SKIP_GO_BUILD),true)
+	@echo "Skipping go build"
+else
 	@$(LOG_TARGET)
 	$(eval COMMAND := $(word 2,$(subst ., ,$*)))
 	$(eval PLATFORM := $(word 1,$(subst ., ,$*)))
@@ -31,6 +37,7 @@ go.build.%:
 	$(eval ARCH := $(word 2,$(subst _, ,$(PLATFORM))))
 	@$(call log, "Building binary $(COMMAND) with commit $(REV) for $(OS) $(ARCH)")
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o $(OUTPUT_DIR)/$(OS)/$(ARCH)/$(COMMAND) -ldflags "$(GO_LDFLAGS)" $(ROOT_PACKAGE)/cmd/$(COMMAND)
+endif
 
 # Build the envoy-gateway binaries in the hosted platforms.
 .PHONY: go.build


### PR DESCRIPTION

**What this PR does / why we need it**:

- Build job now only builds the `envoy-gateway` binary (not `egctl`), with conditional platforms: `linux/amd64` only on PRs and release branches, both `linux/amd64` and `linux/arm64` on main (needed for multi-arch image publish).
- `egctl` is built in a new parallel `build-egctl` job for `linux/amd64` only.
- `benchmark-test` and `resilience-test` now download the pre-built binary artifact (same as conformance/e2e), avoiding a redundant `go build`.
- Added `SKIP_GO_BUILD` Make variable to `golang.mk`: when set to `true`, the `go.build.%` target skips compilation. All downstream jobs that download the pre-built artifact set `SKIP_GO_BUILD=true` so the Make dependency chain (`kube-install-image` → `image.build` → `go.build`) no longer triggers a redundant rebuild.
- Use `chmod +x bin/linux/*/envoy-gateway` wildcard across all jobs instead of listing each architecture explicitly.

**Which issue(s) this PR fixes**:

Fixes #8686

Release Notes: No
