### PR TITLE
fix(egctl): correct user-facing grammar in help text

### DIFF
--- a/internal/cmd/egctl/config_ratelimit.go
+++ b/internal/cmd/egctl/config_ratelimit.go
@@ -46,7 +46,7 @@ func ratelimitConfigCommand() *cobra.Command {
 		},
 	}
 
-	rlConfigCmd.Flags().StringVarP(&namespace, "namespace", "n", defaultRateLimitNamespace, "Specific a namespace to get resources")
+	rlConfigCmd.Flags().StringVarP(&namespace, "namespace", "n", defaultRateLimitNamespace, "Specify a namespace to get resources")
 	return rlConfigCmd
 }
 

--- a/internal/cmd/egctl/status.go
+++ b/internal/cmd/egctl/status.go
@@ -86,7 +86,7 @@ func newStatusCommand() *cobra.Command {
 			case len(args) > 1:
 				return fmt.Errorf("unknown args: %s", strings.Join(args[1:], ","))
 			default:
-				return fmt.Errorf("invalid args: must specific a resources type")
+				return fmt.Errorf("invalid args: must specify a resource type")
 			}
 
 			switch strings.ToLower(resourceType) {
@@ -138,7 +138,7 @@ func newStatusCommand() *cobra.Command {
 	statusCommand.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Show the first status of resources only")
 	statusCommand.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Show the status of resources with details")
 	statusCommand.PersistentFlags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Get the status of resources from all namespaces")
-	statusCommand.PersistentFlags().StringVarP(&namespace, "namespace", "n", "default", "Specific a namespace to get the status of resources")
+	statusCommand.PersistentFlags().StringVarP(&namespace, "namespace", "n", "default", "Specify a namespace to get the status of resources")
 
 	return statusCommand
 }


### PR DESCRIPTION
### What type of PR is this?
fix

### What this PR does / why we need it:
Fixes 3 user-facing `egctl` typos in help and error text.
Small papercut, but its on the normal CLI path so people hit it pretty fast.

### Which issue(s) this PR fixes:
N/A

Release Notes: No

### Repro:
1. On `main`, run `go run ./cmd/egctl config envoy-ratelimit --help`.
2. Run `go run ./cmd/egctl experimental status --help`.
3. The output shows `Specific a namespace...`.
4. `git show origin/main:internal/cmd/egctl/status.go | rg "must specific|Specific a namespace"`
