### PR TITLE
fix: use target resource namespace in BTP RoutingType index

### DIFF
--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -104,7 +104,7 @@ func BuildBTPRoutingTypeIndex(
 			kind := string(ref.Kind)
 			key := btpRoutingKey{
 				Kind:        kind,
-				Namespace:   btp.Namespace,
+				Namespace:   string(ref.Namespace),
 				Name:        string(ref.Name),
 				SectionName: string(ptr.Deref(ref.SectionName, "")),
 			}

--- a/internal/gatewayapi/backendtrafficpolicy_test.go
+++ b/internal/gatewayapi/backendtrafficpolicy_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/ir"
@@ -977,16 +978,17 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 	gatewayNN := types.NamespacedName{Namespace: "default", Name: "gateway-1"}
 
 	tests := []struct {
-		name          string
-		btps          []*egv1a1.BackendTrafficPolicy
-		routes        []client.Object
-		gateways      []*GatewayContext
-		routeKind     gwapiv1.Kind
-		routeNN       types.NamespacedName
-		gatewayNN     types.NamespacedName
-		listenerName  *gwapiv1.SectionName
-		routeRuleName *gwapiv1.SectionName
-		expected      *egv1a1.RoutingType
+		name            string
+		btps            []*egv1a1.BackendTrafficPolicy
+		routes          []client.Object
+		gateways        []*GatewayContext
+		referenceGrants []*gwapiv1b1.ReferenceGrant
+		routeKind       gwapiv1.Kind
+		routeNN         types.NamespacedName
+		gatewayNN       types.NamespacedName
+		listenerName    *gwapiv1.SectionName
+		routeRuleName   *gwapiv1.SectionName
+		expected        *egv1a1.RoutingType
 	}{
 		{
 			name:      "no BTPs",
@@ -1739,11 +1741,78 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 			routeRuleName: new(gwapiv1.SectionName("rule-0")),
 			expected:      &serviceRouting,
 		},
+		{
+			// This test verifies that the index uses the target resource's namespace (ref.Namespace)
+			// instead of the policy's namespace (btp.Namespace) when building the key.
+			// This is critical for cross-namespace targetSelectors to work correctly.
+			name: "BTP with targetSelector matching route in different namespace (cross-namespace)",
+			btps: []*egv1a1.BackendTrafficPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "policy-ns",
+						Name:      "btp-selector",
+					},
+					Spec: egv1a1.BackendTrafficPolicySpec{
+						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
+							TargetSelectors: []egv1a1.TargetSelector{
+								{
+									Kind: gwapiv1.Kind("HTTPRoute"),
+									Namespaces: &egv1a1.TargetSelectorNamespaces{
+										From: egv1a1.TargetNamespaceFromAll,
+									},
+									MatchLabels: map[string]string{"app": "web"},
+								},
+							},
+						},
+						RoutingType: &serviceRouting,
+					},
+				},
+			},
+			routes: []client.Object{
+				&gwapiv1.HTTPRoute{
+					TypeMeta: metav1.TypeMeta{Kind: "HTTPRoute", APIVersion: "gateway.networking.k8s.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "route-ns",
+						Name:      "route-1",
+						Labels:    map[string]string{"app": "web"},
+					},
+				},
+			},
+			gateways: []*GatewayContext{defaultGateway},
+			// ReferenceGrant allows BTP in policy-ns to reference HTTPRoute in route-ns
+			referenceGrants: []*gwapiv1b1.ReferenceGrant{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "route-ns",
+						Name:      "grant-btp",
+					},
+					Spec: gwapiv1b1.ReferenceGrantSpec{
+						From: []gwapiv1b1.ReferenceGrantFrom{
+							{
+								Group:     gwapiv1b1.Group(egv1a1.GroupVersion.Group),
+								Kind:      gwapiv1b1.Kind(egv1a1.KindBackendTrafficPolicy),
+								Namespace: gwapiv1b1.Namespace("policy-ns"),
+							},
+						},
+						To: []gwapiv1b1.ReferenceGrantTo{
+							{
+								Group: gwapiv1b1.Group(gwapiv1.GroupName),
+								Kind:  gwapiv1b1.Kind("HTTPRoute"),
+							},
+						},
+					},
+				},
+			},
+			routeKind: "HTTPRoute",
+			routeNN:   types.NamespacedName{Namespace: "route-ns", Name: "route-1"},
+			gatewayNN: gatewayNN,
+			expected:  &serviceRouting,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			idx := BuildBTPRoutingTypeIndex(tt.btps, tt.routes, tt.gateways, nil, nil)
+			idx := BuildBTPRoutingTypeIndex(tt.btps, tt.routes, tt.gateways, tt.referenceGrants, nil)
 			got := idx.LookupBTPRoutingType(tt.routeKind, tt.routeNN, tt.gatewayNN, tt.listenerName, tt.routeRuleName)
 			require.Equal(t, tt.expected, got)
 		})

--- a/release-notes/current/bug_fixes/9359-btp-routingtype-cross-namespace-targetselectors.md
+++ b/release-notes/current/bug_fixes/9359-btp-routingtype-cross-namespace-targetselectors.md
@@ -1,0 +1,1 @@
+Fixed cross-namespace targetSelectors for BackendTrafficPolicy RoutingType by using the target resource's namespace in the index key instead of the policy's namespace.


### PR DESCRIPTION
# Problem Description

BackendTrafficPolicy (BTP) RoutingType configuration fails to apply when using `TargetSelectors` to select routes across namespaces. The routing type index is built with the BTP's namespace, but lookups use the target route's namespace, causing a mismatch that prevents cross-namespace policy attachment from working.

## Impact

- **Priority**: P1 (High)
- **Severity**: Functional correctness issue
- **Affected Feature**: BackendTrafficPolicy.Spec.RoutingType with cross-namespace TargetSelectors
- **User Impact**: Users attempting to set `RoutingType` (Service/Endpoint routing) on routes in different namespaces via TargetSelectors will find the configuration silently ignored

## Root Cause

**Location**: `internal/gatewayapi/backendtrafficpolicy.go:107`

When building the RoutingType index, the code incorrectly uses `btp.Namespace` instead of the target resource's namespace:

```go
// Line 103-110
for _, ref := range refs {
    kind := string(ref.Kind)
    key := btpRoutingKey{
        Kind:        kind,
        Namespace:   btp.Namespace,  // ❌ BUG: Uses BTP's namespace
        Name:        string(ref.Name),
        SectionName: string(ptr.Deref(ref.SectionName, "")),
    }
    // ... index storage
}
```

However, when looking up the RoutingType, the code correctly uses the target route's namespace:

```go
// Line 156-165
if routeRuleName != nil {
    key := btpRoutingKey{
        Kind:        string(routeKind),
        Namespace:   routeNN.Namespace,  // ✅ Correct: Uses route's namespace
        Name:        routeNN.Name,
        SectionName: string(*routeRuleName),
    }
    if rt, ok := idx.routeRuleLevel[key]; ok {
        return rt
    }
}
```

**Mismatch Scenario**:
- BTP in namespace `ns-A` with `TargetSelector` matching HTTPRoute in namespace `ns-B`
- Index key created: `{Kind: "HTTPRoute", Namespace: "ns-A", Name: "myRoute", ...}`
- Lookup key used: `{Kind: "HTTPRoute", Namespace: "ns-B", Name: "myRoute", ...}`
- Result: **Lookup fails**, RoutingType not found

## Fix

Change line 107 in `internal/gatewayapi/backendtrafficpolicy.go` to use `ref.Namespace` instead of `btp.Namespace`:

```go
Namespace:   string(ref.Namespace),  // Use target resource's namespace
```

## Testing

Added test case to verify cross-namespace TargetSelectors work correctly with ReferenceGrant.

All tests pass (19/19), including the new cross-namespace test case.
