### PR TITLE
fix: bound openid-configuration response read in oidc discovery

### DIFF
--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/mail"
@@ -51,6 +52,11 @@ const (
 	defaultRefreshToken          = true
 	defaultPassThroughAuthHeader = false
 	defaultOIDCHTTPTimeout       = 5 * time.Second
+	// maxOIDCConfigSize caps how much of the issuer's openid-configuration
+	// response we are willing to read. A well-known document is a few KB, so
+	// 1mb is generous while still keeping the issuer from streaming an
+	// unbounded body into the control plane.
+	maxOIDCConfigSize = 1 << 20
 
 	// nolint: gosec
 	oidcHMACSecretName = "envoy-oidc-hmac"
@@ -1952,8 +1958,17 @@ func discoverEndpointsFromIssuer(issuerURL string, providerTLS *ir.TLSUpstreamCo
 		case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest:
 			return &backoff.PermanentError{Err: fmt.Errorf("failed fetching openid-configuration from issuer URL: %s, status code: %d", issuerURL, resp.StatusCode)}
 		case resp.StatusCode == http.StatusOK:
+			// The issuer is externally controlled, so bound the response before
+			// decoding it rather than reading an arbitrary amount into memory.
+			body, err := io.ReadAll(io.LimitReader(resp.Body, maxOIDCConfigSize+1))
+			if err != nil {
+				return err
+			}
+			if int64(len(body)) > maxOIDCConfigSize {
+				return &backoff.PermanentError{Err: fmt.Errorf("openid-configuration response from issuer URL %s exceeds maximum size %d", issuerURL, maxOIDCConfigSize)}
+			}
 			// Do not retry if decoding fails
-			if err = json.NewDecoder(resp.Body).Decode(&config); err != nil {
+			if err = json.Unmarshal(body, &config); err != nil {
 				return &backoff.PermanentError{Err: fmt.Errorf("error decoding openid-configuration response: %w", err)}
 			}
 		default:

--- a/internal/gatewayapi/securitypolicy_test.go
+++ b/internal/gatewayapi/securitypolicy_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -913,6 +914,29 @@ func TestTranslatorFetchEndpointsFromIssuerCacheError(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, cfgAfter)
 	require.Equal(t, int32(1), callCount.Load(), "subsequent fetch should continue using cached error")
+}
+
+func TestDiscoverEndpointsFromIssuerRejectsOversizeBody(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		// Valid JSON that would decode fine, padded well past the size cap so the
+		// only reason to reject it is the bounded read.
+		padding := strings.Repeat("a", 4<<20)
+		_, _ = fmt.Fprintf(w, `{"token_endpoint":%q,"authorization_endpoint":%q,"padding":%q}`,
+			server.URL+"/token", server.URL+"/authorize", padding)
+	}))
+	defer server.Close()
+
+	cfg, err := discoverEndpointsFromIssuer(server.URL, nil)
+	require.Error(t, err)
+	require.Nil(t, cfg)
+	require.Contains(t, err.Error(), "exceeds maximum size")
 }
 
 // / tiny helper to build a minimal SecurityPolicy

--- a/internal/gatewayapi/securitypolicy_test.go
+++ b/internal/gatewayapi/securitypolicy_test.go
@@ -939,6 +939,59 @@ func TestDiscoverEndpointsFromIssuerRejectsOversizeBody(t *testing.T) {
 	require.Contains(t, err.Error(), "exceeds maximum size")
 }
 
+func TestDiscoverEndpointsFromIssuerRetriesTruncatedBody(t *testing.T) {
+	var (
+		callCount atomic.Int32
+		server    *httptest.Server
+	)
+
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if callCount.Add(1) == 1 {
+			// Declare more bytes than are written so the client sees the
+			// connection close mid-body and the read returns an error.
+			w.Header().Set("Content-Length", "1024")
+			_, _ = w.Write([]byte(`{"token_endpoint":`))
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"token_endpoint":%q,"authorization_endpoint":%q}`,
+			server.URL+"/token", server.URL+"/authorize")
+	}))
+	defer server.Close()
+
+	cfg, err := discoverEndpointsFromIssuer(server.URL, nil)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.GreaterOrEqual(t, callCount.Load(), int32(2), "truncated response should be retried")
+}
+
+func TestDiscoverEndpointsFromIssuerRejectsInvalidJSON(t *testing.T) {
+	var callCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token_endpoint":`))
+	}))
+	defer server.Close()
+
+	cfg, err := discoverEndpointsFromIssuer(server.URL, nil)
+	require.Error(t, err)
+	require.Nil(t, cfg)
+	require.Contains(t, err.Error(), "error decoding openid-configuration response")
+	require.Equal(t, int32(1), callCount.Load(), "decode failures should not be retried")
+}
+
 // / tiny helper to build a minimal SecurityPolicy
 func sp(ns, name string) *egv1a1.SecurityPolicy {
 	return &egv1a1.SecurityPolicy{

--- a/release-notes/current.yaml
+++ b/release-notes/current.yaml
@@ -8,6 +8,7 @@ breaking changes: |
 # Updates addressing vulnerabilities, security flaws, or compliance requirements.
 security updates: |
   Fixed xDS server authentication bypass in GatewayNamespaceMode, adding Unary Interceptor and validating SotW requests.
+  Bounded the OIDC issuer openid-configuration response read during SecurityPolicy translation so a misbehaving or malicious issuer cannot stream an unbounded body into the control plane.
 
 # New features or capabilities added in this release.
 new features: |


### PR DESCRIPTION
**What type of PR is this?**

fix

**What this PR does / why we need it**:

When a SecurityPolicy uses OIDC without explicit endpoints, the translator fetches the issuer's `/.well-known/openid-configuration` and decoded it straight from the response body with no limit on how much it would read. The issuer URL is taken from the SecurityPolicy, so a misbehaving or hostile issuer can stream an arbitrarily large body into the control plane and drive its memory up. The wasm fetchers already read remote responses through `io.LimitReader`, so this brings the discovery path in line by capping the body before decoding and rejecting anything over the cap.

**Which issue(s) this PR fixes**:

Release Notes: Yes
