### PR TITLE
e2e: add test for watched namespace

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -181,6 +181,10 @@ jobs:
           ipFamily: ipv4
           profile: xds-name-scheme-v2
           gwapiChannel: experimental
+        - version: v1.35.0
+          ipFamily: ipv4
+          profile: watch-namespaces
+          gwapiChannel: experimental
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: ./tools/github-actions/setup-deps
@@ -237,6 +241,9 @@ jobs:
         - version: v1.35.0
           ipFamily: ipv4
           profile: xds-name-scheme-v2
+        - version: v1.35.0
+          ipFamily: ipv4
+          profile: watch-namespaces
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/experimental_conformance.yaml
+++ b/.github/workflows/experimental_conformance.yaml
@@ -45,6 +45,9 @@ jobs:
             # only run dual test on latest version to save time
             ipFamily: dual
             profile: gateway-namespace-mode
+          - version: v1.35.0
+            ipFamily: ipv4
+            profile: watch-namespaces
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: ./tools/github-actions/setup-deps

--- a/test/config/envoy-gateaway-config/watch-namespaces.yaml
+++ b/test/config/envoy-gateaway-config/watch-namespaces.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-gateway-config
+  namespace: envoy-gateway-system
+data:
+  envoy-gateway.yaml: |
+    apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: EnvoyGateway
+    provider:
+      type: Kubernetes
+      kubernetes:
+        watch:
+          type: Namespaces
+          namespaces:
+          - gateway-conformance-infra
+          - gateway-preserve-case-backend
+          - gateway-upgrade-infra
+          - listenerset-tls-termination-secret
+          - monitoring
+          - multireferencegrants-ns
+    gateway:
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    extensionApis:
+      enableEnvoyPatchPolicy: true
+      enableBackend: true
+    gatewayAPI:
+      enabled: [XListenerSet]
+    rateLimit:
+      backend:
+        type: Redis
+        redis:
+          url: redis.redis-system.svc.cluster.local:6379
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: envoyproxy/envoy:invalid-tag
+    telemetry:
+      traces:
+        sink:
+          type: OpenTelemetry
+          openTelemetry:
+            host: otel-collector.monitoring.svc.cluster.local
+            port: 4317
+            protocol: grpc
+        samplingRate:
+          numerator: 100

--- a/test/config/envoy-gateaway-config/watch-namespaces.yaml
+++ b/test/config/envoy-gateaway-config/watch-namespaces.yaml
@@ -13,6 +13,7 @@ data:
         watch:
           type: Namespaces
           namespaces:
+          - envoy-gateway-system
           - gateway-conformance-infra
           - gateway-preserve-case-backend
           - gateway-upgrade-infra

--- a/test/config/helm/watch-namespaces.yaml
+++ b/test/config/helm/watch-namespaces.yaml
@@ -1,0 +1,1 @@
+# the watch-namespaces configuration is applied via test/config/envoy-gateaway-config/watch-namespaces.yaml


### PR DESCRIPTION
This PR adds an e2e test for "watched namespaces" are specified.

~The test verifies that EG correctly reconciles resources in the `envoy-gateway-system` namespace even when that namespace is not explicitly included in the watched namespaces.~

It turns out `envoy-gateway-system` namespace needs to be explicitly configured in the watched namespaces in the current controller logic. I'm not sure if this is a bug or intended behavior, we can address this later if we want to implicitly include `envoy-gateway-system` namespace.

This test is required to ensure that the https://github.com/envoyproxy/gateway/pull/8764 doesn't break  the "watched namespaces" mode.