### PR TITLE
test: deflake RateLimitGlobalMergeTest/shared_no_client_selectors

### DIFF
--- a/test/e2e/tests/ratelimit.go
+++ b/test/e2e/tests/ratelimit.go
@@ -10,7 +10,6 @@ package tests
 import (
 	"context"
 	"net"
-	"strconv"
 	"testing"
 	"time"
 
@@ -1482,7 +1481,6 @@ var RateLimitGlobalMergeTest = suite.ConformanceTest{
 				Namespace: ns,
 			}
 			expectOkResp.Response.Headers["X-Ratelimit-Limit"] = "100, 100;w=3600"
-			expectOkReq := http.MakeRequest(t, &expectOkResp, gwAddr1, "HTTP", "http")
 
 			expectLimitResp := http.ExpectedResponse{
 				Request: http.Request{
@@ -1495,47 +1493,23 @@ var RateLimitGlobalMergeTest = suite.ConformanceTest{
 			}
 			expectLimitReq := http.MakeRequest(t, &expectLimitResp, gwAddr1, "HTTP", "http")
 
-			// Wait for the rate limit configuration to be ready
-			// This ensures the gateway is properly configured before we start counting requests
+			// Wait for the config to be ready; expectOkResp also pins the limit to 100/hour.
 			MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr1, &expectOkResp)
 
-			// Probe current remaining count (retry on network errors)
-			// Since other tests sharing the same gateway may have consumed some tokens,
-			// we need to check the remaining tokens dynamically instead of assuming a fresh bucket.
-			var remainingHeaders []string
+			// The rate limit service can fail open, so drive requests until a 429 appears
+			// instead of asserting an exact request count.
+			var sent int
 			require.Eventually(t, func() bool {
-				cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(expectOkReq)
+				sent++
+				cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(expectLimitReq)
 				if err != nil {
-					tlog.Logf(t, "failed to capture round trip due to network error: %v, retrying...", err)
-					return false // retry on network errors
+					tlog.Logf(t, "request #%d: network error while draining rate limit bucket: %v, retrying...", sent, err)
+					return false
 				}
-				if http.CompareRoundTrip(t, &expectOkReq, cReq, cRes, expectOkResp) != nil {
-					tlog.Logf(t, "response does not match expected: %v, retrying...", http.CompareRoundTrip(t, &expectOkReq, cReq, cRes, expectOkResp))
-					return false // retry if response does not match expected
-				}
-				remainingHeaders = cRes.Headers["X-Ratelimit-Remaining"]
-				if len(remainingHeaders) == 0 {
-					tlog.Logf(t, "X-Ratelimit-Remaining header not found, retrying...")
-					return false // retry if XDS config is not yet propagated
-				}
-				return true
-			}, suite.TimeoutConfig.MaxTimeToConsistency, suite.TimeoutConfig.RequestTimeout, "probe remaining tokens")
-
-			require.NotEmpty(t, remainingHeaders)
-			remaining, err := strconv.Atoi(remainingHeaders[0])
-			require.NoError(t, err)
-
-			// Consume the remaining tokens
-			if remaining > 0 {
-				if err := GotExactExpectedResponseExceptErrors(t, remaining, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-					t.Errorf("failed to exhaust remaining %d requests: %v", remaining, err)
-				}
-			}
-
-			// The next request should be rate limited
-			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectLimitReq, expectLimitResp); err != nil {
-				t.Errorf("expected 429 after exhaustion: %v", err)
-			}
+				tlog.Logf(t, "request #%d: status=%d, X-Ratelimit-Remaining=%v", sent, cRes.StatusCode, cRes.Headers["X-Ratelimit-Remaining"])
+				return http.CompareRoundTrip(t, &expectLimitReq, cReq, cRes, expectLimitResp) == nil
+			}, suite.TimeoutConfig.MaxTimeToConsistency, 50*time.Millisecond,
+				"expected the shared rate limit to eventually return 429")
 		})
 	},
 }


### PR DESCRIPTION
<!--
Your PR title should be descriptive, and generally start with a type that contains a subsystem name with `()` if necessary
and a summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), the API must be discussed and
agreed before the implementation. We strongly recommend separating API changes into their own PR so
we can review the API first, but the API may also live in the same PR as long as it was agreed
beforehand. This will save you a lot of implementation time if the API gets accepted.
-->

**What this PR does / why we need it**:
<!--
Briefly describe what this PR changes and the motivation behind it. Include enough context for a
reviewer to understand the problem being solved and the approach taken, e.g. what behavior changes,
any alternatives considered, and anything reviewers should pay special attention to.
-->

fix the flaky ratelimit e2e test.
ran the e2e test 50 times in the local kind cluster and all passed.

```
$ make create-cluster
$ kubectl config current-context
$ make kube-install-image
$ make kube-deploy
$ make install-ratelimit
$ make kube-install-examples-image
$ make e2e-prepare
$ make setup-mac-net-connect
$ fails=0
 for i in $(seq 1 50); do
 kubectl exec -n redis-system deploy/redis -- redis-cli FLUSHALL >/dev/null
 if go test -tags e2e -timeout 20m -run TestE2E ./e2e --gateway-class=envoy-gateway --cleanup-base-resources=false --run-test RateLimitGlobalMergeTest >"$TMPDIR/rl_run_$i.log" 2>&1; then
 echo "run $i: PASS"
 else
 echo "run $i: FAIL -> $TMPDIR/rl_run_$i.log"
 fails=$((fails+1))
 fi
 done
 echo "TOTAL FAILURES: $fails / 50"
run 1: PASS
run 2: PASS
run 3: PASS
run 4: PASS
run 5: PASS
run 6: PASS
run 7: PASS
run 8: PASS
run 9: PASS
run 10: PASS
E0707 10:29:46.185755   30011 websocket.go:296] Unknown stream id 1, discarding message
run 11: PASS
run 12: PASS
run 13: PASS
run 14: PASS
run 15: PASS
run 16: PASS
run 17: PASS
run 18: PASS
run 19: PASS
run 20: PASS
run 21: PASS
run 22: PASS
run 23: PASS
run 24: PASS
run 25: PASS
run 26: PASS
run 27: PASS
run 28: PASS
E0707 10:34:06.671796   50172 websocket.go:296] Unknown stream id 1, discarding message
run 29: PASS
run 30: PASS
run 31: PASS
run 32: PASS
run 33: PASS
run 34: PASS
run 35: PASS
run 36: PASS
run 37: PASS
run 38: PASS
run 39: PASS
run 40: PASS
run 41: PASS
run 42: PASS
run 43: PASS
run 44: PASS
run 45: PASS
run 46: PASS
run 47: PASS
run 48: PASS
run 49: PASS
run 50: PASS
TOTAL FAILURES: 0 / 50

```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/envoyproxy/gateway/issues/8113

---

**PR Checklist**
<!--
Please tick the boxes below before requesting a review. PRs that leave required items unchecked may
be delayed or closed. Replace `[ ]` with `[x]` to check a box. If an item does not apply, check it
and add "N/A: <reason>".
-->

- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: If this PR contains API changes (changes under `/api`), the API was discussed and agreed **before** the implementation. The API change can be in a separate PR, or in the same PR, but the API must be agreed before implementation. N/A if this PR does not contain API changes.
- [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (Flaky e2e failures are not considered breakages, but `gen-check`, `lint`, and coverage **MUST** pass.)
- [x] **Tests added/updated**: New/changed code is covered by appropriate tests. N/A if this PR does not contain code changes.
- [x] **Docs**: User-facing changes update the [docs](https://github.com/envoyproxy/gateway/tree/main/site), either in this PR or a follow-up PR. N/A if this PR does not contain user-facing changes.
- [x] **Release notes**: For any non-trivial change, added a release-note fragment under `release-notes/current/<section>/<pr-number>-<slug>.md` (see `release-notes/current/README.md` for sections and naming). N/A if this PR does not contain non-trivial changes.
- [x] **Generated files committed**: Ran `make gen-check` and committed the result if API/helm charts/modules changed.
- [x] **Scope & compatibility**: The PR is reasonably scoped (no unrelated changes) and preserves backward compatibility, or any breaking change is called out above and documented in `release-notes/current/breaking_changes/`.
- [x] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.
