### PR TITLE
[release/v1.8] fix: add unary interceptor and fix fail-open auth in GatewayNamespaceMode (#8986)

### DIFF
--- a/internal/xds/runner/runner.go
+++ b/internal/xds/runner/runner.go
@@ -204,6 +204,7 @@ func (r *Runner) Start(ctx context.Context) error {
 		grpcOpts = append(grpcOpts,
 			grpc.Creds(creds),
 			grpc.StreamInterceptor(jwtInterceptor.Stream()),
+			grpc.UnaryInterceptor(jwtInterceptor.Unary()),
 		)
 	}
 

--- a/internal/xds/server/kubejwt/jwtinterceptor.go
+++ b/internal/xds/server/kubejwt/jwtinterceptor.go
@@ -43,37 +43,41 @@ type wrappedStream struct {
 	validated   bool
 }
 
-func (w *wrappedStream) RecvMsg(m any) error {
-	err := w.ServerStream.RecvMsg(m)
+func (i *JWTAuthInterceptor) authenticate(ctx context.Context, msg any) error {
+	nodeID, err := extractNodeID(msg)
 	if err != nil {
 		return err
 	}
 
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return fmt.Errorf("missing metadata")
+	}
+
+	authHeader := md.Get("authorization")
+	if len(authHeader) == 0 {
+		return fmt.Errorf("missing authorization token in metadata: %s", md)
+	}
+	token := strings.TrimPrefix(authHeader[0], "Bearer ")
+
+	if err := i.validateKubeJWT(ctx, token, nodeID); err != nil {
+		i.logger.Error(err, "failed to validate token")
+		return fmt.Errorf("failed to validate token: %w", err)
+	}
+
+	return nil
+}
+
+func (w *wrappedStream) RecvMsg(m any) error {
+	if err := w.ServerStream.RecvMsg(m); err != nil {
+		return err
+	}
+
 	if !w.validated {
-		if req, ok := m.(*discoveryv3.DeltaDiscoveryRequest); ok {
-			if req.Node == nil || req.Node.Id == "" {
-				return fmt.Errorf("missing node ID in request")
-			}
-			nodeID := req.Node.Id
-
-			md, ok := metadata.FromIncomingContext(w.ctx)
-			if !ok {
-				return fmt.Errorf("missing metadata")
-			}
-
-			authHeader := md.Get("authorization")
-			if len(authHeader) == 0 {
-				return fmt.Errorf("missing authorization token in metadata: %s", md)
-			}
-			token := strings.TrimPrefix(authHeader[0], "Bearer ")
-
-			if err := w.interceptor.validateKubeJWT(w.ctx, token, nodeID); err != nil {
-				w.interceptor.logger.Error(err, "failed to validate token")
-				return fmt.Errorf("failed to validate token: %w", err)
-			}
-
-			w.validated = true
+		if err := w.interceptor.authenticate(w.ctx, m); err != nil {
+			return err
 		}
+		w.validated = true
 	}
 
 	return nil
@@ -88,5 +92,32 @@ func (i *JWTAuthInterceptor) Stream() grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		wrapped := newWrappedStream(ss, ss.Context(), i)
 		return handler(srv, wrapped)
+	}
+}
+
+// Unary intercepts unary gRPC calls for authorization.
+func (i *JWTAuthInterceptor) Unary() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if err := i.authenticate(ctx, req); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+func extractNodeID(m any) (string, error) {
+	switch req := m.(type) {
+	case *discoveryv3.DeltaDiscoveryRequest:
+		if req.Node == nil || req.Node.Id == "" {
+			return "", fmt.Errorf("missing node ID")
+		}
+		return req.Node.Id, nil
+	case *discoveryv3.DiscoveryRequest:
+		if req.Node == nil || req.Node.Id == "" {
+			return "", fmt.Errorf("missing node ID")
+		}
+		return req.Node.Id, nil
+	default:
+		return "", fmt.Errorf("unexpected message type: %T", m)
 	}
 }

--- a/internal/xds/server/kubejwt/jwtinterceptor_test.go
+++ b/internal/xds/server/kubejwt/jwtinterceptor_test.go
@@ -1,0 +1,300 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package kubejwt
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/logging"
+)
+
+func newTestInterceptor(t *testing.T) *JWTAuthInterceptor {
+	t.Helper()
+	logger := logging.DefaultLogger(io.Discard, egv1a1.LogLevelInfo)
+	return &JWTAuthInterceptor{
+		logger: logger.WithName("test"),
+	}
+}
+
+// mockServerStream implements grpc.ServerStream for testing.
+type mockServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (m *mockServerStream) Context() context.Context { return m.ctx }
+func (m *mockServerStream) RecvMsg(_ any) error      { return nil }
+
+// authTestCase defines a single test case for the authenticate method.
+// The same cases are run against both the stream (RecvMsg) and unary interceptor paths.
+type authTestCase struct {
+	name    string
+	msg     any
+	ctx     context.Context
+	wantErr string
+}
+
+func authTestCases() []authTestCase {
+	return []authTestCase{
+		{
+			name:    "unknown message type is rejected (fail-closed)",
+			msg:     &discoveryv3.DiscoveryResponse{},
+			ctx:     context.Background(),
+			wantErr: "unexpected message type",
+		},
+		{
+			name:    "nil message is rejected",
+			msg:     nil,
+			ctx:     context.Background(),
+			wantErr: "unexpected message type",
+		},
+		{
+			name:    "DeltaDiscoveryRequest with nil node is rejected",
+			msg:     &discoveryv3.DeltaDiscoveryRequest{},
+			ctx:     context.Background(),
+			wantErr: "missing node ID",
+		},
+		{
+			name:    "DiscoveryRequest with nil node is rejected",
+			msg:     &discoveryv3.DiscoveryRequest{},
+			ctx:     context.Background(),
+			wantErr: "missing node ID",
+		},
+		{
+			name: "DeltaDiscoveryRequest with empty node ID is rejected",
+			msg: &discoveryv3.DeltaDiscoveryRequest{
+				Node: &corev3.Node{Id: ""},
+			},
+			ctx:     context.Background(),
+			wantErr: "missing node ID",
+		},
+		{
+			name: "DiscoveryRequest with empty node ID is rejected",
+			msg: &discoveryv3.DiscoveryRequest{
+				Node: &corev3.Node{Id: ""},
+			},
+			ctx:     context.Background(),
+			wantErr: "missing node ID",
+		},
+		{
+			name: "DeltaDiscoveryRequest without metadata is rejected",
+			msg: &discoveryv3.DeltaDiscoveryRequest{
+				Node: &corev3.Node{Id: "pod-1"},
+			},
+			ctx:     context.Background(),
+			wantErr: "missing metadata",
+		},
+		{
+			name: "DiscoveryRequest without metadata is rejected",
+			msg: &discoveryv3.DiscoveryRequest{
+				Node: &corev3.Node{Id: "pod-1"},
+			},
+			ctx:     context.Background(),
+			wantErr: "missing metadata",
+		},
+		{
+			name: "DeltaDiscoveryRequest without auth header is rejected",
+			msg: &discoveryv3.DeltaDiscoveryRequest{
+				Node: &corev3.Node{Id: "pod-1"},
+			},
+			ctx:     metadata.NewIncomingContext(context.Background(), metadata.MD{}),
+			wantErr: "missing authorization token",
+		},
+		{
+			name: "DiscoveryRequest without auth header is rejected",
+			msg: &discoveryv3.DiscoveryRequest{
+				Node: &corev3.Node{Id: "pod-1"},
+			},
+			ctx:     metadata.NewIncomingContext(context.Background(), metadata.MD{}),
+			wantErr: "missing authorization token",
+		},
+	}
+}
+
+func TestAuthenticate_Stream(t *testing.T) {
+	interceptor := newTestInterceptor(t)
+
+	for _, tt := range authTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockServerStream{ctx: tt.ctx}
+			ws := &wrappedStream{
+				ServerStream: mock,
+				ctx:          tt.ctx,
+				interceptor:  interceptor,
+				validated:    false,
+			}
+
+			err := ws.RecvMsg(tt.msg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestAuthenticate_Unary(t *testing.T) {
+	interceptor := newTestInterceptor(t)
+	unary := interceptor.Unary()
+	handler := func(_ context.Context, _ any) (any, error) {
+		return nil, nil
+	}
+
+	for _, tt := range authTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := unary(tt.ctx, tt.msg, &grpc.UnaryServerInfo{}, handler)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestExtractNodeID(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     any
+		want    string
+		wantErr string
+	}{
+		{
+			name: "DeltaDiscoveryRequest with valid node ID",
+			msg:  &discoveryv3.DeltaDiscoveryRequest{Node: &corev3.Node{Id: "pod-1"}},
+			want: "pod-1",
+		},
+		{
+			name: "DiscoveryRequest with valid node ID",
+			msg:  &discoveryv3.DiscoveryRequest{Node: &corev3.Node{Id: "pod-2"}},
+			want: "pod-2",
+		},
+		{
+			name:    "DeltaDiscoveryRequest with nil node",
+			msg:     &discoveryv3.DeltaDiscoveryRequest{},
+			wantErr: "missing node ID",
+		},
+		{
+			name:    "DeltaDiscoveryRequest with empty node ID",
+			msg:     &discoveryv3.DeltaDiscoveryRequest{Node: &corev3.Node{Id: ""}},
+			wantErr: "missing node ID",
+		},
+		{
+			name:    "DiscoveryRequest with nil node",
+			msg:     &discoveryv3.DiscoveryRequest{},
+			wantErr: "missing node ID",
+		},
+		{
+			name:    "DiscoveryRequest with empty node ID",
+			msg:     &discoveryv3.DiscoveryRequest{Node: &corev3.Node{Id: ""}},
+			wantErr: "missing node ID",
+		},
+		{
+			name:    "unknown message type is rejected (fail-closed)",
+			msg:     "not-a-discovery-request",
+			wantErr: "unexpected message type",
+		},
+		{
+			name:    "nil message is rejected",
+			msg:     nil,
+			wantErr: "unexpected message type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractNodeID(tt.msg)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRecvMsg(t *testing.T) {
+	interceptor := newTestInterceptor(t)
+
+	mock := &mockServerStream{ctx: context.Background()}
+	ws := &wrappedStream{
+		ServerStream: mock,
+		ctx:          context.Background(),
+		interceptor:  interceptor,
+		validated:    true,
+	}
+
+	// Passes when already validated, even without metadata.
+	err := ws.RecvMsg(&discoveryv3.DeltaDiscoveryRequest{
+		Node: &corev3.Node{Id: "pod-1"},
+	})
+	require.NoError(t, err)
+}
+
+func TestStreamInterceptor(t *testing.T) {
+	tests := []struct {
+		name          string
+		handler       func(t *testing.T) grpc.StreamHandler
+		wantErr       error
+		checkWrapped  bool
+		handlerCalled bool
+	}{
+		{
+			name: "wraps stream with authentication",
+			handler: func(t *testing.T) grpc.StreamHandler {
+				return func(_ any, stream grpc.ServerStream) error {
+					_, ok := stream.(*wrappedStream)
+					assert.True(t, ok, "stream should be wrapped")
+					return nil
+				}
+			},
+			checkWrapped:  true,
+			handlerCalled: true,
+		},
+		{
+			name: "propagates handler error",
+			handler: func(_ *testing.T) grpc.StreamHandler {
+				return func(_ any, _ grpc.ServerStream) error {
+					return fmt.Errorf("handler error")
+				}
+			},
+			wantErr:       fmt.Errorf("handler error"),
+			handlerCalled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interceptor := newTestInterceptor(t)
+			streamInterceptor := interceptor.Stream()
+			mock := &mockServerStream{ctx: context.Background()}
+
+			var called bool
+			wrappedHandler := func(srv any, stream grpc.ServerStream) error {
+				called = true
+				return tt.handler(t)(srv, stream)
+			}
+
+			err := streamInterceptor(nil, mock, &grpc.StreamServerInfo{}, wrappedHandler)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantErr.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.handlerCalled, called)
+		})
+	}
+}

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -5,6 +5,7 @@ breaking changes: |
 
 # Updates addressing vulnerabilities, security flaws, or compliance requirements.
 security updates: |
+  Fixed xDS server authentication bypass in GatewayNamespaceMode, adding Unary Interceptor and validating SotW requests.
 
 # New features or capabilities added in this release.
 new features: |


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/community/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: Yes/No
