### PR TITLE
chore: replace Deprecated CEL ParsedExpr Oneof With CelExprParsed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/envoyproxy/gateway
 go 1.26.3
 
 require (
+	cel.dev/expr v0.25.1
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/avast/retry-go/v5 v5.0.0
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -57,7 +58,6 @@ require (
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/sync v0.20.0
 	gomodules.xyz/jsonpatch/v2 v2.5.0
-	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
 	google.golang.org/grpc v1.81.0
 	google.golang.org/grpc/security/advancedtls v1.0.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
@@ -81,7 +81,6 @@ require (
 )
 
 require (
-	cel.dev/expr v0.25.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
@@ -271,6 +270,7 @@ require (
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/internal/xds/translator/custom_response.go
+++ b/internal/xds/translator/custom_response.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strconv"
 
+	expr "cel.dev/expr"
 	cncfv3 "github.com/cncf/xds/go/xds/core/v3"
 	matcherv3 "github.com/cncf/xds/go/xds/type/matcher/v3"
 	typev3 "github.com/cncf/xds/go/xds/type/v3"
@@ -20,7 +21,6 @@ import (
 	policyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/custom_response/local_response_policy/v3"
 	redirectpolicyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/custom_response/redirect_policy/v3"
 	envoymatcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -311,43 +311,41 @@ func (c *customResponse) buildStatusCodeCELMatcher(codeRange ir.StatusCodeRange)
 	// Build the CEL expression AST: response.code >= codeRange.Start && response.code <= codeRange.End
 	matcher := &matcherv3.CelMatcher{
 		ExprMatch: &typev3.CelExpression{
-			ExprSpecifier: &typev3.CelExpression_ParsedExpr{
-				ParsedExpr: &expr.ParsedExpr{
-					Expr: &expr.Expr{
-						Id: 9,
-						ExprKind: &expr.Expr_CallExpr{
-							CallExpr: &expr.Expr_Call{
-								Function: "_&&_",
-								Args: []*expr.Expr{
-									{
-										Id: 3,
-										ExprKind: &expr.Expr_CallExpr{
-											CallExpr: &expr.Expr_Call{
-												Function: "_>=_",
-												Args: []*expr.Expr{
-													{
-														Id: 2,
-														ExprKind: &expr.Expr_SelectExpr{
-															SelectExpr: &expr.Expr_Select{
-																Operand: &expr.Expr{
-																	Id: 1,
-																	ExprKind: &expr.Expr_IdentExpr{
-																		IdentExpr: &expr.Expr_Ident{
-																			Name: "response",
-																		},
+			CelExprParsed: &expr.ParsedExpr{
+				Expr: &expr.Expr{
+					Id: 9,
+					ExprKind: &expr.Expr_CallExpr{
+						CallExpr: &expr.Expr_Call{
+							Function: "_&&_",
+							Args: []*expr.Expr{
+								{
+									Id: 3,
+									ExprKind: &expr.Expr_CallExpr{
+										CallExpr: &expr.Expr_Call{
+											Function: "_>=_",
+											Args: []*expr.Expr{
+												{
+													Id: 2,
+													ExprKind: &expr.Expr_SelectExpr{
+														SelectExpr: &expr.Expr_Select{
+															Operand: &expr.Expr{
+																Id: 1,
+																ExprKind: &expr.Expr_IdentExpr{
+																	IdentExpr: &expr.Expr_Ident{
+																		Name: "response",
 																	},
 																},
-																Field: "code",
 															},
+															Field: "code",
 														},
 													},
-													{
-														Id: 4,
-														ExprKind: &expr.Expr_ConstExpr{
-															ConstExpr: &expr.Constant{
-																ConstantKind: &expr.Constant_Int64Value{
-																	Int64Value: int64(codeRange.Start),
-																},
+												},
+												{
+													Id: 4,
+													ExprKind: &expr.Expr_ConstExpr{
+														ConstExpr: &expr.Constant{
+															ConstantKind: &expr.Constant_Int64Value{
+																Int64Value: int64(codeRange.Start),
 															},
 														},
 													},
@@ -355,35 +353,35 @@ func (c *customResponse) buildStatusCodeCELMatcher(codeRange ir.StatusCodeRange)
 											},
 										},
 									},
-									{
-										Id: 7,
-										ExprKind: &expr.Expr_CallExpr{
-											CallExpr: &expr.Expr_Call{
-												Function: "_<=_",
-												Args: []*expr.Expr{
-													{
-														Id: 6,
-														ExprKind: &expr.Expr_SelectExpr{
-															SelectExpr: &expr.Expr_Select{
-																Operand: &expr.Expr{
-																	Id: 5,
-																	ExprKind: &expr.Expr_IdentExpr{
-																		IdentExpr: &expr.Expr_Ident{
-																			Name: "response",
-																		},
+								},
+								{
+									Id: 7,
+									ExprKind: &expr.Expr_CallExpr{
+										CallExpr: &expr.Expr_Call{
+											Function: "_<=_",
+											Args: []*expr.Expr{
+												{
+													Id: 6,
+													ExprKind: &expr.Expr_SelectExpr{
+														SelectExpr: &expr.Expr_Select{
+															Operand: &expr.Expr{
+																Id: 5,
+																ExprKind: &expr.Expr_IdentExpr{
+																	IdentExpr: &expr.Expr_Ident{
+																		Name: "response",
 																	},
 																},
-																Field: "code",
 															},
+															Field: "code",
 														},
 													},
-													{
-														Id: 8,
-														ExprKind: &expr.Expr_ConstExpr{
-															ConstExpr: &expr.Constant{
-																ConstantKind: &expr.Constant_Int64Value{
-																	Int64Value: int64(codeRange.End),
-																},
+												},
+												{
+													Id: 8,
+													ExprKind: &expr.Expr_ConstExpr{
+														ConstExpr: &expr.Constant{
+															ConstantKind: &expr.Constant_Int64Value{
+																Int64Value: int64(codeRange.End),
 															},
 														},
 													},

--- a/internal/xds/translator/testdata/out/xds-ir/custom-response.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-response.listeners.yaml
@@ -79,7 +79,7 @@
                             typedConfig:
                               '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
                               exprMatch:
-                                parsedExpr:
+                                celExprParsed:
                                   expr:
                                     callExpr:
                                       args:


### PR DESCRIPTION
This PR replaces the deprecated `ParsedExpr` with `CelExprParsed`.