### PR TITLE
fix: applyBackendTLSSetting panic

### DIFF
--- a/internal/gatewayapi/backendtlspolicy.go
+++ b/internal/gatewayapi/backendtlspolicy.go
@@ -142,10 +142,12 @@ func (t *Translator) applyBackendTLSSetting(
 	}
 
 	// Get the client certificate and common TLS settings from EnvoyProxy resource.
-	if gtwBackendTLSConfig, owner := gtwCtx.GetBackendTLSConfig(); gtwBackendTLSConfig != nil {
-		if envoyProxyClientTLSConfig, err = t.processClientTLSSettings(
-			gtwBackendTLSConfig, owner); err != nil {
-			return nil, err
+	if gtwCtx != nil {
+		if gtwBackendTLSConfig, owner := gtwCtx.GetBackendTLSConfig(); gtwBackendTLSConfig != nil {
+			if envoyProxyClientTLSConfig, err = t.processClientTLSSettings(
+				gtwBackendTLSConfig, owner); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/gatewayapi/testdata/backendtlspolicy-default-ns.in.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-default-ns.in.yaml
@@ -41,6 +41,33 @@ httpRoutes:
               namespace: default
               kind: Backend
               group: gateway.envoyproxy.io
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: httproute-with-wrong-section-name
+      namespace: envoy-gateway
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-btls
+          sectionName: http2
+      rules:
+        - matches:
+            - path:
+                type: Exact
+                value: "/exact"
+          backendRefs:
+            - name: http-backend
+              namespace: default
+              port: 8080
+            - name: backend-ip-tls-1
+              namespace: default
+              kind: Backend
+              group: gateway.envoyproxy.io
+            - name: backend-ip-tls-2
+              namespace: default
+              kind: Backend
+              group: gateway.envoyproxy.io
 referenceGrants:
   - apiVersion: gateway.networking.k8s.io/v1alpha2
     kind: ReferenceGrant

--- a/internal/gatewayapi/testdata/backendtlspolicy-default-ns.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-default-ns.out.yaml
@@ -34,6 +34,22 @@ backendTLSPolicies:
         status: "True"
         type: Accepted
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        name: gateway-btls
+        namespace: envoy-gateway
+        sectionName: http2
+      conditions:
+      - lastTransitionTime: null
+        message: Resolved all the Object references.
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
 - apiVersion: gateway.networking.k8s.io/v1alpha2
   kind: BackendTLSPolicy
   metadata:
@@ -56,6 +72,22 @@ backendTLSPolicies:
         name: gateway-btls
         namespace: envoy-gateway
         sectionName: http
+      conditions:
+      - lastTransitionTime: null
+        message: Resolved all the Object references.
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    - ancestorRef:
+        name: gateway-btls
+        namespace: envoy-gateway
+        sectionName: http2
       conditions:
       - lastTransitionTime: null
         message: Resolved all the Object references.
@@ -208,6 +240,51 @@ httpRoutes:
         name: gateway-btls
         namespace: envoy-gateway
         sectionName: http
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-with-wrong-section-name
+    namespace: envoy-gateway
+  spec:
+    parentRefs:
+    - name: gateway-btls
+      namespace: envoy-gateway
+      sectionName: http2
+    rules:
+    - backendRefs:
+      - name: http-backend
+        namespace: default
+        port: 8080
+      - group: gateway.envoyproxy.io
+        kind: Backend
+        name: backend-ip-tls-1
+        namespace: default
+      - group: gateway.envoyproxy.io
+        kind: Backend
+        name: backend-ip-tls-2
+        namespace: default
+      matches:
+      - path:
+          type: Exact
+          value: /exact
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: No listeners match this parent ref
+        reason: NoMatchingParent
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-btls
+        namespace: envoy-gateway
+        sectionName: http2
 infraIR:
   envoy-gateway/gateway-btls:
     proxy:

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -11,6 +11,7 @@ security updates: |
 new features: |
 
 bug fixes: |
+  Fixed controller panic when processing backend tls settings.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
fixes: https://github.com/envoyproxy/gateway/issues/8997

`applyBackendTLSSetting` will cause panic when a HTTPRoute point to non-exists listener.