### PR TITLE
fix: use int64 format for ratelimit Requests field

### DIFF
--- a/api/v1alpha1/ratelimit_types.go
+++ b/api/v1alpha1/ratelimit_types.go
@@ -438,7 +438,7 @@ type RateLimitValue struct {
 	//
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=4294967295
-	// +kubebuilder:validation:Format=uint32
+	// +kubebuilder:validation:Format=int64
 	Requests uint32        `json:"requests"`
 	Unit     RateLimitUnit `json:"unit"`
 	// FromMetadata sources the limit value from per-request dynamic metadata.

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1827,7 +1827,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: uint32
+                                  format: int64
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -2238,7 +2238,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: uint32
+                                  format: int64
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -1826,7 +1826,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: uint32
+                                  format: int64
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -2237,7 +2237,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: uint32
+                                  format: int64
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -24409,7 +24409,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: uint32
+                                  format: int64
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -24820,7 +24820,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: uint32
+                                  format: int64
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/test/helm/gateway-crds-helm/e2e.out.yaml
+++ b/test/helm/gateway-crds-helm/e2e.out.yaml
@@ -2382,7 +2382,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: uint32
+                                  format: int64
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -2793,7 +2793,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: uint32
+                                  format: int64
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -2382,7 +2382,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: uint32
+                                  format: int64
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer
@@ -2793,7 +2793,7 @@ spec:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
-                                  format: uint32
+                                  format: int64
                                   maximum: 4294967295
                                   minimum: 1
                                   type: integer


### PR DESCRIPTION
**What this PR does / why we need it**:
Refer to https://github.com/envoyproxy/gateway/pull/9376#discussion_r3493696879 and #9166


The Requests field is annotated Maximum=4294967295 (uint32 max), but controller-gen emits format: int32 for the uint32 Go type. Kubernetes 1.36 cross-validates an integer field's maximum against its format range, so int32 + that maximum is rejected.

#9166 worked around this with Format=uint32, which Kubernetes does not recognize and silently ignores. Use Format=int64 instead: it satisfies the 1.36 check, is a recognized OpenAPI format, and matches every other field in the schema that uses Maximum=4294967295. The Go type stays uint32 (allowDangerousTypes), preserving the real value bounds.
