### PR TITLE
docs: describe uint32 vs int32 range issue

### DIFF
--- a/api/v1alpha1/ratelimit_types.go
+++ b/api/v1alpha1/ratelimit_types.go
@@ -433,6 +433,10 @@ type PathMatch struct {
 
 // RateLimitValue defines the limits for rate limiting.
 type RateLimitValue struct {
+	// Requests intentionally sets Format=int64. Controller-gen renders uint32 as
+	// format int32, whose range is below Maximum=4294967295 and would be rejected
+	// in Kubernetes 1.36+
+
 	// Requests is the number of requests (or cost units, when used with
 	// cost-based rate limiting) allowed per Unit.
 	//


### PR DESCRIPTION
<!--
Your PR title should be descriptive, and generally start with a type that contains a subsystem name with `()` if necessary
and a summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), the API must be discussed and
agreed before the implementation. We strongly recommend separating API changes into their own PR so
we can review the API first, but the API may also live in the same PR as long as it was agreed
beforehand. This will save you a lot of implementation time if the API gets accepted.
-->

**What this PR does / why we need it**:
<!--
Briefly describe what this PR changes and the motivation behind it. Include enough context for a
reviewer to understand the problem being solved and the approach taken, e.g. what behavior changes,
any alternatives considered, and anything reviewers should pay special attention to.
-->
Feedback from https://github.com/envoyproxy/gateway/pull/9377#discussion_r3495545936 to describe reasoning behind using kubebuilder Format=int64 on a uint32 field.
