### PR TITLE
fix: persist last successful OIDC discovery across reconciliations to prevent HTTP 500 on transient IdP failures

### DIFF
--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -83,9 +83,13 @@ func (t *Translator) ProcessSecurityPolicies(
 	resources *resource.Resources,
 	xdsIR resource.XdsIRMap,
 ) []*egv1a1.SecurityPolicy {
-	// Cache is only reused during one translation across multiple routes and gateways.
-	// The failed fetches will be retried in the next translation when the provider resources are reconciled again.
+	// Per-round cache deduplicates discovery within a single translation.
+	// The persistent success cache survives across rounds so that a transient
+	// discovery failure does not break every route protected by the OIDC policy.
 	t.oidcDiscoveryCache = newOIDCDiscoveryCache()
+	if t.oidcDiscoverySuccessCache == nil {
+		t.oidcDiscoverySuccessCache = make(map[string]*OpenIDConfig)
+	}
 
 	// SecurityPolicies are already sorted by the provider layer
 
@@ -1900,6 +1904,12 @@ func (o *OpenIDConfig) validate() error {
 func (t *Translator) fetchEndpointsFromIssuer(issuerURL string, providerTLS *ir.TLSUpstreamConfig) (*OpenIDConfig, error) {
 	if config, cachedErr, ok := t.oidcDiscoveryCache.Get(issuerURL); ok {
 		if cachedErr != nil {
+			// Per-round cache has an error, but we may have a previously
+			// successful result in the persistent cache. Fall back to it
+			// so that a transient failure does not break all routes.
+			if cachedConfig, ok := t.oidcDiscoverySuccessCache[issuerURL]; ok {
+				return cachedConfig, nil
+			}
 			return nil, cachedErr
 		}
 		return config, nil
@@ -1907,11 +1917,24 @@ func (t *Translator) fetchEndpointsFromIssuer(issuerURL string, providerTLS *ir.
 
 	config, err := discoverEndpointsFromIssuer(issuerURL, providerTLS)
 	if err != nil {
+		// If discovery fails, fall back to the last successfully retrieved
+		// discovery document so that routes are not broken by a transient
+		// IdP outage or misconfiguration.
+		if cachedConfig, ok := t.oidcDiscoverySuccessCache[issuerURL]; ok {
+			t.Logger.Info("OIDC discovery failed, falling back to cached configuration",
+				"issuer", issuerURL, "error", err)
+			t.oidcDiscoveryCache.Set(issuerURL, cachedConfig, nil)
+			return cachedConfig, nil
+		}
 		t.oidcDiscoveryCache.Set(issuerURL, nil, err)
 		return nil, err
 	}
 
 	t.oidcDiscoveryCache.Set(issuerURL, config, nil)
+	if t.oidcDiscoverySuccessCache == nil {
+		t.oidcDiscoverySuccessCache = make(map[string]*OpenIDConfig)
+	}
+	t.oidcDiscoverySuccessCache[issuerURL] = config
 	return config, nil
 }
 

--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -59,6 +59,12 @@ const (
 	JWKSConfigMapKey = "jwks"
 )
 
+// oidcDiscoverySuccessCache stores the last successfully discovered OIDC configuration per issuer.
+// It persists across translation rounds so that a temporary discovery failure does not break
+// every route protected by the OIDC policy. Only successful results are stored; errors are not
+// cached here, so a failed discovery does not prevent future retries.
+var oidcDiscoverySuccessCache map[string]*OpenIDConfig
+
 // deprecatedFieldsUsedInSecurityPolicy returns a map of deprecated field paths to their alternatives.
 func deprecatedFieldsUsedInSecurityPolicy(policy *egv1a1.SecurityPolicy) map[string]string {
 	deprecatedFields := make(map[string]string)
@@ -87,8 +93,8 @@ func (t *Translator) ProcessSecurityPolicies(
 	// The persistent success cache survives across rounds so that a transient
 	// discovery failure does not break every route protected by the OIDC policy.
 	t.oidcDiscoveryCache = newOIDCDiscoveryCache()
-	if t.oidcDiscoverySuccessCache == nil {
-		t.oidcDiscoverySuccessCache = make(map[string]*OpenIDConfig)
+	if oidcDiscoverySuccessCache == nil {
+		oidcDiscoverySuccessCache = make(map[string]*OpenIDConfig)
 	}
 
 	// SecurityPolicies are already sorted by the provider layer
@@ -1907,7 +1913,7 @@ func (t *Translator) fetchEndpointsFromIssuer(issuerURL string, providerTLS *ir.
 			// Per-round cache has an error, but we may have a previously
 			// successful result in the persistent cache. Fall back to it
 			// so that a transient failure does not break all routes.
-			if cachedConfig, ok := t.oidcDiscoverySuccessCache[issuerURL]; ok {
+			if cachedConfig, ok := oidcDiscoverySuccessCache[issuerURL]; ok {
 				return cachedConfig, nil
 			}
 			return nil, cachedErr
@@ -1920,7 +1926,7 @@ func (t *Translator) fetchEndpointsFromIssuer(issuerURL string, providerTLS *ir.
 		// If discovery fails, fall back to the last successfully retrieved
 		// discovery document so that routes are not broken by a transient
 		// IdP outage or misconfiguration.
-		if cachedConfig, ok := t.oidcDiscoverySuccessCache[issuerURL]; ok {
+		if cachedConfig, ok := oidcDiscoverySuccessCache[issuerURL]; ok {
 			t.Logger.Info("OIDC discovery failed, falling back to cached configuration",
 				"issuer", issuerURL, "error", err)
 			t.oidcDiscoveryCache.Set(issuerURL, cachedConfig, nil)
@@ -1931,10 +1937,10 @@ func (t *Translator) fetchEndpointsFromIssuer(issuerURL string, providerTLS *ir.
 	}
 
 	t.oidcDiscoveryCache.Set(issuerURL, config, nil)
-	if t.oidcDiscoverySuccessCache == nil {
-		t.oidcDiscoverySuccessCache = make(map[string]*OpenIDConfig)
+	if oidcDiscoverySuccessCache == nil {
+		oidcDiscoverySuccessCache = make(map[string]*OpenIDConfig)
 	}
-	t.oidcDiscoverySuccessCache[issuerURL] = config
+	oidcDiscoverySuccessCache[issuerURL] = config
 	return config, nil
 }
 

--- a/internal/gatewayapi/securitypolicy_test.go
+++ b/internal/gatewayapi/securitypolicy_test.go
@@ -915,6 +915,49 @@ func TestTranslatorFetchEndpointsFromIssuerCacheError(t *testing.T) {
 	require.Equal(t, int32(1), callCount.Load(), "subsequent fetch should continue using cached error")
 }
 
+func TestTranslatorFetchEndpointsFromIssuerPersistentFallback(t *testing.T) {
+	var (
+		callCount atomic.Int32
+		server    *httptest.Server
+		serverURL string
+	)
+
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"token_endpoint":%q,"authorization_endpoint":%q}`, serverURL+"/token", serverURL+"/authorize")
+	}))
+	serverURL = server.URL
+
+	tr := &Translator{GatewayControllerName: "gateway.envoyproxy.io/gatewayclass-controller"}
+
+	// Round 1: Successful discovery stores result in persistent cache.
+	tr.oidcDiscoveryCache = newOIDCDiscoveryCache()
+	cfg, err := tr.fetchEndpointsFromIssuer(serverURL, nil)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Equal(t, int32(1), callCount.Load())
+	require.NotNil(t, tr.oidcDiscoverySuccessCache, "success cache should be initialized")
+	require.Contains(t, tr.oidcDiscoverySuccessCache, serverURL, "success should be stored in persistent cache")
+
+	// Simulate a new translation round: fresh per-round cache.
+	tr.oidcDiscoveryCache = newOIDCDiscoveryCache()
+
+	// Now make discovery fail by closing the server.
+	server.Close()
+
+	// Round 2: Discovery fails, but persistent cache has a successful result.
+	cfg, err = tr.fetchEndpointsFromIssuer(serverURL, nil)
+	require.NoError(t, err, "should fall back to persistent cache on failure")
+	require.NotNil(t, cfg, "should return cached configuration")
+	require.Equal(t, int32(1), callCount.Load(), "should not re-fetch after persistent cache hit")
+}
+
 // / tiny helper to build a minimal SecurityPolicy
 func sp(ns, name string) *egv1a1.SecurityPolicy {
 	return &egv1a1.SecurityPolicy{

--- a/internal/gatewayapi/securitypolicy_test.go
+++ b/internal/gatewayapi/securitypolicy_test.go
@@ -942,8 +942,8 @@ func TestTranslatorFetchEndpointsFromIssuerPersistentFallback(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	require.Equal(t, int32(1), callCount.Load())
-	require.NotNil(t, tr.oidcDiscoverySuccessCache, "success cache should be initialized")
-	require.Contains(t, tr.oidcDiscoverySuccessCache, serverURL, "success should be stored in persistent cache")
+	require.NotNil(t, oidcDiscoverySuccessCache, "success cache should be initialized")
+	require.Contains(t, oidcDiscoverySuccessCache, serverURL, "success should be stored in persistent cache")
 
 	// Simulate a new translation round: fresh per-round cache.
 	tr.oidcDiscoveryCache = newOIDCDiscoveryCache()

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -128,6 +128,12 @@ type Translator struct {
 	// oidcDiscoveryCache is the cache for OIDC configurations discovered from issuer's well-known URL.
 	oidcDiscoveryCache *oidcDiscoveryCache
 
+	// oidcDiscoverySuccessCache stores the last successfully discovered OIDC configuration per issuer.
+	// It persists across translation rounds so that a temporary discovery failure does not break
+	// every route protected by the OIDC policy. Only successful results are stored; errors are not
+	// cached here, so a failed discovery does not prevent future retries.
+	oidcDiscoverySuccessCache map[string]*OpenIDConfig
+
 	// Logger is the logger used by the translator.
 	Logger logging.Logger
 }

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -128,12 +128,6 @@ type Translator struct {
 	// oidcDiscoveryCache is the cache for OIDC configurations discovered from issuer's well-known URL.
 	oidcDiscoveryCache *oidcDiscoveryCache
 
-	// oidcDiscoverySuccessCache stores the last successfully discovered OIDC configuration per issuer.
-	// It persists across translation rounds so that a temporary discovery failure does not break
-	// every route protected by the OIDC policy. Only successful results are stored; errors are not
-	// cached here, so a failed discovery does not prevent future retries.
-	oidcDiscoverySuccessCache map[string]*OpenIDConfig
-
 	// Logger is the logger used by the translator.
 	Logger logging.Logger
 }


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:


Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/community/develop/#raising-a-pr
-->
* "fix: fix #9235 bug"

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

caches the last successful OIDC discovery and uses it instead of throwing 500 for all routes whenever the `/.well-known/openid-configuration` cannot be parsed due to some misconfig.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #9235 

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
