### PR TITLE
docs: copy Lua extensions security warning to v1.8 and v1.7

### DIFF
--- a/site/content/en/v1.7/tasks/extensibility/lua.md
+++ b/site/content/en/v1.7/tasks/extensibility/lua.md
@@ -10,6 +10,18 @@ without modifying the Envoy Gateway binary. These comparatively light-weight ext
 Envoy Gateway allows the user to configure Lua extensions using the [EnvoyExtensionPolicy][] CRD.
 This instantiated resource can be linked to a [Gateway][Gateway] or [HTTPRoute][HTTPRoute] resource. If linked to both, the resource linked to the route takes precedence over those linked to Gateway.
 
+{{% alert title="Warning" color="warning" %}}
+Lua scripts execute inside the Envoy proxy process without strong sandboxing. While Envoy Gateway
+sanitizes scripts and restricts the available Lua API surface, the Lua runtime is inherently less
+isolated than a dedicated extension process.
+
+When enabling Lua extensions, admins should take additional measures to reduce risk, including:
+* Using K8s [RBAC][] to restrict who can create or modify `EnvoyExtensionPolicy` resources with Lua scripts.
+* Using [AdmissionControl][] tools (e.g. OPA Gatekeeper, Kyverno) to validate and review Lua scripts before they are admitted.
+* Auditing `EnvoyExtensionPolicy` resources periodically, and enabling [AuditLog][] for API server operations on these resources.
+* Disabling Lua when it is not needed by setting `disableLua` field to `true` in the [EnvoyGateway][] configuration.
+{{% /alert %}}
+
 ## Prerequisites
 
 {{< boilerplate prerequisites >}}
@@ -199,5 +211,9 @@ kubectl delete configmap/cm-lua-valueref
 Checkout the [Developer Guide](/community/develop) to get involved in the project.
 
 [EnvoyExtensionPolicy]: ../../../api/extension_types#envoyextensionpolicy
+[EnvoyGateway]: ../../../api/extension_types#envoygateway
 [Gateway]: https://gateway-api.sigs.k8s.io/reference/api-types/gateway/
 [HTTPRoute]: https://gateway-api.sigs.k8s.io/reference/api-types/httproute/
+[RBAC]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+[AdmissionControl]: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
+[AuditLog]: https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/

--- a/site/content/en/v1.8/tasks/extensibility/lua.md
+++ b/site/content/en/v1.8/tasks/extensibility/lua.md
@@ -10,6 +10,18 @@ without modifying the Envoy Gateway binary. These comparatively light-weight ext
 Envoy Gateway allows the user to configure Lua extensions using the [EnvoyExtensionPolicy][] CRD.
 This instantiated resource can be linked to a [Gateway][Gateway] or [HTTPRoute][HTTPRoute] resource. If linked to both, the resource linked to the route takes precedence over those linked to Gateway.
 
+{{% alert title="Warning" color="warning" %}}
+Lua scripts execute inside the Envoy proxy process without strong sandboxing. While Envoy Gateway
+sanitizes scripts and restricts the available Lua API surface, the Lua runtime is inherently less
+isolated than a dedicated extension process.
+
+When enabling Lua extensions, admins should take additional measures to reduce risk, including:
+* Using K8s [RBAC][] to restrict who can create or modify `EnvoyExtensionPolicy` resources with Lua scripts.
+* Using [AdmissionControl][] tools (e.g. OPA Gatekeeper, Kyverno) to validate and review Lua scripts before they are admitted.
+* Auditing `EnvoyExtensionPolicy` resources periodically, and enabling [AuditLog][] for API server operations on these resources.
+* Disabling Lua when it is not needed by setting `disableLua` field to `true` in the [EnvoyGateway][] configuration.
+{{% /alert %}}
+
 ## Prerequisites
 
 {{< boilerplate prerequisites >}}
@@ -199,5 +211,9 @@ kubectl delete configmap/cm-lua-valueref
 Checkout the [Developer Guide](/community/develop) to get involved in the project.
 
 [EnvoyExtensionPolicy]: ../../../api/extension_types#envoyextensionpolicy
+[EnvoyGateway]: ../../../api/extension_types#envoygateway
 [Gateway]: https://gateway-api.sigs.k8s.io/reference/api-types/gateway/
 [HTTPRoute]: https://gateway-api.sigs.k8s.io/reference/api-types/httproute/
+[RBAC]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+[AdmissionControl]: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
+[AuditLog]: https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/


### PR DESCRIPTION
## Description

PR #9081 added a security warning to the Lua extensions task page, but only on the `latest` docs. This backports that same warning to the **v1.8** and **v1.7** docs.

The only difference from the `latest` version is the final bullet: since `enableLua` was introduced in #9081 and isn't available in v1.8/v1.7, that bullet instead recommends `disableLua: true` in the EnvoyGateway configuration, matching what those releases support.

Also added the link references the warning depends on (`EnvoyGateway`, `RBAC`, `AdmissionControl`, `AuditLog`), which weren't present in those versioned pages.
