### PR TITLE
fix: register ListenerSet and route indexes in offline controller

### DIFF
--- a/internal/provider/kubernetes/controller_offline.go
+++ b/internal/provider/kubernetes/controller_offline.go
@@ -158,17 +158,23 @@ func newOfflineGatewayAPIClient(extensionPolicies []schema.GroupVersionKind) cli
 		WithScheme(scheme).
 		WithIndex(&gwapiv1.Gateway{}, classGatewayIndex, gatewayIndexFunc).
 		WithIndex(&gwapiv1.Gateway{}, secretGatewayIndex, secretGatewayIndexFunc).
+		WithIndex(&gwapiv1.ListenerSet{}, gatewayListenerSetIndex, gatewayListenerSetIndexFunc).
 		WithIndex(&gwapiv1.HTTPRoute{}, gatewayHTTPRouteIndex, gatewayHTTPRouteIndexFunc).
 		WithIndex(&gwapiv1.HTTPRoute{}, backendHTTPRouteIndex, backendHTTPRouteIndexFunc).
+		WithIndex(&gwapiv1.HTTPRoute{}, listenerSetHTTPRouteIndex, listenerSetHTTPRouteIndexFunc).
 		WithIndex(&gwapiv1.HTTPRoute{}, httpRouteFilterHTTPRouteIndex, httpRouteFilterHTTPRouteIndexFunc).
 		WithIndex(&gwapiv1.GRPCRoute{}, gatewayGRPCRouteIndex, gatewayGRPCRouteIndexFunc).
 		WithIndex(&gwapiv1.GRPCRoute{}, backendGRPCRouteIndex, backendGRPCRouteIndexFunc).
+		WithIndex(&gwapiv1.GRPCRoute{}, listenerSetGRPCRouteIndex, listenerSetGRPCRouteIndexFunc).
 		WithIndex(&gwapiv1.TCPRoute{}, gatewayTCPRouteIndex, gatewayTCPRouteIndexFunc).
 		WithIndex(&gwapiv1.TCPRoute{}, backendTCPRouteIndex, backendTCPRouteIndexFunc).
+		WithIndex(&gwapiv1.TCPRoute{}, listenerSetTCPRouteIndex, listenerSetTCPRouteIndexFunc).
 		WithIndex(&gwapiv1.UDPRoute{}, gatewayUDPRouteIndex, gatewayUDPRouteIndexFunc).
 		WithIndex(&gwapiv1.UDPRoute{}, backendUDPRouteIndex, backendUDPRouteIndexFunc).
+		WithIndex(&gwapiv1.UDPRoute{}, listenerSetUDPRouteIndex, listenerSetUDPRouteIndexFunc).
 		WithIndex(&gwapiv1.TLSRoute{}, gatewayTLSRouteIndex, gatewayTLSRouteIndexFunc).
 		WithIndex(&gwapiv1.TLSRoute{}, backendTLSRouteIndex, backendTLSRouteIndexFunc).
+		WithIndex(&gwapiv1.TLSRoute{}, listenerSetTLSRouteIndex, listenerSetTLSRouteIndexFunc).
 		WithIndex(&egv1a1.EnvoyProxy{}, backendEnvoyProxyTelemetryIndex, backendEnvoyProxyTelemetryIndexFunc).
 		WithIndex(&egv1a1.EnvoyProxy{}, secretEnvoyProxyIndex, secretEnvoyProxyIndexFunc).
 		WithIndex(&egv1a1.BackendTrafficPolicy{}, configMapBtpIndex, configMapBtpIndexFunc).
@@ -181,6 +187,7 @@ func newOfflineGatewayAPIClient(extensionPolicies []schema.GroupVersionKind) cli
 		WithIndex(&egv1a1.EnvoyExtensionPolicy{}, backendEnvoyExtensionPolicyIndex, backendEnvoyExtensionPolicyIndexFunc).
 		WithIndex(&egv1a1.EnvoyExtensionPolicy{}, secretEnvoyExtensionPolicyIndex, secretEnvoyExtensionPolicyIndexFunc).
 		WithIndex(&egv1a1.EnvoyExtensionPolicy{}, configMapEepIndex, configMapEepIndexFunc).
+		WithIndex(&egv1a1.EnvoyExtensionPolicy{}, clusterTrustBundleEepIndex, clusterTrustBundleEepIndexFunc).
 		WithIndex(&gwapiv1.BackendTLSPolicy{}, configMapBtlsIndex, configMapBtlsIndexFunc).
 		WithIndex(&gwapiv1.BackendTLSPolicy{}, secretBtlsIndex, secretBtlsIndexFunc).
 		WithIndex(&gwapiv1.BackendTLSPolicy{}, clusterTrustBundleBtlsIndex, clusterTrustBundleBtlsIndexFunc).

--- a/internal/provider/kubernetes/controller_offline_test.go
+++ b/internal/provider/kubernetes/controller_offline_test.go
@@ -140,10 +140,17 @@ func TestNewOfflineGatewayAPIControllerIndexRegistration(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("ListenerSet index", func(t *testing.T) {
+		err := cli.List(context.Background(), &gwapiv1.ListenerSetList{}, client.MatchingFields{gatewayListenerSetIndex: "any"})
+		require.NoError(t, err)
+	})
+
 	t.Run("HTTPRoute indices", func(t *testing.T) {
 		err := cli.List(context.Background(), &gwapiv1.HTTPRouteList{}, client.MatchingFields{gatewayHTTPRouteIndex: "any"})
 		require.NoError(t, err)
 		err = cli.List(context.Background(), &gwapiv1.HTTPRouteList{}, client.MatchingFields{backendHTTPRouteIndex: "any"})
+		require.NoError(t, err)
+		err = cli.List(context.Background(), &gwapiv1.HTTPRouteList{}, client.MatchingFields{listenerSetHTTPRouteIndex: "any"})
 		require.NoError(t, err)
 		err = cli.List(context.Background(), &gwapiv1.HTTPRouteList{}, client.MatchingFields{httpRouteFilterHTTPRouteIndex: "any"})
 		require.NoError(t, err)
@@ -154,12 +161,16 @@ func TestNewOfflineGatewayAPIControllerIndexRegistration(t *testing.T) {
 		require.NoError(t, err)
 		err = cli.List(context.Background(), &gwapiv1.GRPCRouteList{}, client.MatchingFields{backendGRPCRouteIndex: "any"})
 		require.NoError(t, err)
+		err = cli.List(context.Background(), &gwapiv1.GRPCRouteList{}, client.MatchingFields{listenerSetGRPCRouteIndex: "any"})
+		require.NoError(t, err)
 	})
 
 	t.Run("TCPRoute indices", func(t *testing.T) {
 		err := cli.List(context.Background(), &gwapiv1.TCPRouteList{}, client.MatchingFields{gatewayTCPRouteIndex: "any"})
 		require.NoError(t, err)
 		err = cli.List(context.Background(), &gwapiv1.TCPRouteList{}, client.MatchingFields{backendTCPRouteIndex: "any"})
+		require.NoError(t, err)
+		err = cli.List(context.Background(), &gwapiv1.TCPRouteList{}, client.MatchingFields{listenerSetTCPRouteIndex: "any"})
 		require.NoError(t, err)
 	})
 
@@ -168,12 +179,16 @@ func TestNewOfflineGatewayAPIControllerIndexRegistration(t *testing.T) {
 		require.NoError(t, err)
 		err = cli.List(context.Background(), &gwapiv1.UDPRouteList{}, client.MatchingFields{backendUDPRouteIndex: "any"})
 		require.NoError(t, err)
+		err = cli.List(context.Background(), &gwapiv1.UDPRouteList{}, client.MatchingFields{listenerSetUDPRouteIndex: "any"})
+		require.NoError(t, err)
 	})
 
 	t.Run("TLSRoute indices", func(t *testing.T) {
 		err := cli.List(context.Background(), &gwapiv1.TLSRouteList{}, client.MatchingFields{gatewayTLSRouteIndex: "any"})
 		require.NoError(t, err)
 		err = cli.List(context.Background(), &gwapiv1.TLSRouteList{}, client.MatchingFields{backendTLSRouteIndex: "any"})
+		require.NoError(t, err)
+		err = cli.List(context.Background(), &gwapiv1.TLSRouteList{}, client.MatchingFields{listenerSetTLSRouteIndex: "any"})
 		require.NoError(t, err)
 	})
 
@@ -213,6 +228,8 @@ func TestNewOfflineGatewayAPIControllerIndexRegistration(t *testing.T) {
 		err = cli.List(context.Background(), &egv1a1.EnvoyExtensionPolicyList{}, client.MatchingFields{secretEnvoyExtensionPolicyIndex: "any"})
 		require.NoError(t, err)
 		err = cli.List(context.Background(), &egv1a1.EnvoyExtensionPolicyList{}, client.MatchingFields{configMapEepIndex: "any"})
+		require.NoError(t, err)
+		err = cli.List(context.Background(), &egv1a1.EnvoyExtensionPolicyList{}, client.MatchingFields{clusterTrustBundleEepIndex: "any"})
 		require.NoError(t, err)
 	})
 

--- a/release-notes/current/bug_fixes/9320-offline-controller-listenerset-indexes.md
+++ b/release-notes/current/bug_fixes/9320-offline-controller-listenerset-indexes.md
@@ -1,0 +1,1 @@
+Fixed the standalone offline controller used by the File provider to register the missing ListenerSet, ListenerSet-owned route, and ClusterTrustBundle EnvoyExtensionPolicy indexes so reconciliation no longer fails with unregistered index errors.


### PR DESCRIPTION
## Problem

When running Envoy Gateway in standalone (Host) mode with the File provider, the offline controller does not register the `gatewayListenerSetIndex` field index. This causes repeated errors during Gateway reconciliation:

```
error provider kubernetes/controller.go:2061 failed to list ListenerSets
  error: "no index with name gatewayListenerSetIndex has been registered
          for GroupVersionKind gateway.networking.k8s.io/v1, Kind=ListenerSet"
```

The ListenerSet functionality is completely non-functional in standalone mode.

## Root Cause

The offline controller (`internal/provider/kubernetes/controller_offline.go`) used by the File provider was missing several field indexes that the Gateway reconciliation logic depends on. These indexes are registered by the Kubernetes provider in `addListenerSetIndexers`, `addHTTPRouteIndexers`, etc., but were not carried over when the offline controller was created for standalone mode.

## Changes

### `internal/provider/kubernetes/controller_offline.go`

Added 7 missing field indexes to `newOfflineGatewayAPIClient`:

| Index | Type | Purpose |
|---|---|---|
| `gatewayListenerSetIndex` | `ListenerSet` | Query ListenerSets by parent Gateway (root cause) |
| `listenerSetHTTPRouteIndex` | `HTTPRoute` | Query HTTPRoutes by parent ListenerSet |
| `listenerSetGRPCRouteIndex` | `GRPCRoute` | Query GRPCRoutes by parent ListenerSet |
| `listenerSetTCPRouteIndex` | `TCPRoute` | Query TCPRoutes by parent ListenerSet |
| `listenerSetUDPRouteIndex` | `UDPRoute` | Query UDPRoutes by parent ListenerSet |
| `listenerSetTLSRouteIndex` | `TLSRoute` | Query TLSRoutes by parent ListenerSet |
| `clusterTrustBundleEepIndex` | `EnvoyExtensionPolicy` | Query EEPs by ClusterTrustBundle ref |

### `internal/provider/kubernetes/controller_offline_test.go`

Added test coverage for all newly registered indexes in `TestNewOfflineGatewayAPIControllerIndexRegistration`:
- New `ListenerSet_index` sub-test
- Extended `HTTPRoute_indices`, `GRPCRoute_indices`, `TCPRoute_indices`, `UDPRoute_indices`, `TLSRoute_indices`, and `EnvoyExtensionPolicy_indices` sub-tests with listenerSet/clusterTrustBundle index checks

## Verification

- ✅ Unit tests pass (including new `ListenerSet_index` test)
- ✅ End-to-end verification: `gatewayListenerSetIndex` error count drops from multiple-per-reconcile to **0**
- ✅ Build succeeds

## Impact

- **Functionality**: ListenerSet now works correctly in standalone mode
- **Performance**: Eliminates repeated error logging on every reconciliation cycle
- **User Experience**: No more confusing error messages for standalone mode users