### PR TITLE
ci: add tests for Kubernetes 1.36

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -157,32 +157,32 @@ jobs:
       fail-fast: false
       matrix:
         target:
-        - version: v1.32.11
+        - version: v1.33.12
           ipFamily: ipv4
           profile: default
           gwapiChannel: standard
-        - version: v1.33.7
+        - version: v1.34.8
           ipFamily: ipv4
           profile: default
           gwapiChannel: experimental
-        - version: v1.34.3
+        - version: v1.35.5
           ipFamily: ipv6  # only run ipv6 test on this version to save time
           profile: default
           gwapiChannel: experimental
         # TODO: this's IPv4 first, need a way to test IPv6 first.
-        - version: v1.35.0
+        - version: v1.36.1
           ipFamily: dual  # only run dual test on latest version to save time
           profile: default
           gwapiChannel: experimental
-        - version: v1.35.0
+        - version: v1.36.1
           ipFamily: dual  # only run dual test on latest version to save time
           gwapiChannel: experimental
           profile: gateway-namespace-mode
-        - version: v1.35.0
+        - version: v1.36.1
           ipFamily: ipv4
           profile: xds-name-scheme-v2
           gwapiChannel: experimental
-        - version: v1.35.0
+        - version: v1.36.1
           ipFamily: ipv4
           profile: watch-namespaces
           gwapiChannel: experimental
@@ -223,26 +223,26 @@ jobs:
       fail-fast: false
       matrix:
         target:
-        - version: v1.32.11
+        - version: v1.33.12
           ipFamily: ipv4
           profile: default
-        - version: v1.33.7
+        - version: v1.34.8
           ipFamily: ipv4
           profile: default
-        - version: v1.34.3
+        - version: v1.35.5
           ipFamily: ipv6  # only run ipv6 test on this version to save time
           profile: default
         # TODO: this's IPv4 first, need a way to test IPv6 first.
-        - version: v1.35.0
+        - version: v1.36.1
           ipFamily: dual  # only run dual test on latest version to save time
           profile: default
-        - version: v1.35.0
+        - version: v1.36.1
           ipFamily: dual  # only run dual test on latest version to save time
           profile: gateway-namespace-mode
-        - version: v1.35.0
+        - version: v1.36.1
           ipFamily: ipv4
           profile: xds-name-scheme-v2
-        - version: v1.35.0
+        - version: v1.36.1
           ipFamily: ipv4
           profile: watch-namespaces
 

--- a/.github/workflows/experimental_conformance.yaml
+++ b/.github/workflows/experimental_conformance.yaml
@@ -26,26 +26,26 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - version: v1.32.11
+          - version: v1.33.12
             ipFamily: ipv4
             profile: default
-          - version: v1.33.7
+          - version: v1.34.8
             ipFamily: ipv4
             profile: default
-          - version: v1.34.3
+          - version: v1.35.5
             # only run ipv6 test on this version to save time
             ipFamily: ipv6
             profile: default
           # TODO: this's IPv4 first, need a way to test IPv6 first.
-          - version: v1.35.0
+          - version: v1.36.1
             # only run dual test on latest version to save time
             ipFamily: dual
             profile: default
-          - version: v1.35.0
+          - version: v1.36.1
             # only run dual test on latest version to save time
             ipFamily: dual
             profile: gateway-namespace-mode
-          - version: v1.35.0
+          - version: v1.36.1
             ipFamily: ipv4
             profile: watch-namespaces
     steps:

--- a/site/content/en/news/releases/matrix.md
+++ b/site/content/en/news/releases/matrix.md
@@ -7,7 +7,7 @@ Envoy Gateway relies on the Envoy Proxy and the Gateway API, and runs within a K
 
 | Envoy Gateway version | Envoy Proxy version         | Rate Limit version | Gateway API version | Kubernetes version         | End of Life |
 | --------------------- | --------------------------- | ------------------ | ------------------- | -------------------------- | ----------- |
-| latest                | **dev-latest**              | **master**         | **v1.4.1**          | v1.32, v1.33, v1.34, v1.35 | n/a         |
+| latest                | **dev-latest**              | **master**         | **v1.5.1**          | v1.33, v1.34, v1.35, v1.36 | n/a         |
 | v1.8                  | **distroless-v1.38.0**      | **fe26676d**       | **v1.5.1**          | v1.32, v1.33, v1.34, v1.35 | 2026/11/08  |
 | v1.7                  | **distroless-v1.37.0**      | **3fb70258**       | **v1.4.1**          | v1.32, v1.33, v1.34, v1.35 | 2026/08/05  |
 | v1.6                  | **distroless-v1.36.4**      | **3fb70258**       | **v1.4.0**          | v1.30, v1.31, v1.32, v1.33 | 2026/05/13  |

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -395,7 +395,7 @@ require (
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260405152528-6210f847b2c1 // indirect
 	sigs.k8s.io/controller-tools v0.20.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/kind v0.31.0 // indirect
+	sigs.k8s.io/kind v0.32.0 // indirect
 	sigs.k8s.io/kube-api-linter v0.0.0-20260408163332-73b2175ca510 // indirect
 	sigs.k8s.io/kustomize/api v0.20.1 // indirect
 	sigs.k8s.io/kustomize/cmd/config v0.20.1 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1054,8 +1054,8 @@ sigs.k8s.io/controller-tools v0.20.1 h1:gkfMt9YodI0K85oT8rVi80NTXO/kDmabKR5Ajn5G
 sigs.k8s.io/controller-tools v0.20.1/go.mod h1:b4qPmjGU3iZwqn34alUU5tILhNa9+VXK+J3QV0fT/uU=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/kind v0.31.0 h1:UcT4nzm+YM7YEbqiAKECk+b6dsvc/HRZZu9U0FolL1g=
-sigs.k8s.io/kind v0.31.0/go.mod h1:FSqriGaoTPruiXWfRnUXNykF8r2t+fHtK0P0m1AbGF8=
+sigs.k8s.io/kind v0.32.0 h1:p9hscbj98u/qyrjVpjId86LI70nQmbSsipV7wCG10Xk=
+sigs.k8s.io/kind v0.32.0/go.mod h1:FSqriGaoTPruiXWfRnUXNykF8r2t+fHtK0P0m1AbGF8=
 sigs.k8s.io/kube-api-linter v0.0.0-20260408163332-73b2175ca510 h1:N0kQvpmG98Nniz6NiOFGE4ZkrpBYQYh2wEGKDsZJvQY=
 sigs.k8s.io/kube-api-linter v0.0.0-20260408163332-73b2175ca510/go.mod h1:5mP60UakkCye+eOcZ5p98VnV2O49qreW1gq9TdsUf7Q=
 sigs.k8s.io/kustomize/api v0.20.1 h1:iWP1Ydh3/lmldBnH/S5RXgT98vWYMaTUL1ADcr+Sv7I=

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -1,10 +1,9 @@
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 # To know the available versions check:
 # - https://github.com/kubernetes-sigs/controller-tools/blob/main/envtest-releases.yaml
-ENVTEST_K8S_VERSION ?= 1.35.0
+ENVTEST_K8S_VERSION ?= 1.36.0
 # Need run cel validation across multiple versions of k8s
-# TODO: update kubebuilder assets to 1.35.0 when available
-ENVTEST_K8S_VERSIONS ?= 1.32.0 1.33.0 1.34.1 1.35.0
+ENVTEST_K8S_VERSIONS ?= 1.33.0 1.34.1 1.35.0 1.36.0
 
 # GATEWAY_API_VERSION refers to the version of Gateway API CRDs.
 # For more details, see https://gateway-api.sigs.k8s.io/guides/getting-started/#installing-gateway-api


### PR DESCRIPTION
What type of PR is this?

Run e2e and conformance tests on K8s 1.36 in CI.

Since there is no pre-built kind image for 1.36 yet, we build the image instead. This is the current recommendation per https://github.com/kubernetes-sigs/kind/issues/4157.

What this PR does / why we need it:

Update the version matrix to give confidence in the most recent K8s version. Also updates the docs hosted at https://gateway.envoyproxy.io/news/releases/matrix/.

Which issue(s) this PR fixes:

No linked issue.

Release Notes: No