### PR TITLE
fix(egctl): skip missing CRDs in `x status` bulk modes

### DIFF
--- a/internal/cmd/egctl/status.go
+++ b/internal/cmd/egctl/status.go
@@ -15,6 +15,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -92,6 +93,12 @@ func newStatusCommand() *cobra.Command {
 			case "all":
 				for _, rt := range supportedAllTypes {
 					if err = runStatus(ctx, cmd.OutOrStdout(), k8sClient, rt, namespace, quiet, verbose, allNamespaces, true, true); err != nil {
+						if meta.IsNoMatchError(err) {
+							if verbose {
+								fmt.Fprintf(cmd.ErrOrStderr(), "skipping %s: CRD not installed in cluster\n", rt)
+							}
+							continue
+						}
 						return err
 					}
 				}
@@ -99,6 +106,12 @@ func newStatusCommand() *cobra.Command {
 			case "xroute":
 				for _, rt := range supportedXRouteTypes {
 					if err = runStatus(ctx, cmd.OutOrStdout(), k8sClient, rt, namespace, quiet, verbose, allNamespaces, true, true); err != nil {
+						if meta.IsNoMatchError(err) {
+							if verbose {
+								fmt.Fprintf(cmd.ErrOrStderr(), "skipping %s: CRD not installed in cluster\n", rt)
+							}
+							continue
+						}
 						return err
 					}
 				}
@@ -106,6 +119,12 @@ func newStatusCommand() *cobra.Command {
 			case "xpolicy":
 				for _, rt := range supportedXPolicyTypes {
 					if err = runStatus(ctx, cmd.OutOrStdout(), k8sClient, rt, namespace, quiet, verbose, allNamespaces, true, true); err != nil {
+						if meta.IsNoMatchError(err) {
+							if verbose {
+								fmt.Fprintf(cmd.ErrOrStderr(), "skipping %s: CRD not installed in cluster\n", rt)
+							}
+							continue
+						}
 						return err
 					}
 				}

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -18,6 +18,7 @@ bug fixes: |
   Fixed missing deprecated field warning in ClientTrafficPolicy and SecurityPolicy.
   Fixed ClientTrafficPolicy TLS cipher validation rejecting supported IANA/RFC cipher suite names.
   Fixed TLS secrets with non-canonical PEM formatting (e.g. unusual line endings) being passed verbatim to Envoy, which could cause BoringSSL errors such as `BAD_END_LINE`. Cert and key PEM data is now re-encoded to a canonical form before being delivered as xDS resources.
+  Fixed `egctl x status all`/`xroute`/`xpolicy` failing when a Gateway API CRD (e.g. TCPRoute) is not installed in the cluster; missing CRDs are now skipped silently, or reported on stderr with `-v`.
 
 
 # Enhancements that improve performance.


### PR DESCRIPTION
**What type of PR is this?**

fix(egctl)

**What this PR does / why we need it**:

`egctl x status all` (and the related `xroute` / `xpolicy` bulk modes) aborts with an error when any of the Gateway API CRDs it iterates over is not installed in the cluster. For example, clusters that don't install `TCPRoute` see the entire command fail rather than returning status for the kinds that *are* installed — a poor UX for the "give me everything you can find" intent of `all`.

This PR detects the `meta.NoMatchError` returned by the controller-runtime client when a kind has no RESTMapping (i.e. the CRD isn't installed) and skips that kind in the bulk loops. When `-v` is set, a one-line notice is written to stderr so users can tell *why* a kind is missing from the output. Explicit single-resource invocations (e.g. `egctl x status tcproute`) are unchanged — they still error loudly so users get a clear signal when the kind they asked for is unavailable.

Release Notes: Yes