### PR TITLE
test(configloader): fix flaky reload tests

### DIFF
--- a/internal/envoygateway/config/loader/configloader_test.go
+++ b/internal/envoygateway/config/loader/configloader_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -31,104 +32,71 @@ var (
 	minimalConfig string
 )
 
-func TestConfigLoader(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "envoy-gateway-configloader-test")
-	require.NoError(t, err)
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(tmpDir)
+const (
+	reloadTimeout = 30 * time.Second
+	reloadTick    = 10 * time.Millisecond
+)
 
+func TestConfigLoader(t *testing.T) {
+	tmpDir := t.TempDir()
 	cfgPath := tmpDir + "/config.yaml"
 	require.NoError(t, os.WriteFile(cfgPath, []byte(defaultConfig), 0o600))
 	s, err := config.New(os.Stdout, os.Stderr)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer func() {
-		cancel()
-	}()
-
-	changed := 0
-	loader := New(cfgPath, s, func(hookCtx context.Context, _ *config.Server) error {
-		changed++
-		// Only log if the hook context is still active to avoid panic
-		select {
-		case <-hookCtx.Done():
-			return nil
-		default:
-			t.Logf("config changed %d times", changed)
-		}
-		if changed > 1 {
-			cancel()
-		}
+	var reloads atomic.Int32
+	loader := New(cfgPath, s, func(context.Context, *config.Server) error {
+		reloads.Add(1)
 		return nil
 	})
 
-	require.NoError(t, loader.Start(ctx, os.Stdout))
-	go func() {
-		_ = os.WriteFile(cfgPath, []byte(redisConfig), 0o600)
-	}()
+	require.NoError(t, loader.Start(t.Context(), os.Stdout))
+	require.NoError(t, os.WriteFile(cfgPath, []byte(redisConfig), 0o600))
 
-	<-ctx.Done()
+	require.Eventually(t, func() bool {
+		return reloads.Load() > 1
+	}, reloadTimeout, reloadTick)
+	t.Logf("config reloaded %d times", reloads.Load())
 }
 
 func TestConfigLoaderStandaloneExtensionServerAndCustomResource(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "envoy-gateway-configloader-test")
-	require.NoError(t, err)
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(tmpDir)
-
+	tmpDir := t.TempDir()
 	cfgPath := tmpDir + "/config.yaml"
 	require.NoError(t, os.WriteFile(cfgPath, []byte(standaloneConfig), 0o600))
 	s, err := config.New(os.Stdout, os.Stderr)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer func() {
-		cancel()
-	}()
-
-	type testResult struct {
-		changed int32
-		extMgr  *egv1a1.ExtensionManager
-	}
-	resultChannel := make(chan testResult, 1)
-
-	var changed int32
-	loader := New(cfgPath, s, func(hookCtx context.Context, cfg *config.Server) error {
-		// Check if the hook context is canceled before incrementing
-		select {
-		case <-hookCtx.Done():
-			return nil
-		default:
-		}
-		c := atomic.AddInt32(&changed, 1)
-		t.Logf("config changed %d times", c)
-		if c > 1 {
-			resultChannel <- testResult{changed: c, extMgr: cfg.EnvoyGateway.ExtensionManager}
-			cancel()
-		}
+	var reloads atomic.Int32
+	loader := New(cfgPath, s, func(context.Context, *config.Server) error {
+		reloads.Add(1)
 		return nil
 	})
 
-	require.NoError(t, loader.Start(ctx, os.Stdout))
+	require.NoError(t, loader.Start(t.Context(), os.Stdout))
 	require.NotNil(t, loader.cfg.EnvoyGateway)
 	require.Nil(t, loader.cfg.EnvoyGateway.ExtensionManager)
 
-	go func() {
-		_ = os.WriteFile(cfgPath, []byte(standaloneConfigWithExtensionServer), 0o600)
-	}()
+	require.NoError(t, os.WriteFile(cfgPath, []byte(standaloneConfigWithExtensionServer), 0o600))
 
-	<-ctx.Done()
-	res := <-resultChannel // wait until second reload
-	require.Equal(t, int32(2), res.changed)
-	require.NotNil(t, res.extMgr)
-	require.NotNil(t, res.extMgr.PolicyResources)
-	require.Len(t, res.extMgr.PolicyResources, 1)
-	require.Equal(t, "gateway.example.io", res.extMgr.PolicyResources[0].Group)
-	require.Equal(t, "v1alpha1", res.extMgr.PolicyResources[0].Version)
-	require.Equal(t, "ExampleExtPolicy", res.extMgr.PolicyResources[0].Kind)
+	// Wait for the reload to apply the extension server config.
+	var extMgr *egv1a1.ExtensionManager
+	require.Eventually(t, func() bool {
+		cfg := loader.snapshotConfig()
+		if cfg == nil || cfg.EnvoyGateway == nil || cfg.EnvoyGateway.ExtensionManager == nil {
+			return false
+		}
+		extMgr = cfg.EnvoyGateway.ExtensionManager
+		return reloads.Load() > 1
+	}, reloadTimeout, reloadTick)
+	t.Logf("config reloaded %d times", reloads.Load())
+
+	require.Greater(t, reloads.Load(), int32(1))
+	require.NotNil(t, extMgr)
+	require.NotNil(t, extMgr.PolicyResources)
+	require.Len(t, extMgr.PolicyResources, 1)
+	require.Equal(t, "gateway.example.io", extMgr.PolicyResources[0].Group)
+	require.Equal(t, "v1alpha1", extMgr.PolicyResources[0].Version)
+	require.Equal(t, "ExampleExtPolicy", extMgr.PolicyResources[0].Kind)
 }
 
 // TestConfigLoaderDefaultsBeforeValidate ensures the hot-reload path applies defaults
@@ -137,53 +105,30 @@ func TestConfigLoaderStandaloneExtensionServerAndCustomResource(t *testing.T) {
 // Reloading to such a config must therefore succeed and surface the defaulted values
 // to the hook.
 func TestConfigLoaderDefaultsBeforeValidate(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "envoy-gateway-configloader-test")
-	require.NoError(t, err)
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(tmpDir)
-
+	tmpDir := t.TempDir()
 	cfgPath := tmpDir + "/config.yaml"
 	require.NoError(t, os.WriteFile(cfgPath, []byte(defaultConfig), 0o600))
 	s, err := config.New(os.Stdout, os.Stderr)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	type testResult struct {
-		changed int32
-		eg      *egv1a1.EnvoyGateway
-	}
-	resultChannel := make(chan testResult, 1)
-
-	var changed int32
-	loader := New(cfgPath, s, func(hookCtx context.Context, cfg *config.Server) error {
-		select {
-		case <-hookCtx.Done():
-			return nil
-		default:
-		}
-		c := atomic.AddInt32(&changed, 1)
-		if c > 1 {
-			resultChannel <- testResult{changed: c, eg: cfg.EnvoyGateway}
-			cancel()
-		}
+	var reloads atomic.Int32
+	loader := New(cfgPath, s, func(context.Context, *config.Server) error {
+		reloads.Add(1)
 		return nil
 	})
 
-	require.NoError(t, loader.Start(ctx, os.Stdout))
-	go func() {
-		_ = os.WriteFile(cfgPath, []byte(minimalConfig), 0o600)
-	}()
+	require.NoError(t, loader.Start(t.Context(), os.Stdout))
+	require.NoError(t, os.WriteFile(cfgPath, []byte(minimalConfig), 0o600))
+	require.Eventually(t, func() bool {
+		return reloads.Load() > 1
+	}, reloadTimeout, reloadTick)
+	t.Logf("config reloaded %d times", reloads.Load())
 
-	<-ctx.Done()
-	res := <-resultChannel
-	require.Equal(t, int32(2), res.changed)
-	require.NotNil(t, res.eg)
-	require.NotNil(t, res.eg.Gateway)
-	require.Equal(t, egv1a1.GatewayControllerName, res.eg.Gateway.ControllerName)
-	require.NotNil(t, res.eg.Provider)
-	require.Equal(t, egv1a1.ProviderTypeKubernetes, res.eg.Provider.Type)
-	require.NotNil(t, res.eg.Logging)
+	eg := loader.snapshotConfig().EnvoyGateway
+	require.NotNil(t, eg)
+	require.NotNil(t, eg.Gateway)
+	require.Equal(t, egv1a1.GatewayControllerName, eg.Gateway.ControllerName)
+	require.NotNil(t, eg.Provider)
+	require.Equal(t, egv1a1.ProviderTypeKubernetes, eg.Provider.Type)
+	require.NotNil(t, eg.Logging)
 }

--- a/internal/envoygateway/config/loader/configloader_test.go
+++ b/internal/envoygateway/config/loader/configloader_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -31,159 +32,102 @@ var (
 	minimalConfig string
 )
 
-func TestConfigLoader(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "envoy-gateway-configloader-test")
-	require.NoError(t, err)
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(tmpDir)
+const (
+	reloadTimeout = 30 * time.Second
+	reloadTick    = 10 * time.Millisecond
+)
 
+func TestConfigLoader(t *testing.T) {
+	tmpDir := t.TempDir()
 	cfgPath := tmpDir + "/config.yaml"
 	require.NoError(t, os.WriteFile(cfgPath, []byte(defaultConfig), 0o600))
 	s, err := config.New(os.Stdout, os.Stderr)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer func() {
-		cancel()
-	}()
-
-	changed := 0
-	loader := New(cfgPath, s, func(hookCtx context.Context, _ *config.Server) error {
-		changed++
-		// Only log if the hook context is still active to avoid panic
-		select {
-		case <-hookCtx.Done():
-			return nil
-		default:
-			t.Logf("config changed %d times", changed)
-		}
-		if changed > 1 {
-			cancel()
-		}
+	var reloads atomic.Int32
+	loader := New(cfgPath, s, func(context.Context, *config.Server) error {
+		reloads.Add(1)
 		return nil
 	})
 
-	require.NoError(t, loader.Start(ctx, os.Stdout))
-	go func() {
-		_ = os.WriteFile(cfgPath, []byte(redisConfig), 0o600)
-	}()
+	require.NoError(t, loader.Start(t.Context(), os.Stdout))
+	require.NoError(t, os.WriteFile(cfgPath, []byte(redisConfig), 0o600))
 
-	<-ctx.Done()
+	require.Eventually(t, func() bool {
+		return reloads.Load() > 1
+	}, reloadTimeout, reloadTick)
+	t.Logf("config reloaded %d times", reloads.Load())
 }
 
 func TestConfigLoaderStandaloneExtensionServerAndCustomResource(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "envoy-gateway-configloader-test")
-	require.NoError(t, err)
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(tmpDir)
-
+	tmpDir := t.TempDir()
 	cfgPath := tmpDir + "/config.yaml"
 	require.NoError(t, os.WriteFile(cfgPath, []byte(standaloneConfig), 0o600))
 	s, err := config.New(os.Stdout, os.Stderr)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer func() {
-		cancel()
-	}()
-
-	type testResult struct {
-		changed int32
-		extMgr  *egv1a1.ExtensionManager
-	}
-	resultChannel := make(chan testResult, 1)
-
-	var changed int32
-	loader := New(cfgPath, s, func(hookCtx context.Context, cfg *config.Server) error {
-		// Check if the hook context is canceled before incrementing
-		select {
-		case <-hookCtx.Done():
-			return nil
-		default:
-		}
-		c := atomic.AddInt32(&changed, 1)
-		t.Logf("config changed %d times", c)
-		if c > 1 {
-			resultChannel <- testResult{changed: c, extMgr: cfg.EnvoyGateway.ExtensionManager}
-			cancel()
-		}
+	var reloads atomic.Int32
+	loader := New(cfgPath, s, func(context.Context, *config.Server) error {
+		reloads.Add(1)
 		return nil
 	})
 
-	require.NoError(t, loader.Start(ctx, os.Stdout))
+	require.NoError(t, loader.Start(t.Context(), os.Stdout))
 	require.NotNil(t, loader.cfg.EnvoyGateway)
 	require.Nil(t, loader.cfg.EnvoyGateway.ExtensionManager)
 
-	go func() {
-		_ = os.WriteFile(cfgPath, []byte(standaloneConfigWithExtensionServer), 0o600)
-	}()
+	require.NoError(t, os.WriteFile(cfgPath, []byte(standaloneConfigWithExtensionServer), 0o600))
 
-	<-ctx.Done()
-	res := <-resultChannel // wait until second reload
-	require.Equal(t, int32(2), res.changed)
-	require.NotNil(t, res.extMgr)
-	require.NotNil(t, res.extMgr.PolicyResources)
-	require.Len(t, res.extMgr.PolicyResources, 1)
-	require.Equal(t, "gateway.example.io", res.extMgr.PolicyResources[0].Group)
-	require.Equal(t, "v1alpha1", res.extMgr.PolicyResources[0].Version)
-	require.Equal(t, "ExampleExtPolicy", res.extMgr.PolicyResources[0].Kind)
+	// Wait for the reload to apply the extension server config.
+	var extMgr *egv1a1.ExtensionManager
+	require.Eventually(t, func() bool {
+		cfg := loader.snapshotConfig()
+		if cfg == nil || cfg.EnvoyGateway == nil || cfg.EnvoyGateway.ExtensionManager == nil {
+			return false
+		}
+		extMgr = cfg.EnvoyGateway.ExtensionManager
+		return reloads.Load() > 1
+	}, reloadTimeout, reloadTick)
+	t.Logf("config reloaded %d times", reloads.Load())
+
+	require.NotNil(t, extMgr)
+	require.NotNil(t, extMgr.PolicyResources)
+	require.Len(t, extMgr.PolicyResources, 1)
+	require.Equal(t, "gateway.example.io", extMgr.PolicyResources[0].Group)
+	require.Equal(t, "v1alpha1", extMgr.PolicyResources[0].Version)
+	require.Equal(t, "ExampleExtPolicy", extMgr.PolicyResources[0].Kind)
 }
 
 // TestConfigLoaderDefaultsBeforeValidate ensures the hot-reload path applies defaults
 // before validation. A config that omits `gateway` and `provider` fails validation
 // outright (`gateway is unspecified`) but is valid once defaults populate those fields.
 // Reloading to such a config must therefore succeed and surface the defaulted values
-// to the hook.
+// via the loader's config snapshot.
 func TestConfigLoaderDefaultsBeforeValidate(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "envoy-gateway-configloader-test")
-	require.NoError(t, err)
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(tmpDir)
-
+	tmpDir := t.TempDir()
 	cfgPath := tmpDir + "/config.yaml"
 	require.NoError(t, os.WriteFile(cfgPath, []byte(defaultConfig), 0o600))
 	s, err := config.New(os.Stdout, os.Stderr)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	type testResult struct {
-		changed int32
-		eg      *egv1a1.EnvoyGateway
-	}
-	resultChannel := make(chan testResult, 1)
-
-	var changed int32
-	loader := New(cfgPath, s, func(hookCtx context.Context, cfg *config.Server) error {
-		select {
-		case <-hookCtx.Done():
-			return nil
-		default:
-		}
-		c := atomic.AddInt32(&changed, 1)
-		if c > 1 {
-			resultChannel <- testResult{changed: c, eg: cfg.EnvoyGateway}
-			cancel()
-		}
+	var reloads atomic.Int32
+	loader := New(cfgPath, s, func(context.Context, *config.Server) error {
+		reloads.Add(1)
 		return nil
 	})
 
-	require.NoError(t, loader.Start(ctx, os.Stdout))
-	go func() {
-		_ = os.WriteFile(cfgPath, []byte(minimalConfig), 0o600)
-	}()
+	require.NoError(t, loader.Start(t.Context(), os.Stdout))
+	require.NoError(t, os.WriteFile(cfgPath, []byte(minimalConfig), 0o600))
+	require.Eventually(t, func() bool {
+		return reloads.Load() > 1
+	}, reloadTimeout, reloadTick)
+	t.Logf("config reloaded %d times", reloads.Load())
 
-	<-ctx.Done()
-	res := <-resultChannel
-	require.Equal(t, int32(2), res.changed)
-	require.NotNil(t, res.eg)
-	require.NotNil(t, res.eg.Gateway)
-	require.Equal(t, egv1a1.GatewayControllerName, res.eg.Gateway.ControllerName)
-	require.NotNil(t, res.eg.Provider)
-	require.Equal(t, egv1a1.ProviderTypeKubernetes, res.eg.Provider.Type)
-	require.NotNil(t, res.eg.Logging)
+	eg := loader.snapshotConfig().EnvoyGateway
+	require.NotNil(t, eg)
+	require.NotNil(t, eg.Gateway)
+	require.Equal(t, egv1a1.GatewayControllerName, eg.Gateway.ControllerName)
+	require.NotNil(t, eg.Provider)
+	require.Equal(t, egv1a1.ProviderTypeKubernetes, eg.Provider.Type)
+	require.NotNil(t, eg.Logging)
 }


### PR DESCRIPTION
<!--
Your PR title should be descriptive, and generally start with a type that contains a subsystem name with `()` if necessary
and a summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), the API must be discussed and
agreed before the implementation. We strongly recommend separating API changes into their own PR so
we can review the API first, but the API may also live in the same PR as long as it was agreed
beforehand. This will save you a lot of implementation time if the API gets accepted.
-->

**What this PR does / why we need it**:
<!--
Briefly describe what this PR changes and the motivation behind it. Include enough context for a
reviewer to understand the problem being solved and the approach taken, e.g. what behavior changes,
any alternatives considered, and anything reviewers should pay special attention to.
-->

Fix the flaky test in configloader.

The failure is `Log in goroutine after ...has completed: config changed 3 times.`
os.WriteFile truncates the file to empty before writing, so the watcher can occasionally [pick up the empty state and the written state as two separate changes]((https://github.com/envoyproxy/gateway/blob/dc73f48dbc24c82110cdaf4d88b066c46b26de0a/internal/filewatcher/worker.go#L99-L100)). That single write fires 2 reloads instead of 1, and with the initial load that's 3 hook calls. 
The old hook called t.Logf from the loader goroutine, so that 3rd call could fire after the test returned and panic.

Ran the loader tests 300× with the race detector and no failures.

```
$ go test ./internal/envoygateway/config/loader/ -run TestConfigLoader -race -count=300
ok      github.com/envoyproxy/gateway/internal/envoygateway/config/loader       14.359s
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/envoyproxy/gateway/issues/8769

---

**PR Checklist**
<!--
Please tick the boxes below before requesting a review. PRs that leave required items unchecked may
be delayed or closed. Replace `[ ]` with `[x]` to check a box. If an item does not apply, check it
and add "N/A: <reason>".
-->

- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: If this PR contains API changes (changes under `/api`), the API was discussed and agreed **before** the implementation. The API change can be in a separate PR, or in the same PR, but the API must be agreed before implementation. N/A if this PR does not contain API changes.
- [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (Flaky e2e failures are not considered breakages, but `gen-check`, `lint`, and coverage **MUST** pass.)
- [x] **Tests added/updated**: New/changed code is covered by appropriate tests. N/A if this PR does not contain code changes.
- [x] **Docs**: User-facing changes update the [docs](https://github.com/envoyproxy/gateway/tree/main/site), either in this PR or a follow-up PR. N/A if this PR does not contain user-facing changes.
- [x] **Release notes**: For any non-trivial change, added a release-note fragment under `release-notes/current/<section>/<pr-number>-<slug>.md` (see `release-notes/current/README.md` for sections and naming). N/A if this PR does not contain non-trivial changes.
- [x] **Generated files committed**: Ran `make gen-check` and committed the result if API/helm charts/modules changed.
- [x] **Scope & compatibility**: The PR is reasonably scoped (no unrelated changes) and preserves backward compatibility, or any breaking change is called out above and documented in `release-notes/current/breaking_changes/`.
- [x] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.
