### PR TITLE
fix: isHTTPRouteFilterReferencingSecret always returns true

### DIFF
--- a/internal/provider/kubernetes/indexers.go
+++ b/internal/provider/kubernetes/indexers.go
@@ -1154,7 +1154,7 @@ func secretRouteFilterIndexFunc(rawObj client.Object) []string {
 	if filter.Spec.CredentialInjection != nil {
 		secretReferences = append(secretReferences,
 			types.NamespacedName{
-				Namespace: filter.Namespace,
+				Namespace: gatewayapi.NamespaceDerefOr(filter.Spec.CredentialInjection.Credential.ValueRef.Namespace, filter.Namespace),
 				Name:      string(filter.Spec.CredentialInjection.Credential.ValueRef.Name),
 			}.String(),
 		)

--- a/internal/provider/kubernetes/predicates.go
+++ b/internal/provider/kubernetes/predicates.go
@@ -320,7 +320,7 @@ func (r *gatewayAPIReconciler) isHTTPRouteFilterReferencingSecret(nsName *types.
 		return true
 	}
 
-	return true
+	return false
 }
 
 func (r *gatewayAPIReconciler) isBackendTLSPolicyReferencingSecret(nsName *types.NamespacedName) bool {

--- a/internal/provider/kubernetes/predicates_test.go
+++ b/internal/provider/kubernetes/predicates_test.go
@@ -865,6 +865,61 @@ func TestValidateSecretForReconcile(t *testing.T) {
 			secret: test.GetSecret(types.NamespacedName{Namespace: "default", Name: "secret"}),
 			expect: true,
 		},
+		{
+			name: "secret not referenced by any HTTPRouteFilter",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, nil),
+			},
+			secret: test.GetSecret(types.NamespacedName{Namespace: "default", Name: "unrelated-secret"}),
+			expect: false,
+		},
+		{
+			name: "secret referenced by HTTPRouteFilter CredentialInjection",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, nil),
+				&egv1a1.HTTPRouteFilter{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "credential-filter",
+						Namespace: "default",
+					},
+					Spec: egv1a1.HTTPRouteFilterSpec{
+						CredentialInjection: &egv1a1.HTTPCredentialInjectionFilter{
+							Credential: egv1a1.InjectedCredential{
+								ValueRef: gwapiv1.SecretObjectReference{
+									Name: "credential-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: test.GetSecret(types.NamespacedName{Namespace: "default", Name: "credential-secret"}),
+			expect: true,
+		},
+		{
+			name: "secret in another namespace referenced by HTTPRouteFilter CredentialInjection",
+			configs: []client.Object{
+				test.GetGatewayClass("test-gc", egv1a1.GatewayControllerName, nil),
+				&egv1a1.HTTPRouteFilter{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "credential-filter",
+						Namespace: "default",
+					},
+					Spec: egv1a1.HTTPRouteFilterSpec{
+						CredentialInjection: &egv1a1.HTTPCredentialInjectionFilter{
+							Credential: egv1a1.InjectedCredential{
+								ValueRef: gwapiv1.SecretObjectReference{
+									Name:      "credential-secret",
+									Namespace: gatewayapi.NamespacePtr("other-ns"),
+								},
+							},
+						},
+					},
+				},
+			},
+			secret: test.GetSecret(types.NamespacedName{Namespace: "other-ns", Name: "credential-secret"}),
+			expect: true,
+		},
 	}
 
 	// Create the reconciler.
@@ -877,6 +932,7 @@ func TestValidateSecretForReconcile(t *testing.T) {
 		spCRDExists:      true,
 		epCRDExists:      true,
 		eepCRDExists:     true,
+		hrfCRDExists:     true,
 		envoyGateway: &egv1a1.EnvoyGateway{
 			EnvoyGatewaySpec: egv1a1.EnvoyGatewaySpec{
 				ExtensionAPIs: &egv1a1.ExtensionAPISettings{
@@ -895,6 +951,7 @@ func TestValidateSecretForReconcile(t *testing.T) {
 			WithIndex(&egv1a1.EnvoyProxy{}, secretEnvoyProxyIndex, secretEnvoyProxyIndexFunc).
 			WithIndex(&egv1a1.EnvoyExtensionPolicy{}, secretEnvoyExtensionPolicyIndex, secretEnvoyExtensionPolicyIndexFunc).
 			WithIndex(&egv1a1.Backend{}, secretBackendIndex, secretBackendIndexFunc).
+			WithIndex(&egv1a1.HTTPRouteFilter{}, secretHTTPRouteFilterIndex, secretRouteFilterIndexFunc).
 			Build()
 		t.Run(tc.name, func(t *testing.T) {
 			res := r.validateSecretForReconcile(tc.secret)


### PR DESCRIPTION
The isHTTPRouteFilterReferencingSecret function in predicates.go had 'return true' where 'return false' was intended when no HTTPRouteFilter references the given Secret. This caused validateSecretForReconcile to always return true when hrfCRDExists=true, triggering unnecessary reconciliations on every Secret change.

Added unit tests covering:
- Secret not referenced by any HTTPRouteFilter (expect false)
- Secret referenced by HTTPRouteFilter CredentialInjection (expect true)

Fixes https://github.com/envoyproxy/gateway/issues/9339`