### PR TITLE
fix(helm): correct typo in HPA maxReplicas required message

### DIFF
--- a/charts/gateway-helm/templates/envoy-gateway-hpa.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-hpa.yaml
@@ -12,7 +12,7 @@ spec:
   {{- if .Values.hpa.minReplicas }}
   minReplicas: {{ .Values.hpa.minReplicas }}
   {{- end }}
-  maxReplicas: {{ required ".Values.hps.maxReplicas is required when hpa is enabled" .Values.hpa.maxReplicas }}
+  maxReplicas: {{ required ".Values.hpa.maxReplicas is required when hpa is enabled" .Values.hpa.maxReplicas }}
   {{- if .Values.hpa.behavior }}
   behavior:
 {{ toYaml .Values.hpa.behavior | indent 4 }}


### PR DESCRIPTION
**What type of PR is this?**

fix(helm): correct typo in HPA maxReplicas required message

**What this PR does / why we need it**:

Fixes a typo in the `envoy-gateway-hpa.yaml` Helm template.

The validation message incorrectly referenced `.Values.hps.maxReplicas` instead of `.Values.hpa.maxReplicas`.

This change only updates the error message text and does not affect functionality.

**Which issue(s) this PR fixes**:

Fixes #

Release Notes: No