### PR TITLE
chore: add missing labels for the rl service account

### DIFF
--- a/internal/infrastructure/kubernetes/ratelimit/resource_provider.go
+++ b/internal/infrastructure/kubernetes/ratelimit/resource_provider.go
@@ -186,6 +186,7 @@ func (r *ResourceRender) ServiceAccount() (*corev1.ServiceAccount, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: r.Namespace(),
 			Name:      InfraName,
+			Labels:    rateLimitLabels(),
 		},
 	}
 

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/envoy-ratelimit-serviceaccount.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/envoy-ratelimit-serviceaccount.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/component: ratelimit
+    app.kubernetes.io/managed-by: envoy-gateway
+    app.kubernetes.io/name: envoy-ratelimit
   name: envoy-ratelimit
   namespace: envoy-gateway-system
   ownerReferences:

--- a/internal/infrastructure/kubernetes/ratelimit_serviceaccount_test.go
+++ b/internal/infrastructure/kubernetes/ratelimit_serviceaccount_test.go
@@ -53,6 +53,11 @@ func TestCreateOrUpdateRateLimitServiceAccount(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "envoy-gateway-system",
 					Name:      ratelimit.InfraName,
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       "envoy-ratelimit",
+						"app.kubernetes.io/component":  "ratelimit",
+						"app.kubernetes.io/managed-by": "envoy-gateway",
+					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:       ratelimit.ResourceKindServiceAccount,
@@ -76,6 +81,11 @@ func TestCreateOrUpdateRateLimitServiceAccount(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "envoy-gateway-system",
 					Name:      ratelimit.InfraName,
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       "envoy-ratelimit",
+						"app.kubernetes.io/component":  "ratelimit",
+						"app.kubernetes.io/managed-by": "envoy-gateway",
+					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:       ratelimit.ResourceKindServiceAccount,

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -63,6 +63,7 @@ bug fixes: |
   Made ConnectionLimit.Value optional so users can configure MaxConnectionDuration, MaxRequestsPerConnection, or MaxStreamDuration without setting a max connections value.
   Fixed endpoint hostname is not respected when doing active health check.
   Fixed ratelimit deployment missing metrics container port (19001), which prevented PodMonitor/ServiceMonitor from targeting the metrics endpoint.
+  Fixed ratelimit ServiceAccount missing standard Kubernetes app labels.
   Fixed GRPCRoute RequestMirror filter backend not being indexed, causing "service not found" errors for mirror targets that exist in the cluster.
   Fixed GRPCRoute not detecting conflicting RequestMirror and DirectResponse filters, which caused the mirror to be silently dropped.
   Fixed BackendTrafficPolicy `requestBuffer` coexisting with route upgrades by disabling the default WebSocket upgrade on buffered routes and rejecting explicit `requestBuffer` + `httpUpgrade` combinations.


### PR DESCRIPTION
This seems a bug - ratelimit resource provider adds labels to all other resources excepts the service account.