### PR TITLE
docs: fix ClientTrafficPolicy verification steps

### DIFF
--- a/site/content/en/latest/tasks/traffic/client-traffic-policy.md
+++ b/site/content/en/latest/tasks/traffic/client-traffic-policy.md
@@ -68,17 +68,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-tcp-keepalive-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-tcp-keepalive-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy once again:
@@ -242,17 +239,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-proxy-protocol-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-proxy-protocol-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Try the endpoint without using PROXY protocol with curl:
@@ -383,17 +377,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io http-client-ip-detection -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-http-client-ip-detection   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy:

--- a/site/content/en/v1.0/tasks/traffic/client-traffic-policy.md
+++ b/site/content/en/v1.0/tasks/traffic/client-traffic-policy.md
@@ -43,17 +43,14 @@ spec:
 EOF
 ```
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-tcp-keepalive-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-tcp-keepalive-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy once again:
@@ -193,17 +190,14 @@ spec:
 EOF
 ```
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-proxy-protocol-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-proxy-protocol-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Try the endpoint without using PROXY protocol with curl:
@@ -308,17 +302,14 @@ spec:
 EOF
 ```
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io http-client-ip-detection -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-http-client-ip-detection   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Open port-forward to the admin interface port:

--- a/site/content/en/v1.1/tasks/traffic/client-traffic-policy.md
+++ b/site/content/en/v1.1/tasks/traffic/client-traffic-policy.md
@@ -70,17 +70,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-tcp-keepalive-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-tcp-keepalive-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy once again:
@@ -244,17 +241,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-proxy-protocol-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-proxy-protocol-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Try the endpoint without using PROXY protocol with curl:
@@ -385,17 +379,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io http-client-ip-detection -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-http-client-ip-detection   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Open port-forward to the admin interface port:

--- a/site/content/en/v1.2/tasks/traffic/client-traffic-policy.md
+++ b/site/content/en/v1.2/tasks/traffic/client-traffic-policy.md
@@ -68,17 +68,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-tcp-keepalive-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-tcp-keepalive-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy once again:
@@ -242,17 +239,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-proxy-protocol-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-proxy-protocol-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Try the endpoint without using PROXY protocol with curl:
@@ -383,17 +377,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io http-client-ip-detection -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-http-client-ip-detection   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Open port-forward to the admin interface port:

--- a/site/content/en/v1.3/tasks/traffic/client-traffic-policy.md
+++ b/site/content/en/v1.3/tasks/traffic/client-traffic-policy.md
@@ -68,17 +68,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-tcp-keepalive-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-tcp-keepalive-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy once again:
@@ -242,17 +239,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-proxy-protocol-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-proxy-protocol-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Try the endpoint without using PROXY protocol with curl:
@@ -383,17 +377,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io http-client-ip-detection -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-http-client-ip-detection   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Open port-forward to the admin interface port:

--- a/site/content/en/v1.4/tasks/traffic/client-traffic-policy.md
+++ b/site/content/en/v1.4/tasks/traffic/client-traffic-policy.md
@@ -68,17 +68,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-tcp-keepalive-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-tcp-keepalive-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy once again:
@@ -242,17 +239,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-proxy-protocol-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-proxy-protocol-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Try the endpoint without using PROXY protocol with curl:
@@ -383,17 +377,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io http-client-ip-detection -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-http-client-ip-detection   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Open port-forward to the admin interface port:

--- a/site/content/en/v1.5/tasks/traffic/client-traffic-policy.md
+++ b/site/content/en/v1.5/tasks/traffic/client-traffic-policy.md
@@ -68,17 +68,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-tcp-keepalive-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-tcp-keepalive-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy once again:
@@ -242,17 +239,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-proxy-protocol-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-proxy-protocol-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Try the endpoint without using PROXY protocol with curl:
@@ -383,17 +377,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io http-client-ip-detection -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-http-client-ip-detection   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Open port-forward to the admin interface port:

--- a/site/content/en/v1.6/tasks/traffic/client-traffic-policy.md
+++ b/site/content/en/v1.6/tasks/traffic/client-traffic-policy.md
@@ -68,17 +68,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-tcp-keepalive-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-tcp-keepalive-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy once again:
@@ -244,17 +241,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-proxy-protocol-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-proxy-protocol-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Try the endpoint without using PROXY protocol with curl:
@@ -385,17 +379,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io http-client-ip-detection -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-http-client-ip-detection   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy:

--- a/site/content/en/v1.7/tasks/traffic/client-traffic-policy.md
+++ b/site/content/en/v1.7/tasks/traffic/client-traffic-policy.md
@@ -68,17 +68,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-tcp-keepalive-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-tcp-keepalive-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy once again:
@@ -244,17 +241,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-proxy-protocol-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-proxy-protocol-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Try the endpoint without using PROXY protocol with curl:
@@ -385,17 +379,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io http-client-ip-detection -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-http-client-ip-detection   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy:

--- a/site/content/en/v1.8/tasks/traffic/client-traffic-policy.md
+++ b/site/content/en/v1.8/tasks/traffic/client-traffic-policy.md
@@ -68,17 +68,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-tcp-keepalive-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-tcp-keepalive-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy once again:
@@ -242,17 +239,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io enable-proxy-protocol-policy -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-enable-proxy-protocol-policy   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Try the endpoint without using PROXY protocol with curl:
@@ -383,17 +377,14 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-Verify that ClientTrafficPolicy is Accepted:
+Verify that the ClientTrafficPolicy was created and attached to your Gateway:
 
 ```shell
-kubectl get clienttrafficpolicies.gateway.envoyproxy.io -n default
+kubectl get clienttrafficpolicies.gateway.envoyproxy.io http-client-ip-detection -n default -o jsonpath='{.status.ancestors[0].conditions[?(@.type=="Accepted")].message}'
 ```
 
-You should see the policy marked as accepted like this:
-
-```shell
-NAME                          STATUS     AGE
-http-client-ip-detection   Accepted   5s
+```
+Policy has been accepted.
 ```
 
 Curl the example app through Envoy proxy:


### PR DESCRIPTION
**What type of PR is this?**
docs

**What this PR does / why we need it**:
Fix incorrect `kubectl get` output in CTP verification steps — the docs showed a `STATUS` column that doesn't exist on the resource. Replace with a `jsonpath` command that checks the actual accepted condition on the policy ancestor. Also update the heading to accurately describe what is being verified.

**Which issue(s) this PR fixes**:
Fixes #9061

Release Notes: No