### PR TITLE
bump lastVersionTag to v1.8.0

### DIFF
--- a/internal/utils/helm/package.go
+++ b/internal/utils/helm/package.go
@@ -183,10 +183,6 @@ func (pt *PackageTool) loadChart(opts *PackageOptions) (*chart.Chart, error) {
 // extractCRDs Extract the CRDs part of the chart and its sub-charts
 func (pt *PackageTool) extractCRDs(ch *chart.Chart) ([]*resource.Info, error) {
 	allCRDs := ch.CRDObjects()
-	for _, dep := range ch.Dependencies() {
-		allCRDs = append(allCRDs, dep.CRDObjects()...)
-	}
-
 	crdResInfo := make([]*resource.Info, 0, len(allCRDs))
 
 	for _, crd := range allCRDs {

--- a/test/e2e/tests/eg_upgrade.go
+++ b/test/e2e/tests/eg_upgrade.go
@@ -47,7 +47,7 @@ var EGUpgradeTest = suite.ConformanceTest{
 			chartPath := "../../../charts/gateway-helm"
 			relName := "eg"
 			depNS := "envoy-gateway-system"
-			lastVersionTag := "1.7.1" //  the latest prior release
+			lastVersionTag := "1.8.0" //  the latest prior release
 
 			t.Logf("Upgrading from version: %s", lastVersionTag)
 


### PR DESCRIPTION
Update lastVersionTag after v1.8.0 release and fix eg upgrade after we've changed CRD handling