### PR TITLE
fix(xds): preserve path separators in root prefix rewrites

### DIFF
--- a/internal/xds/translator/route.go
+++ b/internal/xds/translator/route.go
@@ -520,6 +520,10 @@ func useRegexRewriteForPrefixMatchReplace(pathMatch *ir.StringMatch, prefixMatch
 		(prefixMatchReplace == "" || prefixMatchReplace == "/")
 }
 
+func prefixPathMatchAll(pathMatch *ir.StringMatch) bool {
+	return pathMatch != nil && pathMatch.Prefix != nil && *pathMatch.Prefix == "/"
+}
+
 func prefix2RegexRewrite(prefix string) *matcherv3.RegexMatchAndSubstitute {
 	return &matcherv3.RegexMatchAndSubstitute{
 		Pattern: &matcherv3.RegexMatcher{
@@ -559,9 +563,17 @@ func buildXdsURLRewriteAction(route *ir.HTTPRoute, urlRewrite *ir.URLRewrite, pa
 			// An empty replace string does not seem to solve the issue so we are using
 			// a regex match and replace instead
 			// Remove this workaround once https://github.com/envoyproxy/envoy/issues/26055 is fixed
-			if useRegexRewriteForPrefixMatchReplace(pathMatch, *urlRewrite.Path.PrefixMatchReplace) {
+			switch {
+			case useRegexRewriteForPrefixMatchReplace(pathMatch, *urlRewrite.Path.PrefixMatchReplace):
 				routeAction.RegexRewrite = prefix2RegexRewrite(*pathMatch.Prefix)
-			} else {
+			case prefixPathMatchAll(pathMatch):
+				routeAction.RegexRewrite = &matcherv3.RegexMatchAndSubstitute{
+					Pattern: &matcherv3.RegexMatcher{
+						Regex: "(^/$)|(.*)",
+					},
+					Substitution: strings.TrimSuffix(*urlRewrite.Path.PrefixMatchReplace, "/") + "\\2",
+				}
+			default:
 				// remove trailing / to fix #3989
 				// when the pathMath.Prefix has suffix / but EG has removed it,
 				// and the urlRewrite.Path.PrefixMatchReplace suffix with / the upstream will get unwanted /

--- a/internal/xds/translator/testdata/in/xds-ir/http-route-rewrite-match-all.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/http-route-rewrite-match-all.yaml
@@ -1,0 +1,27 @@
+http:
+- name: "first-listener"
+  address: "::"
+  port: 10080
+  hostnames:
+  - "*"
+  path:
+    mergeSlashes: true
+    escapedSlashesAction: UnescapeAndRedirect
+  routes:
+  - name: "rewrite-route"
+    pathMatch:
+      prefix: "/"
+    hostname: gateway.envoyproxy.io
+    headerMatches:
+    - name: ":authority"
+      exact: gateway.envoyproxy.io
+    destination:
+      name: "rewrite-route-dest"
+      settings:
+      - endpoints:
+        - host: "1.2.3.4"
+          port: 50000
+        name: "rewrite-route-dest/backend/0"
+    urlRewrite:
+      path:
+        prefixMatchReplace: /docs/

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-match-all.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-match-all.clusters.yaml
@@ -1,0 +1,23 @@
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: rewrite-route-dest
+  ignoreHealthOnHostRemoval: true
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: rewrite-route-dest
+  perConnectionBufferLimitBytes: 32768
+  type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-match-all.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-match-all.endpoints.yaml
@@ -1,0 +1,12 @@
+- clusterName: rewrite-route-dest
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 1.2.3.4
+            portValue: 50000
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: rewrite-route-dest/backend/0

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-match-all.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-match-all.listeners.yaml
@@ -1,0 +1,35 @@
+- address:
+    socketAddress:
+      address: '::'
+      portValue: 10080
+  defaultFilterChain:
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        commonHttpProtocolOptions:
+          headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            suppressEnvoyHeaders: true
+        mergeSlashes: true
+        normalizePath: true
+        pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: first-listener
+        serverHeaderTransformation: PASS_THROUGH
+        statPrefix: http-10080
+        useRemoteAddress: true
+    name: first-listener
+  maxConnectionsToAcceptPerSocketEvent: 1
+  name: first-listener
+  perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-match-all.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-match-all.routes.yaml
@@ -1,0 +1,22 @@
+- ignorePortInHostMatching: true
+  name: first-listener
+  virtualHosts:
+  - domains:
+    - gateway.envoyproxy.io
+    name: first-listener/gateway_envoyproxy_io
+    routes:
+    - match:
+        headers:
+        - name: :authority
+          stringMatch:
+            exact: gateway.envoyproxy.io
+        prefix: /
+      name: rewrite-route
+      route:
+        cluster: rewrite-route-dest
+        regexRewrite:
+          pattern:
+            regex: (^/$)|(.*)
+          substitution: /docs\2
+        upgradeConfigs:
+        - upgradeType: websocket

--- a/release-notes/current/breaking_changes/9415-root-prefix-urlrewrite-xds-shape.md
+++ b/release-notes/current/breaking_changes/9415-root-prefix-urlrewrite-xds-shape.md
@@ -1,0 +1,1 @@
+Root `PathPrefix "/"` `HTTPRoute` URL rewrites with `replacePrefixMatch` now generate `regexRewrite` instead of `prefixRewrite` in the translated xDS `RouteAction` so the replacement prefix preserves the original path separator. EnvoyPatchPolicies or extension servers that patch or inspect the old `prefixRewrite` field for these routes must be updated before upgrade.

--- a/release-notes/current/bug_fixes/6764-root-prefix-urlrewrite.md
+++ b/release-notes/current/bug_fixes/6764-root-prefix-urlrewrite.md
@@ -1,0 +1,1 @@
+Fixed `HTTPRoute` URL rewrites with `PathPrefix "/"` so `replacePrefixMatch` can prepend a new prefix without dropping the separator between the new prefix and the original request path.

--- a/test/e2e/testdata/httproute-rewrite-root-prefix-path.yaml
+++ b/test/e2e/testdata/httproute-rewrite-root-prefix-path.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rewrite-root-prefix-path
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /prefix-match/
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/test/e2e/tests/httproute_rewrite_root_prefix_path.go
+++ b/test/e2e/tests/httproute_rewrite_root_prefix_path.go
@@ -1,0 +1,69 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+//go:build e2e
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteRewriteRootPrefixPath)
+}
+
+var HTTPRouteRewriteRootPrefixPath = suite.ConformanceTest{
+	ShortName:   "HTTPRouteRewriteRootPrefixPath",
+	Description: "An HTTPRoute with a root prefix rewrite preserves the original request path",
+	Manifests:   []string{"testdata/httproute-rewrite-root-prefix-path.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "rewrite-root-prefix-path", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path: "/doc",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/prefix-match/doc",
+					},
+				},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path: "/",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/prefix-match",
+					},
+				},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}


### PR DESCRIPTION
What this PR does / why we need it

Root `PathPrefix "/"` rewrites are a bit busted right now. With a `URLRewrite` `replacePrefixMatch: /prefix/`, `GET /test` hits the backend as `/prefixtest`, not `/prefix/test`.

This switches that one case to regex rewrite. So `/` becomes `/prefix`, and `/test` becomes `/prefix/test`. Non-root prefix rewrites stay the same.

Which issue(s) this PR fixes

Fixes #6764
Related #5256

How to reproduce

1. Apply an `HTTPRoute` with `matches[].path.value: /` and `filters[].urlRewrite.path.replacePrefixMatch: /prefix/`.
2. Send `GET /test`.
3. On main, the backend sees `/prefixtest`.
4. With this PR, the backend sees `/prefix/test`.

Checks

- `go test ./internal/xds/translator -count=1`
- `go test -tags=e2e ./e2e/tests -run TestNonExistent -count=1`
