### PR TITLE
fix(helm): define default EnvoyProxy image

### DIFF
--- a/charts/gateway-helm/README.md
+++ b/charts/gateway-helm/README.md
@@ -163,7 +163,7 @@ helm uninstall eg -n envoy-gateway-system
 | global.images.envoyGateway.image | string | `nil` | Full image for the Envoy Gateway control plane Deployment installed by this chart. |
 | global.images.envoyGateway.pullPolicy | string | `nil` | Image pull policy for the Envoy Gateway control plane Deployment. Default behavior: latest images will be Always else IfNotPresent. |
 | global.images.envoyGateway.pullSecrets | list | `[]` | Pull secrets for the Envoy Gateway control plane Deployment. |
-| global.images.envoyProxy.image | string | `""` | Full image for the managed Envoy Proxy data plane. This updates the generated `envoyProxy` config and does not change the `envoy-gateway` control plane Deployment image. If not specified, the default image built into `envoy-gateway` is used. |
+| global.images.envoyProxy.image | string | `"docker.io/envoyproxy/envoy:distroless-dev"` | Full image for the managed Envoy Proxy data plane. This updates the generated `envoyProxy` config and does not change the `envoy-gateway` control plane Deployment image. If not specified, the default image built into `envoy-gateway` is used. |
 | global.images.envoyProxy.pullPolicy | string | `""` | Image pull policy for the managed Envoy Proxy data plane. Default behavior: IfNotPresent. |
 | global.images.envoyProxy.pullSecrets | list | `[]` | Pull secrets for the managed Envoy Proxy data plane. |
 | global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:master"` |  |

--- a/charts/gateway-helm/templates/_helpers.tpl
+++ b/charts/gateway-helm/templates/_helpers.tpl
@@ -199,17 +199,27 @@ The default Envoy Gateway configuration.
   {{- if .Values.global.images.envoyProxy.pullPolicy }}
     {{- $_ := set $container "imagePullPolicy" .Values.global.images.envoyProxy.pullPolicy }}
   {{- end }}
-  {{- $deployment := dict "container" $container }}
+
+  {{- $workload := dict "container" $container }}
+
   {{- if or .Values.global.imagePullSecrets .Values.global.images.envoyProxy.pullSecrets }}
     {{- $pullSecretsYaml := include "eg.envoyProxy.image.pullSecrets" . }}
     {{- $pullSecrets := dict "imagePullSecrets" ($pullSecretsYaml | fromYaml).imagePullSecrets }}
-    {{- $_ := set $deployment "pod" $pullSecrets }}
+    {{- $_ := set $workload "pod" $pullSecrets }}
   {{- end }}
-  {{- $kubernetes := dict "envoyDeployment" $deployment }}
+
+  {{- $envoyProvider := dig "provider" "kubernetes" dict $envoyProxyBase }}
+  {{- $workloadKey := "envoyDeployment" }}
+
+  {{- if hasKey $envoyProvider "envoyDaemonSet" }}
+    {{- $workloadKey = "envoyDaemonSet" }}
+  {{- end }}
+
+  {{- $kubernetes := dict $workloadKey $workload }}
   {{- $provider := dict "type" "Kubernetes" "kubernetes" $kubernetes }}
   {{- $imageOverride = dict "provider" $provider }}
 {{- end }}
-{{- $merged := mustMergeOverwrite (dict) $envoyProxyBase $imageOverride }}
+{{- $merged := mustMergeOverwrite (dict) (deepCopy $envoyProxyBase) $imageOverride }}
 envoyProxy:
 {{ toYaml $merged | indent 2 }}
 {{- end }}

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -30,7 +30,7 @@ global:
       # This updates the generated `envoyProxy` config and does not change the `envoy-gateway`
       # control plane Deployment image. If not specified, the default image built into
       # `envoy-gateway` is used.
-      image: ""
+      image: "docker.io/envoyproxy/envoy:distroless-dev"
       # -- Image pull policy for the managed Envoy Proxy data plane.
       # Default behavior: IfNotPresent.
       pullPolicy: ""

--- a/release-notes/v1.8.1.yaml
+++ b/release-notes/v1.8.1.yaml
@@ -30,7 +30,7 @@ bug fixes: |
   Fixed Gateway getting stuck at `Programmed=False` after its LoadBalancer Service IP was restored, by ignoring `LastTransitionTime` when comparing status conditions.
   Fixed HPA maxReplicas required message typo in gateway-helm chart.
   Fixed invalid listeners blocking valid ones during conflict detection by validating each listener's spec independently before running conflict resolution.
-
+  Fixed the gateway-helm chart to render the default EnvoyProxy image in the generated EnvoyGateway configuration while preserving existing `envoyDeployment` and `envoyDaemonSet` provider configurations.
 # Enhancements that improve performance.
 performance improvements: |
 

--- a/site/content/en/community/RELEASING.md
+++ b/site/content/en/community/RELEASING.md
@@ -55,7 +55,7 @@ export GITHUB_REMOTE=origin
    ```shell
    git checkout -b release/v${MAJOR_VERSION}.${MINOR_VERSION}
    ```
-
+f
 8. Push the branch to the Envoy Gateway repo.
 
     ```shell
@@ -63,7 +63,7 @@ export GITHUB_REMOTE=origin
     ```
 
 9. Create a topic branch for updating the [Envoy proxy image][] and [Envoy Ratelimit image][] to the tag supported by the release.
- Please note that the tags should be updated in both the source code and the Helm chart. Reference [PR #5872][]
+ Please note that the tags should be updated in both the source code and the Helm chart, including `global.images.envoyProxy.image` in `charts/gateway-helm/values.tmpl.yaml`. Reference [PR #5872][]
    for additional details on updating the image tag.
 
     (+v1.8.x only) After updating the Envoy proxy image tag, update the dynamic module SDK and example dependencies:
@@ -217,7 +217,7 @@ export GITHUB_REMOTE=origin
 
    9. If upstream has updated the [Envoy proxy image][] or [Envoy Ratelimit image][] tag supported by the release,
    you should also create a topic branch for bumping these tags.
-   Please note that the tags should be updated in both the source code and the Helm chart. Reference [PR #5872][]
+   Please note that the tags should be updated in both the source code and the Helm chart, including `global.images.envoyProxy.image` in `charts/gateway-helm/values.tmpl.yaml`. Reference [PR #5872][]
 
 8. Tag the head of your release branch with the release tag. For example:
 
@@ -374,7 +374,7 @@ export GITHUB_REMOTE=origin
 
    9. If upstream has updated the [Envoy proxy image][] or [Envoy Ratelimit image][] tag supported by the release,
    you should also create a topic branch for bumping these tags.
-   Please note that the tags should be updated in both the source code and the Helm chart. Reference [PR #5872][]
+   Please note that the tags should be updated in both the source code and the Helm chart, including `global.images.envoyProxy.image` in `charts/gateway-helm/values.tmpl.yaml`. Reference [PR #5872][]
 
 9. Tag the head of your release branch with the release tag. For example:
 

--- a/site/content/en/community/RELEASING.md
+++ b/site/content/en/community/RELEASING.md
@@ -55,7 +55,6 @@ export GITHUB_REMOTE=origin
    ```shell
    git checkout -b release/v${MAJOR_VERSION}.${MINOR_VERSION}
    ```
-f
 8. Push the branch to the Envoy Gateway repo.
 
     ```shell

--- a/site/content/en/latest/install/gateway-helm-api.md
+++ b/site/content/en/latest/install/gateway-helm-api.md
@@ -102,7 +102,7 @@ The Helm chart for Envoy Gateway
 | global.images.envoyGateway.image | string | `nil` | Full image for the Envoy Gateway control plane Deployment installed by this chart. |
 | global.images.envoyGateway.pullPolicy | string | `nil` | Image pull policy for the Envoy Gateway control plane Deployment. Default behavior: latest images will be Always else IfNotPresent. |
 | global.images.envoyGateway.pullSecrets | list | `[]` | Pull secrets for the Envoy Gateway control plane Deployment. |
-| global.images.envoyProxy.image | string | `""` | Full image for the managed Envoy Proxy data plane. This updates the generated `envoyProxy` config and does not change the `envoy-gateway` control plane Deployment image. If not specified, the default image built into `envoy-gateway` is used. |
+| global.images.envoyProxy.image | string | `"docker.io/envoyproxy/envoy:distroless-dev"` | Full image for the managed Envoy Proxy data plane. This updates the generated `envoyProxy` config and does not change the `envoy-gateway` control plane Deployment image. If not specified, the default image built into `envoy-gateway` is used. |
 | global.images.envoyProxy.pullPolicy | string | `""` | Image pull policy for the managed Envoy Proxy data plane. Default behavior: IfNotPresent. |
 | global.images.envoyProxy.pullSecrets | list | `[]` | Pull secrets for the managed Envoy Proxy data plane. |
 | global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:master"` |  |

--- a/test/helm/gateway-helm/certgen-annotations.out.yaml
+++ b/test/helm/gateway-helm/certgen-annotations.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/certgen-args.out.yaml
+++ b/test/helm/gateway-helm/certgen-args.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/certgen-labels.out.yaml
+++ b/test/helm/gateway-helm/certgen-labels.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/certgen-pod-securitycontext.out.yaml
+++ b/test/helm/gateway-helm/certgen-pod-securitycontext.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
+++ b/test/helm/gateway-helm/certjen-custom-scheduling.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/common-labels.out.yaml
+++ b/test/helm/gateway-helm/common-labels.out.yaml
@@ -40,6 +40,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
+++ b/test/helm/gateway-helm/control-plane-with-pdb.out.yaml
@@ -47,6 +47,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/default-config.out.yaml
+++ b/test/helm/gateway-helm/default-config.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/deployment-annotations.out.yaml
+++ b/test/helm/gateway-helm/deployment-annotations.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/deployment-custom-topology.out.yaml
+++ b/test/helm/gateway-helm/deployment-custom-topology.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/deployment-extraenv.out.yaml
+++ b/test/helm/gateway-helm/deployment-extraenv.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/deployment-images-config.out.yaml
+++ b/test/helm/gateway-helm/deployment-images-config.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/deployment-pod-securitycontext.out.yaml
+++ b/test/helm/gateway-helm/deployment-pod-securitycontext.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/deployment-priorityclass.out.yaml
+++ b/test/helm/gateway-helm/deployment-priorityclass.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/deployment-repo-no-registry.out.yaml
+++ b/test/helm/gateway-helm/deployment-repo-no-registry.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/deployment-securitycontext.out.yaml
+++ b/test/helm/gateway-helm/deployment-securitycontext.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/deployment-volume-mounts.out.yaml
+++ b/test/helm/gateway-helm/deployment-volume-mounts.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/deployment-wasm-cache-volume.out.yaml
+++ b/test/helm/gateway-helm/deployment-wasm-cache-volume.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/envoy-daemonset-image.in.yaml
+++ b/test/helm/gateway-helm/envoy-daemonset-image.in.yaml
@@ -1,0 +1,13 @@
+global:
+  images:
+    envoyProxy:
+      image: "private-hub/envoyproxy/envoy:dev"
+
+config:
+  envoyGateway:
+    envoyProxy:
+      provider:
+        type: Kubernetes
+        kubernetes:
+          envoyDaemonSet:
+            name: test-daemonset

--- a/test/helm/gateway-helm/envoy-daemonset-image.out.yaml
+++ b/test/helm/gateway-helm/envoy-daemonset-image.out.yaml
@@ -35,9 +35,10 @@ data:
     envoyProxy:
       provider:
         kubernetes:
-          envoyDeployment:
+          envoyDaemonSet:
             container:
-              image: docker.io/envoyproxy/envoy:distroless-dev
+              image: private-hub/envoyproxy/envoy:dev
+            name: test-daemonset
         type: Kubernetes
     extensionApis: {}
     gateway:
@@ -60,7 +61,7 @@ data:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
         shutdownManager:
-          image: docker.io/envoyproxy/gateway-dev:latest
+          image: docker.io/envoyproxy/gateway-dev:d4d99594f
       type: Kubernetes
 ---
 # Source: gateway-helm/templates/envoy-gateway-rbac.yaml
@@ -435,11 +436,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
   selector:
     matchLabels:
       control-plane: envoy-gateway
@@ -475,23 +471,14 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: docker.io/envoyproxy/gateway-dev:latest
-        imagePullPolicy: Always
-        startupProbe:
-          failureThreshold: 30
-          httpGet:
-            path: /healthz
-            port: 8081
-          periodSeconds: 1
-          successThreshold: 1
-          timeoutSeconds: 1
+        image: docker.io/envoyproxy/gateway-dev:d4d99594f
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8081
+          initialDelaySeconds: 15
           periodSeconds: 20
-          successThreshold: 1
-          timeoutSeconds: 1
         name: envoy-gateway
         ports:
         - containerPort: 18000
@@ -508,9 +495,8 @@ spec:
           httpGet:
             path: /readyz
             port: 8081
+          initialDelaySeconds: 5
           periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         resources:
           limits:
             memory: 1024Mi
@@ -562,7 +548,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    gateway.networking.k8s.io/bundle-version: v1.6.1
+    gateway.networking.k8s.io/bundle-version: v1.6.0
     gateway.networking.k8s.io/channel: standard
   name: "safe-upgrades.gateway.networking.k8s.io"
 spec:
@@ -595,7 +581,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   annotations:
-    gateway.networking.k8s.io/bundle-version: v1.6.1
+    gateway.networking.k8s.io/bundle-version: v1.6.0
     gateway.networking.k8s.io/channel: standard
   name: safe-upgrades.gateway.networking.k8s.io
 spec:
@@ -776,8 +762,8 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: docker.io/envoyproxy/gateway-dev:latest
-        imagePullPolicy: Always
+        image: docker.io/envoyproxy/gateway-dev:d4d99594f
+        imagePullPolicy: IfNotPresent
         name: envoy-gateway-certgen
         securityContext:
           allowPrivilegeEscalation: false

--- a/test/helm/gateway-helm/envoy-gateway-config.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-config.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config-watch.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config-watch.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-gateway-namespace-config.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/envoy-gateway-gateway-namespace-namespaceselector.out.yaml
+++ b/test/helm/gateway-helm/envoy-gateway-gateway-namespace-namespaceselector.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/envoy-inline-image.in.yaml
+++ b/test/helm/gateway-helm/envoy-inline-image.in.yaml
@@ -1,0 +1,14 @@
+global:
+  images:
+    envoyProxy:
+      image: "docker.io/envoyproxy/envoy:distroless-dev"
+
+config:
+  envoyGateway:
+    envoyProxy:
+      provider:
+        type: Kubernetes
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: "private-hub/envoyproxy/envoy:custom"

--- a/test/helm/gateway-helm/envoy-inline-image.out.yaml
+++ b/test/helm/gateway-helm/envoy-inline-image.out.yaml
@@ -37,7 +37,7 @@ data:
         kubernetes:
           envoyDeployment:
             container:
-              image: docker.io/envoyproxy/envoy:distroless-dev
+              image: private-hub/envoyproxy/envoy:custom
         type: Kubernetes
     extensionApis: {}
     gateway:
@@ -60,7 +60,7 @@ data:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
         shutdownManager:
-          image: docker.io/envoyproxy/gateway-dev:latest
+          image: docker.io/envoyproxy/gateway-dev:d4d99594f
       type: Kubernetes
 ---
 # Source: gateway-helm/templates/envoy-gateway-rbac.yaml
@@ -435,11 +435,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
   selector:
     matchLabels:
       control-plane: envoy-gateway
@@ -475,23 +470,14 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: docker.io/envoyproxy/gateway-dev:latest
-        imagePullPolicy: Always
-        startupProbe:
-          failureThreshold: 30
-          httpGet:
-            path: /healthz
-            port: 8081
-          periodSeconds: 1
-          successThreshold: 1
-          timeoutSeconds: 1
+        image: docker.io/envoyproxy/gateway-dev:d4d99594f
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8081
+          initialDelaySeconds: 15
           periodSeconds: 20
-          successThreshold: 1
-          timeoutSeconds: 1
         name: envoy-gateway
         ports:
         - containerPort: 18000
@@ -508,9 +494,8 @@ spec:
           httpGet:
             path: /readyz
             port: 8081
+          initialDelaySeconds: 5
           periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         resources:
           limits:
             memory: 1024Mi
@@ -562,7 +547,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    gateway.networking.k8s.io/bundle-version: v1.6.1
+    gateway.networking.k8s.io/bundle-version: v1.6.0
     gateway.networking.k8s.io/channel: standard
   name: "safe-upgrades.gateway.networking.k8s.io"
 spec:
@@ -595,7 +580,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   annotations:
-    gateway.networking.k8s.io/bundle-version: v1.6.1
+    gateway.networking.k8s.io/bundle-version: v1.6.0
     gateway.networking.k8s.io/channel: standard
   name: safe-upgrades.gateway.networking.k8s.io
 spec:
@@ -776,8 +761,8 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: docker.io/envoyproxy/gateway-dev:latest
-        imagePullPolicy: Always
+        image: docker.io/envoyproxy/gateway-dev:d4d99594f
+        imagePullPolicy: IfNotPresent
         name: envoy-gateway-certgen
         securityContext:
           allowPrivilegeEscalation: false

--- a/test/helm/gateway-helm/global-pullsecrets-override-deployment.out.yaml
+++ b/test/helm/gateway-helm/global-pullsecrets-override-deployment.out.yaml
@@ -32,6 +32,17 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: private.registry/envoyproxy/envoy:distroless-dev
+            pod:
+              imagePullSecrets:
+              - key1: value1
+              - key2: value2
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/global-pullsecrets-override-global.out.yaml
+++ b/test/helm/gateway-helm/global-pullsecrets-override-global.out.yaml
@@ -32,6 +32,17 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: private.registry/envoyproxy/envoy:distroless-dev
+            pod:
+              imagePullSecrets:
+              - key1: value1
+              - key2: value2
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/global-registry-override-deployment.out.yaml
+++ b/test/helm/gateway-helm/global-registry-override-deployment.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: private.registry/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/global-registry-override-global.out.yaml
+++ b/test/helm/gateway-helm/global-registry-override-global.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: private.registry/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/horizontal-pod-autoscaler-disabled.out.yaml
+++ b/test/helm/gateway-helm/horizontal-pod-autoscaler-disabled.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
+++ b/test/helm/gateway-helm/horizontal-pod-autoscaler.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/namespace-override.out.yaml
+++ b/test/helm/gateway-helm/namespace-override.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/safe-upgrade-policy-disabled.out.yaml
+++ b/test/helm/gateway-helm/safe-upgrade-policy-disabled.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/service-customization.out.yaml
+++ b/test/helm/gateway-helm/service-customization.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/test/helm/gateway-helm/webhook-disabled.out.yaml
+++ b/test/helm/gateway-helm/webhook-disabled.out.yaml
@@ -32,6 +32,13 @@ data:
   envoy-gateway.yaml: |
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: EnvoyGateway
+    envoyProxy:
+      provider:
+        kubernetes:
+          envoyDeployment:
+            container:
+              image: docker.io/envoyproxy/envoy:distroless-dev
+        type: Kubernetes
     extensionApis: {}
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller


### PR DESCRIPTION
**What type of PR is this?**

fix(helm): define default EnvoyProxy image in gateway-helm chart

**What this PR does / why we need it**:

This PR sets `global.images.envoyProxy.image` in `charts/gateway-helm/values.tmpl.yaml` to the same default image used by `DefaultEnvoyProxyImage`.

Previously, the Helm chart left this value empty and relied on the controller-side default image. As a result, the Envoy proxy image was not visible in rendered Helm manifests, making it difficult for image discovery, mirroring, and air-gapped deployment workflows that scan rendered manifests.

This change keeps the Helm chart default aligned with the controller default and ensures the Envoy image appears in rendered chart output.

Additionally, this PR updates the release documentation to ensure the Helm chart value is updated alongside `DefaultEnvoyProxyImage` during future releases, and regenerates the corresponding Helm documentation and golden test outputs.

**Which issue(s) this PR fixes**:

Fixes #9144

Release Notes: No
