### PR TITLE
fix(translator): forceHTTP1UpstreamProtocol takes precedence over useClientProtocol

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -2028,6 +2028,9 @@ func (t *Translator) processServiceImportDestinationSetting(
 	if servicePort.AppProtocol != nil {
 		protocol = serviceAppProtocolToIRAppProtocol(*servicePort.AppProtocol, protocol, false)
 	}
+	// For WebSocket services, force HTTP/1.1 upstream to ensure Envoy can establish a successful connection,
+	// as WebSocket over HTTP/2 is not widely supported by upstreams and can lead to connection failures.
+	forceHTTP1Upstream := servicePort.AppProtocol != nil && isWebSocketServiceAppProtocol(*servicePort.AppProtocol)
 
 	backendIps := serviceImport.Spec.IPs
 	isHeadless := len(backendIps) == 0
@@ -2052,11 +2055,12 @@ func (t *Translator) processServiceImportDestinationSetting(
 	}
 
 	return &ir.DestinationSetting{
-		Name:        name,
-		Protocol:    protocol,
-		Endpoints:   endpoints,
-		AddressType: addrType,
-		Metadata:    buildResourceMetadata(serviceImport, new(gwapiv1.SectionName(strconv.Itoa(int(*backendRef.Port))))),
+		Name:               name,
+		Protocol:           protocol,
+		ForceHTTP1Upstream: forceHTTP1Upstream,
+		Endpoints:          endpoints,
+		AddressType:        addrType,
+		Metadata:           buildResourceMetadata(serviceImport, new(gwapiv1.SectionName(strconv.Itoa(int(*backendRef.Port))))),
 	}, nil
 }
 
@@ -2086,6 +2090,9 @@ func (t *Translator) processServiceDestinationSetting(
 	if servicePort.AppProtocol != nil {
 		protocol = serviceAppProtocolToIRAppProtocol(*servicePort.AppProtocol, protocol, true)
 	}
+	// For WebSocket services, force HTTP/1.1 upstream to ensure Envoy can establish a successful connection,
+	// as WebSocket over HTTP/2 is not widely supported by upstreams and can lead to connection failures.
+	forceHTTP1Upstream := servicePort.AppProtocol != nil && isWebSocketServiceAppProtocol(*servicePort.AppProtocol)
 
 	isHeadless := isServiceHeadless(service)
 
@@ -2107,12 +2114,13 @@ func (t *Translator) processServiceDestinationSetting(
 	}
 
 	return &ir.DestinationSetting{
-		Name:        name,
-		Protocol:    protocol,
-		Endpoints:   endpoints,
-		AddressType: addrType,
-		PreferLocal: processPreferLocalZone(service),
-		Metadata:    buildResourceMetadata(service, new(gwapiv1.SectionName(strconv.Itoa(int(*backendRef.Port))))),
+		Name:               name,
+		Protocol:           protocol,
+		ForceHTTP1Upstream: forceHTTP1Upstream,
+		Endpoints:          endpoints,
+		AddressType:        addrType,
+		PreferLocal:        processPreferLocalZone(service),
+		Metadata:           buildResourceMetadata(service, new(gwapiv1.SectionName(strconv.Itoa(int(*backendRef.Port))))),
 	}, nil
 }
 
@@ -2559,11 +2567,17 @@ func serviceAppProtocolToIRAppProtocol(ap string, defaultProtocol ir.AppProtocol
 	switch {
 	case ap == "kubernetes.io/h2c":
 		return ir.HTTP2
+	case ap == "kubernetes.io/ws" || ap == "kubernetes.io/wss":
+		return ir.HTTP
 	case ap == "grpc" && grpcCompatibility:
 		return ir.GRPC
 	default:
 		return defaultProtocol
 	}
+}
+
+func isWebSocketServiceAppProtocol(ap string) bool {
+	return ap == "kubernetes.io/ws" || ap == "kubernetes.io/wss"
 }
 
 func backendAppProtocolToIRAppProtocol(ap egv1a1.AppProtocolType, defaultProtocol ir.AppProtocol) ir.AppProtocol {

--- a/internal/gatewayapi/route_test.go
+++ b/internal/gatewayapi/route_test.go
@@ -21,6 +21,64 @@ import (
 	"github.com/envoyproxy/gateway/internal/ir"
 )
 
+func TestServiceAppProtocolToIRAppProtocol(t *testing.T) {
+	tests := []struct {
+		name              string
+		appProtocol       string
+		defaultProtocol   ir.AppProtocol
+		grpcCompatibility bool
+		want              ir.AppProtocol
+		wantForceHTTP1    bool
+	}{
+		{
+			name:            "h2c",
+			appProtocol:     "kubernetes.io/h2c",
+			defaultProtocol: ir.HTTP,
+			want:            ir.HTTP2,
+		},
+		{
+			name:            "ws",
+			appProtocol:     "kubernetes.io/ws",
+			defaultProtocol: ir.HTTP2,
+			want:            ir.HTTP,
+			wantForceHTTP1:  true,
+		},
+		{
+			name:            "wss",
+			appProtocol:     "kubernetes.io/wss",
+			defaultProtocol: ir.HTTP2,
+			want:            ir.HTTP,
+			wantForceHTTP1:  true,
+		},
+		{
+			name:              "grpc compatible",
+			appProtocol:       "grpc",
+			defaultProtocol:   ir.HTTP,
+			grpcCompatibility: true,
+			want:              ir.GRPC,
+		},
+		{
+			name:            "grpc not compatible",
+			appProtocol:     "grpc",
+			defaultProtocol: ir.HTTP,
+			want:            ir.HTTP,
+		},
+		{
+			name:            "unknown",
+			appProtocol:     "example.com/custom",
+			defaultProtocol: ir.HTTP,
+			want:            ir.HTTP,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, serviceAppProtocolToIRAppProtocol(tt.appProtocol, tt.defaultProtocol, tt.grpcCompatibility))
+			require.Equal(t, tt.wantForceHTTP1, isWebSocketServiceAppProtocol(tt.appProtocol))
+		})
+	}
+}
+
 func TestGetIREndpointsFromEndpointSlices(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/internal/gatewayapi/testdata/httproute-rule-with-service-websocket-app-protocols.in.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-service-websocket-app-protocols.in.yaml
@@ -1,0 +1,207 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      namespace: envoy-gateway
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: http
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-ws
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/ws"
+          backendRefs:
+            - name: service-ws
+              port: 8080
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-wss
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/wss"
+          backendRefs:
+            - name: service-wss
+              port: 8443
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-serviceimport-ws
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/serviceimport/ws"
+          backendRefs:
+            - group: multicluster.x-k8s.io
+              kind: ServiceImport
+              name: serviceimport-ws
+              port: 8080
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: httproute-serviceimport-wss
+    spec:
+      parentRefs:
+        - namespace: envoy-gateway
+          name: gateway-1
+      rules:
+        - matches:
+            - path:
+                value: "/serviceimport/wss"
+          backendRefs:
+            - group: multicluster.x-k8s.io
+              kind: ServiceImport
+              name: serviceimport-wss
+              port: 8443
+services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      namespace: default
+      name: service-ws
+    spec:
+      clusterIP: 10.0.0.1
+      ports:
+        - name: ws
+          port: 8080
+          targetPort: 8080
+          protocol: TCP
+          appProtocol: kubernetes.io/ws
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      namespace: default
+      name: service-wss
+    spec:
+      clusterIP: 10.0.0.2
+      ports:
+        - name: wss
+          port: 8443
+          targetPort: 8443
+          protocol: TCP
+          appProtocol: kubernetes.io/wss
+serviceImports:
+  - apiVersion: multicluster.x-k8s.io/v1alpha1
+    kind: ServiceImport
+    metadata:
+      namespace: default
+      name: serviceimport-ws
+    spec:
+      ips:
+        - 10.0.1.1
+      ports:
+        - name: ws
+          port: 8080
+          protocol: TCP
+          appProtocol: kubernetes.io/ws
+  - apiVersion: multicluster.x-k8s.io/v1alpha1
+    kind: ServiceImport
+    metadata:
+      namespace: default
+      name: serviceimport-wss
+    spec:
+      ips:
+        - 10.0.1.2
+      ports:
+        - name: wss
+          port: 8443
+          protocol: TCP
+          appProtocol: kubernetes.io/wss
+endpointSlices:
+  - apiVersion: discovery.k8s.io/v1
+    kind: EndpointSlice
+    metadata:
+      namespace: default
+      name: endpointslice-service-ws
+      labels:
+        kubernetes.io/service-name: service-ws
+    addressType: IPv4
+    ports:
+      - name: ws
+        port: 8080
+        protocol: TCP
+    endpoints:
+      - addresses:
+          - "10.244.0.21"
+        conditions:
+          ready: true
+  - apiVersion: discovery.k8s.io/v1
+    kind: EndpointSlice
+    metadata:
+      namespace: default
+      name: endpointslice-service-wss
+      labels:
+        kubernetes.io/service-name: service-wss
+    addressType: IPv4
+    ports:
+      - name: wss
+        port: 8443
+        protocol: TCP
+    endpoints:
+      - addresses:
+          - "10.244.0.22"
+        conditions:
+          ready: true
+  - apiVersion: discovery.k8s.io/v1
+    kind: EndpointSlice
+    metadata:
+      namespace: default
+      name: endpointslice-serviceimport-ws
+      labels:
+        multicluster.kubernetes.io/service-name: serviceimport-ws
+    addressType: IPv4
+    ports:
+      - name: ws
+        port: 8080
+        protocol: TCP
+    endpoints:
+      - addresses:
+          - "10.244.1.21"
+        conditions:
+          ready: true
+  - apiVersion: discovery.k8s.io/v1
+    kind: EndpointSlice
+    metadata:
+      namespace: default
+      name: endpointslice-serviceimport-wss
+      labels:
+        multicluster.kubernetes.io/service-name: serviceimport-wss
+    addressType: IPv4
+    ports:
+      - name: wss
+        port: 8443
+        protocol: TCP
+    endpoints:
+      - addresses:
+          - "10.244.1.22"
+        conditions:
+          ready: true

--- a/internal/gatewayapi/testdata/httproute-rule-with-service-websocket-app-protocols.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-service-websocket-app-protocols.out.yaml
@@ -1,0 +1,367 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 4
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-ws
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+    rules:
+    - backendRefs:
+      - name: service-ws
+        port: 8080
+      matches:
+      - path:
+          value: /ws
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-wss
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+    rules:
+    - backendRefs:
+      - name: service-wss
+        port: 8443
+      matches:
+      - path:
+          value: /wss
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-serviceimport-ws
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+    rules:
+    - backendRefs:
+      - group: multicluster.x-k8s.io
+        kind: ServiceImport
+        name: serviceimport-ws
+        port: 8080
+      matches:
+      - path:
+          value: /serviceimport/ws
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-serviceimport-wss
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+    rules:
+    - backendRefs:
+      - group: multicluster.x-k8s.io
+        kind: ServiceImport
+        name: serviceimport-wss
+        port: 8443
+      matches:
+      - path:
+          value: /serviceimport/wss
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-1
+      namespace: envoy-gateway-system
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-envoy-gateway-gateway-1-196ae069
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: envoy-gateway/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-envoy-gateway-gateway-1-196ae069
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: envoy-gateway/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-serviceimport-wss
+            namespace: default
+          name: httproute/default/httproute-serviceimport-wss/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 10.244.1.22
+              port: 8443
+            forceHTTP1Upstream: true
+            metadata:
+              kind: ServiceImport
+              name: serviceimport-wss
+              namespace: default
+              sectionName: "8443"
+            name: httproute/default/httproute-serviceimport-wss/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-serviceimport-wss
+          namespace: default
+        name: httproute/default/httproute-serviceimport-wss/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /serviceimport/wss
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-serviceimport-ws
+            namespace: default
+          name: httproute/default/httproute-serviceimport-ws/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 10.244.1.21
+              port: 8080
+            forceHTTP1Upstream: true
+            metadata:
+              kind: ServiceImport
+              name: serviceimport-ws
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-serviceimport-ws/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-serviceimport-ws
+          namespace: default
+        name: httproute/default/httproute-serviceimport-ws/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /serviceimport/ws
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-wss
+            namespace: default
+          name: httproute/default/httproute-wss/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 10.244.0.22
+              port: 8443
+            forceHTTP1Upstream: true
+            metadata:
+              kind: Service
+              name: service-wss
+              namespace: default
+              sectionName: "8443"
+            name: httproute/default/httproute-wss/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-wss
+          namespace: default
+        name: httproute/default/httproute-wss/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /wss
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-ws
+            namespace: default
+          name: httproute/default/httproute-ws/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 10.244.0.21
+              port: 8080
+            forceHTTP1Upstream: true
+            metadata:
+              kind: Service
+              name: service-ws
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-ws/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-ws
+          namespace: default
+        name: httproute/default/httproute-ws/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /ws
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -1081,14 +1081,6 @@ func buildTypedExtensionProtocolOptions(args *xdsClusterArgs, requiresAutoHTTPCo
 	// If translation requires HTTP2 enablement or HTTP1 trailers, set appropriate setting
 	// Default to http1 otherwise
 	switch {
-	// If useClientProtocol is set, force Envoy to use the same protocol upstream as downstream, regardless of other settings.
-	case args.useClientProtocol:
-		protocolOptions.UpstreamProtocolOptions = &httpv3.HttpProtocolOptions_UseDownstreamProtocolConfig{
-			UseDownstreamProtocolConfig: &httpv3.HttpProtocolOptions_UseDownstreamHttpConfig{
-				HttpProtocolOptions:  http1Opts,
-				Http2ProtocolOptions: http2Opts,
-			},
-		}
 	// If forceHTTP1UpstreamProtocol is set, force Envoy to use HTTP1 upstream regardless of other settings.
 	case forceHTTP1UpstreamProtocol:
 		protocolOptions.UpstreamProtocolOptions = &httpv3.HttpProtocolOptions_ExplicitHttpConfig_{
@@ -1096,6 +1088,14 @@ func buildTypedExtensionProtocolOptions(args *xdsClusterArgs, requiresAutoHTTPCo
 				ProtocolConfig: &httpv3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{
 					HttpProtocolOptions: http1Opts,
 				},
+			},
+		}
+	// If useClientProtocol is set, force Envoy to use the same protocol upstream as downstream.
+	case args.useClientProtocol:
+		protocolOptions.UpstreamProtocolOptions = &httpv3.HttpProtocolOptions_UseDownstreamProtocolConfig{
+			UseDownstreamProtocolConfig: &httpv3.HttpProtocolOptions_UseDownstreamHttpConfig{
+				HttpProtocolOptions:  http1Opts,
+				Http2ProtocolOptions: http2Opts,
 			},
 		}
 	case requiresHTTP2Options:

--- a/internal/xds/translator/cluster_test.go
+++ b/internal/xds/translator/cluster_test.go
@@ -15,6 +15,7 @@ import (
 	cswrrv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3"
 	override_hostv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/load_balancing_policies/override_host/v3"
 	wrr_localityv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/load_balancing_policies/wrr_locality/v3"
+	httpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -395,6 +396,38 @@ func TestBuildClusterWithEndpointOverrideBackendUtilizationWeightedZones(t *test
 	err = childPolicy.TypedExtensionConfig.TypedConfig.UnmarshalTo(cswrr)
 	require.NoError(t, err)
 	require.Equal(t, 10*time.Second, cswrr.BlackoutPeriod.AsDuration())
+}
+
+func TestBuildClusterForceHTTP1OverridesUseClientProtocol(t *testing.T) {
+	args := &xdsClusterArgs{
+		name:              "test-cluster-force-http1",
+		endpointType:      EndpointTypeStatic,
+		useClientProtocol: true,
+		settings: []*ir.DestinationSetting{{
+			ForceHTTP1Upstream: true,
+			Endpoints: []*ir.DestinationEndpoint{{
+				Host: "127.0.0.1",
+				Port: 8080,
+			}},
+		}},
+	}
+
+	result, err := buildXdsCluster(args)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	anyProtocolOptions := result.cluster.GetTypedExtensionProtocolOptions()[extensionOptionsKey]
+	require.NotNil(t, anyProtocolOptions)
+
+	protocolOptions := &httpv3.HttpProtocolOptions{}
+	require.NoError(t, anyProtocolOptions.UnmarshalTo(protocolOptions))
+
+	explicitHTTPConfig, ok := protocolOptions.UpstreamProtocolOptions.(*httpv3.HttpProtocolOptions_ExplicitHttpConfig_)
+	require.True(t, ok)
+	require.IsType(t,
+		&httpv3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{},
+		explicitHTTPConfig.ExplicitHttpConfig.ProtocolConfig,
+	)
 }
 
 func TestGetHealthCheckOverridesHostname(t *testing.T) {

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -21,7 +21,7 @@ bug fixes: |
   Fixed TLS secrets with non-canonical PEM formatting (e.g. unusual line endings) being passed verbatim to Envoy, which could cause BoringSSL errors such as `BAD_END_LINE`. Cert and key PEM data is now re-encoded to a canonical form before being delivered as xDS resources.
   Fixed `MaxStreamDuration` not being set on `CommonHttpProtocolOptions` for non-route cluster.
   Fixed `egctl x status all`/`xroute`/`xpolicy` failing when a Gateway API CRD (e.g. TCPRoute) is not installed in the cluster; missing CRDs are now skipped silently, or reported on stderr with `-v`.
-
+  Fixed Kubernetes Service and ServiceImport `appProtocol` values `kubernetes.io/ws` and `kubernetes.io/wss` to force HTTP/1.1 upstream connections instead of negotiating HTTP/2, avoiding compatibility issues with WebSocket backends that do not support RFC 8441 extended CONNECT.
 # Enhancements that improve performance.
 performance improvements: |
 


### PR DESCRIPTION


 sets `ForceHTTP1Upstream` on `DestinationSetting` when a Service/ServiceImport port has `appProtocol: kubernetes.io/ws` or `kubernetes.io/wss`. However, in the xDS translator, `useClientProtocol` (from `BackendTrafficPolicy`) is evaluated **before** `forceHTTP1UpstreamProtocol` in the `switch`, which means the downstream protocol is mirrored upstream even when the backend explicitly requires HTTP/1.1. This breaks WebSocket connections on HTTP/2 listeners when a `BackendTrafficPolicy` with `useClientProtocol: true` is in effect.

This PR reorders the protocol-selection switch so that `forceHTTP1UpstreamProtocol` is evaluated first, and adds `TestBuildClusterForceHTTP1OverridesUseClientProtocol` to lock in the precedence.


---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) 