### PR TITLE
fix: clean up stale BackendTrafficPolicy status when it attaches to no target

### DIFF
--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -472,6 +472,14 @@ func (t *Translator) ProcessBackendTrafficPolicies(
 
 	handledPolicies := make(map[types.NamespacedName]*egv1a1.BackendTrafficPolicy, policyMapSize)
 
+	// Tracks policies that were successfully attached to at least one real target
+	// during this pass. Any policy that ends up in res without attaching to a
+	// target has carried-over (deep-copied) status from a previous generation that
+	// is now stale, so we drop that status below. Cleaning up the resulting
+	// detached status on the actual object is handled by the provider status
+	// updater when it observes the status delete (see internal/provider/kubernetes/status.go).
+	attachedPolicies := make(map[types.NamespacedName]bool, policyMapSize)
+
 	// Translate
 	// 1. First translate Policies targeting RouteRules
 	// 2. Next translate Policies targeting xRoutes
@@ -499,8 +507,10 @@ func (t *Translator) ProcessBackendTrafficPolicies(
 					res = append(res, policy)
 				}
 
-				t.processBackendTrafficPolicyForRoute(xdsIR,
-					routeMap, listenerSetMap, gatewayPolicyMap, listenerSetPolicyMap, overrides, merged, policy, currTarget)
+				if t.processBackendTrafficPolicyForRoute(xdsIR,
+					routeMap, listenerSetMap, gatewayPolicyMap, listenerSetPolicyMap, overrides, merged, policy, currTarget) {
+					attachedPolicies[policyName] = true
+				}
 			}
 		}
 	}
@@ -525,8 +535,10 @@ func (t *Translator) ProcessBackendTrafficPolicies(
 					res = append(res, policy)
 				}
 
-				t.processBackendTrafficPolicyForRoute(xdsIR,
-					routeMap, listenerSetMap, gatewayPolicyMap, listenerSetPolicyMap, overrides, merged, policy, currTarget)
+				if t.processBackendTrafficPolicyForRoute(xdsIR,
+					routeMap, listenerSetMap, gatewayPolicyMap, listenerSetPolicyMap, overrides, merged, policy, currTarget) {
+					attachedPolicies[policyName] = true
+				}
 			}
 		}
 	}
@@ -544,8 +556,10 @@ func (t *Translator) ProcessBackendTrafficPolicies(
 					handledPolicies[policyName] = policy
 					res = append(res, policy)
 				}
-				t.processBackendTrafficPolicyForListenerSet(xdsIR,
-					gatewayMap, listenerSetMap, overrides, merged, policy, currTarget)
+				if t.processBackendTrafficPolicyForListenerSet(xdsIR,
+					gatewayMap, listenerSetMap, overrides, merged, policy, currTarget) {
+					attachedPolicies[policyName] = true
+				}
 			}
 		}
 	}
@@ -570,8 +584,10 @@ func (t *Translator) ProcessBackendTrafficPolicies(
 					handledPolicies[policyName] = policy
 					res = append(res, policy)
 				}
-				t.processBackendTrafficPolicyForListenerSet(xdsIR,
-					gatewayMap, listenerSetMap, overrides, merged, policy, currTarget)
+				if t.processBackendTrafficPolicyForListenerSet(xdsIR,
+					gatewayMap, listenerSetMap, overrides, merged, policy, currTarget) {
+					attachedPolicies[policyName] = true
+				}
 			}
 		}
 	}
@@ -589,8 +605,10 @@ func (t *Translator) ProcessBackendTrafficPolicies(
 					handledPolicies[policyName] = policy
 					res = append(res, policy)
 				}
-				t.processBackendTrafficPolicyForGateway(xdsIR,
-					gatewayMap, overrides, merged, policy, currTarget)
+				if t.processBackendTrafficPolicyForGateway(xdsIR,
+					gatewayMap, overrides, merged, policy, currTarget) {
+					attachedPolicies[policyName] = true
+				}
 			}
 		}
 	}
@@ -614,9 +632,27 @@ func (t *Translator) ProcessBackendTrafficPolicies(
 					handledPolicies[policyName] = policy
 					res = append(res, policy)
 				}
-				t.processBackendTrafficPolicyForGateway(xdsIR,
-					gatewayMap, overrides, merged, policy, currTarget)
+				if t.processBackendTrafficPolicyForGateway(xdsIR,
+					gatewayMap, overrides, merged, policy, currTarget) {
+					attachedPolicies[policyName] = true
+				}
 			}
+		}
+	}
+
+	// Drop stale carried-over status for policies that were added to res (their
+	// targetRef/targetRefs resolved to an object reference) but did not actually
+	// attach to any target this pass because the referenced object does not exist
+	// (#8926). Without this, the deep-copied Accepted=True condition with an
+	// out-of-date observedGeneration would be republished as-is. Emptying the
+	// ancestor list makes the gatewayapi runner treat the policy as having no
+	// status, which deletes it from the status store and lets the provider status
+	// updater clean up the stale status on the object. Policies whose selectors
+	// matched nothing (#8927) are never added to res, so they are already handled
+	// by that same delete path.
+	for _, policy := range res {
+		if !attachedPolicies[utils.NamespacedName(policy)] {
+			policy.Status.Ancestors = nil
 		}
 	}
 
@@ -747,7 +783,7 @@ func (t *Translator) processBackendTrafficPolicyForRoute(
 	merged policyScopeGraph,
 	policy *egv1a1.BackendTrafficPolicy,
 	currTarget policyTargetReferenceWithSectionName,
-) {
+) bool {
 	var (
 		targetedRoute RouteContext
 		resolveErr    *status.PolicyResolveError
@@ -759,7 +795,7 @@ func (t *Translator) processBackendTrafficPolicyForRoute(
 	// reconciled by multiple controllers. And the other controller may
 	// have the target route.
 	if targetedRoute == nil {
-		return
+		return false
 	}
 
 	// Collect the route's parent refs for policy status and merge handling.
@@ -834,7 +870,7 @@ func (t *Translator) processBackendTrafficPolicyForRoute(
 			policy.Generation,
 			resolveErr,
 		)
-		return
+		return true
 	}
 
 	if policy.Spec.MergeType == nil {
@@ -951,7 +987,7 @@ func (t *Translator) processBackendTrafficPolicyForRoute(
 	// Check if this policy is overridden by other policies targeting at route rule levels
 	// If policy target is route rule, we can skip the check
 	if currTarget.SectionName != nil {
-		return
+		return true
 	}
 
 	key := policyTargetRouteKey{
@@ -971,6 +1007,8 @@ func (t *Translator) processBackendTrafficPolicyForRoute(
 			policy.Generation,
 		)
 	}
+
+	return true
 }
 
 func (t *Translator) processBackendTrafficPolicyForListenerSet(
@@ -981,7 +1019,7 @@ func (t *Translator) processBackendTrafficPolicyForListenerSet(
 	merged policyScopeGraph,
 	policy *egv1a1.BackendTrafficPolicy,
 	currTarget policyTargetReferenceWithSectionName,
-) {
+) bool {
 	var (
 		targeted   *gwapiv1.ListenerSet
 		resolveErr *status.PolicyResolveError
@@ -990,7 +1028,7 @@ func (t *Translator) processBackendTrafficPolicyForListenerSet(
 	targeted, resolveErr = resolveBackendTrafficPolicyListenerSetTargetRef(currTarget, listenerSetMap)
 	// Skip if the ListenerSet is not found. It may be reconciled by another controller.
 	if targeted == nil {
-		return
+		return false
 	}
 
 	parentGatewayNN := types.NamespacedName{
@@ -1001,7 +1039,7 @@ func (t *Translator) processBackendTrafficPolicyForListenerSet(
 	// The ListenerSet may exist while its parent Gateway is not in the accepted
 	// Gateway set for this translation run.
 	if !ok {
-		return
+		return false
 	}
 
 	// Use the ListenerSet itself as the policy ancestor (not the parent Gateway).
@@ -1016,7 +1054,7 @@ func (t *Translator) processBackendTrafficPolicyForListenerSet(
 			policy.Generation,
 			resolveErr,
 		)
-		return
+		return true
 	}
 
 	// Record the ListenerSet policy under the scope it attaches to. Listener
@@ -1082,6 +1120,7 @@ func (t *Translator) processBackendTrafficPolicyForListenerSet(
 	if deprecatedFields := deprecatedFieldsUsedInBackendTrafficPolicy(policy); len(deprecatedFields) > 0 {
 		status.SetDeprecatedFieldsWarningForPolicyAncestor(&policy.Status, &ancestorRef, t.GatewayControllerName, policy.Generation, deprecatedFields)
 	}
+	return true
 }
 
 func (t *Translator) processBackendTrafficPolicyForGateway(
@@ -1091,7 +1130,7 @@ func (t *Translator) processBackendTrafficPolicyForGateway(
 	merged policyScopeGraph,
 	policy *egv1a1.BackendTrafficPolicy,
 	currTarget policyTargetReferenceWithSectionName,
-) {
+) bool {
 	var (
 		targetedGateway *GatewayContext
 		resolveErr      *status.PolicyResolveError
@@ -1100,7 +1139,7 @@ func (t *Translator) processBackendTrafficPolicyForGateway(
 	// Negative statuses have already been assigned so it's safe to skip
 	targetedGateway, resolveErr = resolveBackendTrafficPolicyGatewayTargetRef(currTarget, gatewayMap)
 	if targetedGateway == nil {
-		return
+		return false
 	}
 
 	// Find its ancestor reference by resolved gateway, even with resolve error
@@ -1115,7 +1154,7 @@ func (t *Translator) processBackendTrafficPolicyForGateway(
 			policy.Generation,
 			resolveErr,
 		)
-		return
+		return true
 	}
 
 	// Record this policy as an override of the parent Gateway scope when the
@@ -1179,6 +1218,8 @@ func (t *Translator) processBackendTrafficPolicyForGateway(
 			policy.Generation,
 		)
 	}
+
+	return true
 }
 
 func resolveBackendTrafficPolicyGatewayTargetRef(

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-selector-no-match.in.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-selector-no-match.in.yaml
@@ -1,0 +1,50 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: listener-1
+      protocol: HTTP
+      port: 8081
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+    labels:
+      app: real-label
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: listener-1
+    rules:
+    - matches:
+      - path:
+          value: "/foo"
+      backendRefs:
+      - name: service-1
+        port: 8080
+backendTrafficPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    namespace: default
+    name: policy-with-unmatched-selector
+  spec:
+    targetSelectors:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      matchLabels:
+        app: no-such-label
+    timeout:
+      tcp:
+        connectTimeout: 15s

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-selector-no-match.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-selector-no-match.out.yaml
@@ -1,0 +1,174 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: listener-1
+      port: 8081
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: listener-1
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    labels:
+      app: real-label
+    name: httproute-1
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+      sectionName: listener-1
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          value: /foo
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: listener-1
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/listener-1
+        ports:
+        - containerPort: 8081
+          name: http-8081
+          protocol: HTTP
+          servicePort: 8081
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-1
+      namespace: envoy-gateway-system
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-envoy-gateway-gateway-1-196ae069
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: envoy-gateway/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-envoy-gateway-gateway-1-196ae069
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: envoy-gateway/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 8081
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: listener-1
+      name: envoy-gateway/gateway-1/listener-1
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8081
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-1
+            namespace: default
+          name: httproute/default/httproute-1/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-1/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-1
+          namespace: default
+        name: httproute/default/httproute-1/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /foo
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-targetref-not-found-stale-status.in.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-targetref-not-found-stale-status.in.yaml
@@ -1,0 +1,63 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: listener-1
+      protocol: HTTP
+      port: 8081
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: listener-1
+    rules:
+    - matches:
+      - path:
+          value: "/foo"
+      backendRefs:
+      - name: service-1
+        port: 8080
+backendTrafficPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    namespace: default
+    name: policy-was-attached-now-missing
+    generation: 2
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: does-not-exist
+    timeout:
+      tcp:
+        connectTimeout: 15s
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-targetref-not-found-stale-status.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-targetref-not-found-stale-status.out.yaml
@@ -1,0 +1,189 @@
+backendTrafficPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    generation: 2
+    name: policy-was-attached-now-missing
+    namespace: default
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: does-not-exist
+    timeout:
+      tcp:
+        connectTimeout: 15s
+  status:
+    ancestors: null
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: listener-1
+      port: 8081
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: listener-1
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-1
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+      sectionName: listener-1
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          value: /foo
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: listener-1
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/listener-1
+        ports:
+        - containerPort: 8081
+          name: http-8081
+          protocol: HTTP
+          servicePort: 8081
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-1
+      namespace: envoy-gateway-system
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-envoy-gateway-gateway-1-196ae069
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: envoy-gateway/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-envoy-gateway-gateway-1-196ae069
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: envoy-gateway/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 8081
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: listener-1
+      name: envoy-gateway/gateway-1/listener-1
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8081
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-1
+            namespace: default
+          name: httproute/default/httproute-1/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-1/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-1
+          namespace: default
+        name: httproute/default/httproute-1/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /foo
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-targetref-not-found.in.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-targetref-not-found.in.yaml
@@ -1,0 +1,47 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: listener-1
+      protocol: HTTP
+      port: 8081
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+      sectionName: listener-1
+    rules:
+    - matches:
+      - path:
+          value: "/foo"
+      backendRefs:
+      - name: service-1
+        port: 8080
+backendTrafficPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    namespace: default
+    name: policy-for-nonexistent-route
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: does-not-exist
+    timeout:
+      tcp:
+        connectTimeout: 15s

--- a/internal/gatewayapi/testdata/backendtrafficpolicy-targetref-not-found.out.yaml
+++ b/internal/gatewayapi/testdata/backendtrafficpolicy-targetref-not-found.out.yaml
@@ -1,0 +1,188 @@
+backendTrafficPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    name: policy-for-nonexistent-route
+    namespace: default
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: does-not-exist
+    timeout:
+      tcp:
+        connectTimeout: 15s
+  status:
+    ancestors: null
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: listener-1
+      port: 8081
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: listener-1
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-1
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+      sectionName: listener-1
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          value: /foo
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: listener-1
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/listener-1
+        ports:
+        - containerPort: 8081
+          name: http-8081
+          protocol: HTTP
+          servicePort: 8081
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-1
+      namespace: envoy-gateway-system
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-envoy-gateway-gateway-1-196ae069
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: envoy-gateway/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-envoy-gateway-gateway-1-196ae069
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: envoy-gateway/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 8081
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: listener-1
+      name: envoy-gateway/gateway-1/listener-1
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8081
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-1
+            namespace: default
+          name: httproute/default/httproute-1/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-1/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-1
+          namespace: default
+        name: httproute/default/httproute-1/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /foo
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/internal/provider/kubernetes/status.go
+++ b/internal/provider/kubernetes/status.go
@@ -413,12 +413,18 @@ func (r *gatewayAPIReconciler) updateStatusFromSubscriptions(ctx context.Context
 			message.Metadata{Runner: string(egv1a1.LogComponentProviderRunner), Message: message.BackendTrafficPolicyStatusMessageName},
 			r.subscriptions.backendTrafficPolicyStatuses,
 			func(update message.Update[types.NamespacedName, *gwapiv1.PolicyStatus], errChan chan error) {
-				// skip delete updates.
-				if update.Delete {
-					return
-				}
 				key := update.Key
 				val := update.Value
+
+				// A delete means the translator no longer produces status for this
+				// policy (e.g. its targetRef points at a nonexistent object, or its
+				// targetSelectors stopped matching anything). Clean up any stale
+				// status this controller previously wrote so it is not left behind.
+				if update.Delete {
+					r.statusUpdater.Send(r.backendTrafficPolicyStatusCleanupUpdate(key, errChan))
+					return
+				}
+
 				r.statusUpdater.Send(Update{
 					NamespacedName: key,
 					Resource:       new(egv1a1.BackendTrafficPolicy),
@@ -730,6 +736,48 @@ func mergeRouteParentStatus(ns string, old, new []gwapiv1.RouteParentStatus) []g
 		}
 	}
 	return merged
+}
+
+// removePolicyStatusForController returns the ancestor statuses with all entries
+// owned by the given controller removed, while preserving ancestors owned by other
+// controllers. It is used to clean up stale status for a policy that this controller
+// no longer attaches to any target. A nil slice is returned when no ancestors remain
+// so the resulting status has an empty (rather than [] with residual) ancestor list.
+func removePolicyStatusForController(ancestors []gwapiv1.PolicyAncestorStatus, controller gwapiv1.GatewayController) []gwapiv1.PolicyAncestorStatus {
+	var remaining []gwapiv1.PolicyAncestorStatus
+	for _, ancestor := range ancestors {
+		if ancestor.ControllerName != controller {
+			remaining = append(remaining, ancestor)
+		}
+	}
+	return remaining
+}
+
+// backendTrafficPolicyStatusCleanupUpdate builds a status Update that strips the
+// ancestor conditions owned by this controller from a BackendTrafficPolicy, while
+// preserving ancestors owned by other controllers. It is used when the translator
+// stops producing status for a policy (its targetRef points at a nonexistent object,
+// or its targetSelectors stopped matching anything) so a stale Accepted=True condition
+// with an out-of-date observedGeneration is not left behind. If the object itself was
+// deleted, the status updater's Get returns NotFound and applying this is a no-op.
+func (r *gatewayAPIReconciler) backendTrafficPolicyStatusCleanupUpdate(key types.NamespacedName, errChan chan error) Update {
+	return Update{
+		NamespacedName: key,
+		Resource:       new(egv1a1.BackendTrafficPolicy),
+		Mutator: MutatorFunc(func(obj client.Object) client.Object {
+			t, ok := obj.(*egv1a1.BackendTrafficPolicy)
+			if !ok {
+				err := fmt.Errorf("unsupported object type %T", obj)
+				if errChan != nil {
+					errChan <- err
+				}
+				panic(err)
+			}
+			tCopy := t.DeepCopy()
+			tCopy.Status.Ancestors = removePolicyStatusForController(tCopy.Status.Ancestors, r.classController)
+			return tCopy
+		}),
+	}
 }
 
 func (r *gatewayAPIReconciler) updateStatusForGateway(ctx context.Context, gtw *gwapiv1.Gateway) {

--- a/internal/provider/kubernetes/status_test.go
+++ b/internal/provider/kubernetes/status_test.go
@@ -6,11 +6,20 @@
 package kubernetes
 
 import (
+	"context"
+	"os"
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/envoygateway"
+	"github.com/envoyproxy/gateway/internal/logging"
 )
 
 func Test_mergeRouteParentStatus(t *testing.T) {
@@ -886,4 +895,160 @@ func Test_mergeRouteParentStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_removePolicyStatusForController(t *testing.T) {
+	const ours = gwapiv1.GatewayController("gateway.envoyproxy.io/gatewayclass-controller")
+	const theirs = gwapiv1.GatewayController("istio.io/gateway-controller")
+
+	ancestor := func(controller gwapiv1.GatewayController, name string) gwapiv1.PolicyAncestorStatus {
+		return gwapiv1.PolicyAncestorStatus{
+			ControllerName: controller,
+			AncestorRef:    gwapiv1.ParentReference{Name: gwapiv1.ObjectName(name)},
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(gwapiv1.PolicyConditionAccepted),
+					Status:             metav1.ConditionTrue,
+					Reason:             string(gwapiv1.PolicyReasonAccepted),
+					ObservedGeneration: 1,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		ancestors  []gwapiv1.PolicyAncestorStatus
+		controller gwapiv1.GatewayController
+		want       []gwapiv1.PolicyAncestorStatus
+	}{
+		{
+			// #8926 / #8927: policy attached to nothing this pass, its only ancestor
+			// is ours and stale -> it gets cleared so the stale Accepted=True is gone.
+			name:       "single stale ancestor of ours is cleared",
+			ancestors:  []gwapiv1.PolicyAncestorStatus{ancestor(ours, "gateway1")},
+			controller: ours,
+			want:       nil,
+		},
+		{
+			// Multi-controller: only our ancestor is removed, the other controller's
+			// status is preserved untouched.
+			name:       "only our ancestor removed, other controller preserved",
+			ancestors:  []gwapiv1.PolicyAncestorStatus{ancestor(theirs, "gateway1"), ancestor(ours, "gateway2")},
+			controller: ours,
+			want:       []gwapiv1.PolicyAncestorStatus{ancestor(theirs, "gateway1")},
+		},
+		{
+			name:       "no ancestors of ours leaves status untouched",
+			ancestors:  []gwapiv1.PolicyAncestorStatus{ancestor(theirs, "gateway1")},
+			controller: ours,
+			want:       []gwapiv1.PolicyAncestorStatus{ancestor(theirs, "gateway1")},
+		},
+		{
+			name:       "empty input returns empty",
+			ancestors:  nil,
+			controller: ours,
+			want:       nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removePolicyStatusForController(tt.ancestors, tt.controller); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removePolicyStatusForController() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBackendTrafficPolicyStatusCleanupOnDelete exercises the delete-path cleanup
+// end-to-end through the real UpdateHandler.apply against a fake client. It covers
+// both filed issues (a BackendTrafficPolicy whose target went missing, #8926, and one
+// whose selectors stopped matching, #8927) since both surface identically: the object
+// carries a stale Accepted=True condition with an out-of-date observedGeneration that
+// must be removed once the translator stops producing status for it.
+func TestBackendTrafficPolicyStatusCleanupOnDelete(t *testing.T) {
+	const ours = gwapiv1.GatewayController("gateway.envoyproxy.io/gatewayclass-controller")
+	const theirs = gwapiv1.GatewayController("istio.io/gateway-controller")
+
+	staleAncestor := func(controller gwapiv1.GatewayController, name string) gwapiv1.PolicyAncestorStatus {
+		return gwapiv1.PolicyAncestorStatus{
+			ControllerName: controller,
+			AncestorRef:    gwapiv1.ParentReference{Name: gwapiv1.ObjectName(name)},
+			Conditions: []metav1.Condition{{
+				Type:               string(gwapiv1.PolicyConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(gwapiv1.PolicyReasonAccepted),
+				ObservedGeneration: 1, // stale: object generation below is 2
+			}},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		existing      *egv1a1.BackendTrafficPolicy
+		key           types.NamespacedName
+		wantAncestors []gwapiv1.PolicyAncestorStatus
+	}{
+		{
+			name: "stale status owned solely by our controller is cleared",
+			existing: &egv1a1.BackendTrafficPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-1", Generation: 2},
+				Status:     gwapiv1.PolicyStatus{Ancestors: []gwapiv1.PolicyAncestorStatus{staleAncestor(ours, "gateway-1")}},
+			},
+			key:           types.NamespacedName{Namespace: "default", Name: "btp-1"},
+			wantAncestors: nil,
+		},
+		{
+			name: "only our ancestor is cleared, other controller's status preserved",
+			existing: &egv1a1.BackendTrafficPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-2", Generation: 2},
+				Status: gwapiv1.PolicyStatus{Ancestors: []gwapiv1.PolicyAncestorStatus{
+					staleAncestor(theirs, "gateway-1"),
+					staleAncestor(ours, "gateway-2"),
+				}},
+			},
+			key:           types.NamespacedName{Namespace: "default", Name: "btp-2"},
+			wantAncestors: []gwapiv1.PolicyAncestorStatus{staleAncestor(theirs, "gateway-1")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fakeclient.NewClientBuilder().
+				WithScheme(envoygateway.GetScheme()).
+				WithObjects(tt.existing).
+				WithStatusSubresource(tt.existing).
+				Build()
+
+			logger := logging.DefaultLogger(os.Stdout, egv1a1.LogLevelInfo)
+			u := NewUpdateHandler(logger.Logger, cli, cli)
+			r := &gatewayAPIReconciler{
+				log:             logger,
+				classController: ours,
+			}
+
+			u.apply(r.backendTrafficPolicyStatusCleanupUpdate(tt.key, nil))
+
+			got := &egv1a1.BackendTrafficPolicy{}
+			require.NoError(t, cli.Get(context.Background(), tt.key, got))
+			require.Equal(t, tt.wantAncestors, got.Status.Ancestors)
+		})
+	}
+
+	t.Run("delete for an already-removed object is a no-op", func(t *testing.T) {
+		cli := fakeclient.NewClientBuilder().WithScheme(envoygateway.GetScheme()).Build()
+		logger := logging.DefaultLogger(os.Stdout, egv1a1.LogLevelInfo)
+		u := NewUpdateHandler(logger.Logger, cli, cli)
+		r := &gatewayAPIReconciler{
+			log:             logger,
+			classController: ours,
+		}
+
+		// Must not panic or error when the object no longer exists.
+		u.apply(r.backendTrafficPolicyStatusCleanupUpdate(types.NamespacedName{Namespace: "default", Name: "gone"}, nil))
+
+		got := &egv1a1.BackendTrafficPolicy{}
+		err := cli.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "gone"}, got)
+		require.Error(t, err) // still not found
+	})
 }

--- a/release-notes/current/bug_fixes/8926-btp-status-target-not-found.md
+++ b/release-notes/current/bug_fixes/8926-btp-status-target-not-found.md
@@ -1,0 +1,1 @@
+Fixed BackendTrafficPolicy status going stale when the policy stops attaching to any target. A policy whose `targetRef`/`targetRefs` points at a nonexistent object or whose `targetSelectors` no longer match anything now has its stale ancestor status cleaned up instead of retaining an outdated `Accepted=True` condition with an out-of-date `observedGeneration`.


### PR DESCRIPTION
## What this fixes

A `BackendTrafficPolicy` that resolves to **zero targets** currently keeps a stale status. This addresses two issues with the same symptom but different root causes:

* **Fixes #8926** — `targetRef`/`targetRefs` pointing at a nonexistent object. The policy stays in the result set carrying its deep-copied prior status, so `Accepted=True` persists with an out-of-date `observedGeneration`.
* **Fixes #8927** — `targetSelectors` that match nothing. The policy never enters the result set, so its status is never reconciled and stays stale.

## The approach

Per review feedback on #9416, the stale status is cleaned up in the **provider status updater** rather than by synthesizing a condition in the translator:

* **Translator** (`ProcessBackendTrafficPolicies`): stops propagating carried-over stale status for a policy that attached to zero targets this pass. This is subtractive — no synthesized condition and no invented `ancestorRef`. Both cases then produce no status for the policy, which the gatewayapi runner turns into a status-store delete.
* **Provider** (`internal/provider/kubernetes/status.go`, BackendTrafficPolicy updater): handles the resulting status delete by stripping the ancestor conditions owned by this controller from the live object, while preserving ancestors owned by other controllers. If the object itself was deleted, the status updater's `Get` returns `NotFound` and applying the update is a no-op.

## Scope & follow-up

This PR is intentionally scoped to `BackendTrafficPolicy` to stay focused on the two filed issues. The same two structural gaps exist identically across the sibling policy types (`SecurityPolicy`, `ClientTrafficPolicy`, `BackendTLSPolicy`, `EnvoyExtensionPolicy`, `ExtensionServerPolicy`):

1. the translator's early-return-without-status on a missing/zero target, and
2. the `if update.Delete { return }` skip in each status updater (the route path even carries a `TODO` about the same dangling-status problem).

Both halves here were written to be extractable into shared helpers, so if the maintainers are happy with the approach and cleanup semantics, I'm glad to generalize it across the other policy types in a follow-up PR.

## Testing

* New golden fixtures reproducing each case:
  * `backendtrafficpolicy-targetref-not-found` (#8926)
  * `backendtrafficpolicy-targetref-not-found-stale-status` (#8926 with a pre-existing on-object stale status)
  * `backendtrafficpolicy-selector-no-match` (#8927)
* A new end-to-end provider test drives the delete-path cleanup through the real `UpdateHandler.apply` against a fake client: stale status owned by our controller is cleared, another controller's status is preserved, and a delete for an already-removed object is a no-op.
* `go test ./internal/gatewayapi/... ./internal/provider/kubernetes/...` passes; `go vet` and `gofmt` are clean. Regenerating goldens changed no existing files.

## Release note

Added `release-notes/current/bug_fixes/8926-btp-status-target-not-found.md`.

Made with Cursor

Made with [Cursor](https://cursor.com)