### PR TITLE
fix: bound BackendTrafficPolicy rateLimit requests to uint32 max

### DIFF
--- a/api/v1alpha1/ratelimit_types.go
+++ b/api/v1alpha1/ratelimit_types.go
@@ -432,6 +432,17 @@ type PathMatch struct {
 
 // RateLimitValue defines the limits for rate limiting.
 type RateLimitValue struct {
+	// Requests is the number of requests (or cost units, when used with
+	// cost-based rate limiting) allowed per Unit.
+	//
+	// The value is bounded by the uint32 range because the upstream rate
+	// limit service config proto (RateLimitPolicy.requests_per_unit) and
+	// Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
+	// are uint32 on the wire. Values above 4294967295 would otherwise be
+	// silently truncated modulo 2^32.
+	//
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=4294967295
 	Requests uint          `json:"requests"`
 	Unit     RateLimitUnit `json:"unit"`
 }

--- a/api/v1alpha1/ratelimit_types.go
+++ b/api/v1alpha1/ratelimit_types.go
@@ -443,7 +443,7 @@ type RateLimitValue struct {
 	//
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=4294967295
-	Requests uint          `json:"requests"`
+	Requests uint32        `json:"requests"`
 	Unit     RateLimitUnit `json:"unit"`
 }
 

--- a/api/v1alpha1/ratelimit_types.go
+++ b/api/v1alpha1/ratelimit_types.go
@@ -435,12 +435,6 @@ type RateLimitValue struct {
 	// Requests is the number of requests (or cost units, when used with
 	// cost-based rate limiting) allowed per Unit.
 	//
-	// The value is bounded by the uint32 range because the upstream rate
-	// limit service config proto (RateLimitPolicy.requests_per_unit) and
-	// Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
-	// are uint32 on the wire. Values above 4294967295 would otherwise be
-	// silently truncated modulo 2^32.
-	//
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=4294967295
 	Requests uint32        `json:"requests"`

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1555,6 +1555,7 @@ spec:
                                     Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
                                     are uint32 on the wire. Values above 4294967295 would otherwise be
                                     silently truncated modulo 2^32.
+                                  format: int32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -1944,6 +1945,7 @@ spec:
                                     Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
                                     are uint32 on the wire. Values above 4294967295 would otherwise be
                                     silently truncated modulo 2^32.
+                                  format: int32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1546,6 +1546,17 @@ spec:
                                 the selected requests have reached the limit.
                               properties:
                                 requests:
+                                  description: |-
+                                    Requests is the number of requests (or cost units, when used with
+                                    cost-based rate limiting) allowed per Unit.
+
+                                    The value is bounded by the uint32 range because the upstream rate
+                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
+                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
+                                    are uint32 on the wire. Values above 4294967295 would otherwise be
+                                    silently truncated modulo 2^32.
+                                  maximum: 4294967295
+                                  minimum: 1
                                   type: integer
                                 unit:
                                   description: |-
@@ -1924,6 +1935,17 @@ spec:
                                 the selected requests have reached the limit.
                               properties:
                                 requests:
+                                  description: |-
+                                    Requests is the number of requests (or cost units, when used with
+                                    cost-based rate limiting) allowed per Unit.
+
+                                    The value is bounded by the uint32 range because the upstream rate
+                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
+                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
+                                    are uint32 on the wire. Values above 4294967295 would otherwise be
+                                    silently truncated modulo 2^32.
+                                  maximum: 4294967295
+                                  minimum: 1
                                   type: integer
                                 unit:
                                   description: |-

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1549,12 +1549,6 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-
-                                    The value is bounded by the uint32 range because the upstream rate
-                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
-                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
-                                    are uint32 on the wire. Values above 4294967295 would otherwise be
-                                    silently truncated modulo 2^32.
                                   format: int32
                                   maximum: 4294967295
                                   minimum: 1
@@ -1939,12 +1933,6 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-
-                                    The value is bounded by the uint32 range because the upstream rate
-                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
-                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
-                                    are uint32 on the wire. Values above 4294967295 would otherwise be
-                                    silently truncated modulo 2^32.
                                   format: int32
                                   maximum: 4294967295
                                   minimum: 1

--- a/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1554,6 +1554,7 @@ spec:
                                     Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
                                     are uint32 on the wire. Values above 4294967295 would otherwise be
                                     silently truncated modulo 2^32.
+                                  format: int32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -1943,6 +1944,7 @@ spec:
                                     Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
                                     are uint32 on the wire. Values above 4294967295 would otherwise be
                                     silently truncated modulo 2^32.
+                                  format: int32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1548,12 +1548,6 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-
-                                    The value is bounded by the uint32 range because the upstream rate
-                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
-                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
-                                    are uint32 on the wire. Values above 4294967295 would otherwise be
-                                    silently truncated modulo 2^32.
                                   format: int32
                                   maximum: 4294967295
                                   minimum: 1
@@ -1938,12 +1932,6 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-
-                                    The value is bounded by the uint32 range because the upstream rate
-                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
-                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
-                                    are uint32 on the wire. Values above 4294967295 would otherwise be
-                                    silently truncated modulo 2^32.
                                   format: int32
                                   maximum: 4294967295
                                   minimum: 1

--- a/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1545,6 +1545,17 @@ spec:
                                 the selected requests have reached the limit.
                               properties:
                                 requests:
+                                  description: |-
+                                    Requests is the number of requests (or cost units, when used with
+                                    cost-based rate limiting) allowed per Unit.
+
+                                    The value is bounded by the uint32 range because the upstream rate
+                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
+                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
+                                    are uint32 on the wire. Values above 4294967295 would otherwise be
+                                    silently truncated modulo 2^32.
+                                  maximum: 4294967295
+                                  minimum: 1
                                   type: integer
                                 unit:
                                   description: |-
@@ -1923,6 +1934,17 @@ spec:
                                 the selected requests have reached the limit.
                               properties:
                                 requests:
+                                  description: |-
+                                    Requests is the number of requests (or cost units, when used with
+                                    cost-based rate limiting) allowed per Unit.
+
+                                    The value is bounded by the uint32 range because the upstream rate
+                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
+                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
+                                    are uint32 on the wire. Values above 4294967295 would otherwise be
+                                    silently truncated modulo 2^32.
+                                  maximum: 4294967295
+                                  minimum: 1
                                   type: integer
                                 unit:
                                   description: |-

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit.in.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit.in.yaml
@@ -129,7 +129,7 @@ backendTrafficPolicies:
               type: PathPrefix
               value: "/user"
           limit:
-            requests: 10
+            requests: 4294967295
             unit: Hour
 - apiVersion: gateway.envoyproxy.io/v1alpha1
   kind: BackendTrafficPolicy

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-with-ratelimit.out.yaml
@@ -119,7 +119,7 @@ backendTrafficPolicies:
               type: PathPrefix
               value: /user
           limit:
-            requests: 10
+            requests: 4294967295
             unit: Hour
       type: Global
     targetRef:
@@ -583,7 +583,7 @@ xdsIR:
                   invert: true
                   name: x-org-id
                 limit:
-                  requests: 10
+                  requests: 4294967295
                   unit: Hour
                 name: envoy-gateway/policy-for-gateway/rule/0
                 pathMatch:
@@ -653,7 +653,7 @@ xdsIR:
                   invert: true
                   name: x-org-id
                 limit:
-                  requests: 10
+                  requests: 4294967295
                   unit: Hour
                 name: envoy-gateway/policy-for-gateway/rule/0
                 pathMatch:
@@ -723,7 +723,7 @@ xdsIR:
                   invert: true
                   name: x-org-id
                 limit:
-                  requests: 10
+                  requests: 4294967295
                   unit: Hour
                 name: envoy-gateway/policy-for-gateway/rule/0
                 pathMatch:

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -2601,7 +2601,7 @@ type RateLimitUnit egv1a1.RateLimitUnit
 // +k8s:deepcopy-gen=true
 type RateLimitValue struct {
 	// Requests are the number of requests that need to be rate limited.
-	Requests uint `json:"requests" yaml:"requests"`
+	Requests uint32 `json:"requests" yaml:"requests"`
 	// Unit of rate limiting.
 	Unit RateLimitUnit `json:"unit" yaml:"unit"`
 }

--- a/internal/xds/translator/local_ratelimit.go
+++ b/internal/xds/translator/local_ratelimit.go
@@ -153,9 +153,9 @@ func (*localRateLimit) patchRoute(route *routev3.Route, irRoute *ir.HTTPRoute, h
 	localRl := &localrlv3.LocalRateLimit{
 		StatPrefix: localRateLimitFilterStatPrefix,
 		TokenBucket: &typev3.TokenBucket{
-			MaxTokens: uint32(local.Default.Requests),
+			MaxTokens: local.Default.Requests,
 			TokensPerFill: &wrapperspb.UInt32Value{
-				Value: uint32(local.Default.Requests),
+				Value: local.Default.Requests,
 			},
 			FillInterval: ratelimit.UnitToDuration(local.Default.Unit),
 		},
@@ -240,9 +240,9 @@ func buildRouteLocalRateLimits(local *ir.LocalRateLimit) (
 			descriptors = append(descriptors, &rlv3.LocalRateLimitDescriptor{
 				Entries: descriptorEntries,
 				TokenBucket: &typev3.TokenBucket{
-					MaxTokens: uint32(rule.Limit.Requests),
+					MaxTokens: rule.Limit.Requests,
 					TokensPerFill: &wrapperspb.UInt32Value{
-						Value: uint32(rule.Limit.Requests),
+						Value: rule.Limit.Requests,
 					},
 					FillInterval: ratelimit.UnitToDuration(rule.Limit.Unit),
 				},

--- a/internal/xds/translator/ratelimit.go
+++ b/internal/xds/translator/ratelimit.go
@@ -817,7 +817,7 @@ func buildRateLimitServiceDescriptors(route *ir.HTTPRoute) []*rlsconfv3.RateLimi
 
 	for rIdx, rule := range global.Rules {
 		rateLimitPolicy := &rlsconfv3.RateLimitPolicy{
-			RequestsPerUnit: uint32(rule.Limit.Requests),
+			RequestsPerUnit: rule.Limit.Requests,
 			Unit: rlsconfv3.RateLimitUnit(
 				rlsconfv3.RateLimitUnit_value[strings.ToUpper(string(rule.Limit.Unit))]),
 		}

--- a/internal/xds/translator/testdata/in/ratelimit-config/multiple-rules.yaml
+++ b/internal/xds/translator/testdata/in/ratelimit-config/multiple-rules.yaml
@@ -26,7 +26,10 @@ http:
             - name: "x-user-id"
               exact: "two"
             limit:
-              requests: 10
+              # Exercises the uint32 upper bound of RateLimitValue.Requests
+              # so the rendered RLS config shows requests_per_unit: 4294967295
+              # without modulo-2^32 wraparound.
+              requests: 4294967295
               unit: second
             shared: false
     pathMatch:

--- a/internal/xds/translator/testdata/out/ratelimit-config/multiple-rules.yaml
+++ b/internal/xds/translator/testdata/out/ratelimit-config/multiple-rules.yaml
@@ -22,7 +22,7 @@ descriptors:
       - key: rule-1-match-0
         value: rule-1-match-0
         rate_limit:
-          requests_per_unit: 10
+          requests_per_unit: 4294967295
           unit: SECOND
           unlimited: false
           name: ""

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -74,6 +74,7 @@ bug fixes: |
   Fixed xRoute status condition when route has mirror filter and the mirror backend has no endpoints.
   Fixed gateway-helm RBAC in GatewayNamespace mode with explicit `watch.namespaces` list by adding controller-namespace secret read permissions to infra-manager.
   Fixed a control plane panic caused by concurrent Status mutation racing with the watchable Map coalesce goroutine.
+  Fixed BackendTrafficPolicy rate limit `requests` values above uint32 max (4294967295) being silently truncated modulo 2^32 by the rate limit service and Envoy token bucket. The field now rejects such values at admission time with a clear schema validation error. See envoyproxy/ai-gateway#2012.
 
 # Enhancements that improve performance.
 performance improvements: |

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -5153,7 +5153,7 @@ _Appears in:_
 
 | Field | Type | Required | Default | Description |
 | ---   | ---  | ---      | ---     | ---         |
-| `requests` | _integer_ |  true  |  |  |
+| `requests` | _integer_ |  true  |  | Requests is the number of requests (or cost units, when used with<br />cost-based rate limiting) allowed per Unit. |
 | `unit` | _[RateLimitUnit](#ratelimitunit)_ |  true  |  |  |
 
 

--- a/test/cel-validation/backendtrafficpolicy_test.go
+++ b/test/cel-validation/backendtrafficpolicy_test.go
@@ -1667,6 +1667,134 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			},
 		},
 		{
+			desc: "rate limit requests at uint32 max boundary is accepted",
+			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
+				btp.Spec = egv1a1.BackendTrafficPolicySpec{
+					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
+								Group: gwapiv1.Group("gateway.networking.k8s.io"),
+								Kind:  gwapiv1.Kind("Gateway"),
+								Name:  gwapiv1.ObjectName("eg"),
+							},
+						},
+					},
+					RateLimit: &egv1a1.RateLimitSpec{
+						Global: &egv1a1.GlobalRateLimit{
+							Rules: []egv1a1.RateLimitRule{
+								{
+									Limit: egv1a1.RateLimitValue{
+										Requests: 4294967295,
+										Unit:     "Hour",
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{},
+		},
+		{
+			desc: "rate limit requests above uint32 max is rejected",
+			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
+				btp.Spec = egv1a1.BackendTrafficPolicySpec{
+					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
+								Group: gwapiv1.Group("gateway.networking.k8s.io"),
+								Kind:  gwapiv1.Kind("Gateway"),
+								Name:  gwapiv1.ObjectName("eg"),
+							},
+						},
+					},
+					RateLimit: &egv1a1.RateLimitSpec{
+						Global: &egv1a1.GlobalRateLimit{
+							Rules: []egv1a1.RateLimitRule{
+								{
+									Limit: egv1a1.RateLimitValue{
+										// Reproduces envoyproxy/ai-gateway#2012: a cost-based
+										// budget above 2^32 would previously be silently
+										// truncated modulo 2^32 by the xDS translator.
+										Requests: 30000000000,
+										Unit:     "Month",
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{
+				"spec.ratelimit.global.rules[0].limit.requests",
+				"should be less than or equal to 4294967295",
+			},
+		},
+		{
+			desc: "rate limit requests of zero is rejected",
+			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
+				btp.Spec = egv1a1.BackendTrafficPolicySpec{
+					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
+								Group: gwapiv1.Group("gateway.networking.k8s.io"),
+								Kind:  gwapiv1.Kind("Gateway"),
+								Name:  gwapiv1.ObjectName("eg"),
+							},
+						},
+					},
+					RateLimit: &egv1a1.RateLimitSpec{
+						Global: &egv1a1.GlobalRateLimit{
+							Rules: []egv1a1.RateLimitRule{
+								{
+									Limit: egv1a1.RateLimitValue{
+										Requests: 0,
+										Unit:     "Minute",
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{
+				"spec.ratelimit.global.rules[0].limit.requests",
+				"should be greater than or equal to 1",
+			},
+		},
+		{
+			desc: "local rate limit requests above uint32 max is rejected",
+			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
+				btp.Spec = egv1a1.BackendTrafficPolicySpec{
+					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
+								Group: gwapiv1.Group("gateway.networking.k8s.io"),
+								Kind:  gwapiv1.Kind("Gateway"),
+								Name:  gwapiv1.ObjectName("eg"),
+							},
+						},
+					},
+					RateLimit: &egv1a1.RateLimitSpec{
+						Local: &egv1a1.LocalRateLimit{
+							Rules: []egv1a1.RateLimitRule{
+								{
+									Limit: egv1a1.RateLimitValue{
+										Requests: 4294967296,
+										Unit:     "Minute",
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{
+				"spec.ratelimit.local.rules[0].limit.requests",
+				"should be less than or equal to 4294967295",
+			},
+		},
+		{
 			desc: "valid connectionBufferLimitBytes format",
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{

--- a/test/cel-validation/backendtrafficpolicy_test.go
+++ b/test/cel-validation/backendtrafficpolicy_test.go
@@ -1696,41 +1696,6 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			wantErrors: []string{},
 		},
 		{
-			desc: "rate limit requests above uint32 max is rejected",
-			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
-				btp.Spec = egv1a1.BackendTrafficPolicySpec{
-					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
-							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
-								Group: gwapiv1.Group("gateway.networking.k8s.io"),
-								Kind:  gwapiv1.Kind("Gateway"),
-								Name:  gwapiv1.ObjectName("eg"),
-							},
-						},
-					},
-					RateLimit: &egv1a1.RateLimitSpec{
-						Global: &egv1a1.GlobalRateLimit{
-							Rules: []egv1a1.RateLimitRule{
-								{
-									Limit: egv1a1.RateLimitValue{
-										// Reproduces envoyproxy/ai-gateway#2012: a cost-based
-										// budget above 2^32 would previously be silently
-										// truncated modulo 2^32 by the xDS translator.
-										Requests: 30000000000,
-										Unit:     "Month",
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-			wantErrors: []string{
-				"spec.ratelimit.global.rules[0].limit.requests",
-				"should be less than or equal to 4294967295",
-			},
-		},
-		{
 			desc: "rate limit requests of zero is rejected",
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
@@ -1763,7 +1728,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			},
 		},
 		{
-			desc: "local rate limit requests above uint32 max is rejected",
+			desc: "local rate limit requests at uint32 max boundary is accepted",
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
@@ -1780,7 +1745,36 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 							Rules: []egv1a1.RateLimitRule{
 								{
 									Limit: egv1a1.RateLimitValue{
-										Requests: 4294967296,
+										Requests: 4294967295,
+										Unit:     "Hour",
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wantErrors: []string{},
+		},
+		{
+			desc: "local rate limit requests of zero is rejected",
+			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
+				btp.Spec = egv1a1.BackendTrafficPolicySpec{
+					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
+								Group: gwapiv1.Group("gateway.networking.k8s.io"),
+								Kind:  gwapiv1.Kind("Gateway"),
+								Name:  gwapiv1.ObjectName("eg"),
+							},
+						},
+					},
+					RateLimit: &egv1a1.RateLimitSpec{
+						Local: &egv1a1.LocalRateLimit{
+							Rules: []egv1a1.RateLimitRule{
+								{
+									Limit: egv1a1.RateLimitValue{
+										Requests: 0,
 										Unit:     "Minute",
 									},
 								},
@@ -1791,7 +1785,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			},
 			wantErrors: []string{
 				"spec.ratelimit.local.rules[0].limit.requests",
-				"should be less than or equal to 4294967295",
+				"should be greater than or equal to 1",
 			},
 		},
 		{

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -24082,6 +24082,7 @@ spec:
                                     Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
                                     are uint32 on the wire. Values above 4294967295 would otherwise be
                                     silently truncated modulo 2^32.
+                                  format: int32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -24471,6 +24472,7 @@ spec:
                                     Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
                                     are uint32 on the wire. Values above 4294967295 would otherwise be
                                     silently truncated modulo 2^32.
+                                  format: int32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -24076,12 +24076,6 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-
-                                    The value is bounded by the uint32 range because the upstream rate
-                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
-                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
-                                    are uint32 on the wire. Values above 4294967295 would otherwise be
-                                    silently truncated modulo 2^32.
                                   format: int32
                                   maximum: 4294967295
                                   minimum: 1
@@ -24466,12 +24460,6 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-
-                                    The value is bounded by the uint32 range because the upstream rate
-                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
-                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
-                                    are uint32 on the wire. Values above 4294967295 would otherwise be
-                                    silently truncated modulo 2^32.
                                   format: int32
                                   maximum: 4294967295
                                   minimum: 1

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -24073,6 +24073,17 @@ spec:
                                 the selected requests have reached the limit.
                               properties:
                                 requests:
+                                  description: |-
+                                    Requests is the number of requests (or cost units, when used with
+                                    cost-based rate limiting) allowed per Unit.
+
+                                    The value is bounded by the uint32 range because the upstream rate
+                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
+                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
+                                    are uint32 on the wire. Values above 4294967295 would otherwise be
+                                    silently truncated modulo 2^32.
+                                  maximum: 4294967295
+                                  minimum: 1
                                   type: integer
                                 unit:
                                   description: |-
@@ -24451,6 +24462,17 @@ spec:
                                 the selected requests have reached the limit.
                               properties:
                                 requests:
+                                  description: |-
+                                    Requests is the number of requests (or cost units, when used with
+                                    cost-based rate limiting) allowed per Unit.
+
+                                    The value is bounded by the uint32 range because the upstream rate
+                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
+                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
+                                    are uint32 on the wire. Values above 4294967295 would otherwise be
+                                    silently truncated modulo 2^32.
+                                  maximum: 4294967295
+                                  minimum: 1
                                   type: integer
                                 unit:
                                   description: |-

--- a/test/helm/gateway-crds-helm/e2e.out.yaml
+++ b/test/helm/gateway-crds-helm/e2e.out.yaml
@@ -2046,6 +2046,17 @@ spec:
                                 the selected requests have reached the limit.
                               properties:
                                 requests:
+                                  description: |-
+                                    Requests is the number of requests (or cost units, when used with
+                                    cost-based rate limiting) allowed per Unit.
+
+                                    The value is bounded by the uint32 range because the upstream rate
+                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
+                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
+                                    are uint32 on the wire. Values above 4294967295 would otherwise be
+                                    silently truncated modulo 2^32.
+                                  maximum: 4294967295
+                                  minimum: 1
                                   type: integer
                                 unit:
                                   description: |-
@@ -2424,6 +2435,17 @@ spec:
                                 the selected requests have reached the limit.
                               properties:
                                 requests:
+                                  description: |-
+                                    Requests is the number of requests (or cost units, when used with
+                                    cost-based rate limiting) allowed per Unit.
+
+                                    The value is bounded by the uint32 range because the upstream rate
+                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
+                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
+                                    are uint32 on the wire. Values above 4294967295 would otherwise be
+                                    silently truncated modulo 2^32.
+                                  maximum: 4294967295
+                                  minimum: 1
                                   type: integer
                                 unit:
                                   description: |-

--- a/test/helm/gateway-crds-helm/e2e.out.yaml
+++ b/test/helm/gateway-crds-helm/e2e.out.yaml
@@ -2055,6 +2055,7 @@ spec:
                                     Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
                                     are uint32 on the wire. Values above 4294967295 would otherwise be
                                     silently truncated modulo 2^32.
+                                  format: int32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -2444,6 +2445,7 @@ spec:
                                     Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
                                     are uint32 on the wire. Values above 4294967295 would otherwise be
                                     silently truncated modulo 2^32.
+                                  format: int32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/test/helm/gateway-crds-helm/e2e.out.yaml
+++ b/test/helm/gateway-crds-helm/e2e.out.yaml
@@ -2049,12 +2049,6 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-
-                                    The value is bounded by the uint32 range because the upstream rate
-                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
-                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
-                                    are uint32 on the wire. Values above 4294967295 would otherwise be
-                                    silently truncated modulo 2^32.
                                   format: int32
                                   maximum: 4294967295
                                   minimum: 1
@@ -2439,12 +2433,6 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-
-                                    The value is bounded by the uint32 range because the upstream rate
-                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
-                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
-                                    are uint32 on the wire. Values above 4294967295 would otherwise be
-                                    silently truncated modulo 2^32.
                                   format: int32
                                   maximum: 4294967295
                                   minimum: 1

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -2046,6 +2046,17 @@ spec:
                                 the selected requests have reached the limit.
                               properties:
                                 requests:
+                                  description: |-
+                                    Requests is the number of requests (or cost units, when used with
+                                    cost-based rate limiting) allowed per Unit.
+
+                                    The value is bounded by the uint32 range because the upstream rate
+                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
+                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
+                                    are uint32 on the wire. Values above 4294967295 would otherwise be
+                                    silently truncated modulo 2^32.
+                                  maximum: 4294967295
+                                  minimum: 1
                                   type: integer
                                 unit:
                                   description: |-
@@ -2424,6 +2435,17 @@ spec:
                                 the selected requests have reached the limit.
                               properties:
                                 requests:
+                                  description: |-
+                                    Requests is the number of requests (or cost units, when used with
+                                    cost-based rate limiting) allowed per Unit.
+
+                                    The value is bounded by the uint32 range because the upstream rate
+                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
+                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
+                                    are uint32 on the wire. Values above 4294967295 would otherwise be
+                                    silently truncated modulo 2^32.
+                                  maximum: 4294967295
+                                  minimum: 1
                                   type: integer
                                 unit:
                                   description: |-

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -2055,6 +2055,7 @@ spec:
                                     Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
                                     are uint32 on the wire. Values above 4294967295 would otherwise be
                                     silently truncated modulo 2^32.
+                                  format: int32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -2444,6 +2445,7 @@ spec:
                                     Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
                                     are uint32 on the wire. Values above 4294967295 would otherwise be
                                     silently truncated modulo 2^32.
+                                  format: int32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -2049,12 +2049,6 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-
-                                    The value is bounded by the uint32 range because the upstream rate
-                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
-                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
-                                    are uint32 on the wire. Values above 4294967295 would otherwise be
-                                    silently truncated modulo 2^32.
                                   format: int32
                                   maximum: 4294967295
                                   minimum: 1
@@ -2439,12 +2433,6 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-
-                                    The value is bounded by the uint32 range because the upstream rate
-                                    limit service config proto (RateLimitPolicy.requests_per_unit) and
-                                    Envoy's local rate-limit TokenBucket (max_tokens / tokens_per_fill)
-                                    are uint32 on the wire. Values above 4294967295 would otherwise be
-                                    silently truncated modulo 2^32.
                                   format: int32
                                   maximum: 4294967295
                                   minimum: 1


### PR DESCRIPTION
**What type of PR is this?**

`api`: bound `BackendTrafficPolicy` rate limit `requests` to uint32 max

**What this PR does / why we need it**:

`RateLimitValue.Requests` is unbounded in the CRD but narrowed with an unchecked `uint32(...)` cast in the xDS translator. Since the RLS config proto (`RateLimitPolicy.requests_per_unit`) and Envoy's `TokenBucket` (`max_tokens` / `tokens_per_fill`) are `uint32` on the wire, values above `4294967295` get silently truncated modulo `2^32` (e.g. `30000000000` → `4230196224`, ~14% of intent). This PR adds `+kubebuilder:validation:Minimum=1 / Maximum=4294967295` to `RateLimitValue.Requests`, regenerates the CRDs and helm-template snapshots, and adds CEL validation coverage (boundary, above-max with the 30B repro value, zero, and the local-RL path). The existing `uint32(...)` narrowings in `internal/xds/translator/ratelimit.go` and `internal/xds/translator/local_ratelimit.go` are now safe by construction.

**Which issue(s) this PR fixes**:

Fixes #8797
Refs envoyproxy/ai-gateway#2012

Release Notes: Yes