### PR TITLE
bound tar header size before allocation in wasm fetchers

### DIFF
--- a/internal/wasm/httpfetcher.go
+++ b/internal/wasm/httpfetcher.go
@@ -193,6 +193,9 @@ func getFirstFileFromTar(b []byte) []byte {
 		return nil
 	}
 
+	if h.Size < 0 || h.Size > maxWasmSize {
+		return nil
+	}
 	ret := make([]byte, h.Size)
 	_, err = io.ReadFull(tr, ret)
 	if err != nil {

--- a/internal/wasm/imagefetcher.go
+++ b/internal/wasm/imagefetcher.go
@@ -284,8 +284,11 @@ func extractWasmPluginBinary(r io.Reader) ([]byte, error) {
 			return nil, err
 		}
 
-		ret := make([]byte, h.Size)
 		if filepath.Base(h.Name) == wasmPluginFileName {
+			if h.Size < 0 || h.Size > maxWasmSize {
+				return nil, fmt.Errorf("%s is too large: %d bytes", wasmPluginFileName, h.Size)
+			}
+			ret := make([]byte, h.Size)
 			_, err := io.ReadFull(tr, ret)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read %s: %w", wasmPluginFileName, err)


### PR DESCRIPTION
getFirstFileFromTar in httpfetcher.go and extractWasmPluginBinary in imagefetcher.go call make([]byte, h.Size) using the size from the untrusted tar header of a downloaded wasm module, so a crafted tarball declaring a huge size panics with makeslice on the control plane. Reject sizes above maxWasmSize (and negatives) before allocating, matching the existing 256mb cap.