### PR TITLE
fix(gatewayapi): reject unsupported BackendRef URLRewrite path rewrites

### DIFF
--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-urlrewrite-path-filter.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-urlrewrite-path-filter.in.yaml
@@ -1,0 +1,50 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-1
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/test"
+          backendRefs:
+            - name: service-1
+              port: 8080
+              weight: 50
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplaceFullPath
+                      replaceFullPath: /rewritten-a
+
+            - name: service-2
+              port: 8080
+              weight: 50
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplaceFullPath
+                      replaceFullPath: /rewritten-b

--- a/internal/gatewayapi/testdata/httproute-with-invalid-backendref-urlrewrite-path-filter.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-with-invalid-backendref-urlrewrite-path-filter.out.yaml
@@ -1,0 +1,171 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-1
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+    rules:
+    - backendRefs:
+      - filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              replaceFullPath: /rewritten-a
+              type: ReplaceFullPath
+        name: service-1
+        port: 8080
+        weight: 50
+      - filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              replaceFullPath: /rewritten-b
+              type: ReplaceFullPath
+        name: service-2
+        port: 8080
+        weight: 50
+      matches:
+      - path:
+          value: /test
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: |-
+          Failed to process route rule 0 backendRef 0: URLRewrite path modifier is not supported within BackendRef.
+          Failed to process route rule 0 backendRef 1: URLRewrite path modifier is not supported within BackendRef.
+        reason: UnsupportedRefValue
+        status: "False"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-1
+      namespace: envoy-gateway-system
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-envoy-gateway-gateway-1-196ae069
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: envoy-gateway/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-envoy-gateway-gateway-1-196ae069
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: envoy-gateway/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - directResponse:
+          statusCode: 500
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-1
+          namespace: default
+        name: httproute/default/httproute-1/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /test
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/internal/gatewayapi/validate.go
+++ b/internal/gatewayapi/validate.go
@@ -104,6 +104,19 @@ func (t *Translator) validateBackendRefFilters(backendRef BackendRefContext, rou
 				unsupportedFilters = true
 				continue
 			}
+
+			// BackendRef URLRewrite only supports hostname rewrites.
+			// Path rewrites are not supported because Envoy weighted clusters
+			// do not support path rewrite actions.
+			if filter.Type == gwapiv1.HTTPRouteFilterURLRewrite &&
+				filter.URLRewrite != nil &&
+				filter.URLRewrite.Path != nil {
+				return status.NewRouteStatusError(
+					errors.New("URLRewrite path modifier is not supported within BackendRef"),
+					status.RouteReasonUnsupportedRefValue,
+				)
+			}
+
 			if filter.Type != gwapiv1.HTTPRouteFilterRequestHeaderModifier &&
 				filter.Type != gwapiv1.HTTPRouteFilterResponseHeaderModifier &&
 				filter.Type != gwapiv1.HTTPRouteFilterExtensionRef &&
@@ -111,6 +124,7 @@ func (t *Translator) validateBackendRefFilters(backendRef BackendRefContext, rou
 				unsupportedFilters = true
 			}
 		}
+
 	case resource.KindGRPCRoute:
 		for _, filter := range filters.([]gwapiv1.GRPCRouteFilter) {
 			if filter.Type != gwapiv1.GRPCRouteFilterRequestHeaderModifier &&
@@ -118,6 +132,7 @@ func (t *Translator) validateBackendRefFilters(backendRef BackendRefContext, rou
 				unsupportedFilters = true
 			}
 		}
+
 	default:
 		return nil
 	}


### PR DESCRIPTION
**What type of PR is this?**

fix(gatewayapi): reject unsupported BackendRef URLRewrite path rewrites

**What this PR does / why we need it**:

BackendRef URLRewrite filters currently accept path modifiers, but path rewrites are not translated when backend-specific filters are converted into Envoy weighted cluster configuration. As a result, the configuration is accepted but silently ignored and the backend receives the original request path.

This PR adds validation for BackendRef URLRewrite filters and rejects configurations that specify a path modifier with `UnsupportedRefValue`, while continuing to allow hostname rewrites which are already supported.

This prevents users from creating configurations that appear valid but have no effect at runtime.

**Which issue(s) this PR fixes**:

Fixes #9095

Release Notes: No
