### PR TITLE
perf: resolve ClientTrafficPolicy targets once

### DIFF
--- a/internal/gatewayapi/clienttrafficpolicy.go
+++ b/internal/gatewayapi/clienttrafficpolicy.go
@@ -228,23 +228,28 @@ func (t *Translator) ProcessClientTrafficPolicies(
 		}
 	}
 
+	// Resolve each policy's targets.
+	policyTargets := make([][]policyTargetReferenceWithSectionName, len(clientTrafficPolicies))
+	for i, currPolicy := range clientTrafficPolicies {
+		policyTargets[i] = resolvePolicyTargetsForGatewayAndListenerSet(
+			currPolicy.Spec.PolicyTargetReferences,
+			gateways,
+			resources.ListenerSets,
+			resources.ReferenceGrants,
+			egv1a1.GroupName,
+			egv1a1.KindClientTrafficPolicy,
+			currPolicy.Namespace,
+			t.GetNamespace,
+		)
+	}
+
 	// Policy with no section set (targeting all sections of a Gateway or ListenerSet).
 	// ListenerSet-wide policies are processed before Gateway-wide so that the more specific
 	// target always wins regardless of input order.
 	for _, passKind := range []gwapiv1.Kind{resource.KindListenerSet, resource.KindGateway} {
 		for i, currPolicy := range clientTrafficPolicies {
 			policyName := utils.NamespacedName(currPolicy)
-			targetRefs := resolvePolicyTargetsForGatewayAndListenerSet(
-				currPolicy.Spec.PolicyTargetReferences,
-				gateways,
-				resources.ListenerSets,
-				resources.ReferenceGrants,
-				egv1a1.GroupName,
-				egv1a1.KindClientTrafficPolicy,
-				currPolicy.Namespace,
-				t.GetNamespace,
-			)
-			for _, currTarget := range targetRefs {
+			for _, currTarget := range policyTargets[i] {
 				if !hasSectionName(&currTarget) {
 
 					if currTarget.Kind != passKind {


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up to https://github.com/envoyproxy/gateway/pull/9026#discussion_r3431210648.

Previously `resolvePolicyTargetsForGatewayAndListenerSet` was called inside that `passKind` loop, so every policy's targets were resolved twice. This hoists the resolution into a precomputed slice (`policyTargets`) ahead of the loop, leaving target resolution to run once per policy. The two-pass ordering behavior is unchanged.


<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add the description to the release-notes/current.yaml file and include this file in the PR.
-->
Release Notes: No
