### PR TITLE
docs: move v1.8 CRD upgrade note

### DIFF
--- a/site/content/en/news/releases/notes/v1.8.0.md
+++ b/site/content/en/news/releases/notes/v1.8.0.md
@@ -6,7 +6,6 @@ publishdate: 2026-05-12
 Date: May 12, 2026
 
 ## Breaking changes
-- Bumped the bundled Gateway API CRDs to [v1.5.1](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.1). The controller now unconditionally starts an informer for ListenerSet, so the updated Gateway API CRDs must be installed before upgrading.
 - The DirectResponse body in HTTPFilter now supports Envoy command operators for dynamic content. Existing configurations including the template syntax (%) will be interpolated.
 - The `0s` timeout in SecurityPolicy is now treated as infinite timeout instead of immediate timeout.
 - Fixed EnvoyProxy `samplingFraction` translation to correctly convert the Gateway API fraction into Envoy's percentage-based `random_sampling` field. Existing `samplingFraction` configurations will now sample 100x more frequently than in previous releases; divide previous values by 100 to preserve prior sampling rates.
@@ -18,6 +17,7 @@ Date: May 12, 2026
 - 
 
 ## New features
+- Bumped the bundled Gateway API CRDs to [v1.5.1](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.1).
 - Added support for optional active health check configuration.
 - Added support for shadow mode in local rate limiting.
 - Added support for MergeType in SecurityPolicy to enable route-level policies to merge with parent Gateway/Listener policies, similar to BackendTrafficPolicy.

--- a/site/content/en/news/releases/v1.8.md
+++ b/site/content/en/news/releases/v1.8.md
@@ -158,7 +158,8 @@ Envoy Gateway v1.8.0 introduces powerful enhancements, resolves critical issues,
 ## 📝 Upgrade Notes
 
 - We encourage all users to upgrade to v1.8.0 to take advantage of the new features, security improvements, and performance gains. For full details, see the [Release Notes][] and updated [Documentation][docs].
-- See upgrading from previous version via [helm install](../../v1.8/install/install-helm.md#upgrading-from-the-previous-version) or [yaml install](../../v1.8/install/install-yaml.md#upgrading-from-the-previous-version) for more. Note that CRDs should be upgraded first before gateway controller.
+- Bumped the bundled Gateway API CRDs to [v1.5.1](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.1). The controller now unconditionally starts an informer for ListenerSet, so the updated Gateway API CRDs must be installed before upgrading.
+- For upgrade instructions, see [Helm](../../v1.8/install/install-helm.md#upgrading-from-the-previous-version) or [YAML](../../v1.8/install/install-yaml.md#upgrading-from-the-previous-version).
 
 [Release Notes]: ./notes/v1.8.0.md
 [docs]: https://gateway.envoyproxy.io


### PR DESCRIPTION
Move the Gateway API v1.5.1 / ListenerSet prerequisite into the v1.8 upgrade notes and keep the Gateway API bump listed under v1.8.0 new features. This puts the CRD ordering requirement in the upgrade path while preserving the release note for the version bump.

Fixes: https://github.com/envoyproxy/gateway/issues/8991

Test plan:
- git diff --check HEAD^ -- site/content/en/news/releases/notes/v1.8.0.md site/content/en/news/releases/v1.8.md
