### PR TITLE
fix: consolidate destination AppProtocol handling

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -2509,7 +2509,7 @@ func (t *Translator) processBackendDestinationSetting(
 		protocol = resolveBackendProtocol(string(ap), protocol)
 		// For WebSocket backends, force HTTP/1.1 upstream to ensure Envoy can establish a successful connection,
 		// as WebSocket over HTTP/2 is not widely supported by upstreams and can lead to connection failures.
-		forceHTTP1Upstream = forceHTTP1Upstream || isWebSocketAppProtocol(string(ap))
+		forceHTTP1Upstream = forceHTTP1Upstream || shouldForceHTTP1Upstream(protocol, (*string)(&ap))
 	}
 
 	ds := &ir.DestinationSetting{Name: name}

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -2041,11 +2041,11 @@ func (t *Translator) processServiceImportDestinationSetting(
 	}
 
 	if servicePort.AppProtocol != nil {
-		protocol = serviceAppProtocolToIRAppProtocol(*servicePort.AppProtocol, protocol, false)
+		protocol = appProtocolToIRAppProtocol(*servicePort.AppProtocol, protocol)
 	}
 	// For WebSocket services, force HTTP/1.1 upstream to ensure Envoy can establish a successful connection,
 	// as WebSocket over HTTP/2 is not widely supported by upstreams and can lead to connection failures.
-	forceHTTP1Upstream := servicePort.AppProtocol != nil && isWebSocketServiceAppProtocol(*servicePort.AppProtocol)
+	forceHTTP1Upstream := servicePort.AppProtocol != nil && isWebSocketAppProtocol(*servicePort.AppProtocol)
 
 	backendIps := serviceImport.Spec.IPs
 	isHeadless := len(backendIps) == 0
@@ -2113,11 +2113,11 @@ func (t *Translator) processServiceDestinationSetting(
 
 	// support HTTPRouteBackendProtocolH2C/GRPC
 	if servicePort.AppProtocol != nil {
-		protocol = serviceAppProtocolToIRAppProtocol(*servicePort.AppProtocol, protocol, true)
+		protocol = appProtocolToIRAppProtocol(*servicePort.AppProtocol, protocol)
 	}
 	// For WebSocket services, force HTTP/1.1 upstream to ensure Envoy can establish a successful connection,
 	// as WebSocket over HTTP/2 is not widely supported by upstreams and can lead to connection failures.
-	forceHTTP1Upstream := servicePort.AppProtocol != nil && isWebSocketServiceAppProtocol(*servicePort.AppProtocol)
+	forceHTTP1Upstream := servicePort.AppProtocol != nil && isWebSocketAppProtocol(*servicePort.AppProtocol)
 
 	isHeadless := isServiceHeadless(service)
 
@@ -2258,7 +2258,12 @@ func inspectAppProtocolByRouteKind(kind gwapiv1.Kind) ir.AppProtocol {
 	case resource.KindGRPCRoute:
 		return ir.GRPC
 	case resource.KindTLSRoute:
-		return ir.HTTPS
+		// TLSRoute is translated into an ir.TCPRoute. The upstream protocol is
+		// plain TCP from Envoy's perspective; whether the upstream connection is
+		// secured by TLS is governed by ds.TLS (e.g. via BackendTLSPolicy), not by
+		// the AppProtocol. Returning ir.TCP keeps the IR semantically accurate and
+		// avoids emitting HTTP protocol options on a TCP proxy cluster.
+		return ir.TCP
 	}
 	return ir.TCP
 }
@@ -2502,10 +2507,10 @@ func (t *Translator) processBackendDestinationSetting(
 	addrTypeMap := make(map[ir.DestinationAddressType]int)
 	backend := t.GetBackend(backendNamespace, string(backendRef.Name))
 	for _, ap := range backend.Spec.AppProtocols {
-		protocol = backendAppProtocolToIRAppProtocol(ap, protocol)
+		protocol = appProtocolToIRAppProtocol(string(ap), protocol)
 		// For WebSocket backends, force HTTP/1.1 upstream to ensure Envoy can establish a successful connection,
 		// as WebSocket over HTTP/2 is not widely supported by upstreams and can lead to connection failures.
-		forceHTTP1Upstream = forceHTTP1Upstream || isWebSocketBackendAppProtocol(ap)
+		forceHTTP1Upstream = forceHTTP1Upstream || isWebSocketAppProtocol(string(ap))
 	}
 
 	ds := &ir.DestinationSetting{Name: name}
@@ -2572,43 +2577,38 @@ func (t *Translator) processBackendDestinationSetting(
 	return ds
 }
 
-// serviceAppProtocolToIRAppProtocol translates the appProtocol string into an ir.AppProtocol.
+// appProtocolToIRAppProtocol translates an appProtocol string into an ir.AppProtocol.
+// It recognizes both the Kubernetes Service convention ("kubernetes.io/*") and the
+// Envoy Gateway Backend convention ("gateway.envoyproxy.io/*").
 //
-// When grpcCompatibility is enabled, `grpc` will be parsed as a valid option for HTTP2.
-// See https://github.com/envoyproxy/gateway/issues/5485#issuecomment-2731322578.
-func serviceAppProtocolToIRAppProtocol(ap string, defaultProtocol ir.AppProtocol, grpcCompatibility bool) ir.AppProtocol {
+// appProtocol describes an HTTP-layer protocol (h2c/ws/grpc), so it only refines the
+// upstream protocol of HTTP-based routes. For non-HTTP routes (e.g. TCPRoute, TLSRoute
+// and UDPRoute, whose default protocol is TCP/UDP), the route is a raw L4 proxy and the
+// appProtocol is irrelevant; returning the default avoids emitting HTTP protocol options
+// on an L4 cluster.
+func appProtocolToIRAppProtocol(ap string, defaultProtocol ir.AppProtocol) ir.AppProtocol {
+	if defaultProtocol != ir.HTTP {
+		return defaultProtocol
+	}
 	switch {
-	case ap == "kubernetes.io/h2c":
+	case ap == "kubernetes.io/h2c" || ap == string(egv1a1.AppProtocolTypeH2C):
 		return ir.HTTP2
-	case ap == "kubernetes.io/ws" || ap == "kubernetes.io/wss":
+	case isWebSocketAppProtocol(ap):
 		return ir.HTTP
-	case ap == "grpc" && grpcCompatibility:
+	case ap == "grpc":
 		return ir.GRPC
 	default:
 		return defaultProtocol
 	}
 }
 
-func isWebSocketServiceAppProtocol(ap string) bool {
-	return ap == "kubernetes.io/ws" || ap == "kubernetes.io/wss"
-}
-
-func backendAppProtocolToIRAppProtocol(ap egv1a1.AppProtocolType, defaultProtocol ir.AppProtocol) ir.AppProtocol {
+// isWebSocketAppProtocol reports whether the given appProtocol denotes WebSocket
+// traffic, covering both the Kubernetes Service convention ("kubernetes.io/ws[s]")
+// and the Envoy Gateway Backend convention ("gateway.envoyproxy.io/ws[s]").
+func isWebSocketAppProtocol(ap string) bool {
 	switch ap {
-	case egv1a1.AppProtocolTypeH2C:
-		return ir.HTTP2
-	case egv1a1.AppProtocolTypeWS, egv1a1.AppProtocolTypeWSS:
-		return ir.HTTP
-	case "grpc":
-		return ir.GRPC
-	default:
-		return defaultProtocol
-	}
-}
-
-func isWebSocketBackendAppProtocol(ap egv1a1.AppProtocolType) bool {
-	switch ap {
-	case egv1a1.AppProtocolTypeWS, egv1a1.AppProtocolTypeWSS:
+	case "kubernetes.io/ws", "kubernetes.io/wss",
+		string(egv1a1.AppProtocolTypeWS), string(egv1a1.AppProtocolTypeWSS):
 		return true
 	default:
 		return false

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -2599,6 +2599,7 @@ func resolveBackendProtocol(backendAppProtocol string, defaultProtocol ir.AppPro
 	case backendAppProtocol == "kubernetes.io/h2c" || backendAppProtocol == string(egv1a1.AppProtocolTypeH2C):
 		return ir.HTTP2
 	// HTTPRoute can route to gRPC backends, returning ir.GRPC allows the IR to emit gRPC protocol options on the cluster.
+	// Kubernetes does not standardize grpc as a Kubernetes appProtocol value, but some projects like Istio uses "grpc" as a convention for gRPC backends, so we recognize it here.
 	case backendAppProtocol == "grpc":
 		return ir.GRPC
 	default:

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -2593,7 +2593,7 @@ func resolveBackendProtocol(backendAppProtocol string, defaultProtocol ir.AppPro
 	switch {
 	case backendAppProtocol == "kubernetes.io/h2c" || backendAppProtocol == string(egv1a1.AppProtocolTypeH2C):
 		return ir.HTTP2
-	// HTTPRoute can reoute to gRPC backends, returning ir.GRPC allows the IR to emit gRPC protocol options on the cluster.
+	// HTTPRoute can route to gRPC backends, returning ir.GRPC allows the IR to emit gRPC protocol options on the cluster.
 	case backendAppProtocol == "grpc":
 		return ir.GRPC
 	default:

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -2593,9 +2593,7 @@ func appProtocolToIRAppProtocol(ap string, defaultProtocol ir.AppProtocol) ir.Ap
 	switch {
 	case ap == "kubernetes.io/h2c" || ap == string(egv1a1.AppProtocolTypeH2C):
 		return ir.HTTP2
-	case isWebSocketAppProtocol(ap):
-		return ir.HTTP
-	case ap == "grpc":
+	case ap == "grpc": // HTTPRoute can reoute to gRPC backends, returning ir.GRPC allows the IR to emit gRPC protocol options on the cluster.
 		return ir.GRPC
 	default:
 		return defaultProtocol

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -2044,6 +2044,8 @@ func (t *Translator) processServiceImportDestinationSetting(
 	if servicePort.AppProtocol != nil {
 		protocol = resolveBackendProtocol(*servicePort.AppProtocol, protocol)
 	}
+	// For WebSocket backends, force HTTP/1.1 upstream to ensure Envoy can establish a successful connection,
+	// as WebSocket over HTTP/2 is not widely supported by upstreams and can lead to connection failures.
 	forceHTTP1Upstream := shouldForceHTTP1Upstream(protocol, servicePort.AppProtocol)
 
 	backendIps := serviceImport.Spec.IPs
@@ -2115,6 +2117,8 @@ func (t *Translator) processServiceDestinationSetting(
 	if servicePort.AppProtocol != nil {
 		protocol = resolveBackendProtocol(*servicePort.AppProtocol, protocol)
 	}
+	// For WebSocket backends, force HTTP/1.1 upstream to ensure Envoy can establish a successful connection,
+	// as WebSocket over HTTP/2 is not widely supported by upstreams and can lead to connection failures.
 	forceHTTP1Upstream := shouldForceHTTP1Upstream(protocol, servicePort.AppProtocol)
 
 	isHeadless := isServiceHeadless(service)
@@ -2587,6 +2591,7 @@ func (t *Translator) processBackendDestinationSetting(
 // appProtocol is irrelevant; returning the default avoids emitting HTTP protocol options
 // on an L4 cluster.
 func resolveBackendProtocol(backendAppProtocol string, defaultProtocol ir.AppProtocol) ir.AppProtocol {
+	// The backendAppProtocol is only relevant for HTTP-based routes, so if the default protocol is not HTTP, return the default.
 	if defaultProtocol != ir.HTTP {
 		return defaultProtocol
 	}

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -2022,13 +2022,14 @@ func (t *Translator) processServiceImportDestinationSetting(
 	name string,
 	backendRef gwapiv1.BackendObjectReference,
 	backendNamespace string,
-	protocol ir.AppProtocol,
+	defaultProtocol ir.AppProtocol,
 	envoyProxy *egv1a1.EnvoyProxy,
 	btpRoutingType *egv1a1.RoutingType,
 ) (*ir.DestinationSetting, status.Error) {
 	var (
 		endpoints []*ir.DestinationEndpoint
 		addrType  *ir.DestinationAddressType
+		protocol  = defaultProtocol
 	)
 
 	serviceImport := t.GetServiceImport(backendNamespace, string(backendRef.Name))
@@ -2041,11 +2042,9 @@ func (t *Translator) processServiceImportDestinationSetting(
 	}
 
 	if servicePort.AppProtocol != nil {
-		protocol = appProtocolToIRAppProtocol(*servicePort.AppProtocol, protocol)
+		protocol = resolveBackendProtocol(*servicePort.AppProtocol, protocol)
 	}
-	// For WebSocket services, force HTTP/1.1 upstream to ensure Envoy can establish a successful connection,
-	// as WebSocket over HTTP/2 is not widely supported by upstreams and can lead to connection failures.
-	forceHTTP1Upstream := servicePort.AppProtocol != nil && isWebSocketAppProtocol(*servicePort.AppProtocol)
+	forceHTTP1Upstream := shouldForceHTTP1Upstream(protocol, servicePort.AppProtocol)
 
 	backendIps := serviceImport.Spec.IPs
 	isHeadless := len(backendIps) == 0
@@ -2083,7 +2082,7 @@ func (t *Translator) processServiceDestinationSetting(
 	name string,
 	backendRef gwapiv1.BackendObjectReference,
 	backendNamespace string,
-	protocol ir.AppProtocol,
+	defaultProtocol ir.AppProtocol,
 	envoyProxy *egv1a1.EnvoyProxy,
 	btpRoutingType *egv1a1.RoutingType,
 ) (*ir.DestinationSetting, status.Error) {
@@ -2091,6 +2090,7 @@ func (t *Translator) processServiceDestinationSetting(
 		endpoints []*ir.DestinationEndpoint
 		addrType  *ir.DestinationAddressType
 	)
+	protocol := defaultProtocol
 
 	service := t.GetService(backendNamespace, string(backendRef.Name))
 	// ExternalName Services have no ClusterIP and no EndpointSlices, so they cannot be
@@ -2113,11 +2113,9 @@ func (t *Translator) processServiceDestinationSetting(
 
 	// support HTTPRouteBackendProtocolH2C/GRPC
 	if servicePort.AppProtocol != nil {
-		protocol = appProtocolToIRAppProtocol(*servicePort.AppProtocol, protocol)
+		protocol = resolveBackendProtocol(*servicePort.AppProtocol, protocol)
 	}
-	// For WebSocket services, force HTTP/1.1 upstream to ensure Envoy can establish a successful connection,
-	// as WebSocket over HTTP/2 is not widely supported by upstreams and can lead to connection failures.
-	forceHTTP1Upstream := servicePort.AppProtocol != nil && isWebSocketAppProtocol(*servicePort.AppProtocol)
+	forceHTTP1Upstream := shouldForceHTTP1Upstream(protocol, servicePort.AppProtocol)
 
 	isHeadless := isServiceHeadless(service)
 
@@ -2499,15 +2497,16 @@ func (t *Translator) processBackendDestinationSetting(
 	name string,
 	backendRef gwapiv1.BackendObjectReference,
 	backendNamespace string,
-	protocol ir.AppProtocol,
+	defaultProtocol ir.AppProtocol,
 ) *ir.DestinationSetting {
 	var dstAddrType *ir.DestinationAddressType
+	protocol := defaultProtocol
 	forceHTTP1Upstream := false
 
 	addrTypeMap := make(map[ir.DestinationAddressType]int)
 	backend := t.GetBackend(backendNamespace, string(backendRef.Name))
 	for _, ap := range backend.Spec.AppProtocols {
-		protocol = appProtocolToIRAppProtocol(string(ap), protocol)
+		protocol = resolveBackendProtocol(string(ap), protocol)
 		// For WebSocket backends, force HTTP/1.1 upstream to ensure Envoy can establish a successful connection,
 		// as WebSocket over HTTP/2 is not widely supported by upstreams and can lead to connection failures.
 		forceHTTP1Upstream = forceHTTP1Upstream || isWebSocketAppProtocol(string(ap))
@@ -2577,26 +2576,44 @@ func (t *Translator) processBackendDestinationSetting(
 	return ds
 }
 
-// appProtocolToIRAppProtocol translates an appProtocol string into an ir.AppProtocol.
-// It recognizes both the Kubernetes Service convention ("kubernetes.io/*") and the
-// Envoy Gateway Backend convention ("gateway.envoyproxy.io/*").
+// resolveBackendProtocol computes the upstream ir.AppProtocol for a backend from the
+// backend's own appProtocol and the route's default (fallback) protocol. It recognizes
+// both the Kubernetes Service convention ("kubernetes.io/*") and the Envoy Gateway
+// Backend convention ("gateway.envoyproxy.io/*").
 //
-// appProtocol describes an HTTP-layer protocol (h2c/ws/grpc), so it only refines the
-// upstream protocol of HTTP-based routes. For non-HTTP routes (e.g. TCPRoute, TLSRoute
+// backendAppProtocol describes an HTTP-layer protocol (h2c/ws/grpc), so it only refines
+// the upstream protocol of HTTP-based routes. For non-HTTP routes (e.g. TCPRoute, TLSRoute
 // and UDPRoute, whose default protocol is TCP/UDP), the route is a raw L4 proxy and the
 // appProtocol is irrelevant; returning the default avoids emitting HTTP protocol options
 // on an L4 cluster.
-func appProtocolToIRAppProtocol(ap string, defaultProtocol ir.AppProtocol) ir.AppProtocol {
+func resolveBackendProtocol(backendAppProtocol string, defaultProtocol ir.AppProtocol) ir.AppProtocol {
 	if defaultProtocol != ir.HTTP {
 		return defaultProtocol
 	}
 	switch {
-	case ap == "kubernetes.io/h2c" || ap == string(egv1a1.AppProtocolTypeH2C):
+	case backendAppProtocol == "kubernetes.io/h2c" || backendAppProtocol == string(egv1a1.AppProtocolTypeH2C):
 		return ir.HTTP2
-	case ap == "grpc": // HTTPRoute can reoute to gRPC backends, returning ir.GRPC allows the IR to emit gRPC protocol options on the cluster.
+	// HTTPRoute can reoute to gRPC backends, returning ir.GRPC allows the IR to emit gRPC protocol options on the cluster.
+	case backendAppProtocol == "grpc":
 		return ir.GRPC
 	default:
 		return defaultProtocol
+	}
+}
+
+// shouldForceHTTP1Upstream reports whether the upstream connection should be forced to
+// HTTP/1.1. WebSocket over HTTP/2 is not widely supported by upstreams and can lead to
+// connection failures, so a WebSocket backend on an HTTP-based route must use HTTP/1.1.
+func shouldForceHTTP1Upstream(appProtocol ir.AppProtocol, backendAppProtocol *string) bool {
+	return backendAppProtocol != nil && isHTTPProtocol(appProtocol) && isWebSocketAppProtocol(*backendAppProtocol)
+}
+
+func isHTTPProtocol(appProtocol ir.AppProtocol) bool {
+	switch appProtocol {
+	case ir.HTTP, ir.HTTP2, ir.GRPC:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/gatewayapi/route_test.go
+++ b/internal/gatewayapi/route_test.go
@@ -98,7 +98,7 @@ func TestAppProtocolToIRAppProtocol(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, appProtocolToIRAppProtocol(tt.appProtocol, tt.defaultProtocol))
+			require.Equal(t, tt.want, resolveBackendProtocol(tt.appProtocol, tt.defaultProtocol))
 			require.Equal(t, tt.wantForceHTTP1, isWebSocketAppProtocol(tt.appProtocol))
 		})
 	}

--- a/internal/gatewayapi/route_test.go
+++ b/internal/gatewayapi/route_test.go
@@ -21,47 +21,59 @@ import (
 	"github.com/envoyproxy/gateway/internal/ir"
 )
 
-func TestServiceAppProtocolToIRAppProtocol(t *testing.T) {
+func TestAppProtocolToIRAppProtocol(t *testing.T) {
 	tests := []struct {
-		name              string
-		appProtocol       string
-		defaultProtocol   ir.AppProtocol
-		grpcCompatibility bool
-		want              ir.AppProtocol
-		wantForceHTTP1    bool
+		name            string
+		appProtocol     string
+		defaultProtocol ir.AppProtocol
+		want            ir.AppProtocol
+		wantForceHTTP1  bool
 	}{
 		{
-			name:            "h2c",
+			name:            "h2c service convention",
 			appProtocol:     "kubernetes.io/h2c",
 			defaultProtocol: ir.HTTP,
 			want:            ir.HTTP2,
 		},
 		{
-			name:            "ws",
+			name:            "h2c backend convention",
+			appProtocol:     "gateway.envoyproxy.io/h2c",
+			defaultProtocol: ir.HTTP,
+			want:            ir.HTTP2,
+		},
+		{
+			name:            "ws service convention",
 			appProtocol:     "kubernetes.io/ws",
-			defaultProtocol: ir.HTTP2,
-			want:            ir.HTTP,
-			wantForceHTTP1:  true,
-		},
-		{
-			name:            "wss",
-			appProtocol:     "kubernetes.io/wss",
-			defaultProtocol: ir.HTTP2,
-			want:            ir.HTTP,
-			wantForceHTTP1:  true,
-		},
-		{
-			name:              "grpc compatible",
-			appProtocol:       "grpc",
-			defaultProtocol:   ir.HTTP,
-			grpcCompatibility: true,
-			want:              ir.GRPC,
-		},
-		{
-			name:            "grpc not compatible",
-			appProtocol:     "grpc",
 			defaultProtocol: ir.HTTP,
 			want:            ir.HTTP,
+			wantForceHTTP1:  true,
+		},
+		{
+			name:            "wss service convention",
+			appProtocol:     "kubernetes.io/wss",
+			defaultProtocol: ir.HTTP,
+			want:            ir.HTTP,
+			wantForceHTTP1:  true,
+		},
+		{
+			name:            "ws backend convention",
+			appProtocol:     "gateway.envoyproxy.io/ws",
+			defaultProtocol: ir.HTTP,
+			want:            ir.HTTP,
+			wantForceHTTP1:  true,
+		},
+		{
+			name:            "wss backend convention",
+			appProtocol:     "gateway.envoyproxy.io/wss",
+			defaultProtocol: ir.HTTP,
+			want:            ir.HTTP,
+			wantForceHTTP1:  true,
+		},
+		{
+			name:            "grpc",
+			appProtocol:     "grpc",
+			defaultProtocol: ir.HTTP,
+			want:            ir.GRPC,
 		},
 		{
 			name:            "unknown",
@@ -69,12 +81,25 @@ func TestServiceAppProtocolToIRAppProtocol(t *testing.T) {
 			defaultProtocol: ir.HTTP,
 			want:            ir.HTTP,
 		},
+		{
+			// appProtocol must not refine the protocol of non-HTTP (L4) routes.
+			name:            "h2c ignored on non-HTTP route",
+			appProtocol:     "kubernetes.io/h2c",
+			defaultProtocol: ir.TCP,
+			want:            ir.TCP,
+		},
+		{
+			name:            "grpc ignored on non-HTTP route",
+			appProtocol:     "grpc",
+			defaultProtocol: ir.TCP,
+			want:            ir.TCP,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, serviceAppProtocolToIRAppProtocol(tt.appProtocol, tt.defaultProtocol, tt.grpcCompatibility))
-			require.Equal(t, tt.wantForceHTTP1, isWebSocketServiceAppProtocol(tt.appProtocol))
+			require.Equal(t, tt.want, appProtocolToIRAppProtocol(tt.appProtocol, tt.defaultProtocol))
+			require.Equal(t, tt.wantForceHTTP1, isWebSocketAppProtocol(tt.appProtocol))
 		})
 	}
 }

--- a/internal/gatewayapi/route_test.go
+++ b/internal/gatewayapi/route_test.go
@@ -98,8 +98,10 @@ func TestAppProtocolToIRAppProtocol(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, resolveBackendProtocol(tt.appProtocol, tt.defaultProtocol))
-			require.Equal(t, tt.wantForceHTTP1, isWebSocketAppProtocol(tt.appProtocol))
+			protocol := resolveBackendProtocol(tt.appProtocol, tt.defaultProtocol)
+			require.Equal(t, tt.want, protocol)
+			ap := tt.appProtocol
+			require.Equal(t, tt.wantForceHTTP1, shouldForceHTTP1Upstream(protocol, &ap))
 		})
 	}
 }

--- a/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.in.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.in.yaml
@@ -73,7 +73,7 @@ serviceImports:
         - port: 9000
           name: grpc
           protocol: TCP
-          appProtocol: grpc  # This is NOOP.
+          appProtocol: grpc  # This takes effect.
 
 endpointSlices:
   - apiVersion: discovery.k8s.io/v1

--- a/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
@@ -216,7 +216,7 @@ xdsIR:
               namespace: default
               sectionName: "9000"
             name: httproute/envoy-gateway/httproute-btls/rule/0/backend/1
-            protocol: HTTP
+            protocol: GRPC
             tls:
               alpnProtocols: null
               caCertificate:

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-passthrough.out.yaml
@@ -274,7 +274,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-tls-fingerprint.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-with-listener-with-tls-terminate-and-tls-fingerprint.out.yaml
@@ -313,7 +313,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/listenerset-tlsroute.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-tlsroute.out.yaml
@@ -327,7 +327,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tls-app-passthrough/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute
@@ -365,7 +365,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tls-app-terminate/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-attaching-to-gateway.out.yaml
@@ -148,7 +148,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/tlsroute-hostname-intersection.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-hostname-intersection.out.yaml
@@ -272,7 +272,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute
@@ -300,7 +300,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-3/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute
@@ -369,7 +369,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-2/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-multiple.out.yaml
@@ -181,7 +181,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute
@@ -209,7 +209,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-2/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/tlsroute-with-backend.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-backend.out.yaml
@@ -166,7 +166,7 @@ xdsIR:
               name: backend-ip
               namespace: default
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-backendref-in-other-namespace-allowed-by-refgrant.out.yaml
@@ -149,7 +149,7 @@ xdsIR:
               namespace: test-service-namespace
               sectionName: "8080"
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-hostname.out.yaml
@@ -147,7 +147,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-empty-listener-hostname.out.yaml
@@ -149,7 +149,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/tlsroute-with-tls-terminate-hostname-match.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-tls-terminate-hostname-match.out.yaml
@@ -158,7 +158,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/tlsroute-with-tls-terminate-multiple-routes.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-tls-terminate-multiple-routes.out.yaml
@@ -226,7 +226,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute
@@ -260,7 +260,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-2/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute
@@ -294,7 +294,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-3/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/gatewayapi/testdata/tlsroute-with-tls-terminate.out.yaml
+++ b/internal/gatewayapi/testdata/tlsroute-with-tls-terminate.out.yaml
@@ -155,7 +155,7 @@ xdsIR:
               namespace: default
               sectionName: "8080"
             name: tlsroute/default/tlsroute-1/rule/-1/backend/0
-            protocol: HTTPS
+            protocol: TCP
             weight: 1
         metadata:
           kind: TLSRoute

--- a/internal/xds/translator/testdata/in/xds-ir/tls-route-termination.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/tls-route-termination.yaml
@@ -22,7 +22,7 @@ tcp:
           port: 50000
         - host: "5.6.7.8"
           port: 50001
-        protocol: HTTPS
+        protocol: TCP
         name: "tls-termination-foo-dest/backend/0"
   - name: "tls-route-termination-bar"
     tls:
@@ -42,5 +42,5 @@ tcp:
         - host: "bar"
           port: 50000
         addressType: FQDN
-        protocol: HTTPS
+        protocol: TCP
         name: "tls-termination-bar-dest/backend/0"


### PR DESCRIPTION
This PR unifies the AppProtocol-to-IR translation logic across different route kinds and makes the default protocol selection semantically correct for L4 routes. As a result, the DS AppProtocol handling becomes easier to understand and maintain.

- Fix #9154: `inspectAppProtocolByRouteKind` now returns `ir.TCP` (was `ir.HTTPS`) for `TLSRoute`. A `TLSRoute` is translated into an `ir.TCPRoute`; upstream TLS is governed by `ds.TLS `(e.g. via `BackendTLSPolicy`), not by `Protocol: HTTPS`. This keeps the IR accurate and avoids implying HTTP protocol options on a TCP-proxy cluster.
- Consolidate `serviceAppProtocolToIRAppProtocol` and `backendAppProtocolToIRAppProtocol` into a single `appProtocolToIRAppProtocol`, and `isWebSocketServiceAppProtocol` and `isWebSocketBackendAppProtocol` into a single `isWebSocketAppProtocol`. Both now recognize the Kubernetes Service convention (`kubernetes.io/*`) and the Envoy Gateway Backend convention (`gateway.envoyproxy.io/*`).
- Guard on HTTP routes: AppProtocol (`h2c/ws/grpc`) is an HTTP-layer concept, so it only refines the upstream protocol when the route's default protocol is ir.HTTP. Non-HTTP (L4) routes keep their TCP/UDP protocol regardless of a backend's AppProtocol.

Behavior change: removes the old `grpcCompatibility` gate to unify the handling of `Service` and `ServiceImport`. The gate was unnecessary and made this code path harder to understand and maintain. A `ServiceImport` port with `appProtocol: grpc` referenced by an `HTTPRoute` now resolves to GRPC (previously a no-op for `ServiceImport`). This is just API translation behavior change, the xDS translator treats GRPC as HTTP2. 

**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"

Before raising a PR, please go through this section of the developer guide, https://gateway.envoyproxy.io/community/develop/#raising-a-pr
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #9154

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
Please add a new fragment file under release-notes/current/<section>/<pr-number>-<slug>.md and include it in the PR.
See release-notes/current/README.md for the available sections and the naming convention.
-->
Release Notes: No - there is no user-facing behavior change.
