### PR TITLE
bump ratelimit, dynamic modules, and proxy versions for v1.8.0-rc.1

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -26,7 +26,7 @@ const (
 	// DefaultDeploymentMemoryResourceRequests for deployment memory resource
 	DefaultDeploymentMemoryResourceRequests = "512Mi"
 	// DefaultEnvoyProxyImage is the default image used by envoyproxy
-	DefaultEnvoyProxyImage = "docker.io/envoyproxy/envoy:distroless-dev"
+	DefaultEnvoyProxyImage = "docker.io/envoyproxy/envoy:distroless-v1.38.0"
 	// DefaultShutdownManagerCPUResourceRequests for shutdown manager cpu resource
 	DefaultShutdownManagerCPUResourceRequests = "10m"
 	// DefaultShutdownManagerMemoryResourceRequests for shutdown manager memory resource
@@ -34,7 +34,7 @@ const (
 	// DefaultShutdownManagerImage is the default image used for the shutdown manager.
 	DefaultShutdownManagerImage = "docker.io/envoyproxy/gateway-dev:latest"
 	// DefaultRateLimitImage is the default image used by ratelimit.
-	DefaultRateLimitImage = "docker.io/envoyproxy/ratelimit:master"
+	DefaultRateLimitImage = "docker.io/envoyproxy/ratelimit:fe26676d"
 	// HTTPProtocol is the common-used http protocol.
 	HTTPProtocol = "http"
 	// GRPCProtocol is the common-used grpc protocol.

--- a/charts/gateway-helm/README.md
+++ b/charts/gateway-helm/README.md
@@ -116,7 +116,7 @@ helm uninstall eg -n envoy-gateway-system
 | global.images.envoyProxy.image | string | `""` |  |
 | global.images.envoyProxy.pullPolicy | string | `""` |  |
 | global.images.envoyProxy.pullSecrets | list | `[]` |  |
-| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:master"` |  |
+| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:fe26676d"` |  |
 | global.images.ratelimit.pullPolicy | string | `"IfNotPresent"` |  |
 | global.images.ratelimit.pullSecrets | list | `[]` |  |
 | hpa.behavior | object | `{}` |  |

--- a/charts/gateway-helm/templates/_helpers.tpl
+++ b/charts/gateway-helm/templates/_helpers.tpl
@@ -139,7 +139,7 @@ The name of the Envoy Ratelimit image.
 {{-   $repositoryTag := $imageParts._1 -}}
 {{-   $repositoryParts := splitn ":" 2 $repositoryTag -}}
 {{-   $repositoryName := $repositoryParts._0 -}}
-{{-   $imageTag := default "master" $repositoryParts._1 -}}
+{{-   $imageTag := default "fe26676d" $repositoryParts._1 -}}
 {{-   printf "%s/%s:%s" $registryName $repositoryName $imageTag -}}
 {{- end -}}
 
@@ -168,7 +168,7 @@ Resolve the Envoy Proxy image.
 {{-   $repositoryTag := $imageParts._1 -}}
 {{-   $repositoryParts := splitn ":" 2 $repositoryTag -}}
 {{-   $repositoryName := $repositoryParts._0 -}}
-{{-   $imageTag := default "distroless-dev" $repositoryParts._1 -}}
+{{-   $imageTag := default "distroless-v1.38.0" $repositoryParts._1 -}}
 {{-   printf "%s/%s:%s" $registryName $repositoryName $imageTag -}}
 {{- end -}}
 

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -19,7 +19,7 @@ global:
       pullSecrets: []
     ratelimit:
       # This is the full image name including the hub, repo, and tag.
-      image: "docker.io/envoyproxy/ratelimit:master"
+      image: "docker.io/envoyproxy/ratelimit:fe26676d"
       # Specify image pull policy if default behavior isn't desired.
       # Default behavior: latest images will be Always else IfNotPresent.
       pullPolicy: IfNotPresent

--- a/examples/dynamic-module-test/Dockerfile
+++ b/examples/dynamic-module-test/Dockerfile
@@ -1,6 +1,6 @@
 # ENVOY_VERSION must match the SDK version in go.mod to ensure ABI compatibility.
 # Update both together when changing the target Envoy version.
-ARG ENVOY_VERSION=dev
+ARG ENVOY_VERSION=v1.38.0
 
 FROM golang:1.26.2 AS builder
 

--- a/examples/dynamic-module-test/Makefile
+++ b/examples/dynamic-module-test/Makefile
@@ -2,7 +2,7 @@
 IMAGE_PREFIX ?= envoyproxy/gateway-
 APP_NAME ?= dynamic-module-test
 TAG ?= latest
-ENVOY_VERSION ?= dev
+ENVOY_VERSION ?= v1.38.0
 
 .PHONY: docker-buildx
 docker-buildx:

--- a/examples/dynamic-module-test/go.mod
+++ b/examples/dynamic-module-test/go.mod
@@ -2,4 +2,4 @@ module github.com/envoyproxy/gateway/examples/dynamic-module-test
 
 go 1.26.2
 
-require github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260305043144-94d5888d4c19
+require github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260430163524-c90c9e9ba9b2

--- a/examples/dynamic-module-test/go.sum
+++ b/examples/dynamic-module-test/go.sum
@@ -1,2 +1,2 @@
-github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260305043144-94d5888d4c19 h1:BxTFdsiDqcSqcozAoHrPaCiav1OyzPM75F8fKfgebmI=
-github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260305043144-94d5888d4c19/go.mod h1:NpQosaDAX20s0ak0o/4b5dLOdvkbk15XqoakhSNX1Gg=
+github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260430163524-c90c9e9ba9b2 h1:8Gwzw+ZDUa0KDICaaIqNvjwjzqLev9GItVviLPCRXww=
+github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260430163524-c90c9e9ba9b2/go.mod h1:NpQosaDAX20s0ak0o/4b5dLOdvkbk15XqoakhSNX1Gg=

--- a/internal/envoygateway/config/loader/testdata/default.yaml
+++ b/internal/envoygateway/config/loader/testdata/default.yaml
@@ -9,7 +9,7 @@ provider:
   kubernetes:
     rateLimitDeployment:
       container:
-        image: docker.io/envoyproxy/ratelimit:master
+        image: docker.io/envoyproxy/ratelimit:fe26676d
       patch:
         type: StrategicMerge
         value:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
@@ -71,7 +71,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
@@ -234,7 +234,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
@@ -183,7 +183,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
@@ -249,7 +249,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
@@ -243,7 +243,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
@@ -234,7 +234,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
@@ -234,7 +234,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
@@ -234,7 +234,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
@@ -239,7 +239,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
@@ -73,7 +73,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
@@ -238,7 +238,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
@@ -234,7 +234,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
@@ -234,7 +234,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
@@ -234,7 +234,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-priority-class-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-priority-class-name.yaml
@@ -234,7 +234,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
@@ -234,7 +234,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -75,7 +75,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -75,7 +75,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
@@ -253,7 +253,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -238,7 +238,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -187,7 +187,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
@@ -239,7 +239,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
@@ -253,7 +253,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
@@ -239,7 +239,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -247,7 +247,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
@@ -240,7 +240,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -238,7 +238,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -238,7 +238,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -243,7 +243,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -77,7 +77,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -238,7 +238,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -242,7 +242,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -238,7 +238,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
@@ -238,7 +238,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -238,7 +238,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-priority-class-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-priority-class-name.yaml
@@ -238,7 +238,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -238,7 +238,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
@@ -253,7 +253,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -686,7 +686,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.annotations['topology.kubernetes.io/zone']
-        image: docker.io/envoyproxy/envoy:distroless-dev
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/default.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:master
+        image: docker.io/envoyproxy/ratelimit:fe26676d
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/disable-prometheus.yaml
@@ -74,7 +74,7 @@ spec:
           value: tcp
         - name: REDIS_URL
           value: redis.redis.svc:6379
-        image: docker.io/envoyproxy/ratelimit:master
+        image: docker.io/envoyproxy/ratelimit:fe26676d
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing-custom.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing-custom.yaml
@@ -99,7 +99,7 @@ spec:
           value: "0.6"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://trace-collector.envoy-gateway-system.svc.cluster.local:4317
-        image: docker.io/envoyproxy/ratelimit:master
+        image: docker.io/envoyproxy/ratelimit:fe26676d
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/enable-tracing.yaml
@@ -99,7 +99,7 @@ spec:
           value: "1.0"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://trace-collector.envoy-gateway-system.svc.cluster.local:4318
-        image: docker.io/envoyproxy/ratelimit:master
+        image: docker.io/envoyproxy/ratelimit:fe26676d
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-annotations.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-annotations.yaml
@@ -86,7 +86,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:master
+        image: docker.io/envoyproxy/ratelimit:fe26676d
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-labels.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/merge-labels.yaml
@@ -86,7 +86,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:master
+        image: docker.io/envoyproxy/ratelimit:fe26676d
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment-containers.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment-containers.yaml
@@ -86,7 +86,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:master
+        image: docker.io/envoyproxy/ratelimit:fe26676d
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/patch-deployment.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:master
+        image: docker.io/envoyproxy/ratelimit:fe26676d
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-node-selector.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:master
+        image: docker.io/envoyproxy/ratelimit:fe26676d
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/ratelimit/testdata/deployments/with-topology-spread-constraints.yaml
@@ -84,7 +84,7 @@ spec:
           value: :19001
         - name: PROMETHEUS_MAPPER_YAML
           value: /etc/statsd-exporter/conf.yaml
-        image: docker.io/envoyproxy/ratelimit:master
+        image: docker.io/envoyproxy/ratelimit:fe26676d
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/site/content/en/latest/install/gateway-helm-api.md
+++ b/site/content/en/latest/install/gateway-helm-api.md
@@ -80,7 +80,7 @@ The Helm chart for Envoy Gateway
 | global.images.envoyProxy.image | string | `""` |  |
 | global.images.envoyProxy.pullPolicy | string | `""` |  |
 | global.images.envoyProxy.pullSecrets | list | `[]` |  |
-| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:master"` |  |
+| global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:fe26676d"` |  |
 | global.images.ratelimit.pullPolicy | string | `"IfNotPresent"` |  |
 | global.images.ratelimit.pullSecrets | list | `[]` |  |
 | hpa.behavior | object | `{}` |  |

--- a/test/helm/gateway-helm/certgen-annotations.out.yaml
+++ b/test/helm/gateway-helm/certgen-annotations.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/certgen-args.out.yaml
+++ b/test/helm/gateway-helm/certgen-args.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/certgen-labels.out.yaml
+++ b/test/helm/gateway-helm/certgen-labels.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
+++ b/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/common-labels.out.yaml
+++ b/test/helm/gateway-helm/common-labels.out.yaml
@@ -46,7 +46,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
+++ b/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
@@ -53,7 +53,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/default-config.out.yaml
+++ b/test/helm/gateway-helm/default-config.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-annotations.out.yaml
+++ b/test/helm/gateway-helm/deployment-annotations.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-custom-topology.out.yaml
+++ b/test/helm/gateway-helm/deployment-custom-topology.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-extraenv.out.yaml
+++ b/test/helm/gateway-helm/deployment-extraenv.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-images-config.out.yaml
+++ b/test/helm/gateway-helm/deployment-images-config.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-priorityclass.out.yaml
+++ b/test/helm/gateway-helm/deployment-priorityclass.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-repo-no-registry.out.yaml
+++ b/test/helm/gateway-helm/deployment-repo-no-registry.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-securitycontext.out.yaml
+++ b/test/helm/gateway-helm/deployment-securitycontext.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/deployment-volume-mounts.out.yaml
+++ b/test/helm/gateway-helm/deployment-volume-mounts.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/envoy-gateway-config.in.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-config.in.yaml
@@ -15,7 +15,7 @@ config:
           enabled: false
         rateLimitDeployment:
           container:
-            image: private-hub/envoyproxy/ratelimit:master
+            image: private-hub/envoyproxy/ratelimit:fe26676d
     logging:
       level:
         default: debug

--- a/test/helm/gateway-helm/envoy-gateway-config.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-config.out.yaml
@@ -40,7 +40,7 @@ data:
           enabled: false
         rateLimitDeployment:
           container:
-            image: private-hub/envoyproxy/ratelimit:master
+            image: private-hub/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config-watch.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config-watch.out.yaml
@@ -40,7 +40,7 @@ data:
           type: GatewayNamespace
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config.out.yaml
@@ -40,7 +40,7 @@ data:
           type: GatewayNamespace
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/envoy-gateway-gateway-namespace-namespaceselector.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-gateway-namespace-namespaceselector.out.yaml
@@ -40,7 +40,7 @@ data:
           type: GatewayNamespace
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/global-pullsecrets-override-deployment.in.yaml
+++ b/test/helm/gateway-helm/global-pullsecrets-override-deployment.in.yaml
@@ -12,7 +12,7 @@ global:
         - key5: "value5"
         - key6: "value6"
     ratelimit:
-      image: "docker.io/envoyproxy/ratelimit:master"
+      image: "docker.io/envoyproxy/ratelimit:fe26676d"
 
 deployment:
   envoyGateway:

--- a/test/helm/gateway-helm/global-pullsecrets-override-deployment.out.yaml
+++ b/test/helm/gateway-helm/global-pullsecrets-override-deployment.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: private.registry/envoyproxy/ratelimit:master
+            image: private.registry/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/global-pullsecrets-override-global.in.yaml
+++ b/test/helm/gateway-helm/global-pullsecrets-override-global.in.yaml
@@ -12,4 +12,4 @@ global:
         - key5: "value5"
         - key6: "value6"
     ratelimit:
-      image: "docker.io/envoyproxy/ratelimit:master"
+      image: "docker.io/envoyproxy/ratelimit:fe26676d"

--- a/test/helm/gateway-helm/global-pullsecrets-override-global.out.yaml
+++ b/test/helm/gateway-helm/global-pullsecrets-override-global.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: private.registry/envoyproxy/ratelimit:master
+            image: private.registry/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/global-registry-override-deployment.in.yaml
+++ b/test/helm/gateway-helm/global-registry-override-deployment.in.yaml
@@ -5,7 +5,7 @@ global:
       image: "docker.io/envoyproxy/gateway-dev:latest"
       pullPolicy: Always
     ratelimit:
-      image: "docker.io/envoyproxy/ratelimit:master"
+      image: "docker.io/envoyproxy/ratelimit:fe26676d"
 
 deployment:
   envoyGateway:

--- a/test/helm/gateway-helm/global-registry-override-deployment.out.yaml
+++ b/test/helm/gateway-helm/global-registry-override-deployment.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: private.registry/envoyproxy/ratelimit:master
+            image: private.registry/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/global-registry-override-global.in.yaml
+++ b/test/helm/gateway-helm/global-registry-override-global.in.yaml
@@ -5,4 +5,4 @@ global:
       image: "docker.io/envoyproxy/gateway-dev:latest"
       pullPolicy: Always
     ratelimit:
-      image: "docker.io/envoyproxy/ratelimit:master"
+      image: "docker.io/envoyproxy/ratelimit:fe26676d"

--- a/test/helm/gateway-helm/global-registry-override-global.out.yaml
+++ b/test/helm/gateway-helm/global-registry-override-global.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: private.registry/envoyproxy/ratelimit:master
+            image: private.registry/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/horizontal-pod-autoscaler-disabled.out.yaml
+++ b/test/helm/gateway-helm/horizontal-pod-autoscaler-disabled.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
+++ b/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/namespace-override.out.yaml
+++ b/test/helm/gateway-helm/namespace-override.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/service-customization.out.yaml
+++ b/test/helm/gateway-helm/service-customization.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:

--- a/test/helm/gateway-helm/webhook-disabled.out.yaml
+++ b/test/helm/gateway-helm/webhook-disabled.out.yaml
@@ -38,7 +38,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:master
+            image: docker.io/envoyproxy/ratelimit:fe26676d
           patch:
             type: StrategicMerge
             value:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump Envoy Proxy, Envoy Dynamic Modules, and Envoy Ratelimit versions for v1.8.0-rc.1
