### PR TITLE
fix(api): increase RateLimitSelectCondition.headers MaxItems from 16 to 64

### DIFF
--- a/api/v1alpha1/ratelimit_types.go
+++ b/api/v1alpha1/ratelimit_types.go
@@ -229,8 +229,6 @@ type RateLimitSelectCondition struct {
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=64
-	// Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
-	// Revert this change once the upstream Gateway API supports items more than 64.
 	Headers []HeaderMatch `json:"headers,omitempty"`
 
 	// Methods is a list of request methods to match. Multiple method values are ORed together,

--- a/api/v1alpha1/ratelimit_types.go
+++ b/api/v1alpha1/ratelimit_types.go
@@ -228,7 +228,9 @@ type RateLimitSelectCondition struct {
 	// meaning, a request MUST match all the specified headers.
 	//
 	// +optional
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
+	// Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
+	// Revert this change once the upstream Gateway API supports items more than 64.
 	Headers []HeaderMatch `json:"headers,omitempty"`
 
 	// Methods is a list of request methods to match. Multiple method values are ORed together,

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1468,9 +1468,6 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-
-                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
-                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -1855,9 +1852,6 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-
-                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
-                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1468,6 +1468,9 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
+
+                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
+                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -1506,7 +1509,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 16
+                                    maxItems: 64
                                     type: array
                                   methods:
                                     description: |-
@@ -1852,6 +1855,9 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
+
+                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
+                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -1890,7 +1896,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 16
+                                    maxItems: 64
                                     type: array
                                   methods:
                                     description: |-

--- a/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1467,6 +1467,9 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
+
+                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
+                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -1505,7 +1508,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 16
+                                    maxItems: 64
                                     type: array
                                   methods:
                                     description: |-
@@ -1851,6 +1854,9 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
+
+                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
+                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -1889,7 +1895,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 16
+                                    maxItems: 64
                                     type: array
                                   methods:
                                     description: |-

--- a/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1467,9 +1467,6 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-
-                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
-                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -1854,9 +1851,6 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-
-                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
-                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -5228,7 +5228,7 @@ _Appears in:_
 
 | Field | Type | Required | Default | Description |
 | ---   | ---  | ---      | ---     | ---         |
-| `headers` | _[HeaderMatch](#headermatch) array_ |  false  |  | Headers is a list of request headers to match. Multiple header values are ANDed together,<br />meaning, a request MUST match all the specified headers.<br />Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.<br />Revert this change once the upstream Gateway API supports items more than 64. |
+| `headers` | _[HeaderMatch](#headermatch) array_ |  false  |  | Headers is a list of request headers to match. Multiple header values are ANDed together,<br />meaning, a request MUST match all the specified headers. |
 | `methods` | _[MethodMatch](#methodmatch) array_ |  false  |  | Methods is a list of request methods to match. Multiple method values are ORed together,<br />meaning, a request can match any one of the specified methods. If not specified, it matches all methods. |
 | `path` | _[PathMatch](#pathmatch)_ |  false  |  | Path is the request path to match.<br />Support Exact, PathPrefix and RegularExpression match types. |
 | `sourceCIDR` | _[SourceMatch](#sourcematch)_ |  false  |  | SourceCIDR is the client IP Address range to match on. |

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -5228,7 +5228,7 @@ _Appears in:_
 
 | Field | Type | Required | Default | Description |
 | ---   | ---  | ---      | ---     | ---         |
-| `headers` | _[HeaderMatch](#headermatch) array_ |  false  |  | Headers is a list of request headers to match. Multiple header values are ANDed together,<br />meaning, a request MUST match all the specified headers. |
+| `headers` | _[HeaderMatch](#headermatch) array_ |  false  |  | Headers is a list of request headers to match. Multiple header values are ANDed together,<br />meaning, a request MUST match all the specified headers.<br />Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.<br />Revert this change once the upstream Gateway API supports items more than 64. |
 | `methods` | _[MethodMatch](#methodmatch) array_ |  false  |  | Methods is a list of request methods to match. Multiple method values are ORed together,<br />meaning, a request can match any one of the specified methods. If not specified, it matches all methods. |
 | `path` | _[PathMatch](#pathmatch)_ |  false  |  | Path is the request path to match.<br />Support Exact, PathPrefix and RegularExpression match types. |
 | `sourceCIDR` | _[SourceMatch](#sourcematch)_ |  false  |  | SourceCIDR is the client IP Address range to match on. |

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -23995,9 +23995,6 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-
-                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
-                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -24382,9 +24379,6 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-
-                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
-                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -23995,6 +23995,9 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
+
+                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
+                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -24033,7 +24036,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 16
+                                    maxItems: 64
                                     type: array
                                   methods:
                                     description: |-
@@ -24379,6 +24382,9 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
+
+                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
+                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -24417,7 +24423,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 16
+                                    maxItems: 64
                                     type: array
                                   methods:
                                     description: |-

--- a/test/helm/gateway-crds-helm/e2e.out.yaml
+++ b/test/helm/gateway-crds-helm/e2e.out.yaml
@@ -1968,6 +1968,9 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
+
+                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
+                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -2006,7 +2009,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 16
+                                    maxItems: 64
                                     type: array
                                   methods:
                                     description: |-
@@ -2352,6 +2355,9 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
+
+                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
+                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -2390,7 +2396,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 16
+                                    maxItems: 64
                                     type: array
                                   methods:
                                     description: |-

--- a/test/helm/gateway-crds-helm/e2e.out.yaml
+++ b/test/helm/gateway-crds-helm/e2e.out.yaml
@@ -1968,9 +1968,6 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-
-                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
-                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -2355,9 +2352,6 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-
-                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
-                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -1968,6 +1968,9 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
+
+                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
+                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -2006,7 +2009,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 16
+                                    maxItems: 64
                                     type: array
                                   methods:
                                     description: |-
@@ -2352,6 +2355,9 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
+
+                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
+                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -2390,7 +2396,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 16
+                                    maxItems: 64
                                     type: array
                                   methods:
                                     description: |-

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -1968,9 +1968,6 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-
-                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
-                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -2355,9 +2352,6 @@ spec:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-
-                                      Increase the maxItems from 16 to 64, aligning with HTTPHeaderFilter.
-                                      Revert this change once the upstream Gateway API supports items more than 64.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.


### PR DESCRIPTION
Fixes #8895

## What this PR does

Increases the `MaxItems` limit for `RateLimitSelectCondition.Headers` from 16 to 64, allowing users to specify more header matching rules in rate limit configurations.

## Why 64?

This aligns with the existing `HTTPHeaderFilter` pattern already defined in this codebase (`shared_types.go:1031`), which also increased the limit from 16 to 64 for the same reason.

## Changes

- `api/v1alpha1/ratelimit_types.go`: Changed `+kubebuilder:validation:MaxItems=16` to `+kubebuilder:validation:MaxItems=64` on the `Headers` field of `RateLimitSelectCondition`
- Added a comment noting this can be reverted once upstream Gateway API supports more than 64 items
