### PR TITLE
gatewayapi(extproc): use Backend FQDN hostname as gRPC :authority

### DIFF
--- a/internal/gatewayapi/envoyextensionpolicy.go
+++ b/internal/gatewayapi/envoyextensionpolicy.go
@@ -846,17 +846,39 @@ func (t *Translator) buildExtProc(
 		return nil, err
 	}
 
-	if extProc.BackendRefs[0].Port != nil {
-		authority = fmt.Sprintf(
-			"%s.%s:%d",
-			extProc.BackendRefs[0].Name,
-			NamespaceDerefOr(extProc.BackendRefs[0].Namespace, policy.Namespace),
-			*extProc.BackendRefs[0].Port)
-	} else {
-		authority = fmt.Sprintf(
-			"%s.%s",
-			extProc.BackendRefs[0].Name,
-			NamespaceDerefOr(extProc.BackendRefs[0].Namespace, policy.Namespace))
+	// When the backendRef is a Backend CRD with an FQDN endpoint, use
+	// the endpoint hostname as the gRPC :authority. The Kubernetes-style
+	// <name>.<namespace> form is correct for in-cluster Service refs,
+	// but FQDN backends commonly sit behind an ingress/gateway that
+	// routes on :authority (Istio, nginx, etc.); sending the CR name
+	// instead of the FQDN hostname breaks virtual-host matching on the
+	// upstream (#8791).
+	backendRef := extProc.BackendRefs[0]
+	backendNamespace := NamespaceDerefOr(backendRef.Namespace, policy.Namespace)
+	if backendRef.Group != nil && string(*backendRef.Group) == egv1a1.GroupName &&
+		backendRef.Kind != nil && string(*backendRef.Kind) == egv1a1.KindBackend {
+		if backend := t.GetBackend(backendNamespace, string(backendRef.Name)); backend != nil {
+			for _, bep := range backend.Spec.Endpoints {
+				if bep.FQDN != nil {
+					authority = fmt.Sprintf("%s:%d", bep.FQDN.Hostname, bep.FQDN.Port)
+					break
+				}
+			}
+		}
+	}
+	if authority == "" {
+		if backendRef.Port != nil {
+			authority = fmt.Sprintf(
+				"%s.%s:%d",
+				backendRef.Name,
+				backendNamespace,
+				*backendRef.Port)
+		} else {
+			authority = fmt.Sprintf(
+				"%s.%s",
+				backendRef.Name,
+				backendNamespace)
+		}
 	}
 
 	traffic, err := translateTrafficFeatures(extProc.BackendSettings)

--- a/internal/gatewayapi/envoyextensionpolicy.go
+++ b/internal/gatewayapi/envoyextensionpolicy.go
@@ -855,8 +855,14 @@ func (t *Translator) buildExtProc(
 	// upstream (#8791).
 	backendRef := extProc.BackendRefs[0]
 	backendNamespace := NamespaceDerefOr(backendRef.Namespace, policy.Namespace)
-	if backendRef.Group != nil && string(*backendRef.Group) == egv1a1.GroupName &&
-		backendRef.Kind != nil && string(*backendRef.Kind) == egv1a1.KindBackend {
+	// validateExtServiceBackendReference / ext_service.go already
+	// accept Kind: Backend with the group field omitted (defaulted to
+	// egv1a1.GroupName), so match the same relaxed shape here. Using
+	// strict non-nil pointer checks would skip a valid config and fall
+	// through to the misrouted <name>.<namespace>[:port] authority.
+	backendKind := KindDerefOr(backendRef.Kind, "")
+	backendGroup := GroupDerefOr(backendRef.Group, egv1a1.GroupName)
+	if backendKind == egv1a1.KindBackend && backendGroup == egv1a1.GroupName {
 		if backend := t.GetBackend(backendNamespace, string(backendRef.Name)); backend != nil {
 			for _, bep := range backend.Spec.Endpoints {
 				if bep.FQDN != nil {

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-dns-lookup-family.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-dns-lookup-family.out.yaml
@@ -425,7 +425,7 @@ xdsIR:
             weight: 1
         envoyExtensions:
           extProcs:
-          - authority: backend-fqdn2.default:9090
+          - authority: backend-v2.gateway-conformance-infra.svc.cluster.local:9090
             destination:
               metadata:
                 kind: EnvoyExtensionPolicy


### PR DESCRIPTION
## Summary

Fixes #8791.

`buildExtProc` in `internal/gatewayapi/envoyextensionpolicy.go` unconditionally set the ext_proc gRPC `:authority` to `<backendRef-name>.<namespace>`. For an in-cluster Kubernetes Service backend this matches the endpoint and works. For a Backend CRD with FQDN endpoints, i.e. an ext_proc service reached over the public internet or through a service-mesh ingress, the upstream typically routes on `:authority`, and the CR-name-derived authority never matches a virtual host on the other side. Users were working around this with an `EnvoyPatchPolicy` JSONPatch rewriting the filter config after the fact.

## Fix

When the backendRef is a Backend CR (group `gateway.envoyproxy.io`, kind `Backend`) and has at least one FQDN endpoint, build `:authority` from `<fqdn-hostname>:<fqdn-port>`. Fall through to the existing `<name>.<namespace>[:port]` formula for:
- Service refs
- Backend CRs without FQDN endpoints (IP / Unix socket)
- Any case where `GetBackend` returns nil (same behaviour as before)

No API change; the behaviour flips only for Backend CRs whose endpoints contain an FQDN.

## Test plan

- [x] `go build ./internal/gatewayapi/...` clean
- [x] `go vet ./internal/gatewayapi/...` clean
- [x] `go test ./internal/gatewayapi/...` green (all existing translate tests pass).
- [ ] Manual: create a Backend CR with `endpoints: [{ fqdn: { hostname: my-service.example.com, port: 443 } }]`, attach it via `EnvoyExtensionPolicy.extProc.backendRefs`, and confirm the generated xDS `HttpFilter -> ext_proc -> grpc_service.envoy_grpc.authority == "my-service.example.com:443"` instead of `<crd-name>.<namespace>`.