### PR TITLE
fix(charts): add tokenreviews and subjectaccessreviews to controller ClusterRole

### DIFF
--- a/charts/gateway-helm/templates/_rbac.tpl
+++ b/charts/gateway-helm/templates/_rbac.tpl
@@ -22,6 +22,8 @@ All cluster scoped resources for Envoy Gateway RBAC.
 - {{ include "eg.rbac.cluster.gateway.networking" . | nindent 2 | trim }}
 - {{ include "eg.rbac.cluster.gateway.networking.status" . | nindent 2 | trim }}
 - {{ include "eg.rbac.cluster.multiclusterservices" . | nindent 2 | trim }}
+- {{ include "eg.rbac.cluster.auth" . | nindent 2 | trim }}
+- {{ include "eg.rbac.cluster.authz" . | nindent 2 | trim }}
 {{- end }}
 
 {{/*
@@ -190,6 +192,24 @@ verbs:
 - get
 - list
 - watch
+{{- end }}
+
+{{- define "eg.rbac.cluster.auth" -}}
+apiGroups:
+- authentication.k8s.io
+resources:
+- tokenreviews
+verbs:
+- create
+{{- end }}
+
+{{- define "eg.rbac.cluster.authz" -}}
+apiGroups:
+- authorization.k8s.io
+resources:
+- subjectaccessreviews
+verbs:
+- create
 {{- end }}
 
 {{- define "eg.rbac.cluster.gateway.networking.status" -}}


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/gateway/issues/8887

## What this PR does / why we need it

The controller ClusterRole is missing `authentication.k8s.io/tokenreviews` and `authorization.k8s.io/subjectaccessreviews` permissions. This causes "failed to call TokenReview API to verify service account jwt" errors when deploying Gateway and EnvoyProxy in a different namespace from the controller.

## Changes

Added two new RBAC template defines to `charts/gateway-helm/templates/_rbac.tpl`:

- `eg.rbac.cluster.auth` — grants `create` on `authentication.k8s.io/tokenreviews`
- `eg.rbac.cluster.authz` — grants `create` on `authorization.k8s.io/subjectaccessreviews`

Both are now included in the `eg.rbac.cluster` template, which renders into the controller's ClusterRole.

## Special notes for reviewers

- The fix follows the existing pattern in `_rbac.tpl` where each RBAC rule is a separate Helm template define included from `eg.rbac.cluster`
- The `eg.rbac.infra.tokenreview` define already exists for the infra-manager (namespaced Role), but the controller itself needs these permissions at cluster scope