### PR TITLE
chore: enable cleanup-test-resources

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -34,8 +34,8 @@ require (
 	k8s.io/client-go v0.36.1
 	k8s.io/kubectl v0.36.1
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/gateway-api v1.5.1
-	sigs.k8s.io/gateway-api/conformance v1.5.1
+	sigs.k8s.io/gateway-api monthly-2026.05
+	sigs.k8s.io/gateway-api/conformance monthly-2026.05
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -315,7 +315,7 @@ ifeq ($(E2E_RUN_TEST),)
 	cd test/ && go test $(E2E_TEST_ARGS) ./e2e/multiple_gc $(E2E_TEST_SUITE_ARGS)  --cleanup-base-resources=true
 	cd test/ && LAST_VERSION_TAG=$(shell cat VERSION) go test $(E2E_TEST_ARGS) ./e2e/upgrade $(E2E_TEST_SUITE_ARGS) --gateway-class=upgrade --cleanup-base-resources=$(E2E_CLEANUP)
 else
-	cd test/ && go test $(E2E_TEST_ARGS) ./e2e $(E2E_TEST_SUITE_ARGS) --gateway-class=envoy-gateway --cleanup-base-resources=$(E2E_CLEANUP) \
+	cd test/ && go test $(E2E_TEST_ARGS) ./e2e $(E2E_TEST_SUITE_ARGS) --gateway-class=envoy-gateway --cleanup-base-resources=$(E2E_CLEANUP) --cleanup-test-resources=$(E2E_CLEANUP)\
 		--run-test $(E2E_RUN_TEST) $(E2E_REDIRECT)
 endif
 


### PR DESCRIPTION
This PR enables the Gateway API `cleanup-test-resources` test option.

```
E2E_CLEANUP=false E2E_RUN_TEST=WasmOCIImageCodeSource make run-e2e
```
This `E2E_CLEANUP` option now preserves both the base and test resources, which makes it easier to debug flaky/failed e2e tests.