### PR TITLE
docs(gateway-helm): clarify envoyProxy image values

### DIFF
--- a/charts/gateway-helm/README.md
+++ b/charts/gateway-helm/README.md
@@ -35,6 +35,9 @@ Once Helm has been set up correctly, install the chart from dockerhub:
 ``` shell
 helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace
 ```
+
+Image overrides target different components. `global.images.envoyGateway.*` configures the Envoy Gateway control plane Deployment rendered by this chart. `global.images.envoyProxy.*` configures the managed Envoy Proxy data plane through the generated `EnvoyGateway` config.
+
 This command installs both Gateway API CRDs and Envoy Gateway CRDs. If your Kubernetes provider already manages
 Gateway API CRDs for the cluster, confirm that the provider-installed Gateway API version and channel are compatible
 with the Envoy Gateway release and the Gateway API resources you plan to use. If they are compatible, install only the
@@ -135,12 +138,12 @@ helm uninstall eg -n envoy-gateway-system
 | deployment.replicas | int | `1` |  |
 | global.imagePullSecrets | list | `[]` | Global override for image pull secrets |
 | global.imageRegistry | string | `""` | Global override for image registry |
-| global.images.envoyGateway.image | string | `nil` |  |
-| global.images.envoyGateway.pullPolicy | string | `nil` |  |
-| global.images.envoyGateway.pullSecrets | list | `[]` |  |
-| global.images.envoyProxy.image | string | `""` |  |
-| global.images.envoyProxy.pullPolicy | string | `""` |  |
-| global.images.envoyProxy.pullSecrets | list | `[]` |  |
+| global.images.envoyGateway.image | string | `nil` | Full image for the Envoy Gateway control plane Deployment installed by this chart. |
+| global.images.envoyGateway.pullPolicy | string | `nil` | Image pull policy for the Envoy Gateway control plane Deployment. Default behavior: latest images will be Always else IfNotPresent. |
+| global.images.envoyGateway.pullSecrets | list | `[]` | Pull secrets for the Envoy Gateway control plane Deployment. |
+| global.images.envoyProxy.image | string | `""` | Full image for the managed Envoy Proxy data plane. This updates the generated `envoyProxy` config and does not change the `envoy-gateway` control plane Deployment image. If not specified, the default image built into `envoy-gateway` is used. |
+| global.images.envoyProxy.pullPolicy | string | `""` | Image pull policy for the managed Envoy Proxy data plane. Default behavior: IfNotPresent. |
+| global.images.envoyProxy.pullSecrets | list | `[]` | Pull secrets for the managed Envoy Proxy data plane. |
 | global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:master"` |  |
 | global.images.ratelimit.pullPolicy | string | `"IfNotPresent"` |  |
 | global.images.ratelimit.pullSecrets | list | `[]` |  |

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -10,12 +10,12 @@ global:
   # Override image-specific values directly if a global override is not desired.
   images:
     envoyGateway:
-      # This is the full image name including the hub, repo, and tag.
+      # -- Full image for the Envoy Gateway control plane Deployment installed by this chart.
       image: ${GatewayImage}
-      # Specify image pull policy if default behavior isn't desired.
+      # -- Image pull policy for the Envoy Gateway control plane Deployment.
       # Default behavior: latest images will be Always else IfNotPresent.
       pullPolicy: ${GatewayImagePullPolicy}
-      # List of secrets in the same namespace of the component that can be used to pull images from private repositories.
+      # -- Pull secrets for the Envoy Gateway control plane Deployment.
       pullSecrets: []
     ratelimit:
       # This is the full image name including the hub, repo, and tag.
@@ -26,13 +26,15 @@ global:
       # List of secrets in the same namespace of the component that can be used to pull images from private repositories.
       pullSecrets: []
     envoyProxy:
-      # This is the full image name including the hub, repo, and tag for the Envoy Proxy data plane.
-      # If not specified, uses the default image built into envoy-gateway.
+      # -- Full image for the managed Envoy Proxy data plane.
+      # This updates the generated `envoyProxy` config and does not change the `envoy-gateway`
+      # control plane Deployment image. If not specified, the default image built into
+      # `envoy-gateway` is used.
       image: ""
-      # Specify image pull policy if default behavior isn't desired.
+      # -- Image pull policy for the managed Envoy Proxy data plane.
       # Default behavior: IfNotPresent.
       pullPolicy: ""
-      # List of secrets in the same namespace of the component that can be used to pull images from private repositories.
+      # -- Pull secrets for the managed Envoy Proxy data plane.
       pullSecrets: []
 
 # -- Labels to apply to all resources

--- a/site/content/en/latest/install/gateway-helm-api.md
+++ b/site/content/en/latest/install/gateway-helm-api.md
@@ -78,12 +78,12 @@ The Helm chart for Envoy Gateway
 | deployment.replicas | int | `1` |  |
 | global.imagePullSecrets | list | `[]` | Global override for image pull secrets |
 | global.imageRegistry | string | `""` | Global override for image registry |
-| global.images.envoyGateway.image | string | `nil` |  |
-| global.images.envoyGateway.pullPolicy | string | `nil` |  |
-| global.images.envoyGateway.pullSecrets | list | `[]` |  |
-| global.images.envoyProxy.image | string | `""` |  |
-| global.images.envoyProxy.pullPolicy | string | `""` |  |
-| global.images.envoyProxy.pullSecrets | list | `[]` |  |
+| global.images.envoyGateway.image | string | `nil` | Full image for the Envoy Gateway control plane Deployment installed by this chart. |
+| global.images.envoyGateway.pullPolicy | string | `nil` | Image pull policy for the Envoy Gateway control plane Deployment. Default behavior: latest images will be Always else IfNotPresent. |
+| global.images.envoyGateway.pullSecrets | list | `[]` | Pull secrets for the Envoy Gateway control plane Deployment. |
+| global.images.envoyProxy.image | string | `""` | Full image for the managed Envoy Proxy data plane. This updates the generated `envoyProxy` config and does not change the `envoy-gateway` control plane Deployment image. If not specified, the default image built into `envoy-gateway` is used. |
+| global.images.envoyProxy.pullPolicy | string | `""` | Image pull policy for the managed Envoy Proxy data plane. Default behavior: IfNotPresent. |
+| global.images.envoyProxy.pullSecrets | list | `[]` | Pull secrets for the managed Envoy Proxy data plane. |
 | global.images.ratelimit.image | string | `"docker.io/envoyproxy/ratelimit:master"` |  |
 | global.images.ratelimit.pullPolicy | string | `"IfNotPresent"` |  |
 | global.images.ratelimit.pullSecrets | list | `[]` |  |

--- a/tools/helm-docs/readme.gateway-helm.gotmpl
+++ b/tools/helm-docs/readme.gateway-helm.gotmpl
@@ -25,6 +25,9 @@ Once Helm has been set up correctly, install the chart from dockerhub:
 ``` shell
 helm install eg oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest -n envoy-gateway-system --create-namespace
 ```
+
+Image overrides target different components. `global.images.envoyGateway.*` configures the Envoy Gateway control plane Deployment rendered by this chart. `global.images.envoyProxy.*` configures the managed Envoy Proxy data plane through the generated `EnvoyGateway` config.
+
 This command installs both Gateway API CRDs and Envoy Gateway CRDs. If your Kubernetes provider already manages
 Gateway API CRDs for the cluster, confirm that the provider-installed Gateway API version and channel are compatible
 with the Envoy Gateway release and the Gateway API resources you plan to use. If they are compatible, install only the


### PR DESCRIPTION
**What type of PR is this?**

docs

**What this PR does / why we need it**:

This is a docs fix for the image override flow.

`global.images.envoyProxy.*` already works, but the chart docs leave those fields blank and dont say it targets the managed Envoy Proxy data plane, not the `envoy-gateway` control plane Deployment. Thats where folks get tripped up.

Repro:

```sh
helm template eg oci://docker.io/envoyproxy/gateway-helm --version v1.8.1 \
  -n envoy-gateway-system \
  --set global.images.envoyProxy.image=my.registry/envoyproxy/envoy:debug \
  --set global.imageRegistry=mirror.registry
```

In the render, `envoy-gateway.yaml` gets `envoyProxy.provider.kubernetes.envoyDeployment.container.image: mirror.registry/envoyproxy/envoy:debug`, while the `envoy-gateway` Deployment keeps the control plane image. So the behavior is fine, the docs were just kinda fuzzy.

**Which issue(s) this PR fixes**:

Fixes #9096

Release Notes: No
