### PR TITLE
fix rate limit validation on K8s 1.36

### DIFF
--- a/api/v1alpha1/ratelimit_types.go
+++ b/api/v1alpha1/ratelimit_types.go
@@ -437,6 +437,7 @@ type RateLimitValue struct {
 	//
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=4294967295
+	// +kubebuilder:validation:Format=uint32
 	Requests uint32        `json:"requests"`
 	Unit     RateLimitUnit `json:"unit"`
 }

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1762,7 +1762,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: int32
+                                  format: uint32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -2146,7 +2146,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: int32
+                                  format: uint32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1761,7 +1761,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: int32
+                                  format: uint32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -2145,7 +2145,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: int32
+                                  format: uint32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -24289,7 +24289,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: int32
+                                  format: uint32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -24673,7 +24673,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: int32
+                                  format: uint32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/test/helm/gateway-crds-helm/e2e.out.yaml
+++ b/test/helm/gateway-crds-helm/e2e.out.yaml
@@ -2262,7 +2262,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: int32
+                                  format: uint32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -2646,7 +2646,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: int32
+                                  format: uint32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -2262,7 +2262,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: int32
+                                  format: uint32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -2646,7 +2646,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: int32
+                                  format: uint32
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer


### PR DESCRIPTION
Starting with K8s 1.36 the int range and maximum are validated against each other, which breaks the BTP tests.

This can be fixed validating the field as int64.

**What this PR does / why we need it**:

The issue was discovered while adding CI validation for K8s 1.36 in https://github.com/envoyproxy/gateway/pull/8990.

CI action failing with 1.36: https://github.com/envoyproxy/gateway/actions/runs/26950365285/job/79513790168

Release Notes: No
