### PR TITLE
fix: CTP port overlap check fails when gateway name is a prefix of another

### DIFF
--- a/internal/gatewayapi/clienttrafficpolicy.go
+++ b/internal/gatewayapi/clienttrafficpolicy.go
@@ -401,10 +401,10 @@ func validatePortOverlapForClientTrafficPolicy(l *ListenerContext, xds *ir.Xds, 
 				// is turned on, validate that all the listeners affected by this policy originated
 				// from the same Gateway resource. The name of the Gateway from which this listener
 				// originated is part of the listener's name by construction.
-				gatewayName := extractGatewayNameFromListener(irListenerName)
+				gatewayName := extractGatewayNameFromListener(irListenerName) + "/"
 				conflictingListeners := []string{}
 				for _, currName := range sameListeners {
-					if strings.Index(currName, gatewayName) != 0 {
+					if !strings.HasPrefix(currName, gatewayName) {
 						conflictingListeners = append(conflictingListeners, currName)
 					}
 				}


### PR DESCRIPTION
When mergeGateways is enabled, two gateways with names like `gw` and `gw-b` on the same port should conflict. They don't, because the prefix check in `validatePortOverlapForClientTrafficPolicy` uses `strings.Index` without a trailing slash, so `"envoy-gateway/gw"` matches `"envoy-gateway/gw-b/http"`.

The same class of bug was fixed in #9026 for `extractListenerSetPrefixFromListener` by adding a trailing slash. Same approach here.

Changes:
- `extractGatewayNameFromListener(irListenerName) + "/"` -- adds trailing slash to the prefix
- `strings.HasPrefix(currName, gatewayName)` instead of `strings.Index(...) != 0` -- clearer intent, same behavior

Repro: create gateways `gw` and `gw-b` both with port 8081, apply a gateway-wide CTP targeting `gw`. Before this fix it's accepted (wrong). After, it correctly returns an error about multiple listeners on the same port.

Fixes #9226