### PR TITLE
[release/v1.8] bump golang to 1.26.3

### DIFF
--- a/examples/backend-utilization/Dockerfile
+++ b/examples/backend-utilization/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/backend-utilization/go.mod
+++ b/examples/backend-utilization/go.mod
@@ -1,3 +1,3 @@
 module github.com/envoyproxy/gateway-backend-utilization
 
-go 1.26.2
+go 1.26.3

--- a/examples/dynamic-module-test/Dockerfile
+++ b/examples/dynamic-module-test/Dockerfile
@@ -2,7 +2,7 @@
 # Update both together when changing the target Envoy version.
 ARG ENVOY_VERSION=v1.38.0
 
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 WORKDIR /build
 COPY go.mod go.sum ./

--- a/examples/dynamic-module-test/go.mod
+++ b/examples/dynamic-module-test/go.mod
@@ -1,5 +1,5 @@
 module github.com/envoyproxy/gateway/examples/dynamic-module-test
 
-go 1.26.2
+go 1.26.3
 
 require github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260430163524-c90c9e9ba9b2

--- a/examples/envoy-ext-auth/Dockerfile
+++ b/examples/envoy-ext-auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/envoy-ext-auth/go.mod
+++ b/examples/envoy-ext-auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-grcp-ext-auth
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260304210048-a81710db7097

--- a/examples/extension-server/go.mod
+++ b/examples/extension-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/exampleorg/envoygateway-extension
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/envoyproxy/gateway v1.3.1

--- a/examples/grpc-ext-proc/Dockerfile
+++ b/examples/grpc-ext-proc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/grpc-ext-proc/go.mod
+++ b/examples/grpc-ext-proc/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-grpc-ext-proc
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260304210048-a81710db7097

--- a/examples/preserve-case-backend/Dockerfile
+++ b/examples/preserve-case-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/preserve-case-backend/go.mod
+++ b/examples/preserve-case-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-preserve-case-backend
 
-go 1.26.2
+go 1.26.3
 
 require github.com/valyala/fasthttp v1.70.0
 

--- a/examples/simple-extension-server/Dockerfile
+++ b/examples/simple-extension-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/simple-extension-server/go.mod
+++ b/examples/simple-extension-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-simple-extension-server
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/envoyproxy/gateway v1.7.2

--- a/examples/static-file-server/Dockerfile
+++ b/examples/static-file-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 ARG GO_LDFLAGS=""
 

--- a/examples/static-file-server/go.mod
+++ b/examples/static-file-server/go.mod
@@ -1,3 +1,3 @@
 module github.com/envoyproxy/static-file-server
 
-go 1.26.2
+go 1.26.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/docsy-example
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 // indirect

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway/test
 
-go 1.26.2
+go 1.26.3
 
 replace github.com/envoyproxy/gateway => ../
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.26.2
+go 1.26.3
 
 tool (
 	github.com/bufbuild/buf/cmd/buf


### PR DESCRIPTION
Needed for https://github.com/envoyproxy/gateway/pull/8949

CC @zirain 