### PR TITLE
fix(gatewayapi): reject entire cert chain when leaf is expired

### DIFF
--- a/internal/gatewayapi/tls.go
+++ b/internal/gatewayapi/tls.go
@@ -256,6 +256,8 @@ func filterValidCertificates(data []byte) ([]byte, status.ListenerError) {
 				break
 			}
 		}
+		// If the first PEM block (leaf) is expired or not-yet-valid, the entire
+		// chain is unusable. The private key matches the leaf, not the intermediate CA.
 		if !blockValid && blockIndex == 0 {
 			firstBlockInvalid = true
 		}

--- a/internal/gatewayapi/tls.go
+++ b/internal/gatewayapi/tls.go
@@ -201,6 +201,11 @@ func parseCertsFromTLSSecretsData(secrets []*corev1.Secret) ([]*corev1.Secret, [
 // It accepts certificate bundles (multiple PEM blocks) and returns only the valid certificates.
 // A certificate is considered valid if the current time is within its NotBefore and NotAfter period.
 //
+// If the first PEM block (the leaf certificate) is expired or not yet valid, the entire chain
+// is considered invalid. This prevents a partial chain (e.g. intermediate CA without the leaf)
+// from being passed to Envoy, which would cause a KEY_VALUES_MISMATCH error because the
+// private key matches the leaf, not the intermediate.
+//
 // Return a status.ListenerError with InvalidCertificateRef Condition if no valid certificates are found in the provided data,
 // Return a status.ListenerError with PartiallyInvalidCertificateRef Condition if some certificates are invalid but also valid certificates exist.
 func filterValidCertificates(data []byte) ([]byte, status.ListenerError) {
@@ -214,9 +219,11 @@ func filterValidCertificates(data []byte) ([]byte, status.ListenerError) {
 	now := time.Now()
 	var errs []error
 	validData := make([]byte, 0, len(data))
+	var firstBlockInvalid bool
 
 	// Process each PEM block in the data
 	rest := data
+	blockIndex := 0
 	for len(rest) > 0 {
 		block, remaining := pem.Decode(rest)
 		if block == nil {
@@ -228,6 +235,10 @@ func filterValidCertificates(data []byte) ([]byte, status.ListenerError) {
 		certs, err := x509.ParseCertificates(block.Bytes)
 		if err != nil {
 			errs = append(errs, err)
+			if blockIndex == 0 {
+				firstBlockInvalid = true
+			}
+			blockIndex++
 			continue
 		}
 
@@ -245,10 +256,24 @@ func filterValidCertificates(data []byte) ([]byte, status.ListenerError) {
 				break
 			}
 		}
+		if !blockValid && blockIndex == 0 {
+			firstBlockInvalid = true
+		}
 		// Only include this PEM block if all certificates in it are valid
 		if blockValid {
 			validData = append(validData, pem.EncodeToMemory(block)...)
 		}
+		blockIndex++
+	}
+
+	// If the first PEM block (leaf certificate) was invalid, the entire chain is unusable.
+	// The private key matches the leaf, not the intermediate CA, so passing a partial
+	// chain would cause Envoy to reject it with KEY_VALUES_MISMATCH.
+	if firstBlockInvalid {
+		return nil, status.NewListenerStatusError(
+			errors.Join(errs...),
+			gwapiv1.ListenerReasonInvalidCertificateRef,
+		)
 	}
 
 	if len(validData) == 0 {

--- a/internal/gatewayapi/tls.go
+++ b/internal/gatewayapi/tls.go
@@ -235,9 +235,6 @@ func filterValidCertificates(data []byte) ([]byte, status.ListenerError) {
 		certs, err := x509.ParseCertificates(block.Bytes)
 		if err != nil {
 			errs = append(errs, err)
-			if blockIndex == 0 {
-				firstBlockInvalid = true
-			}
 			blockIndex++
 			continue
 		}

--- a/internal/gatewayapi/tls_test.go
+++ b/internal/gatewayapi/tls_test.go
@@ -6,11 +6,17 @@
 package gatewayapi
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -408,6 +414,54 @@ func TestFilterValidCertificates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFilterValidCertificates_ExpiredLeafWithValidChain(t *testing.T) {
+	// Generate an expired leaf certificate and a valid intermediate CA cert.
+	// When the leaf is expired but the chain is valid, filterValidCertificates
+	// should reject the entire chain (not just the leaf) because the private
+	// key matches the leaf, not the intermediate.
+
+	// Create a valid cert (not expired)
+	validKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	validTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Intermediate CA"},
+		NotBefore:    time.Now().Add(-24 * time.Hour),
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		IsCA:         true,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	validCertDER, err := x509.CreateCertificate(rand.Reader, validTemplate, validTemplate, &validKey.PublicKey, validKey)
+	require.NoError(t, err)
+	validCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: validCertDER})
+
+	// Create an expired leaf cert
+	expiredKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	expiredTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "expired.example.com"},
+		NotBefore:    time.Now().Add(-48 * time.Hour),
+		NotAfter:     time.Now().Add(-24 * time.Hour), // expired yesterday
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	expiredCertDER, err := x509.CreateCertificate(rand.Reader, expiredTemplate, validTemplate, &expiredKey.PublicKey, validKey)
+	require.NoError(t, err)
+	expiredCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: expiredCertDER})
+
+	// Chain: expired leaf + valid intermediate
+	chainData := append(expiredCertPEM, validCertPEM...)
+
+	// The entire chain should be rejected because the leaf is expired
+	result, listenerErr := filterValidCertificates(chainData)
+	require.Error(t, listenerErr)
+	require.Nil(t, result)
+	require.Equal(t, gwapiv1.ListenerReasonInvalidCertificateRef, listenerErr.Reason())
+	require.Contains(t, listenerErr.Error(), "expired")
 }
 
 func TestAppendDedupPEMCertsWithSeen(t *testing.T) {

--- a/internal/gatewayapi/tls_test.go
+++ b/internal/gatewayapi/tls_test.go
@@ -454,7 +454,7 @@ func TestFilterValidCertificates_ExpiredLeafWithValidChain(t *testing.T) {
 	expiredCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: expiredCertDER})
 
 	// Chain: expired leaf + valid intermediate
-	chainData = append(expiredCertPEM, validCertPEM...)
+	chainData := append(expiredCertPEM, validCertPEM...)
 
 	// The entire chain should be rejected because the leaf is expired
 	result, listenerErr := filterValidCertificates(chainData)

--- a/internal/gatewayapi/tls_test.go
+++ b/internal/gatewayapi/tls_test.go
@@ -454,7 +454,7 @@ func TestFilterValidCertificates_ExpiredLeafWithValidChain(t *testing.T) {
 	expiredCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: expiredCertDER})
 
 	// Chain: expired leaf + valid intermediate
-	chainData := append(expiredCertPEM, validCertPEM...)
+	chainData = append(expiredCertPEM, validCertPEM...)
 
 	// The entire chain should be rejected because the leaf is expired
 	result, listenerErr := filterValidCertificates(chainData)


### PR DESCRIPTION
When a TLS secret contains a certificate chain where the leaf certificate is expired but the intermediate CA is still valid, `filterValidCertificates` was filtering out only the expired leaf. The remaining chain (intermediate CA only) was passed to Envoy, which then rejected it with KEY_VALUES_MISMATCH because the private key belongs to the leaf, not the CA.

This fix checks if the first PEM block (the leaf) is expired. If it is, the entire chain is rejected -- same as if all certs were expired.

Fixes #9225