### PR TITLE
fix: UDP/TCP RouteMultipleRoutesAttachment conformance test 

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -1617,10 +1617,6 @@ func (t *Translator) processUDPRouteParentRefs(udpRoute *UDPRouteContext, resour
 
 		accepted := false
 		for _, listener := range parentRef.listeners {
-			// only one route is allowed for a UDP listener
-			if listener.AttachedRoutes() >= 1 {
-				continue
-			}
 			accepted = true
 			listener.IncrementAttachedRoutes()
 			if !listener.IsReady() {
@@ -1631,7 +1627,9 @@ func (t *Translator) processUDPRouteParentRefs(udpRoute *UDPRouteContext, resour
 
 			gwXdsIR := xdsIR[irKey]
 			irListener := gwXdsIR.GetUDPListener(irListenerName(listener))
-			if irListener != nil {
+			// When there's multiple UDPRoutes attached to same listener,
+			// the oldest one win.
+			if irListener != nil && irListener.Route == nil {
 				irRoute := &ir.UDPRoute{
 					Name: irUDPRouteName(udpRoute),
 					Destination: &ir.RouteDestination{
@@ -1769,10 +1767,6 @@ func (t *Translator) processTCPRouteParentRefs(tcpRoute *TCPRouteContext, resour
 
 		accepted := false
 		for _, listener := range parentRef.listeners {
-			// only one route is allowed for a TCP listener
-			if listener.AttachedRoutes() >= 1 {
-				continue
-			}
 			accepted = true
 			listener.IncrementAttachedRoutes()
 			if !listener.IsReady() {

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -1776,7 +1776,9 @@ func (t *Translator) processTCPRouteParentRefs(tcpRoute *TCPRouteContext, resour
 
 			gwXdsIR := xdsIR[irKey]
 			irListener := gwXdsIR.GetTCPListener(irListenerName(listener))
-			if irListener != nil {
+			// When there's multiple TCPRoutes attached to same listener,
+			// the oldest one win.
+			if irListener != nil && len(irListener.Routes) == 0 {
 				irRoute := &ir.TCPRoute{
 					Name: irTCPRouteName(tcpRoute),
 					Destination: &ir.RouteDestination{

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -1627,8 +1627,9 @@ func (t *Translator) processUDPRouteParentRefs(udpRoute *UDPRouteContext, resour
 
 			gwXdsIR := xdsIR[irKey]
 			irListener := gwXdsIR.GetUDPListener(irListenerName(listener))
-			// When there's multiple UDPRoutes attached to same listener,
-			// the oldest one win.
+			// When multiple UDPRoutes target the same Gateway listener, all of must report Accepted=True.
+			// Only the oldest route is attached to the listener, and the listener's AttachedRoutes count must reflect this.
+			// https://github.com/kubernetes-sigs/gateway-api/blob/cf34ac933d068c6008598cce945819ce9cee16be/conformance/tests/udproute-multiple-routes-attachment.go#L107
 			if irListener != nil && irListener.Route == nil {
 				irRoute := &ir.UDPRoute{
 					Name: irUDPRouteName(udpRoute),
@@ -1776,8 +1777,9 @@ func (t *Translator) processTCPRouteParentRefs(tcpRoute *TCPRouteContext, resour
 
 			gwXdsIR := xdsIR[irKey]
 			irListener := gwXdsIR.GetTCPListener(irListenerName(listener))
-			// When there's multiple TCPRoutes attached to same listener,
-			// the oldest one win.
+			// When multiple TCPRoutes target the same Gateway listener, all of must report Accepted=True.
+			// Only the oldest route is attached to the listener, and the listener's AttachedRoutes count must reflect this.
+			// https://github.com/kubernetes-sigs/gateway-api/blob/cf34ac933d068c6008598cce945819ce9cee16be/conformance/tests/tcproute-multiple-routes-attachment.go#L104
 			if irListener != nil && len(irListener.Routes) == 0 {
 				irRoute := &ir.TCPRoute{
 					Name: irTCPRouteName(tcpRoute),

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
@@ -15,7 +15,7 @@ gateways:
       protocol: TCP
   status:
     listeners:
-    - attachedRoutes: 1
+    - attachedRoutes: 2
       conditions:
       - lastTransitionTime: null
         message: Sending translated listener configuration to the data plane
@@ -103,9 +103,9 @@ tcpRoutes:
     parents:
     - conditions:
       - lastTransitionTime: null
-        message: Multiple routes on the same TCP listener
-        reason: UnsupportedValue
-        status: "False"
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Resolved all the Object references for the Route
@@ -182,3 +182,27 @@ xdsIR:
           name: tcproute-1
           namespace: default
         name: tcproute/default/tcproute-1
+      - destination:
+          metadata:
+            kind: TCPRoute
+            name: tcproute-2
+            namespace: default
+          name: tcproute/default/tcproute-2/rule/-1
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8163
+            metadata:
+              kind: Service
+              name: service-2
+              namespace: default
+              sectionName: "8163"
+            name: tcproute/default/tcproute-2/rule/-1/backend/0
+            protocol: TCP
+            weight: 1
+        metadata:
+          kind: TCPRoute
+          name: tcproute-2
+          namespace: default
+        name: tcproute/default/tcproute-2

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-tcproutes.out.yaml
@@ -182,27 +182,3 @@ xdsIR:
           name: tcproute-1
           namespace: default
         name: tcproute/default/tcproute-1
-      - destination:
-          metadata:
-            kind: TCPRoute
-            name: tcproute-2
-            namespace: default
-          name: tcproute/default/tcproute-2/rule/-1
-          settings:
-          - addressType: IP
-            endpoints:
-            - host: 7.7.7.7
-              port: 8163
-            metadata:
-              kind: Service
-              name: service-2
-              namespace: default
-              sectionName: "8163"
-            name: tcproute/default/tcproute-2/rule/-1/backend/0
-            protocol: TCP
-            weight: 1
-        metadata:
-          kind: TCPRoute
-          name: tcproute-2
-          namespace: default
-        name: tcproute/default/tcproute-2

--- a/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-udproutes.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-single-listener-with-multiple-udproutes.out.yaml
@@ -15,7 +15,7 @@ gateways:
       protocol: UDP
   status:
     listeners:
-    - attachedRoutes: 1
+    - attachedRoutes: 2
       conditions:
       - lastTransitionTime: null
         message: Sending translated listener configuration to the data plane
@@ -103,9 +103,9 @@ udpRoutes:
     parents:
     - conditions:
       - lastTransitionTime: null
-        message: Multiple routes on the same UDP listener
-        reason: UnsupportedValue
-        status: "False"
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Resolved all the Object references for the Route

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
@@ -215,30 +215,6 @@ xdsIR:
           name: tcproute-1
           namespace: default
         name: tcproute/default/tcproute-1
-      - destination:
-          metadata:
-            kind: TCPRoute
-            name: tcproute-2
-            namespace: default
-          name: tcproute/default/tcproute-2/rule/-1
-          settings:
-          - addressType: IP
-            endpoints:
-            - host: 7.7.7.7
-              port: 8163
-            metadata:
-              kind: Service
-              name: service-2
-              namespace: default
-              sectionName: "8163"
-            name: tcproute/default/tcproute-2/rule/-1/backend/0
-            protocol: TCP
-            weight: 1
-        metadata:
-          kind: TCPRoute
-          name: tcproute-2
-          namespace: default
-        name: tcproute/default/tcproute-2
     - address: 0.0.0.0
       externalPort: 162
       metadata:
@@ -273,27 +249,3 @@ xdsIR:
           name: tcproute-1
           namespace: default
         name: tcproute/default/tcproute-1
-      - destination:
-          metadata:
-            kind: TCPRoute
-            name: tcproute-2
-            namespace: default
-          name: tcproute/default/tcproute-2/rule/-1
-          settings:
-          - addressType: IP
-            endpoints:
-            - host: 7.7.7.7
-              port: 8163
-            metadata:
-              kind: Service
-              name: service-2
-              namespace: default
-              sectionName: "8163"
-            name: tcproute/default/tcproute-2/rule/-1/backend/0
-            protocol: TCP
-            weight: 1
-        metadata:
-          kind: TCPRoute
-          name: tcproute-2
-          namespace: default
-        name: tcproute/default/tcproute-2

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-tcproutes-without-sectionname.out.yaml
@@ -21,7 +21,7 @@ gateways:
       protocol: TCP
   status:
     listeners:
-    - attachedRoutes: 1
+    - attachedRoutes: 2
       conditions:
       - lastTransitionTime: null
         message: Sending translated listener configuration to the data plane
@@ -42,7 +42,7 @@ gateways:
       supportedKinds:
       - group: gateway.networking.k8s.io
         kind: TCPRoute
-    - attachedRoutes: 1
+    - attachedRoutes: 2
       conditions:
       - lastTransitionTime: null
         message: Sending translated listener configuration to the data plane
@@ -136,9 +136,9 @@ tcpRoutes:
     parents:
     - conditions:
       - lastTransitionTime: null
-        message: Multiple routes on the same TCP listener
-        reason: UnsupportedValue
-        status: "False"
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Resolved all the Object references for the Route
@@ -215,6 +215,30 @@ xdsIR:
           name: tcproute-1
           namespace: default
         name: tcproute/default/tcproute-1
+      - destination:
+          metadata:
+            kind: TCPRoute
+            name: tcproute-2
+            namespace: default
+          name: tcproute/default/tcproute-2/rule/-1
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8163
+            metadata:
+              kind: Service
+              name: service-2
+              namespace: default
+              sectionName: "8163"
+            name: tcproute/default/tcproute-2/rule/-1/backend/0
+            protocol: TCP
+            weight: 1
+        metadata:
+          kind: TCPRoute
+          name: tcproute-2
+          namespace: default
+        name: tcproute/default/tcproute-2
     - address: 0.0.0.0
       externalPort: 162
       metadata:
@@ -249,3 +273,27 @@ xdsIR:
           name: tcproute-1
           namespace: default
         name: tcproute/default/tcproute-1
+      - destination:
+          metadata:
+            kind: TCPRoute
+            name: tcproute-2
+            namespace: default
+          name: tcproute/default/tcproute-2/rule/-1
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8163
+            metadata:
+              kind: Service
+              name: service-2
+              namespace: default
+              sectionName: "8163"
+            name: tcproute/default/tcproute-2/rule/-1/backend/0
+            protocol: TCP
+            weight: 1
+        metadata:
+          kind: TCPRoute
+          name: tcproute-2
+          namespace: default
+        name: tcproute/default/tcproute-2

--- a/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-without-sectionname.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-two-listeners-with-udproutes-without-sectionname.out.yaml
@@ -21,7 +21,7 @@ gateways:
       protocol: UDP
   status:
     listeners:
-    - attachedRoutes: 1
+    - attachedRoutes: 2
       conditions:
       - lastTransitionTime: null
         message: Sending translated listener configuration to the data plane
@@ -42,7 +42,7 @@ gateways:
       supportedKinds:
       - group: gateway.networking.k8s.io
         kind: UDPRoute
-    - attachedRoutes: 1
+    - attachedRoutes: 2
       conditions:
       - lastTransitionTime: null
         message: Sending translated listener configuration to the data plane
@@ -136,9 +136,9 @@ udpRoutes:
     parents:
     - conditions:
       - lastTransitionTime: null
-        message: Multiple routes on the same UDP listener
-        reason: UnsupportedValue
-        status: "False"
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Resolved all the Object references for the Route

--- a/test/conformance/suite.go
+++ b/test/conformance/suite.go
@@ -51,9 +51,6 @@ func conformanceOpts(t *testing.T) suite.ConformanceOptions {
 	opts.SkipTests = append(opts.SkipTests,
 		// TODO: retry after https://github.com/envoyproxy/gateway/pull/9196 merged
 		tests.GatewayListenerUnsupportedProtocol.ShortName,
-		// TODO: will be fixed in https://github.com/envoyproxy/gateway/pull/9247
-		tests.TCPRouteMultipleRoutesAttachment.ShortName,
-		tests.UDPRouteMultipleRoutesAttachment.ShortName,
 	)
 
 	opts.Hook = e2e.Hook


### PR DESCRIPTION
wait https://github.com/envoyproxy/gateway/pull/9232

fix UDPRouteMultipleRoutesAttachment and TCPRouteMultipleRoutesAttachment conformance test

Multiple TCP/UDP routes are allowed to accepted by a gateway, only the oldest route receives traffic.