### PR TITLE
fix(translator): use DnsCluster for DNS settings

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -407,10 +407,18 @@
                     }
                   ]
                 },
+                "clusterType": {
+                  "name": "envoy.cluster.dns",
+                  "typedConfig": {
+                    "@type": "type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster",
+                    "dnsLookupFamily": "V4_PREFERRED",
+                    "dnsRefreshRate": "30s",
+                    "respectDnsTtl": true
+                  }
+                },
                 "commonLbConfig": {},
                 "connectTimeout": "10s",
                 "dnsLookupFamily": "V4_PREFERRED",
-                "dnsRefreshRate": "30s",
                 "ignoreHealthOnHostRemoval": true,
                 "loadAssignment": {
                   "clusterName": "raw_githubusercontent_com_443",
@@ -453,7 +461,6 @@
                 },
                 "name": "raw_githubusercontent_com_443",
                 "perConnectionBufferLimitBytes": 32768,
-                "respectDnsTtl": true,
                 "transportSocket": {
                   "name": "envoy.transport_sockets.tls",
                   "typedConfig": {
@@ -467,8 +474,7 @@
                     },
                     "sni": "raw.githubusercontent.com"
                   }
-                },
-                "type": "STRICT_DNS"
+                }
               }
             }
           ]

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -229,10 +229,16 @@ xds:
           circuitBreakers:
             thresholds:
             - maxRetries: 1024
+          clusterType:
+            name: envoy.cluster.dns
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+              dnsLookupFamily: V4_PREFERRED
+              dnsRefreshRate: 30s
+              respectDnsTtl: true
           commonLbConfig: {}
           connectTimeout: 10s
           dnsLookupFamily: V4_PREFERRED
-          dnsRefreshRate: 30s
           ignoreHealthOnHostRemoval: true
           loadAssignment:
             clusterName: raw_githubusercontent_com_443
@@ -257,7 +263,6 @@ xds:
                     localityWeightedLbConfig: {}
           name: raw_githubusercontent_com_443
           perConnectionBufferLimitBytes: 32768
-          respectDnsTtl: true
           transportSocket:
             name: envoy.transport_sockets.tls
             typedConfig:
@@ -267,7 +272,6 @@ xds:
                   trustedCa:
                     filename: /etc/ssl/certs/ca-certificates.crt
               sni: raw.githubusercontent.com
-          type: STRICT_DNS
     - '@type': type.googleapis.com/envoy.admin.v3.ListenersConfigDump
       dynamicListeners:
       - activeState:

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
@@ -39,10 +39,16 @@ xds:
         circuitBreakers:
           thresholds:
           - maxRetries: 1024
+        clusterType:
+          name: envoy.cluster.dns
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+            dnsLookupFamily: V4_PREFERRED
+            dnsRefreshRate: 30s
+            respectDnsTtl: true
         commonLbConfig: {}
         connectTimeout: 10s
         dnsLookupFamily: V4_PREFERRED
-        dnsRefreshRate: 30s
         ignoreHealthOnHostRemoval: true
         loadAssignment:
           clusterName: raw_githubusercontent_com_443
@@ -67,7 +73,6 @@ xds:
                   localityWeightedLbConfig: {}
         name: raw_githubusercontent_com_443
         perConnectionBufferLimitBytes: 32768
-        respectDnsTtl: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:
@@ -77,4 +82,3 @@ xds:
                 trustedCa:
                   filename: /etc/ssl/certs/ca-certificates.crt
             sni: raw.githubusercontent.com
-        type: STRICT_DNS

--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -15,6 +15,8 @@ import (
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	commondnsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/common/dns/v3"
+	dnsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/dns/v3"
 	dfpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/dynamic_forward_proxy/v3"
 	commondfpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/common/dynamic_forward_proxy/v3"
 	codecv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/upstream_codec/v3"
@@ -57,6 +59,7 @@ const (
 	tcpClusterPerConnectionBufferLimitBytes = 32768
 	tcpClusterPerConnectTimeout             = 10 * time.Second
 	dfpClusterTypeName                      = "envoy.clusters.dynamic_forward_proxy"
+	dnsClusterTypeName                      = "envoy.cluster.dns"
 	dfpDNSCacheName                         = "envoy-gateway-dfp-cache"
 )
 
@@ -167,6 +170,25 @@ func computeDNSLookupFamily(ipFamily *egv1a1.IPFamily, dns *ir.DNS) clusterv3.Cl
 	}
 
 	return dnsLookupFamily
+}
+
+// toCommonDNSLookupFamily maps the cluster-level DNS lookup family to the equivalent value in
+// the DnsCluster extension, which uses a distinct enum type with a different set of values.
+func toCommonDNSLookupFamily(family clusterv3.Cluster_DnsLookupFamily) commondnsv3.DnsLookupFamily {
+	switch family {
+	case clusterv3.Cluster_AUTO:
+		return commondnsv3.DnsLookupFamily_AUTO
+	case clusterv3.Cluster_V4_ONLY:
+		return commondnsv3.DnsLookupFamily_V4_ONLY
+	case clusterv3.Cluster_V6_ONLY:
+		return commondnsv3.DnsLookupFamily_V6_ONLY
+	case clusterv3.Cluster_V4_PREFERRED:
+		return commondnsv3.DnsLookupFamily_V4_PREFERRED
+	case clusterv3.Cluster_ALL:
+		return commondnsv3.DnsLookupFamily_ALL
+	default:
+		return commondnsv3.DnsLookupFamily_AUTO
+	}
 }
 
 func dfpCacheName(ipFamily *egv1a1.IPFamily, dns *ir.DNS) string {
@@ -513,17 +535,31 @@ func buildXdsCluster(args *xdsClusterArgs) (*buildClusterResult, error) {
 			},
 		}
 	default:
-		cluster.ClusterDiscoveryType = &clusterv3.Cluster_Type{Type: clusterv3.Cluster_STRICT_DNS}
-		cluster.DnsRefreshRate = durationpb.New(30 * time.Second)
-		cluster.RespectDnsTtl = true
+		// STRICT_DNS discovery configured through the DnsCluster extension. The inline
+		// cluster.DnsRefreshRate and cluster.RespectDnsTtl fields are deprecated, so the
+		// equivalent settings are carried on the DnsCluster typed config instead. Leaving
+		// all_addresses_in_single_endpoint unset keeps strict (per-address) DNS semantics.
+		dnsCluster := &dnsv3.DnsCluster{
+			DnsRefreshRate:  durationpb.New(30 * time.Second),
+			RespectDnsTtl:   true,
+			DnsLookupFamily: toCommonDNSLookupFamily(dnsLookupFamily),
+		}
 		if args.dns != nil {
 			if args.dns.DNSRefreshRate != nil {
-				cluster.DnsRefreshRate = durationpb.New(args.dns.DNSRefreshRate.Duration)
+				dnsCluster.DnsRefreshRate = durationpb.New(args.dns.DNSRefreshRate.Duration)
 			}
 			if args.dns.RespectDNSTTL != nil {
-				cluster.RespectDnsTtl = ptr.Deref(args.dns.RespectDNSTTL, true)
+				dnsCluster.RespectDnsTtl = ptr.Deref(args.dns.RespectDNSTTL, true)
 			}
 		}
+		dnsClusterAny, err := proto.ToAnyWithValidation(dnsCluster)
+		if err != nil {
+			return nil, err
+		}
+		cluster.ClusterDiscoveryType = &clusterv3.Cluster_ClusterType{ClusterType: &clusterv3.Cluster_CustomClusterType{
+			Name:        dnsClusterTypeName,
+			TypedConfig: dnsClusterAny,
+		}}
 	}
 
 	return &buildClusterResult{

--- a/internal/xds/translator/cluster_test.go
+++ b/internal/xds/translator/cluster_test.go
@@ -12,6 +12,8 @@ import (
 	bootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	commondnsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/common/dns/v3"
+	dnsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/dns/v3"
 	cswrrv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3"
 	override_hostv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/load_balancing_policies/override_host/v3"
 	wrr_localityv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/load_balancing_policies/wrr_locality/v3"
@@ -48,7 +50,12 @@ func TestBuildXdsCluster(t *testing.T) {
 	require.NoError(t, err)
 	dynamicXdsCluster := result.cluster
 	require.Equal(t, bootstrapXdsCluster.Name, dynamicXdsCluster.Name)
-	require.Equal(t, bootstrapXdsCluster.ClusterDiscoveryType, dynamicXdsCluster.ClusterDiscoveryType)
+	require.Equal(t, dnsClusterTypeName, dynamicXdsCluster.GetClusterType().GetName())
+	dnsCluster := &dnsv3.DnsCluster{}
+	require.NoError(t, dynamicXdsCluster.GetClusterType().GetTypedConfig().UnmarshalTo(dnsCluster))
+	require.Equal(t, durationpb.New(30*time.Second), dnsCluster.DnsRefreshRate)
+	require.True(t, dnsCluster.RespectDnsTtl)
+	require.Equal(t, commondnsv3.DnsLookupFamily_V4_PREFERRED, dnsCluster.DnsLookupFamily)
 	require.Equal(t, bootstrapXdsCluster.TransportSocket, dynamicXdsCluster.TransportSocket)
 	requireCmpNoDiff(t, bootstrapXdsCluster.TransportSocket, dynamicXdsCluster.TransportSocket)
 	requireCmpNoDiff(t, bootstrapXdsCluster.ConnectTimeout, dynamicXdsCluster.ConnectTimeout)

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-cel.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-cel.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: accesslog-0
@@ -52,8 +58,6 @@
             localityWeightedLbConfig: {}
   name: accesslog-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.clusters.yaml
@@ -26,10 +26,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: accesslog-0
@@ -54,10 +60,8 @@
             localityWeightedLbConfig: {}
   name: accesslog-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   trackClusterStats:
     perEndpointStats: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: accesslog-0
@@ -52,8 +58,6 @@
             localityWeightedLbConfig: {}
   name: accesslog-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-multi-cel.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-multi-cel.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: accesslog-0
@@ -52,8 +58,6 @@
             localityWeightedLbConfig: {}
   name: accesslog-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-otel-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-otel-headers.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: accesslog-0
@@ -52,8 +58,6 @@
             localityWeightedLbConfig: {}
   name: accesslog-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-types.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-types.clusters.yaml
@@ -204,10 +204,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: accesslog_otel_0_3
@@ -232,8 +238,6 @@
             localityWeightedLbConfig: {}
   name: accesslog_otel_0_3
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -244,10 +248,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: accesslog_otel_1_3
@@ -272,8 +282,6 @@
             localityWeightedLbConfig: {}
   name: accesslog_otel_1_3
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -284,10 +292,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: accesslog_otel_2_3
@@ -312,8 +326,6 @@
             localityWeightedLbConfig: {}
   name: accesslog_otel_2_3
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-with-format.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-with-format.clusters.yaml
@@ -54,10 +54,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: accesslog-0
@@ -81,8 +87,6 @@
             localityWeightedLbConfig: {}
   name: accesslog-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
@@ -63,10 +63,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: accesslog-0
@@ -91,8 +97,6 @@
             localityWeightedLbConfig: {}
   name: accesslog-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.clusters.yaml
@@ -47,10 +47,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: two_example_com_443
@@ -75,7 +81,6 @@
             localityWeightedLbConfig: {}
   name: two_example_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -85,14 +90,19 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: two.example.com
-  type: STRICT_DNS
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: one_example_com_443
@@ -117,7 +127,6 @@
             localityWeightedLbConfig: {}
   name: one_example_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -127,4 +136,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: one.example.com
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.clusters.yaml
@@ -47,10 +47,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: two_example_com_443
@@ -75,7 +81,6 @@
             localityWeightedLbConfig: {}
   name: two_example_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -85,14 +90,19 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: two.example.com
-  type: STRICT_DNS
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: one_example_com_443
@@ -117,7 +127,6 @@
             localityWeightedLbConfig: {}
   name: one_example_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -127,4 +136,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: one.example.com
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.clusters.yaml
@@ -1,10 +1,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: one_example_com_443
@@ -29,7 +35,6 @@
             localityWeightedLbConfig: {}
   name: one_example_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -39,14 +44,19 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: one.example.com
-  type: STRICT_DNS
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: two_example_com_80
@@ -71,5 +81,3 @@
             localityWeightedLbConfig: {}
   name: two_example_com_80
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/dns-lookup-family.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/dns-lookup-family.clusters.yaml
@@ -1,10 +1,15 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V6_ONLY
+      dnsRefreshRate: 5s
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V6_ONLY
-  dnsRefreshRate: 5s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: httproute/default/httproute-1/rule/0
@@ -28,14 +33,18 @@
             localityWeightedLbConfig: {}
   name: httproute/default/httproute-1/rule/0
   perConnectionBufferLimitBytes: 32768
-  type: STRICT_DNS
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V6_ONLY
+      dnsRefreshRate: 5s
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V6_ONLY
-  dnsRefreshRate: 5s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: grpcroute/default/grpcroute-1/rule/0
@@ -59,7 +68,6 @@
             localityWeightedLbConfig: {}
   name: grpcroute/default/grpcroute-1/rule/0
   perConnectionBufferLimitBytes: 32768
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -70,10 +78,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: securitypolicy/envoy-gateway/policy-for-gateway-1/extauth/0
@@ -97,15 +111,19 @@
             localityWeightedLbConfig: {}
   name: securitypolicy/envoy-gateway/policy-for-gateway-1/extauth/0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: ALL
+      dnsRefreshRate: 5s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: ALL
-  dnsRefreshRate: 5s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: envoyextensionpolicy/default/policy-for-httproute/extproc/0
@@ -129,8 +147,6 @@
             localityWeightedLbConfig: {}
   name: envoyextensionpolicy/default/policy-for-httproute/extproc/0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -141,10 +157,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_ONLY
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_ONLY
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: accesslog_otel_0_1
@@ -169,8 +191,6 @@
             localityWeightedLbConfig: {}
   name: accesslog_otel_0_1
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/dynamicmodule.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/dynamicmodule.clusters.yaml
@@ -93,10 +93,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: modules_example_com_443
@@ -121,7 +127,6 @@
             localityWeightedLbConfig: {}
   name: modules_example_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -131,4 +136,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: modules.example.com
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.clusters.yaml
@@ -70,10 +70,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
@@ -102,7 +108,6 @@
             localityWeightedLbConfig: {}
   name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: dummy.transport_socket
     typedConfig:
@@ -134,7 +139,6 @@
               ads: {}
               resourceApiVersion: V3
         sni: primary.foo.com
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -148,10 +152,16 @@
       maxPendingRequests: 1024
       maxRequests: 1022
       maxRetries: 1023
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
@@ -176,5 +186,3 @@
             localityWeightedLbConfig: {}
   name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-body.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-body.clusters.yaml
@@ -70,10 +70,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
@@ -98,8 +104,6 @@
             localityWeightedLbConfig: {}
   name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -110,10 +114,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
@@ -138,5 +148,3 @@
             localityWeightedLbConfig: {}
   name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.clusters.yaml
@@ -70,10 +70,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
@@ -98,8 +104,6 @@
             localityWeightedLbConfig: {}
   name: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -110,10 +114,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
@@ -138,5 +148,3 @@
             localityWeightedLbConfig: {}
   name: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-query-parameters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-query-parameters.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -52,7 +58,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -68,7 +73,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/health-check-host-hierarchy.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check-host-hierarchy.clusters.yaml
@@ -1,10 +1,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   healthChecks:
   - healthyThreshold: 1
     httpHealthCheck:
@@ -42,15 +48,19 @@
             localityWeightedLbConfig: {}
   name: btp-host-route-dest
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   healthChecks:
   - healthyThreshold: 1
     httpHealthCheck:
@@ -90,15 +100,19 @@
             localityWeightedLbConfig: {}
   name: backend-host-route-dest
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   healthChecks:
   - healthyThreshold: 1
     httpHealthCheck:
@@ -135,5 +149,3 @@
             localityWeightedLbConfig: {}
   name: route-host-route-dest
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-dns-cluster.clusters.yaml
@@ -1,10 +1,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: first-route-dest
@@ -35,5 +41,3 @@
             localityWeightedLbConfig: {}
   name: first-route-dest
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/http2-mixed.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-mixed.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: first-route-dest/backend/1
@@ -52,5 +58,3 @@
             localityWeightedLbConfig: {}
   name: first-route-dest/backend/1
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: localhost_443
@@ -52,7 +58,6 @@
             localityWeightedLbConfig: {}
   name: localhost_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -62,4 +67,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: localhost
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.clusters.yaml
@@ -31,10 +31,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: www_googleapis_com_443
@@ -59,7 +65,6 @@
             localityWeightedLbConfig: {}
   name: www_googleapis_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -69,7 +74,6 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: www.googleapis.com
-  type: STRICT_DNS
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
@@ -47,10 +47,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: localhost_80
@@ -75,8 +81,6 @@
             localityWeightedLbConfig: {}
   name: localhost_80
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
@@ -47,10 +47,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: localhost_443
@@ -75,7 +81,6 @@
             localityWeightedLbConfig: {}
   name: localhost_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -85,4 +90,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: localhost
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: localhost_443
@@ -52,7 +58,6 @@
             localityWeightedLbConfig: {}
   name: localhost_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -62,4 +67,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: localhost
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
@@ -102,10 +102,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -130,7 +136,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -146,7 +151,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: localhost_443
@@ -52,7 +58,6 @@
             localityWeightedLbConfig: {}
   name: localhost_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -62,4 +67,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: localhost
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.clusters.yaml
@@ -27,10 +27,16 @@
       maxPendingRequests: 1
       maxRequests: 4294967295
       maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: ALL
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 15s
   dnsLookupFamily: ALL
-  dnsRefreshRate: 30s
   healthChecks:
   - healthyThreshold: 1
     httpHealthCheck:
@@ -80,7 +86,6 @@
     interval: 2s
     maxEjectionPercent: 100
   perConnectionBufferLimitBytes: 100000000
-  respectDnsTtl: true
   transportSocket:
     name: dummy.transport_socket
     typedConfig:
@@ -112,7 +117,6 @@
               ads: {}
               resourceApiVersion: V3
         sni: foo.bar.com
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: localhost_443
@@ -52,7 +58,6 @@
             localityWeightedLbConfig: {}
   name: localhost_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -62,4 +67,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: localhost
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.clusters.yaml
@@ -93,10 +93,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: oauth_foo_com_443
@@ -121,7 +127,6 @@
             localityWeightedLbConfig: {}
   name: oauth_foo_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -131,4 +136,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: oauth.foo.com
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: oauth_foo_com_443
@@ -52,7 +58,6 @@
             localityWeightedLbConfig: {}
   name: oauth_foo_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -62,4 +67,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: oauth.foo.com
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.clusters.yaml
@@ -27,10 +27,16 @@
       maxPendingRequests: 1
       maxRequests: 4294967295
       maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: ALL
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 15s
   dnsLookupFamily: ALL
-  dnsRefreshRate: 30s
   healthChecks:
   - healthyThreshold: 1
     httpHealthCheck:
@@ -80,7 +86,6 @@
     interval: 2s
     maxEjectionPercent: 100
   perConnectionBufferLimitBytes: 100000000
-  respectDnsTtl: true
   transportSocket:
     name: dummy.transport_socket
     typedConfig:
@@ -112,7 +117,6 @@
               ads: {}
               resourceApiVersion: V3
         sni: oauth.foo.com
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-provider-traffic-features.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-provider-traffic-features.clusters.yaml
@@ -34,10 +34,16 @@
       maxPendingRequests: 1
       maxRequests: 4294967295
       maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: ALL
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 15s
   dnsLookupFamily: ALL
-  dnsRefreshRate: 30s
   healthChecks:
   - healthyThreshold: 1
     httpHealthCheck:
@@ -83,7 +89,6 @@
     interval: 2s
     maxEjectionPercent: 100
   perConnectionBufferLimitBytes: 100000000
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -93,7 +98,6 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: oauth.foo.com
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
@@ -47,10 +47,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: oauth_foo_com_443
@@ -75,7 +81,6 @@
             localityWeightedLbConfig: {}
   name: oauth_foo_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -85,14 +90,19 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: oauth.foo.com
-  type: STRICT_DNS
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: oauth_bar_com_443
@@ -117,7 +127,6 @@
             localityWeightedLbConfig: {}
   name: oauth_bar_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -127,4 +136,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: oauth.bar.com
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-both-type.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-both-type.clusters.yaml
@@ -47,10 +47,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -75,7 +81,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -91,7 +96,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
@@ -70,10 +70,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -98,7 +104,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -114,7 +119,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.clusters.yaml
@@ -70,10 +70,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -98,7 +104,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -114,7 +119,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.clusters.yaml
@@ -76,10 +76,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -104,7 +110,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   trackClusterStats:
     perEndpointStats: true
   transportSocket:
@@ -122,7 +127,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-global-shared.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-global-shared.clusters.yaml
@@ -101,10 +101,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -129,7 +135,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   trackClusterStats:
     perEndpointStats: true
   transportSocket:
@@ -147,7 +152,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.clusters.yaml
@@ -70,10 +70,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -98,7 +104,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -114,7 +119,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-multi-global-shared.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-multi-global-shared.clusters.yaml
@@ -76,10 +76,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -104,7 +110,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   trackClusterStats:
     perEndpointStats: true
   transportSocket:
@@ -122,7 +127,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-per-rule-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-per-rule-headers.clusters.yaml
@@ -61,10 +61,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -89,7 +95,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -105,7 +110,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip-invert.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip-invert.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -52,7 +58,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -68,7 +73,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
@@ -93,10 +93,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -121,7 +127,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -137,7 +142,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
@@ -93,10 +93,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: ratelimit_cluster
@@ -121,7 +127,6 @@
             localityWeightedLbConfig: {}
   name: ratelimit_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -137,7 +142,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: oidc_example_com_443
@@ -52,7 +58,6 @@
             localityWeightedLbConfig: {}
   name: oidc_example_com_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -62,4 +67,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: oidc.example.com
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: tls-passthrough-bar-dest
@@ -52,5 +58,3 @@
             localityWeightedLbConfig: {}
   name: tls-passthrough-bar-dest
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-termination.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-termination.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: tls-termination-bar-dest
@@ -52,5 +58,3 @@
             localityWeightedLbConfig: {}
   name: tls-termination-bar-dest
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-datadog.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-datadog.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: tracing-0
@@ -52,5 +58,3 @@
             localityWeightedLbConfig: {}
   name: tracing-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.clusters.yaml
@@ -26,10 +26,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: tracing-0
@@ -54,10 +60,8 @@
             localityWeightedLbConfig: {}
   name: tracing-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   trackClusterStats:
     perEndpointStats: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-otel-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-otel-headers.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: tracing-0
@@ -52,8 +58,6 @@
             localityWeightedLbConfig: {}
   name: tracing-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-otel-sampler-always-on.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-otel-sampler-always-on.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: tracing-0
@@ -52,8 +58,6 @@
             localityWeightedLbConfig: {}
   name: tracing-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-otel-sampler.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-otel-sampler.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: tracing-0
@@ -52,8 +58,6 @@
             localityWeightedLbConfig: {}
   name: tracing-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-span-name.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-span-name.clusters.yaml
@@ -61,10 +61,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: tracing
@@ -96,8 +102,6 @@
           namespace: envoy-gateway
   name: tracing
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-zipkin.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-zipkin.clusters.yaml
@@ -24,10 +24,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: tracing-0
@@ -52,5 +58,3 @@
             localityWeightedLbConfig: {}
   name: tracing-0
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
-  type: STRICT_DNS

--- a/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
@@ -25,10 +25,16 @@
     thresholds:
     - maxConnections: 2048
       maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 15s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: tracing-0
@@ -61,8 +67,6 @@
     interval: 5s
     maxEjectionPercent: 10
   perConnectionBufferLimitBytes: 20971520
-  respectDnsTtl: true
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/internal/xds/translator/testdata/out/xds-ir/wasm.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/wasm.clusters.yaml
@@ -47,10 +47,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: wasm_cluster
@@ -75,7 +81,6 @@
             localityWeightedLbConfig: {}
   name: wasm_cluster
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -91,7 +96,6 @@
         validationContext:
           trustedCa:
             filename: /certs/ca.crt
-  type: STRICT_DNS
   typedExtensionProtocolOptions:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions


### PR DESCRIPTION
**What type of PR is this?**

fix(translator)

**What this PR does / why we need it**:

This updates STRICT_DNS cluster generation to configure DNS refresh rate and respect-DNS-TTL settings through the `envoy.cluster.dns` `DnsCluster` extension instead of the deprecated top-level `cluster.DnsRefreshRate` and `cluster.RespectDnsTtl` fields.

It also explicitly maps the cluster DNS lookup family enum to the `DnsCluster` DNS lookup family enum, since the enum values differ. `all_addresses_in_single_endpoint` is left unset to preserve the existing strict DNS per-address semantics.

The affected translator and egctl golden testdata were regenerated.

**Which issue(s) this PR fixes**:

Fixes #6192

Release Notes: No