### PR TITLE
test: use registry.k8s.io instead of staging

### DIFF
--- a/examples/kubernetes/application.yaml
+++ b/examples/kubernetes/application.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/examples/kubernetes/gateway-namespace-mode.yaml
+++ b/examples/kubernetes/gateway-namespace-mode.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       serviceAccountName: team-a-backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: team-a-backend
           ports:
@@ -102,7 +102,7 @@ spec:
     spec:
       serviceAccountName: team-b-backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: team-b-backend
           ports:

--- a/examples/kubernetes/http-routing.yaml
+++ b/examples/kubernetes/http-routing.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
         - name: example-backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:
@@ -119,7 +119,7 @@ spec:
     spec:
       containers:
         - name: foo-backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:
@@ -186,7 +186,7 @@ spec:
     spec:
       containers:
         - name: bar-backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:
@@ -233,7 +233,7 @@ spec:
     spec:
       containers:
         - name: bar-canary-backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:

--- a/examples/kubernetes/merged-gateways.yaml
+++ b/examples/kubernetes/merged-gateways.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       serviceAccountName: merged-backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: merged-backend
           ports:

--- a/examples/kubernetes/mergepatch.yaml
+++ b/examples/kubernetes/mergepatch.yaml
@@ -78,7 +78,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/examples/kubernetes/quickstart.yaml
+++ b/examples/kubernetes/quickstart.yaml
@@ -54,7 +54,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/examples/kubernetes/tcp-routing.yaml
+++ b/examples/kubernetes/tcp-routing.yaml
@@ -70,7 +70,7 @@ spec:
         version: v1
     spec:
       containers:
-      - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+      - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         imagePullPolicy: IfNotPresent
         name: backend-1
         ports:
@@ -104,7 +104,7 @@ spec:
         version: v1
     spec:
       containers:
-      - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+      - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         imagePullPolicy: IfNotPresent
         name: backend-2
         ports:

--- a/examples/kubernetes/tls-passthrough.yaml
+++ b/examples/kubernetes/tls-passthrough.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: passthrough-echoserver
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           ports:
             - containerPort: 8443
           env:

--- a/examples/kubernetes/tls-termination.yaml
+++ b/examples/kubernetes/tls-termination.yaml
@@ -63,7 +63,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-      - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+      - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         imagePullPolicy: IfNotPresent
         name: backend
         ports:

--- a/examples/kubernetes/zone-aware-routing.yaml
+++ b/examples/kubernetes/zone-aware-routing.yaml
@@ -30,7 +30,7 @@ spec:
               topologyKey: topology.kubernetes.io/zone
               namespaceSelector: {}
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:
@@ -77,7 +77,7 @@ spec:
               topologyKey: topology.kubernetes.io/zone
               namespaceSelector: {}
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/internal/cmd/egctl/testdata/translate/in/echo-gateway-api.yaml
+++ b/internal/cmd/egctl/testdata/translate/in/echo-gateway-api.yaml
@@ -55,7 +55,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/internal/cmd/egctl/testdata/translate/in/envoy-patch-policy.yaml
+++ b/internal/cmd/egctl/testdata/translate/in/envoy-patch-policy.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/internal/cmd/egctl/testdata/translate/in/jwt-single-route-single-match-to-xds.yaml
+++ b/internal/cmd/egctl/testdata/translate/in/jwt-single-route-single-match-to-xds.yaml
@@ -55,7 +55,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/internal/cmd/egctl/testdata/translate/in/quickstart.yaml
+++ b/internal/cmd/egctl/testdata/translate/in/quickstart.yaml
@@ -55,7 +55,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/site/content/en/latest/tasks/operations/deployment-mode.md
+++ b/site/content/en/latest/tasks/operations/deployment-mode.md
@@ -133,7 +133,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:
@@ -238,7 +238,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:
@@ -421,7 +421,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:
@@ -526,7 +526,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/site/content/en/latest/tasks/traffic/failover.md
+++ b/site/content/en/latest/tasks/traffic/failover.md
@@ -63,7 +63,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: active 
           ports:
@@ -110,7 +110,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: passive 
           ports:
@@ -164,7 +164,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: active 
           ports:
@@ -211,7 +211,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: passive 
           ports:
@@ -481,7 +481,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: active 
           ports:
@@ -523,7 +523,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: active 
           ports:

--- a/site/content/en/latest/tasks/traffic/http-request-mirroring.md
+++ b/site/content/en/latest/tasks/traffic/http-request-mirroring.md
@@ -59,7 +59,7 @@ spec:
     spec:
       serviceAccountName: backend-2
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend-2
           ports:
@@ -120,7 +120,7 @@ spec:
     spec:
       serviceAccountName: backend-2
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend-2
           ports:

--- a/site/content/en/latest/tasks/traffic/http-traffic-splitting.md
+++ b/site/content/en/latest/tasks/traffic/http-traffic-splitting.md
@@ -163,7 +163,7 @@ spec:
     spec:
       serviceAccountName: backend-2
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend-2
           ports:
@@ -224,7 +224,7 @@ spec:
     spec:
       serviceAccountName: backend-2
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend-2
           ports:

--- a/site/content/en/latest/tasks/traffic/tcp-routing.md
+++ b/site/content/en/latest/tasks/traffic/tcp-routing.md
@@ -145,7 +145,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend-1
           ports:
@@ -179,7 +179,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend-2
           ports:
@@ -249,7 +249,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend-1
           ports:
@@ -283,7 +283,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend-2
           ports:

--- a/test/e2e/base/manifests.yaml
+++ b/test/e2e/base/manifests.yaml
@@ -89,7 +89,7 @@ spec:
       containers:
         - name: infra-backend-v1
           # From https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:
@@ -137,7 +137,7 @@ spec:
     spec:
       containers:
         - name: infra-backend-v2
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
         - name: infra-backend-v3
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:
@@ -233,7 +233,7 @@ spec:
     spec:
       containers:
         - name: tls-backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           volumeMounts:
             - name: secret-volume
               mountPath: /etc/secret-volume
@@ -311,7 +311,7 @@ spec:
     spec:
       containers:
         - name: web-backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:
@@ -408,7 +408,7 @@ spec:
     spec:
       containers:
         - name: tls-backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           volumeMounts:
             - name: secret-volume
               mountPath: /etc/secret-volume

--- a/test/e2e/testdata/backend-health-check-with-override.yaml
+++ b/test/e2e/testdata/backend-health-check-with-override.yaml
@@ -38,7 +38,7 @@ spec:
       containers:
       - name: multi-ports-backend
         # From https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         ports:
         - containerPort: 8080
           name: http
@@ -63,7 +63,7 @@ spec:
       # Sidecar for health check on port 9090
       - name: multi-ports-backend-health
         # From https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         ports:
         - containerPort: 9090
           name: health
@@ -121,7 +121,7 @@ spec:
       containers:
       - name: single-port-backend
         # From https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         ports:
         - containerPort: 8080
           name: http-and-health

--- a/test/e2e/testdata/backend-tls-settings.yaml
+++ b/test/e2e/testdata/backend-tls-settings.yaml
@@ -178,7 +178,7 @@ spec:
     spec:
       containers:
         - name: tls-backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           volumeMounts:
             - name: secret-volume
               mountPath: /etc/secret-volume

--- a/test/e2e/testdata/grpcroute-to-backend-fqdn.yaml
+++ b/test/e2e/testdata/grpcroute-to-backend-fqdn.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: grpc-infra-backend-v1
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+        image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         env:
         - name: POD_NAME
           valueFrom:

--- a/test/e2e/testdata/grpcroute-to-backend-ip.yaml
+++ b/test/e2e/testdata/grpcroute-to-backend-ip.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: grpc-infra-backend-v1
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+        image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         env:
         - name: POD_NAME
           valueFrom:

--- a/test/e2e/testdata/httproute-with-dynamic-resolver-backend-with-tls.yaml
+++ b/test/e2e/testdata/httproute-with-dynamic-resolver-backend-with-tls.yaml
@@ -118,7 +118,7 @@ spec:
     spec:
       containers:
       - name: tls-backend
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         volumeMounts:
         - name: secret-volume
           mountPath: /etc/secret-volume

--- a/test/e2e/testdata/listenerset-grpc.yaml
+++ b/test/e2e/testdata/listenerset-grpc.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: grpc-listener-backend
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+        image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         env:
         - name: POD_NAME
           valueFrom:

--- a/test/e2e/testdata/multi-referencegrants-same-namespace-services.yaml
+++ b/test/e2e/testdata/multi-referencegrants-same-namespace-services.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: app-backend-v1
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         env:
         - name: POD_NAME
           valueFrom:
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
       - name: app-backend-v2
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         env:
         - name: POD_NAME
           valueFrom:
@@ -131,7 +131,7 @@ spec:
     spec:
       containers:
       - name: app-backend-v3
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         env:
         - name: POD_NAME
           valueFrom:

--- a/test/e2e/testdata/weighted-backend-mixed-valid-and-invalid.yaml
+++ b/test/e2e/testdata/weighted-backend-mixed-valid-and-invalid.yaml
@@ -63,7 +63,7 @@ spec:
     spec:
       containers:
         - name: infra-backend-without-endpoints
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:

--- a/test/e2e/testdata/weighted-zones.yaml
+++ b/test/e2e/testdata/weighted-zones.yaml
@@ -72,7 +72,7 @@ spec:
       containers:
         - name: weighted-zones-backend
           # From https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:
@@ -112,7 +112,7 @@ spec:
       containers:
         - name: weighted-zones-backend
           # From https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:

--- a/test/e2e/testdata/zone-aware-routing-deployments.yaml
+++ b/test/e2e/testdata/zone-aware-routing-deployments.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: zone-aware-backend
           # From https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:
@@ -69,7 +69,7 @@ spec:
       containers:
         - name: zone-aware-backend
           # From https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:

--- a/test/e2e/upgrade/manifests.yaml
+++ b/test/e2e/upgrade/manifests.yaml
@@ -109,7 +109,7 @@ spec:
       containers:
         - name: infra-backend
           # From https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:

--- a/test/fuzz/testdata/FuzzGatewayAPIToXDS/failover
+++ b/test/fuzz/testdata/FuzzGatewayAPIToXDS/failover
@@ -30,7 +30,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: active
           ports:
@@ -77,7 +77,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: passive
           ports:
@@ -183,7 +183,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: active
           ports:

--- a/test/fuzz/testdata/FuzzGatewayAPIToXDS/http_traffic_splitting
+++ b/test/fuzz/testdata/FuzzGatewayAPIToXDS/http_traffic_splitting
@@ -37,7 +37,7 @@ spec:
     spec:
       serviceAccountName: backend-2
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend-2
           ports:

--- a/test/fuzz/testdata/FuzzGatewayAPIToXDS/multi_tenancy
+++ b/test/fuzz/testdata/FuzzGatewayAPIToXDS/multi_tenancy
@@ -59,7 +59,7 @@ spec:
     spec:
       serviceAccountName: backend
       containers:
-        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+        - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/test/resilience/testdata/base.yaml
+++ b/test/resilience/testdata/base.yaml
@@ -65,7 +65,7 @@ spec:
       containers:
         - name: backend
           # From https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
           env:
             - name: POD_NAME
               valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:
k8s-infra SIG has requested that implementations and core switch from the staging registry over to registry.k8s.io. We're also well overdue to update these image targets.

Relates to https://github.com/kubernetes-sigs/gateway-api/pull/4728

K8s slack: https://kubernetes.slack.com/archives/CR0H13KGA/p1775079862624539