### PR TITLE
fix: do not downgrade ALPN for only hostnames-overlapping listeners

### DIFF
--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -508,14 +508,14 @@ func checkOverlappingHostnames(httpsListeners []*ListenerContext) {
 			if gateway1.Name == gateway2.Name &&
 				gateway1.Namespace == gateway2.Namespace {
 				message = fmt.Sprintf(
-					"The hostname %s overlaps with the hostname %s in listener %s. ALPN will default to HTTP/1.1 to prevent HTTP/2 connection coalescing, unless explicitly configured via ClientTrafficPolicy",
+					"The hostname %s overlaps with the hostname %s in listener %s.",
 					overlappingListeners[i].hostname1,
 					overlappingListeners[i].hostname2,
 					overlappingListeners[i].listener2,
 				)
 			} else {
 				message = fmt.Sprintf(
-					"The hostname %s overlaps with the hostname %s in listener %s of gateway %s. ALPN will default to HTTP/1.1 to prevent HTTP/2 connection coalescing, unless explicitly configured via ClientTrafficPolicy",
+					"The hostname %s overlaps with the hostname %s in listener %s of gateway %s.",
 					overlappingListeners[i].hostname1,
 					overlappingListeners[i].hostname2,
 					overlappingListeners[i].listener2,
@@ -529,9 +529,6 @@ func checkOverlappingHostnames(httpsListeners []*ListenerContext) {
 				gwapiv1.ListenerReasonOverlappingHostnames,
 				message,
 			)
-			if listener.httpIR != nil {
-				listener.httpIR.TLSOverlaps = true
-			}
 		}
 	}
 }

--- a/internal/gatewayapi/listener_test.go
+++ b/internal/gatewayapi/listener_test.go
@@ -385,6 +385,7 @@ func TestCheckOverlappingHostnames(t *testing.T) {
 			for i := range tt.gateway.listeners {
 				tt.gateway.listeners[i].listenerStatusIdx = i
 				tt.gateway.listeners[i].gateway = tt.gateway
+				tt.gateway.listeners[i].httpIR = &ir.HTTPListener{}
 				tt.gateway.Status.Listeners[i] = gwapiv1.ListenerStatus{
 					Name:       tt.gateway.listeners[i].Name,
 					Conditions: []metav1.Condition{},
@@ -419,6 +420,10 @@ func TestCheckOverlappingHostnames(t *testing.T) {
 					// expectedHostname == "" means matching all hostnames
 					t.Errorf("expected condition for listener %d, got nil or False", idx)
 				}
+			}
+			for idx, listener := range tt.gateway.listeners {
+				require.NotNil(t, listener.httpIR)
+				assert.False(t, listener.httpIR.TLSOverlaps, "hostname overlap must not trigger ALPN downgrade for listener %d", idx)
 			}
 
 			if len(tt.expected) == 0 {
@@ -647,6 +652,7 @@ func TestCheckOverlappingCertificates(t *testing.T) {
 				}
 				gateway.listeners[i].listenerStatusIdx = i
 				gateway.listeners[i].gateway = gateway
+				gateway.listeners[i].httpIR = &ir.HTTPListener{}
 			}
 
 			// Process overlapping certificates
@@ -699,6 +705,15 @@ func TestCheckOverlappingCertificates(t *testing.T) {
 						}
 					}
 				}
+			}
+
+			expectedTLSOverlaps := map[string]bool{}
+			for _, expected := range tt.expectedStatus {
+				expectedTLSOverlaps[expected.listenerName] = true
+			}
+			for _, listener := range gateway.listeners {
+				require.NotNil(t, listener.httpIR)
+				assert.Equal(t, expectedTLSOverlaps[string(listener.Name)], listener.httpIR.TLSOverlaps, "unexpected TLSOverlaps for listener %s", listener.Name)
 			}
 		})
 	}

--- a/internal/gatewayapi/testdata/clienttrafficpolicy-http3.out.yaml
+++ b/internal/gatewayapi/testdata/clienttrafficpolicy-http3.out.yaml
@@ -92,8 +92,7 @@ gateways:
         type: ResolvedRefs
       - lastTransitionTime: null
         message: The hostname *.example.com overlaps with the hostname bar.example.com
-          in listener https-bar. ALPN will default to HTTP/1.1 to prevent HTTP/2 connection
-          coalescing, unless explicitly configured via ClientTrafficPolicy
+          in listener https-bar.
         reason: OverlappingHostnames
         status: "True"
         type: OverlappingTLSConfig
@@ -122,8 +121,7 @@ gateways:
         type: ResolvedRefs
       - lastTransitionTime: null
         message: The hostname foo.example.com overlaps with the hostname *.example.com
-          in listener https-wildcard. ALPN will default to HTTP/1.1 to prevent HTTP/2
-          connection coalescing, unless explicitly configured via ClientTrafficPolicy
+          in listener https-wildcard.
         reason: OverlappingHostnames
         status: "True"
         type: OverlappingTLSConfig
@@ -152,8 +150,7 @@ gateways:
         type: ResolvedRefs
       - lastTransitionTime: null
         message: The hostname bar.example.com overlaps with the hostname *.example.com
-          in listener https-wildcard. ALPN will default to HTTP/1.1 to prevent HTTP/2
-          connection coalescing, unless explicitly configured via ClientTrafficPolicy
+          in listener https-wildcard.
         reason: OverlappingHostnames
         status: "True"
         type: OverlappingTLSConfig
@@ -304,7 +301,6 @@ xdsIR:
           privateKey: '[redacted]'
         maxVersion: "1.3"
         minVersion: "1.2"
-      tlsOverlaps: true
     - address: 0.0.0.0
       externalPort: 443
       hostnames:
@@ -359,7 +355,6 @@ xdsIR:
           privateKey: '[redacted]'
         maxVersion: "1.3"
         minVersion: "1.2"
-      tlsOverlaps: true
     - address: 0.0.0.0
       externalPort: 443
       hostnames:
@@ -414,7 +409,6 @@ xdsIR:
           privateKey: '[redacted]'
         maxVersion: "1.3"
         minVersion: "1.2"
-      tlsOverlaps: true
     readyListener:
       address: 0.0.0.0
       ipFamily: IPv4

--- a/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames-merged-gateways.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames-merged-gateways.out.yaml
@@ -39,9 +39,7 @@ gateways:
         type: ResolvedRefs
       - lastTransitionTime: null
         message: The hostname foo.example.com overlaps with the hostname *.example.com
-          in listener https-1 of gateway gateway-2. ALPN will default to HTTP/1.1
-          to prevent HTTP/2 connection coalescing, unless explicitly configured via
-          ClientTrafficPolicy
+          in listener https-1 of gateway gateway-2.
         reason: OverlappingHostnames
         status: "True"
         type: OverlappingTLSConfig
@@ -102,9 +100,7 @@ gateways:
         type: ResolvedRefs
       - lastTransitionTime: null
         message: The hostname *.example.com overlaps with the hostname foo.example.com
-          in listener https-1 of gateway gateway-1. ALPN will default to HTTP/1.1
-          to prevent HTTP/2 connection coalescing, unless explicitly configured via
-          ClientTrafficPolicy
+          in listener https-1 of gateway gateway-1.
         reason: OverlappingHostnames
         status: "True"
         type: OverlappingTLSConfig
@@ -277,7 +273,6 @@ xdsIR:
         - certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMyRENDQWNBQ0FRQXdEUVlKS29aSWh2Y05BUUVMQlFBd0xURVZNQk1HQTFVRUNnd01aWGhoYlhCc1pTQkoKYm1NdU1SUXdFZ1lEVlFRRERBdGxlR0Z0Y0d4bExtTnZiVEFlRncweU5UQTBNakV3T1RFd05ETmFGdzB6TlRBMApNVGt3T1RFd05ETmFNRGN4RmpBVUJnTlZCQU1NRFNvdVpYaGhiWEJzWlM1amIyMHhIVEFiQmdOVkJBb01GR1Y0CllXMXdiR1VnYjNKbllXNXBlbUYwYVc5dU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0MKQVFFQXY0anl4TUh1YzQzMHdvWkk4M1JSMXVxU2gvbm9MVWVPdDZnMkNKaFVFYXNaeUNOMzN3bFRRRDE0SEhkSwpOb1k4SThWd1pOZFZCNGpjRzlnb3dDVmVQY3lqRzZPaGl1aUZNWnU2NzV6dWZEWnRlRTNEY3lTbFgrY2lSbVZZCkNuSmk3QkV3NlJMUUJ0bVV6WGxtYmRpVXE5djJwalVBL2R3ZnRLRHRZTHFrVytvTSt5MWg3cjRJV0JVK2RVcU0KcGtTem5VSCtKN1JoRkFsdytmRWlVSFRLemlCMkVtdjc3Mi91bS96NHdMWnJIeWNGbmc4L1FCM0JIUktXVTV4eQp3bWNTQ2xrVlMvWWNpMFVXcnR2eGhwck9wTUhQUGR2QkZ2M2NaWGNpUUJjb0ZNcGxsQzV0UURvdWJ0dEV1d3JpCi8rVktKWkUrSVl4ei9YeUd3Y3dJRnIzWG13SURBUUFCTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBU3VLaE8KcGtwL1VSclphbEU0OUlnc0xkN3hSTlBhREVkQ1RWZ3Qvc3praUhnSDB1NDBVaVV6KzVzaDRpdlJOazRqTm1zRwprb3FwQlBVS3pvVmtrSTcxUWQ4bHh1VzF2dkxZMXVvM0RIS2svdDFpUWVZWWpERlk3YzUxVG1BT015WUdKTlhxCi9EbW84UWgzaFB1RnI3a29kUjBLSkJyc0RsMEhoWVBjUnpWOW1sQ2lrU1B4THJGTUNwZGx0QUw2UEprSVpucUgKc1g5dEtVZk1uYW5jMkpHZTZVTDE1ODBEV2xQTUcrMU1qRElCVXdxWWYzaWNKb0NYclAwbzNmckRKcTE2VnpidApkalRtVGswakx1bGkvQ2JCZzh4dWp4emo4bmRPcVNkd05kd091OWoxSmZ2Q0I1RjZ4S0VTenowOVo5TzlOZUM5CjMrd1pLTlRSOXVEdDRKNksKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
           name: envoy-gateway/tls-secret-example-com
           privateKey: '[redacted]'
-      tlsOverlaps: true
     - address: 0.0.0.0
       externalPort: 443
       hostnames:
@@ -298,7 +293,6 @@ xdsIR:
         - certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMyRENDQWNBQ0FRQXdEUVlKS29aSWh2Y05BUUVMQlFBd0xURVZNQk1HQTFVRUNnd01aWGhoYlhCc1pTQkoKYm1NdU1SUXdFZ1lEVlFRRERBdGxlR0Z0Y0d4bExtTnZiVEFlRncweU5UQTBNakV3T1RFd05ETmFGdzB6TlRBMApNVGt3T1RFd05ETmFNRGN4RmpBVUJnTlZCQU1NRFNvdVpYaGhiWEJzWlM1amIyMHhIVEFiQmdOVkJBb01GR1Y0CllXMXdiR1VnYjNKbllXNXBlbUYwYVc5dU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0MKQVFFQXY0anl4TUh1YzQzMHdvWkk4M1JSMXVxU2gvbm9MVWVPdDZnMkNKaFVFYXNaeUNOMzN3bFRRRDE0SEhkSwpOb1k4SThWd1pOZFZCNGpjRzlnb3dDVmVQY3lqRzZPaGl1aUZNWnU2NzV6dWZEWnRlRTNEY3lTbFgrY2lSbVZZCkNuSmk3QkV3NlJMUUJ0bVV6WGxtYmRpVXE5djJwalVBL2R3ZnRLRHRZTHFrVytvTSt5MWg3cjRJV0JVK2RVcU0KcGtTem5VSCtKN1JoRkFsdytmRWlVSFRLemlCMkVtdjc3Mi91bS96NHdMWnJIeWNGbmc4L1FCM0JIUktXVTV4eQp3bWNTQ2xrVlMvWWNpMFVXcnR2eGhwck9wTUhQUGR2QkZ2M2NaWGNpUUJjb0ZNcGxsQzV0UURvdWJ0dEV1d3JpCi8rVktKWkUrSVl4ei9YeUd3Y3dJRnIzWG13SURBUUFCTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBU3VLaE8KcGtwL1VSclphbEU0OUlnc0xkN3hSTlBhREVkQ1RWZ3Qvc3praUhnSDB1NDBVaVV6KzVzaDRpdlJOazRqTm1zRwprb3FwQlBVS3pvVmtrSTcxUWQ4bHh1VzF2dkxZMXVvM0RIS2svdDFpUWVZWWpERlk3YzUxVG1BT015WUdKTlhxCi9EbW84UWgzaFB1RnI3a29kUjBLSkJyc0RsMEhoWVBjUnpWOW1sQ2lrU1B4THJGTUNwZGx0QUw2UEprSVpucUgKc1g5dEtVZk1uYW5jMkpHZTZVTDE1ODBEV2xQTUcrMU1qRElCVXdxWWYzaWNKb0NYclAwbzNmckRKcTE2VnpidApkalRtVGswakx1bGkvQ2JCZzh4dWp4emo4bmRPcVNkd05kd091OWoxSmZ2Q0I1RjZ4S0VTenowOVo5TzlOZUM5CjMrd1pLTlRSOXVEdDRKNksKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
           name: envoy-gateway/tls-secret-example-com
           privateKey: '[redacted]'
-      tlsOverlaps: true
     - address: 0.0.0.0
       externalPort: 443
       hostnames:

--- a/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames.in.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames.in.yaml
@@ -28,17 +28,6 @@ gateways:
           tls:
             mode: Terminate
             certificateRefs:
-              - name: tls-secret-example-com
-        - name: https-3
-          protocol: HTTPS
-          port: 443
-          hostname: "foo.bar.com"
-          allowedRoutes:
-            namespaces:
-              from: All
-          tls:
-            mode: Terminate
-            certificateRefs:
               - name: tls-secret-foo-bar-com
 secrets:
   - apiVersion: v1

--- a/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-multiple-https-listeners-with-overlapping-hostnames.out.yaml
@@ -27,17 +27,6 @@ gateways:
       protocol: HTTPS
       tls:
         certificateRefs:
-        - name: tls-secret-example-com
-        mode: Terminate
-    - allowedRoutes:
-        namespaces:
-          from: All
-      hostname: foo.bar.com
-      name: https-3
-      port: 443
-      protocol: HTTPS
-      tls:
-        certificateRefs:
         - name: tls-secret-foo-bar-com
         mode: Terminate
   status:
@@ -61,8 +50,7 @@ gateways:
         type: ResolvedRefs
       - lastTransitionTime: null
         message: The hostname foo.example.com overlaps with the hostname *.example.com
-          in listener https-2. ALPN will default to HTTP/1.1 to prevent HTTP/2 connection
-          coalescing, unless explicitly configured via ClientTrafficPolicy
+          in listener https-2.
         reason: OverlappingHostnames
         status: "True"
         type: OverlappingTLSConfig
@@ -91,35 +79,11 @@ gateways:
         type: ResolvedRefs
       - lastTransitionTime: null
         message: The hostname *.example.com overlaps with the hostname foo.example.com
-          in listener https-1. ALPN will default to HTTP/1.1 to prevent HTTP/2 connection
-          coalescing, unless explicitly configured via ClientTrafficPolicy
+          in listener https-1.
         reason: OverlappingHostnames
         status: "True"
         type: OverlappingTLSConfig
       name: https-2
-      supportedKinds:
-      - group: gateway.networking.k8s.io
-        kind: HTTPRoute
-      - group: gateway.networking.k8s.io
-        kind: GRPCRoute
-    - attachedRoutes: 1
-      conditions:
-      - lastTransitionTime: null
-        message: Sending translated listener configuration to the data plane
-        reason: Programmed
-        status: "True"
-        type: Programmed
-      - lastTransitionTime: null
-        message: Listener has been successfully translated
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: null
-        message: Listener references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      name: https-3
       supportedKinds:
       - group: gateway.networking.k8s.io
         kind: HTTPRoute
@@ -256,7 +220,6 @@ xdsIR:
         - certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMyRENDQWNBQ0FRQXdEUVlKS29aSWh2Y05BUUVMQlFBd0xURVZNQk1HQTFVRUNnd01aWGhoYlhCc1pTQkoKYm1NdU1SUXdFZ1lEVlFRRERBdGxlR0Z0Y0d4bExtTnZiVEFlRncweU5UQTBNakV3T1RFd05ETmFGdzB6TlRBMApNVGt3T1RFd05ETmFNRGN4RmpBVUJnTlZCQU1NRFNvdVpYaGhiWEJzWlM1amIyMHhIVEFiQmdOVkJBb01GR1Y0CllXMXdiR1VnYjNKbllXNXBlbUYwYVc5dU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0MKQVFFQXY0anl4TUh1YzQzMHdvWkk4M1JSMXVxU2gvbm9MVWVPdDZnMkNKaFVFYXNaeUNOMzN3bFRRRDE0SEhkSwpOb1k4SThWd1pOZFZCNGpjRzlnb3dDVmVQY3lqRzZPaGl1aUZNWnU2NzV6dWZEWnRlRTNEY3lTbFgrY2lSbVZZCkNuSmk3QkV3NlJMUUJ0bVV6WGxtYmRpVXE5djJwalVBL2R3ZnRLRHRZTHFrVytvTSt5MWg3cjRJV0JVK2RVcU0KcGtTem5VSCtKN1JoRkFsdytmRWlVSFRLemlCMkVtdjc3Mi91bS96NHdMWnJIeWNGbmc4L1FCM0JIUktXVTV4eQp3bWNTQ2xrVlMvWWNpMFVXcnR2eGhwck9wTUhQUGR2QkZ2M2NaWGNpUUJjb0ZNcGxsQzV0UURvdWJ0dEV1d3JpCi8rVktKWkUrSVl4ei9YeUd3Y3dJRnIzWG13SURBUUFCTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBU3VLaE8KcGtwL1VSclphbEU0OUlnc0xkN3hSTlBhREVkQ1RWZ3Qvc3praUhnSDB1NDBVaVV6KzVzaDRpdlJOazRqTm1zRwprb3FwQlBVS3pvVmtrSTcxUWQ4bHh1VzF2dkxZMXVvM0RIS2svdDFpUWVZWWpERlk3YzUxVG1BT015WUdKTlhxCi9EbW84UWgzaFB1RnI3a29kUjBLSkJyc0RsMEhoWVBjUnpWOW1sQ2lrU1B4THJGTUNwZGx0QUw2UEprSVpucUgKc1g5dEtVZk1uYW5jMkpHZTZVTDE1ODBEV2xQTUcrMU1qRElCVXdxWWYzaWNKb0NYclAwbzNmckRKcTE2VnpidApkalRtVGswakx1bGkvQ2JCZzh4dWp4emo4bmRPcVNkd05kd091OWoxSmZ2Q0I1RjZ4S0VTenowOVo5TzlOZUM5CjMrd1pLTlRSOXVEdDRKNksKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
           name: envoy-gateway/tls-secret-example-com
           privateKey: '[redacted]'
-      tlsOverlaps: true
     - address: 0.0.0.0
       externalPort: 443
       hostnames:
@@ -298,58 +261,6 @@ xdsIR:
           name: httproute-1
           namespace: envoy-gateway
         name: httproute/envoy-gateway/httproute-1/rule/0/match/0/*_example_com
-        pathMatch:
-          distinct: false
-          name: ""
-          prefix: /
-      tls:
-        alpnProtocols: null
-        certificates:
-        - certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMyRENDQWNBQ0FRQXdEUVlKS29aSWh2Y05BUUVMQlFBd0xURVZNQk1HQTFVRUNnd01aWGhoYlhCc1pTQkoKYm1NdU1SUXdFZ1lEVlFRRERBdGxlR0Z0Y0d4bExtTnZiVEFlRncweU5UQTBNakV3T1RFd05ETmFGdzB6TlRBMApNVGt3T1RFd05ETmFNRGN4RmpBVUJnTlZCQU1NRFNvdVpYaGhiWEJzWlM1amIyMHhIVEFiQmdOVkJBb01GR1Y0CllXMXdiR1VnYjNKbllXNXBlbUYwYVc5dU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0MKQVFFQXY0anl4TUh1YzQzMHdvWkk4M1JSMXVxU2gvbm9MVWVPdDZnMkNKaFVFYXNaeUNOMzN3bFRRRDE0SEhkSwpOb1k4SThWd1pOZFZCNGpjRzlnb3dDVmVQY3lqRzZPaGl1aUZNWnU2NzV6dWZEWnRlRTNEY3lTbFgrY2lSbVZZCkNuSmk3QkV3NlJMUUJ0bVV6WGxtYmRpVXE5djJwalVBL2R3ZnRLRHRZTHFrVytvTSt5MWg3cjRJV0JVK2RVcU0KcGtTem5VSCtKN1JoRkFsdytmRWlVSFRLemlCMkVtdjc3Mi91bS96NHdMWnJIeWNGbmc4L1FCM0JIUktXVTV4eQp3bWNTQ2xrVlMvWWNpMFVXcnR2eGhwck9wTUhQUGR2QkZ2M2NaWGNpUUJjb0ZNcGxsQzV0UURvdWJ0dEV1d3JpCi8rVktKWkUrSVl4ei9YeUd3Y3dJRnIzWG13SURBUUFCTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBU3VLaE8KcGtwL1VSclphbEU0OUlnc0xkN3hSTlBhREVkQ1RWZ3Qvc3praUhnSDB1NDBVaVV6KzVzaDRpdlJOazRqTm1zRwprb3FwQlBVS3pvVmtrSTcxUWQ4bHh1VzF2dkxZMXVvM0RIS2svdDFpUWVZWWpERlk3YzUxVG1BT015WUdKTlhxCi9EbW84UWgzaFB1RnI3a29kUjBLSkJyc0RsMEhoWVBjUnpWOW1sQ2lrU1B4THJGTUNwZGx0QUw2UEprSVpucUgKc1g5dEtVZk1uYW5jMkpHZTZVTDE1ODBEV2xQTUcrMU1qRElCVXdxWWYzaWNKb0NYclAwbzNmckRKcTE2VnpidApkalRtVGswakx1bGkvQ2JCZzh4dWp4emo4bmRPcVNkd05kd091OWoxSmZ2Q0I1RjZ4S0VTenowOVo5TzlOZUM5CjMrd1pLTlRSOXVEdDRKNksKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-          name: envoy-gateway/tls-secret-example-com
-          privateKey: '[redacted]'
-      tlsOverlaps: true
-    - address: 0.0.0.0
-      externalPort: 443
-      hostnames:
-      - foo.bar.com
-      metadata:
-        kind: Gateway
-        name: gateway-1
-        namespace: envoy-gateway
-        sectionName: https-3
-      name: envoy-gateway/gateway-1/https-3
-      path:
-        escapedSlashesAction: UnescapeAndRedirect
-        mergeSlashes: true
-      port: 10443
-      routes:
-      - destination:
-          metadata:
-            kind: HTTPRoute
-            name: httproute-1
-            namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
-          settings:
-          - addressType: IP
-            endpoints:
-            - host: 7.7.7.7
-              port: 8080
-            metadata:
-              kind: Service
-              name: service-1
-              namespace: envoy-gateway
-              sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
-            protocol: HTTP
-            weight: 1
-        hostname: foo.bar.com
-        isHTTP2: false
-        metadata:
-          kind: HTTPRoute
-          name: httproute-1
-          namespace: envoy-gateway
-        name: httproute/envoy-gateway/httproute-1/rule/0/match/0/foo_bar_com
         pathMatch:
           distinct: false
           name: ""

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -298,8 +298,8 @@ type HTTPListener struct {
 	Hostnames []string `json:"hostnames" yaml:"hostnames"`
 	// Tls configuration. If omitted, the gateway will expose a plain text HTTP server.
 	TLS *TLSConfig `json:"tls,omitempty" yaml:"tls,omitempty"`
-	// TLSOverlaps indicates if the listener has TLS configuration that overlaps with other listeners.
-	// HTTP2 should be disabled if this is true to avoid the HTTP/2 Connection Coalescing issue (see https://gateway-api.sigs.k8s.io/geps/gep-3567/)
+	// TLSOverlaps indicates if the listener's certificate SANs overlap with another listener's certificate SANs.
+	// HTTP/2 should be disabled if this is true to avoid the HTTP/2 Connection Coalescing issue (see https://gateway-api.sigs.k8s.io/geps/gep-3567/)
 	// We use a standalone field to avoid messing with the ClientTrafficPolicy ALPN config.
 	TLSOverlaps bool `json:"tlsOverlaps,omitempty" yaml:"tlsOverlaps,omitempty"`
 	// Routes associated with HTTP traffic to the service.

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -13,6 +13,7 @@ new features: |
 bug fixes: |
   Fixed SecurityPolicy merge using the wrong policy as the owner for resource references and IR generation.
   Fixed active HTTP health checks to use Backend endpoint hostnames before falling back to the effective Route hostname.
+  Fixed HTTPS listeners with overlapping hostnames but disjoint certificate SANs to preserve HTTP/2 ALPN by default.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
This PR preserves HTTP/2 for only hostname-overlapping listeners. Listeners with overlapping certificates are still downgraded to HTTP/1.1.

fix: #8754 