### PR TITLE
fix: DNS resolution in IPv6-only clusters

### DIFF
--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
@@ -188,6 +188,7 @@ spec:
                         timeout: 5s
               name: xds_cluster
               type: STRICT_DNS
+              dns_lookup_family: V6_ONLY
               transport_socket:
                 name: envoy.transport_sockets.tls
                 typed_config:

--- a/internal/xds/bootstrap/bootstrap.yaml.tpl
+++ b/internal/xds/bootstrap/bootstrap.yaml.tpl
@@ -203,6 +203,9 @@ static_resources:
   - name: otel_metric_sink_{{ $idx }}
     connect_timeout: 0.250s
     type: STRICT_DNS
+    {{- if eq $.IPFamily "IPv6" }}
+    dns_lookup_family: V6_ONLY
+    {{- end }}
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
@@ -300,6 +303,9 @@ static_resources:
   {{- end }}
     name: xds_cluster
     type: STRICT_DNS
+    {{- if eq .IPFamily "IPv6" }}
+    dns_lookup_family: V6_ONLY
+    {{- end }}
     transport_socket:
       name: envoy.transport_sockets.tls
       typed_config:

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -297,6 +297,34 @@ func TestGetRenderedBootstrapConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "ipv6-with-otel",
+			opts: &RenderBootstrapConfigOptions{
+				IPFamily: new(egv1a1.IPv6),
+				ProxyMetrics: &egv1a1.ProxyMetrics{
+					Prometheus: &egv1a1.ProxyPrometheusProvider{
+						Disable: true,
+					},
+					Sinks: []egv1a1.ProxyMetricSink{
+						{
+							Type: egv1a1.MetricSinkTypeOpenTelemetry,
+							OpenTelemetry: &egv1a1.ProxyOpenTelemetrySink{
+								Host: new("otel-collector.monitoring.svc"),
+								Port: 4317,
+							},
+						},
+					},
+				},
+				SdsConfig: sds,
+			},
+		},
+		{
+			name: "dualstack",
+			opts: &RenderBootstrapConfigOptions{
+				IPFamily: new(egv1a1.DualStack),
+				SdsConfig: sds,
+			},
+		},
+		{
 			name: "topology-injector-disabled",
 			opts: &RenderBootstrapConfigOptions{
 				ProxyMetrics: &egv1a1.ProxyMetrics{

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -320,7 +320,7 @@ func TestGetRenderedBootstrapConfig(t *testing.T) {
 		{
 			name: "dualstack",
 			opts: &RenderBootstrapConfigOptions{
-				IPFamily: new(egv1a1.DualStack),
+				IPFamily:  new(egv1a1.DualStack),
 				SdsConfig: sds,
 			},
 		},

--- a/internal/xds/bootstrap/testdata/render/dualstack.yaml
+++ b/internal/xds/bootstrap/testdata/render/dualstack.yaml
@@ -6,7 +6,7 @@ admin:
       path: /dev/null
   address:
     socket_address:
-      address: ::1
+      address: 127.0.0.1
       port_value: 19000
 cluster_manager:
   local_cluster_name: local_cluster
@@ -97,7 +97,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: ::1
+                address: 127.0.0.1
                 port_value: 19000
   - connect_timeout: 10s
     eds_cluster_config:
@@ -138,7 +138,6 @@ static_resources:
               timeout: 5s
     name: xds_cluster
     type: STRICT_DNS
-    dns_lookup_family: V6_ONLY
     transport_socket:
       name: envoy.transport_sockets.tls
       typed_config:

--- a/internal/xds/bootstrap/testdata/render/ipv6-with-otel.yaml
+++ b/internal/xds/bootstrap/testdata/render/ipv6-with-otel.yaml
@@ -49,56 +49,34 @@ dynamic_resources:
     ads: {}
     initial_fetch_timeout: 0s
     resource_api_version: V3
+stats_sinks:
+- name: "envoy.stat_sinks.open_telemetry"
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig
+    grpc_service:
+      envoy_grpc:
+        cluster_name: otel_metric_sink_0
 static_resources:
-  listeners:
-  - name: envoy-gateway-proxy-stats-::-19001
-    address:
-      socket_address:
-        address: '::'
-        port_value: 19001
-        protocol: TCP
-        ipv4_compat: true
-    bypass_overload_manager: true
-    filter_chains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          stat_prefix: eg-stats-http
-          normalize_path: true
-          route_config:
-            name: local_route
-            virtual_hosts:
-            - name: prometheus_stats
-              domains:
-              - "*"
-              routes:
-              - match:
-                  path: /stats/prometheus
-                  headers:
-                  - name: ":method"
-                    string_match:
-                      exact: GET
-                route:
-                  cluster: prometheus_stats
-          http_filters:
-          - name: envoy.filters.http.router
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   clusters:
-  - name: prometheus_stats
+  - name: otel_metric_sink_0
     connect_timeout: 0.250s
-    type: STATIC
+    type: STRICT_DNS
+    dns_lookup_family: V6_ONLY
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+        explicit_http_config:
+          http2_protocol_options: {}
     lb_policy: ROUND_ROBIN
     load_assignment:
-      cluster_name: prometheus_stats
+      cluster_name: otel_metric_sink_0
       endpoints:
       - lb_endpoints:
         - endpoint:
             address:
               socket_address:
-                address: ::1
-                port_value: 19000
+                address: otel-collector.monitoring.svc
+                port_value: 4317
   - connect_timeout: 10s
     eds_cluster_config:
       eds_config:

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -13,7 +13,7 @@ new features: |
 bug fixes: |
   Fixed the xDS server in GatewayNamespaceMode serving a stale certificate after cert-manager rotation by re-reading the cert from disk on every TLS handshake.
   Fixed controller panic when processing backend tls settings.
-  Fixed DNS resolution failure in IPv6-only clusters: bootstrap STRICT_DNS clusters now set dns_lookup_family to V6_ONLY for IPv6 and ALL for DualStack.
+  Fixed DNS resolution failure in IPv6-only clusters: bootstrap STRICT_DNS clusters now set dns_lookup_family to V6_ONLY for IPv6.
 
 # Enhancements that improve performance.
 performance improvements: |

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -13,6 +13,7 @@ new features: |
 bug fixes: |
   Fixed the xDS server in GatewayNamespaceMode serving a stale certificate after cert-manager rotation by re-reading the cert from disk on every TLS handshake.
   Fixed controller panic when processing backend tls settings.
+  Fixed DNS resolution failure in IPv6-only clusters: bootstrap STRICT_DNS clusters now set dns_lookup_family to V6_ONLY for IPv6 and ALL for DualStack.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/community/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

Fixed DNS resolution failure in IPv6-only clusters, with `dns_lookup_family` set, defaulting to AUTO, 
Bootstrap STRICT_DNS clusters now set dns_lookup_family to V6_ONLY for IPv6, which makes sure to use an IPv6 socket.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/envoyproxy/gateway/issues/8881

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes
