### PR TITLE
fix: correct the config hot reload validation order

### DIFF
--- a/internal/envoygateway/config/loader/configloader.go
+++ b/internal/envoygateway/config/loader/configloader.go
@@ -75,14 +75,15 @@ func (r *Loader) Start(ctx context.Context, logOut io.Writer) error {
 					continue
 				}
 
+				// Set defaults for unset fields before validation so the validator
+				// always sees a fully-defaulted struct.
+				eg.SetEnvoyGatewayDefaults()
+				eg.Logging.SetEnvoyGatewayLoggingDefaults()
+
 				if err := validation.ValidateEnvoyGateway(eg); err != nil {
 					r.logger.Error(err, "failed to validate EnvoyGateway config")
 					continue
 				}
-
-				// Set defaults for unset fields
-				eg.SetEnvoyGatewayDefaults()
-				eg.Logging.SetEnvoyGatewayLoggingDefaults()
 
 				r.cfgMu.Lock()
 				r.cfg.EnvoyGateway = eg

--- a/internal/envoygateway/config/loader/configloader_test.go
+++ b/internal/envoygateway/config/loader/configloader_test.go
@@ -27,6 +27,8 @@ var (
 	standaloneConfig string
 	//go:embed testdata/standalone-enable-extension-server.yaml
 	standaloneConfigWithExtensionServer string
+	//go:embed testdata/minimal.yaml
+	minimalConfig string
 )
 
 func TestConfigLoader(t *testing.T) {
@@ -127,4 +129,61 @@ func TestConfigLoaderStandaloneExtensionServerAndCustomResource(t *testing.T) {
 	require.Equal(t, "gateway.example.io", res.extMgr.PolicyResources[0].Group)
 	require.Equal(t, "v1alpha1", res.extMgr.PolicyResources[0].Version)
 	require.Equal(t, "ExampleExtPolicy", res.extMgr.PolicyResources[0].Kind)
+}
+
+// TestConfigLoaderDefaultsBeforeValidate ensures the hot-reload path applies defaults
+// before validation. A config that omits `gateway` and `provider` fails validation
+// outright (`gateway is unspecified`) but is valid once defaults populate those fields.
+// Reloading to such a config must therefore succeed and surface the defaulted values
+// to the hook.
+func TestConfigLoaderDefaultsBeforeValidate(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "envoy-gateway-configloader-test")
+	require.NoError(t, err)
+	defer func(path string) {
+		_ = os.RemoveAll(path)
+	}(tmpDir)
+
+	cfgPath := tmpDir + "/config.yaml"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(defaultConfig), 0o600))
+	s, err := config.New(os.Stdout, os.Stderr)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type testResult struct {
+		changed int32
+		eg      *egv1a1.EnvoyGateway
+	}
+	resultChannel := make(chan testResult, 1)
+
+	var changed int32
+	loader := New(cfgPath, s, func(hookCtx context.Context, cfg *config.Server) error {
+		select {
+		case <-hookCtx.Done():
+			return nil
+		default:
+		}
+		c := atomic.AddInt32(&changed, 1)
+		if c > 1 {
+			resultChannel <- testResult{changed: c, eg: cfg.EnvoyGateway}
+			cancel()
+		}
+		return nil
+	})
+
+	require.NoError(t, loader.Start(ctx, os.Stdout))
+	go func() {
+		_ = os.WriteFile(cfgPath, []byte(minimalConfig), 0o600)
+	}()
+
+	<-ctx.Done()
+	res := <-resultChannel
+	require.Equal(t, int32(2), res.changed)
+	require.NotNil(t, res.eg)
+	require.NotNil(t, res.eg.Gateway)
+	require.Equal(t, egv1a1.GatewayControllerName, res.eg.Gateway.ControllerName)
+	require.NotNil(t, res.eg.Provider)
+	require.Equal(t, egv1a1.ProviderTypeKubernetes, res.eg.Provider.Type)
+	require.NotNil(t, res.eg.Logging)
 }

--- a/internal/envoygateway/config/loader/testdata/minimal.yaml
+++ b/internal/envoygateway/config/loader/testdata/minimal.yaml
@@ -1,0 +1,2 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyGateway

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -37,6 +37,7 @@ bug fixes: |
   Fixed API key auth credential ordering to avoid unnecessary xDS updates.
   Fixed the generated `install.yaml` creating a duplicate ValidatingAdmissionPolicy and its binding which caused `kustomize build` to fail with a duplicate resource error.
   Fixed ListenerSet hostname conflict resolution to apply listener precedence: Gateway-owned listeners win over ListenerSet listeners, and among ListenerSet listeners the first in processing order wins. Conflicted ListenerSet listeners now correctly report Accepted=False with the conflict reason. The Gateway's AttachedListenerSets count now only reflects ListenerSets with at least one accepted listener.
+  Fixed EnvoyGateway config hot-reload to apply defaults before validation, so validators always run against a fully-defaulted struct on both the startup and reload paths.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
**What type of PR is this?**
fix

**What this PR does / why we need it**:
The EnvoyGateway config loader applies validation and defaulting in opposite orders depending on whether the config is loaded at startup or via hot-reload (file-watcher reload).

In hot-reload path, it validates the configuration then does a defaulting. It happens to work today because the current validators short-circuit on nil/empty values (e.g. validateEnvoyGatewayKubernetesProvider returns nil if provider.Watch == nil) rather than reading defaulted fields.
As soon as a validator is added that reasonably assumes a field has been defaulted (e.g. switches on a defaulted enum, or checks a numeric default), it will pass at startup but produce false errors — or miss real errors — on hot-reload.

**Which issue(s) this PR fixes**:
Fixes https://github.com/envoyproxy/gateway/issues/9059

Release Notes: Yes
