### PR TITLE
docs: explain how to scrape proxy metrics with an existing Prometheus

### DIFF
--- a/site/content/en/latest/tasks/observability/proxy-metric.md
+++ b/site/content/en/latest/tasks/observability/proxy-metric.md
@@ -117,6 +117,27 @@ To completely remove Prometheus resources from the cluster, set the `prometheus.
 helm upgrade eg-addons oci://docker.io/envoyproxy/gateway-addons-helm --version {{< helm-version >}} -n monitoring --reuse-values --set prometheus.enabled=false 
 ```
 
+### Scrape proxy metrics with an existing Prometheus
+
+If you already run Prometheus via the [Prometheus Operator](https://prometheus-operator.dev/) (for example through
+`kube-prometheus-stack`) you do not need the bundled Prometheus from `gateway-addons-helm`. Disable it as shown
+above and have your existing Prometheus discover the proxy pods by applying a `PodMonitor` that targets the
+`metrics` port served by the Envoy proxy at `/stats/prometheus`:
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/envoyproxy/gateway/latest/examples/kubernetes/metric/pod-monitor.yaml
+```
+
+The `PodMonitor` selects pods labelled `app.kubernetes.io/name=envoy` and `app.kubernetes.io/component=proxy`
+in any namespace (Envoy Gateway places proxy pods in `envoy-gateway-system` by default but the namespace can be
+customised via the `EnvoyProxy` resource), and scrapes the `metrics` port that Envoy exposes for the
+Prometheus admin endpoint.
+
+The Prometheus Operator only watches `PodMonitor` and `ServiceMonitor` resources that match the
+`podMonitorSelector` / `podMonitorNamespaceSelector` configured on your `Prometheus` custom resource. If the
+target labels do not match the defaults set by your chart, override the `PodMonitor` `metadata.labels` to add
+the label your `Prometheus` selects on (commonly `release: <helm-release-name>` for `kube-prometheus-stack`).
+
 ### OpenTelemetry Metrics
 
 Envoy Gateway can export metrics to an OpenTelemetry sink. Use the following command to send metrics to the


### PR DESCRIPTION
**What type of PR is this?**

docs

**What this PR does / why we need it**:

The `proxy-metric` task only documents the bundled Prometheus that ships
with `gateway-addons-helm`. Users who already run a Prometheus Operator
install (commonly `kube-prometheus-stack`) had no documented path to make
that existing Prometheus discover the Envoy proxy pods. The working
`PodMonitor` in `examples/kubernetes/metric/pod-monitor.yaml` was
undocumented, so users either reinvented it or assumed it was unsupported.

This adds a short "Scrape proxy metrics with an existing Prometheus"
section that references the existing example file via the standard
`raw.githubusercontent.com/.../latest/examples/...` pattern used elsewhere
in the task docs, and calls out the operator selector gotcha
(`podMonitorSelector` / `podMonitorNamespaceSelector`) so users add the
right label on their `PodMonitor` when their `Prometheus` CR only matches
a specific release label.

**Which issue(s) this PR fixes**:

Fixes #5139

Release Notes: No
