### PR TITLE
fix(docs): links still pointing to /contributions

### DIFF
--- a/site/layouts/shortcodes/adopters.html
+++ b/site/layouts/shortcodes/adopters.html
@@ -10,7 +10,7 @@
       </div>
     </a>
     {{ end }}
-    <a class="adopter" href="https://github.com/envoyproxy/gateway/blob/main/site/content/en/contributions/ADOPTERS.md" target="_blank" rel="noopener noreferrer">
+    <a class="adopter" href="https://github.com/envoyproxy/gateway/blob/main/site/content/en/community/ADOPTERS.md" target="_blank" rel="noopener noreferrer">
       <img src="/img/add-your-logo-here.svg" alt="Add your logo here!" loading="lazy">
       <div class="adopter-info">
         <p>Using Envoy Gateway? You can add your logo here! Click to learn more.</p>

--- a/site/layouts/shortcodes/enterprise_support.html
+++ b/site/layouts/shortcodes/enterprise_support.html
@@ -10,7 +10,7 @@
       </div>
     </a>
     {{ end }}
-    <a class="adopter" href="https://github.com/envoyproxy/gateway/blob/main/site/content/en/contributions/ENTERPRISE_SUPPORT.md" target="_blank" rel="noopener noreferrer">
+    <a class="adopter" href="https://github.com/envoyproxy/gateway/blob/main/site/content/en/community/ENTERPRISE_SUPPORT.md" target="_blank" rel="noopener noreferrer">
       <img src="/img/add-your-logo-here.svg" alt="Add your logo here!" loading="lazy">
       <div class="adopter-info">
         <p>Provide enterprise support for Envoy Gateway? You can add your company here! Click to learn more.</p>


### PR DESCRIPTION
Fixes a couple of links in the homepage that are still pointing to `content/en/contributions`. https://github.com/envoyproxy/gateway/pull/8427 recently moved these files under `content/en/community`.
<!--
https://gateway.envoyproxy.io/community/develop/#raising-a-pr
-->
Release Notes: No
