### PR TITLE
perf: deduplicate JWT authn providers

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -660,7 +660,7 @@
                               "typedConfig": {
                                 "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                                 "providers": {
-                                  "httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example": {
+                                  "jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7": {
                                     "forward": true,
                                     "normalizePayloadInMetadata": {
                                       "spaceDelimitedClaims": [
@@ -681,8 +681,8 @@
                                   }
                                 },
                                 "requirementMap": {
-                                  "httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com": {
-                                    "providerName": "httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example"
+                                  "jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c": {
+                                    "providerName": "jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7"
                                   }
                                 }
                               }
@@ -779,7 +779,7 @@
                         "typedPerFilterConfig": {
                           "envoy.filters.http.jwt_authn": {
                             "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
-                            "requirementName": "httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com"
+                            "requirementName": "jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c"
                           }
                         }
                       }

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -660,7 +660,7 @@
                               "typedConfig": {
                                 "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                                 "providers": {
-                                  "jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7": {
+                                  "example_7815c684b265ae47": {
                                     "forward": true,
                                     "normalizePayloadInMetadata": {
                                       "spaceDelimitedClaims": [
@@ -681,8 +681,8 @@
                                   }
                                 },
                                 "requirementMap": {
-                                  "jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c": {
-                                    "providerName": "jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7"
+                                  "example_610fd14578c340be": {
+                                    "providerName": "example_7815c684b265ae47"
                                   }
                                 }
                               }
@@ -779,7 +779,7 @@
                         "typedPerFilterConfig": {
                           "envoy.filters.http.jwt_authn": {
                             "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
-                            "requirementName": "jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c"
+                            "requirementName": "example_610fd14578c340be"
                           }
                         }
                       }

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -398,7 +398,7 @@ xds:
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                       providers:
-                        jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7:
+                        example_7815c684b265ae47:
                           forward: true
                           normalizePayloadInMetadata:
                             spaceDelimitedClaims:
@@ -413,8 +413,8 @@ xds:
                               timeout: 10s
                               uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/jwt/jwks.json
                       requirementMap:
-                        jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c:
-                          providerName: jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7
+                        example_610fd14578c340be:
+                          providerName: example_7815c684b265ae47
                   - name: envoy.filters.http.router
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -470,4 +470,4 @@ xds:
               typedPerFilterConfig:
                 envoy.filters.http.jwt_authn:
                   '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                  requirementName: jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c
+                  requirementName: example_610fd14578c340be

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -398,7 +398,7 @@ xds:
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                       providers:
-                        httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example:
+                        jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7:
                           forward: true
                           normalizePayloadInMetadata:
                             spaceDelimitedClaims:
@@ -413,8 +413,8 @@ xds:
                               timeout: 10s
                               uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/jwt/jwks.json
                       requirementMap:
-                        httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com:
-                          providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example
+                        jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c:
+                          providerName: jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7
                   - name: envoy.filters.http.router
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -470,4 +470,4 @@ xds:
               typedPerFilterConfig:
                 envoy.filters.http.jwt_authn:
                   '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                  requirementName: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com
+                  requirementName: jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
@@ -130,7 +130,7 @@ xds:
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                     providers:
-                      jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7:
+                      example_7815c684b265ae47:
                         forward: true
                         normalizePayloadInMetadata:
                           spaceDelimitedClaims:
@@ -145,8 +145,8 @@ xds:
                             timeout: 10s
                             uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/jwt/jwks.json
                     requirementMap:
-                      jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c:
-                        providerName: jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7
+                      example_610fd14578c340be:
+                        providerName: example_7815c684b265ae47
                 - name: envoy.filters.http.router
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.listener.yaml
@@ -130,7 +130,7 @@ xds:
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                     providers:
-                      httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example:
+                      jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7:
                         forward: true
                         normalizePayloadInMetadata:
                           spaceDelimitedClaims:
@@ -145,8 +145,8 @@ xds:
                             timeout: 10s
                             uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/jwt/jwks.json
                     requirementMap:
-                      httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com:
-                        providerName: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com/example
+                      jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c:
+                        providerName: jwt/provider/example/7815c684b265ae4707ff29403025c5fc69b3ba9eaf73af78df453b153af89dd7
                 - name: envoy.filters.http.router
                   typedConfig:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.route.yaml
@@ -36,4 +36,4 @@ xds:
             typedPerFilterConfig:
               envoy.filters.http.jwt_authn:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                requirementName: httproute/envoy-gateway-system/backend/rule/0/match/0/www_example_com
+                requirementName: jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.route.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.route.yaml
@@ -36,4 +36,4 @@ xds:
             typedPerFilterConfig:
               envoy.filters.http.jwt_authn:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                requirementName: jwt/requirement/a98219faafd68054c015f3a94a4b6bf0d33b51c2b5a5ee0d4bf0d528f644444c
+                requirementName: example_610fd14578c340be

--- a/internal/xds/translator/jwt.go
+++ b/internal/xds/translator/jwt.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"strings"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -273,6 +272,24 @@ func buildJWTRequirement(reqs []*jwtauthnv3.JwtRequirement) *jwtauthnv3.JwtRequi
 	}
 }
 
+// maxJWTNameLength bounds the length of generated JWT provider and requirement
+// names. The readable prefix is derived from user-controlled provider names and,
+// for requirements, grows with the number of combined providers, so without a
+// cap the generated name could become long enough to fail Envoy xDS validation.
+const maxJWTNameLength = 256
+
+// boundedJWTName joins a human-readable prefix with a content-derived hash,
+// truncating the prefix if necessary so the total length stays within
+// maxJWTNameLength. The hash suffix is always preserved, so names remain unique
+// even when the prefix is truncated.
+func boundedJWTName(prefix, hash string) string {
+	suffix := "_" + hash
+	if maxPrefix := maxJWTNameLength - len(suffix); len(prefix) > maxPrefix {
+		prefix = prefix[:maxPrefix]
+	}
+	return prefix + suffix
+}
+
 // jwtProviderName returns a deterministic name for a JWT provider that combines
 // the IR provider name with a hash of the generated Envoy provider config. The
 // hash lets identical providers share a single entry across routes, while the
@@ -282,7 +299,7 @@ func jwtProviderName(providerName string, provider *jwtauthnv3.JwtProvider) (str
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s_%s", providerName, hash), nil
+	return boundedJWTName(providerName, hash), nil
 }
 
 // jwtRequirementName returns a deterministic name for a JWT requirement. The
@@ -301,7 +318,7 @@ func jwtRequirementName(jwt *ir.JWT, requirement *jwtauthnv3.JwtRequirement) (st
 	if jwt.AllowMissing {
 		names = append(names, "missing")
 	}
-	return fmt.Sprintf("%s_%s", strings.Join(names, "-or-"), hash), nil
+	return boundedJWTName(strings.Join(names, "-or-"), hash), nil
 }
 
 // protoHash returns the first 16 hex characters of the SHA-256 digest of the

--- a/internal/xds/translator/jwt.go
+++ b/internal/xds/translator/jwt.go
@@ -294,7 +294,7 @@ func protoHash(message gproto.Message) (string, error) {
 		return "", err
 	}
 	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:8]), nil
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // buildXdsUpstreamTLSSocket returns an xDS TransportSocket that uses the system trust store

--- a/internal/xds/translator/jwt.go
+++ b/internal/xds/translator/jwt.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -121,7 +122,7 @@ func buildJWTAuthn(irListener *ir.HTTPListener, jwtAuthn *jwtauthnv3.JwtAuthenti
 		}
 
 		requirement := buildJWTRequirement(reqs)
-		requirementName, err := jwtRequirementName(requirement)
+		requirementName, err := jwtRequirementName(route.Security.JWT, requirement)
 		if err != nil {
 			return err
 		}
@@ -272,29 +273,47 @@ func buildJWTRequirement(reqs []*jwtauthnv3.JwtRequirement) *jwtauthnv3.JwtRequi
 	}
 }
 
+// jwtProviderName returns a deterministic name for a JWT provider that combines
+// the IR provider name with a hash of the generated Envoy provider config. The
+// hash lets identical providers share a single entry across routes, while the
+// prefix keeps the generated name readable.
 func jwtProviderName(providerName string, provider *jwtauthnv3.JwtProvider) (string, error) {
 	hash, err := protoHash(provider)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("jwt/provider/%s/%s", providerName, hash), nil
+	return fmt.Sprintf("%s_%s", providerName, hash), nil
 }
 
-func jwtRequirementName(requirement *jwtauthnv3.JwtRequirement) (string, error) {
+// jwtRequirementName returns a deterministic name for a JWT requirement. The
+// name combines the referenced IR provider names (plus "missing" when missing
+// tokens are allowed) with a hash of the generated Envoy requirement config, so
+// identical requirements are deduplicated while the name stays human readable.
+func jwtRequirementName(jwt *ir.JWT, requirement *jwtauthnv3.JwtRequirement) (string, error) {
 	hash, err := protoHash(requirement)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("jwt/requirement/%s", hash), nil
+	names := make([]string, 0, len(jwt.Providers)+1)
+	for i := range jwt.Providers {
+		names = append(names, jwt.Providers[i].Name)
+	}
+	if jwt.AllowMissing {
+		names = append(names, "missing")
+	}
+	return fmt.Sprintf("%s_%s", strings.Join(names, "-or-"), hash), nil
 }
 
+// protoHash returns the first 16 hex characters of the SHA-256 digest of the
+// deterministically-marshaled proto message. This follows the existing xDS
+// naming precedent set by sdsClusterNameFromURL.
 func protoHash(message gproto.Message) (string, error) {
 	b, err := gproto.MarshalOptions{Deterministic: true}.Marshal(message)
 	if err != nil {
 		return "", err
 	}
 	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:]), nil
+	return hex.EncodeToString(sum[:8]), nil
 }
 
 // buildXdsUpstreamTLSSocket returns an xDS TransportSocket that uses the system trust store
@@ -349,7 +368,7 @@ func (*jwt) patchRoute(route *routev3.Route, irRoute *ir.HTTPRoute, _ *ir.HTTPLi
 		if err != nil {
 			return err
 		}
-		requirementName, err := jwtRequirementName(buildJWTRequirement(reqs))
+		requirementName, err := jwtRequirementName(irRoute.Security.JWT, buildJWTRequirement(reqs))
 		if err != nil {
 			return err
 		}

--- a/internal/xds/translator/jwt.go
+++ b/internal/xds/translator/jwt.go
@@ -6,6 +6,8 @@
 package translator
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -15,6 +17,7 @@ import (
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -109,134 +112,189 @@ func buildJWTAuthn(irListener *ir.HTTPListener, jwtAuthn *jwtauthnv3.JwtAuthenti
 			jwtAuthn.RequirementMap = make(map[string]*jwtauthnv3.JwtRequirement, len(route.Security.JWT.Providers))
 		}
 
-		var reqs []*jwtauthnv3.JwtRequirement
-		for i := range route.Security.JWT.Providers {
-			var (
-				irProvider = route.Security.JWT.Providers[i]
-				err        error
-			)
-
-			claimToHeaders := make([]*jwtauthnv3.JwtClaimToHeader, 0, len(irProvider.ClaimToHeaders))
-			for _, claimToHeader := range irProvider.ClaimToHeaders {
-				claimToHeader := &jwtauthnv3.JwtClaimToHeader{
-					HeaderName: claimToHeader.Header,
-					ClaimName:  claimToHeader.Claim,
-				}
-				claimToHeaders = append(claimToHeaders, claimToHeader)
-			}
-			jwtProvider := &jwtauthnv3.JwtProvider{
-				Issuer:            irProvider.Issuer,
-				Audiences:         irProvider.Audiences,
-				PayloadInMetadata: irProvider.Name,
-				ClaimToHeaders:    claimToHeaders,
-				Forward:           true,
-				NormalizePayloadInMetadata: &jwtauthnv3.JwtProvider_NormalizePayload{
-					// Normalize the scopes to facilitate matching in Authorization.
-					SpaceDelimitedClaims: []string{"scope", "scp"},
-				},
-			}
-			if irProvider.LocalJWKS != nil {
-				local := &jwtauthnv3.JwtProvider_LocalJwks{
-					LocalJwks: &corev3.DataSource{
-						Specifier: &corev3.DataSource_InlineString{
-							InlineString: *irProvider.LocalJWKS,
-						},
-					},
-				}
-				jwtProvider.JwksSourceSpecifier = local
-			} else {
-				var jwksCluster string
-
-				jwks := irProvider.RemoteJWKS
-				if jwks.Destination != nil && len(jwks.Destination.Settings) > 0 {
-					jwksCluster = jwks.Destination.Name
-				} else {
-					var cluster *urlCluster
-					if cluster, err = url2Cluster(jwks.URI); err != nil {
-						return err
-					}
-					jwksCluster = cluster.name
-				}
-
-				jwksTimeout := durationpb.New(defaultExtServiceRequestTimeout)
-				if jwks.Traffic != nil &&
-					jwks.Traffic.Timeout != nil &&
-					jwks.Traffic.Timeout.HTTP != nil &&
-					jwks.Traffic.Timeout.HTTP.RequestTimeout != nil {
-					jwksTimeout = durationpb.New(jwks.Traffic.Timeout.HTTP.RequestTimeout.Duration)
-				}
-
-				remote := &jwtauthnv3.JwtProvider_RemoteJwks{
-					RemoteJwks: &jwtauthnv3.RemoteJwks{
-						HttpUri: &corev3.HttpUri{
-							Uri: jwks.URI,
-							HttpUpstreamType: &corev3.HttpUri_Cluster{
-								Cluster: jwksCluster,
-							},
-							Timeout: jwksTimeout,
-						},
-
-						AsyncFetch: &jwtauthnv3.JwksAsyncFetch{},
-					},
-				}
-				if jwks.CacheDuration != nil {
-					remote.RemoteJwks.CacheDuration = durationpb.New(jwks.CacheDuration.Duration)
-				}
-				if jwks.FailedRefetchDuration != nil {
-					remote.RemoteJwks.AsyncFetch.FailedRefetchDuration = durationpb.New(jwks.FailedRefetchDuration.Duration)
-				}
-				// Set the retry policy if it exists.
-				if jwks.Traffic != nil && jwks.Traffic.Retry != nil {
-					var rp *corev3.RetryPolicy
-					if rp, err = buildNonRouteRetryPolicy(jwks.Traffic.Retry); err != nil {
-						return err
-					}
-					remote.RemoteJwks.RetryPolicy = rp
-				}
-				jwtProvider.JwksSourceSpecifier = remote
-			}
-
-			if irProvider.RecomputeRoute != nil {
-				jwtProvider.ClearRouteCache = *irProvider.RecomputeRoute
-			}
-
-			if irProvider.ExtractFrom != nil {
-				jwtProvider.FromHeaders = buildJwtFromHeaders(irProvider.ExtractFrom.Headers)
-				jwtProvider.FromCookies = irProvider.ExtractFrom.Cookies
-				jwtProvider.FromParams = irProvider.ExtractFrom.Params
-			}
-
-			providerKey := fmt.Sprintf("%s/%s", route.Name, irProvider.Name)
+		providers, reqs, err := buildJWTRequirements(route.Security.JWT)
+		if err != nil {
+			return err
+		}
+		for providerKey, jwtProvider := range providers {
 			jwtAuthn.Providers[providerKey] = jwtProvider
-			reqs = append(reqs, &jwtauthnv3.JwtRequirement{
-				RequiresType: &jwtauthnv3.JwtRequirement_ProviderName{
-					ProviderName: providerKey,
-				},
-			})
 		}
 
-		if route.Security.JWT.AllowMissing {
-			reqs = append(reqs, &jwtauthnv3.JwtRequirement{
-				RequiresType: &jwtauthnv3.JwtRequirement_AllowMissing{
-					AllowMissing: &emptypb.Empty{},
-				},
-			})
+		requirement := buildJWTRequirement(reqs)
+		requirementName, err := jwtRequirementName(requirement)
+		if err != nil {
+			return err
 		}
-
-		if len(reqs) == 1 {
-			jwtAuthn.RequirementMap[route.Name] = reqs[0]
-		} else {
-			orListReqs := &jwtauthnv3.JwtRequirement{
-				RequiresType: &jwtauthnv3.JwtRequirement_RequiresAny{
-					RequiresAny: &jwtauthnv3.JwtRequirementOrList{
-						Requirements: reqs,
-					},
-				},
-			}
-			jwtAuthn.RequirementMap[route.Name] = orListReqs
-		}
+		jwtAuthn.RequirementMap[requirementName] = requirement
 	}
 	return nil
+}
+
+func buildJWTRequirements(jwt *ir.JWT) (map[string]*jwtauthnv3.JwtProvider, []*jwtauthnv3.JwtRequirement, error) {
+	providers := make(map[string]*jwtauthnv3.JwtProvider, len(jwt.Providers))
+	reqs := make([]*jwtauthnv3.JwtRequirement, 0, len(jwt.Providers)+1)
+
+	for i := range jwt.Providers {
+		irProvider := jwt.Providers[i]
+		jwtProvider, err := buildJWTProvider(&irProvider)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		providerKey, err := jwtProviderName(irProvider.Name, jwtProvider)
+		if err != nil {
+			return nil, nil, err
+		}
+		providers[providerKey] = jwtProvider
+		reqs = append(reqs, &jwtauthnv3.JwtRequirement{
+			RequiresType: &jwtauthnv3.JwtRequirement_ProviderName{
+				ProviderName: providerKey,
+			},
+		})
+	}
+
+	if jwt.AllowMissing {
+		reqs = append(reqs, &jwtauthnv3.JwtRequirement{
+			RequiresType: &jwtauthnv3.JwtRequirement_AllowMissing{
+				AllowMissing: &emptypb.Empty{},
+			},
+		})
+	}
+
+	return providers, reqs, nil
+}
+
+func buildJWTProvider(irProvider *ir.JWTProvider) (*jwtauthnv3.JwtProvider, error) {
+	claimToHeaders := make([]*jwtauthnv3.JwtClaimToHeader, 0, len(irProvider.ClaimToHeaders))
+	for _, claimToHeader := range irProvider.ClaimToHeaders {
+		claimToHeader := &jwtauthnv3.JwtClaimToHeader{
+			HeaderName: claimToHeader.Header,
+			ClaimName:  claimToHeader.Claim,
+		}
+		claimToHeaders = append(claimToHeaders, claimToHeader)
+	}
+	jwtProvider := &jwtauthnv3.JwtProvider{
+		Issuer:            irProvider.Issuer,
+		Audiences:         irProvider.Audiences,
+		PayloadInMetadata: irProvider.Name,
+		ClaimToHeaders:    claimToHeaders,
+		Forward:           true,
+		NormalizePayloadInMetadata: &jwtauthnv3.JwtProvider_NormalizePayload{
+			// Normalize the scopes to facilitate matching in Authorization.
+			SpaceDelimitedClaims: []string{"scope", "scp"},
+		},
+	}
+	if irProvider.LocalJWKS != nil {
+		local := &jwtauthnv3.JwtProvider_LocalJwks{
+			LocalJwks: &corev3.DataSource{
+				Specifier: &corev3.DataSource_InlineString{
+					InlineString: *irProvider.LocalJWKS,
+				},
+			},
+		}
+		jwtProvider.JwksSourceSpecifier = local
+	} else {
+		var jwksCluster string
+
+		jwks := irProvider.RemoteJWKS
+		if jwks.Destination != nil && len(jwks.Destination.Settings) > 0 {
+			jwksCluster = jwks.Destination.Name
+		} else {
+			cluster, err := url2Cluster(jwks.URI)
+			if err != nil {
+				return nil, err
+			}
+			jwksCluster = cluster.name
+		}
+
+		jwksTimeout := durationpb.New(defaultExtServiceRequestTimeout)
+		if jwks.Traffic != nil &&
+			jwks.Traffic.Timeout != nil &&
+			jwks.Traffic.Timeout.HTTP != nil &&
+			jwks.Traffic.Timeout.HTTP.RequestTimeout != nil {
+			jwksTimeout = durationpb.New(jwks.Traffic.Timeout.HTTP.RequestTimeout.Duration)
+		}
+
+		remote := &jwtauthnv3.JwtProvider_RemoteJwks{
+			RemoteJwks: &jwtauthnv3.RemoteJwks{
+				HttpUri: &corev3.HttpUri{
+					Uri: jwks.URI,
+					HttpUpstreamType: &corev3.HttpUri_Cluster{
+						Cluster: jwksCluster,
+					},
+					Timeout: jwksTimeout,
+				},
+
+				AsyncFetch: &jwtauthnv3.JwksAsyncFetch{},
+			},
+		}
+		if jwks.CacheDuration != nil {
+			remote.RemoteJwks.CacheDuration = durationpb.New(jwks.CacheDuration.Duration)
+		}
+		if jwks.FailedRefetchDuration != nil {
+			remote.RemoteJwks.AsyncFetch.FailedRefetchDuration = durationpb.New(jwks.FailedRefetchDuration.Duration)
+		}
+		// Set the retry policy if it exists.
+		if jwks.Traffic != nil && jwks.Traffic.Retry != nil {
+			rp, err := buildNonRouteRetryPolicy(jwks.Traffic.Retry)
+			if err != nil {
+				return nil, err
+			}
+			remote.RemoteJwks.RetryPolicy = rp
+		}
+		jwtProvider.JwksSourceSpecifier = remote
+	}
+
+	if irProvider.RecomputeRoute != nil {
+		jwtProvider.ClearRouteCache = *irProvider.RecomputeRoute
+	}
+
+	if irProvider.ExtractFrom != nil {
+		jwtProvider.FromHeaders = buildJwtFromHeaders(irProvider.ExtractFrom.Headers)
+		jwtProvider.FromCookies = irProvider.ExtractFrom.Cookies
+		jwtProvider.FromParams = irProvider.ExtractFrom.Params
+	}
+
+	return jwtProvider, nil
+}
+
+func buildJWTRequirement(reqs []*jwtauthnv3.JwtRequirement) *jwtauthnv3.JwtRequirement {
+	if len(reqs) == 1 {
+		return reqs[0]
+	}
+
+	return &jwtauthnv3.JwtRequirement{
+		RequiresType: &jwtauthnv3.JwtRequirement_RequiresAny{
+			RequiresAny: &jwtauthnv3.JwtRequirementOrList{
+				Requirements: reqs,
+			},
+		},
+	}
+}
+
+func jwtProviderName(providerName string, provider *jwtauthnv3.JwtProvider) (string, error) {
+	hash, err := protoHash(provider)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("jwt/provider/%s/%s", providerName, hash), nil
+}
+
+func jwtRequirementName(requirement *jwtauthnv3.JwtRequirement) (string, error) {
+	hash, err := protoHash(requirement)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("jwt/requirement/%s", hash), nil
+}
+
+func protoHash(message gproto.Message) (string, error) {
+	b, err := gproto.MarshalOptions{Deterministic: true}.Marshal(message)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:8]), nil
 }
 
 // buildXdsUpstreamTLSSocket returns an xDS TransportSocket that uses the system trust store
@@ -287,8 +345,17 @@ func (*jwt) patchRoute(route *routev3.Route, irRoute *ir.HTTPRoute, _ *ir.HTTPLi
 			return nil
 		}
 
+		_, reqs, err := buildJWTRequirements(irRoute.Security.JWT)
+		if err != nil {
+			return err
+		}
+		requirementName, err := jwtRequirementName(buildJWTRequirement(reqs))
+		if err != nil {
+			return err
+		}
+
 		routeCfgProto := &jwtauthnv3.PerRouteConfig{
-			RequirementSpecifier: &jwtauthnv3.PerRouteConfig_RequirementName{RequirementName: irRoute.Name},
+			RequirementSpecifier: &jwtauthnv3.PerRouteConfig_RequirementName{RequirementName: requirementName},
 		}
 
 		routeCfgAny, err := proto.ToAnyWithValidation(routeCfgProto)

--- a/internal/xds/translator/jwt_test.go
+++ b/internal/xds/translator/jwt_test.go
@@ -1,0 +1,69 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"testing"
+
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	jwtauthnv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/jwt_authn/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/gateway/internal/ir"
+)
+
+func TestJWTAuthnDeduplicatesIdenticalRouteProviders(t *testing.T) {
+	provider := ir.JWTProvider{
+		Name:   "azure-jwt",
+		Issuer: "https://sts.windows.net/example/",
+		RemoteJWKS: &ir.RemoteJWKS{
+			URI: "https://login.microsoftonline.com/common/discovery/keys",
+		},
+	}
+	irListener := &ir.HTTPListener{
+		Routes: []*ir.HTTPRoute{
+			{
+				Name: "httproute/default/route-a/rule/0/match/0/example.com",
+				Security: &ir.SecurityFeatures{
+					JWT: &ir.JWT{
+						Providers: []ir.JWTProvider{provider},
+					},
+				},
+			},
+			{
+				Name: "httproute/default/route-b/rule/0/match/0/example.com",
+				Security: &ir.SecurityFeatures{
+					JWT: &ir.JWT{
+						Providers: []ir.JWTProvider{provider},
+					},
+				},
+			},
+		},
+	}
+
+	var jwtAuthn jwtauthnv3.JwtAuthentication
+	require.NoError(t, buildJWTAuthn(irListener, &jwtAuthn))
+	require.Len(t, jwtAuthn.GetProviders(), 1)
+	require.Len(t, jwtAuthn.GetRequirementMap(), 1)
+
+	var requirementName string
+	for name := range jwtAuthn.GetRequirementMap() {
+		requirementName = name
+	}
+	for providerName := range jwtAuthn.GetProviders() {
+		require.Equal(t, providerName, jwtAuthn.GetRequirementMap()[requirementName].GetProviderName())
+	}
+
+	jwtFilter := &jwt{}
+	for _, irRoute := range irListener.Routes {
+		xdsRoute := &routev3.Route{}
+		require.NoError(t, jwtFilter.patchRoute(xdsRoute, irRoute, irListener))
+
+		var perRouteConfig jwtauthnv3.PerRouteConfig
+		require.NoError(t, xdsRoute.GetTypedPerFilterConfig()["envoy.filters.http.jwt_authn"].UnmarshalTo(&perRouteConfig))
+		require.Equal(t, requirementName, perRouteConfig.GetRequirementName())
+	}
+}

--- a/internal/xds/translator/jwt_test.go
+++ b/internal/xds/translator/jwt_test.go
@@ -6,6 +6,7 @@
 package translator
 
 import (
+	"strings"
 	"testing"
 
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -65,5 +66,41 @@ func TestJWTAuthnDeduplicatesIdenticalRouteProviders(t *testing.T) {
 		var perRouteConfig jwtauthnv3.PerRouteConfig
 		require.NoError(t, xdsRoute.GetTypedPerFilterConfig()["envoy.filters.http.jwt_authn"].UnmarshalTo(&perRouteConfig))
 		require.Equal(t, requirementName, perRouteConfig.GetRequirementName())
+	}
+}
+
+func TestJWTAuthnNamesAreBounded(t *testing.T) {
+	// Build a JWT config with many long provider names so the joined,
+	// human-readable prefix would exceed the length guard if left unbounded.
+	providers := make([]ir.JWTProvider, 0, 50)
+	for i := 0; i < 50; i++ {
+		providers = append(providers, ir.JWTProvider{
+			Name:   strings.Repeat("very-long-jwt-provider-name", 3),
+			Issuer: "https://issuer.example.com/",
+			RemoteJWKS: &ir.RemoteJWKS{
+				URI: "https://issuer.example.com/keys",
+			},
+		})
+	}
+	irJWT := &ir.JWT{Providers: providers, AllowMissing: true}
+	irListener := &ir.HTTPListener{
+		Routes: []*ir.HTTPRoute{
+			{
+				Name:     "httproute/default/route-a/rule/0/match/0/example.com",
+				Security: &ir.SecurityFeatures{JWT: irJWT},
+			},
+		},
+	}
+
+	var jwtAuthn jwtauthnv3.JwtAuthentication
+	require.NoError(t, buildJWTAuthn(irListener, &jwtAuthn))
+
+	for providerName := range jwtAuthn.GetProviders() {
+		require.LessOrEqual(t, len(providerName), maxJWTNameLength)
+	}
+	for requirementName := range jwtAuthn.GetRequirementMap() {
+		require.LessOrEqual(t, len(requirementName), maxJWTNameLength)
+		// The uniqueness-guaranteeing hash suffix must survive truncation.
+		require.Contains(t, requirementName, "_")
 	}
 }

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example1/02327216cb0dba2135b1ac9fdc9ee8353f7469c02f72851a8d0393d44fd1e86b:
+              example1_02327216cb0dba21:
                 audiences:
                 - two.foo.com
                 forward: true
@@ -35,7 +35,7 @@
                     cluster: two_example_com_443
                     timeout: 10s
                     uri: https://two.example.com/jwt/public-key/jwks.json
-              jwt/provider/example1/ee7c27dda4c8e01e584ab8ca63089b3f6f5d6da7d8eed2720245256abbf3019d:
+              example1_ee7c27dda4c8e01e:
                 audiences:
                 - one.foo.com
                 forward: true
@@ -53,10 +53,10 @@
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/08f241a5e0676684ca923fdce9a8efd3434f0f14a9cdd598b50cb0b470447a4e:
-                providerName: jwt/provider/example1/ee7c27dda4c8e01e584ab8ca63089b3f6f5d6da7d8eed2720245256abbf3019d
-              jwt/requirement/bd10aba78008229742963accf7aa2f3ac242f3c97e632ab6b90dc821773c7deb:
-                providerName: jwt/provider/example1/02327216cb0dba2135b1ac9fdc9ee8353f7469c02f72851a8d0393d44fd1e86b
+              example1_3b6358ed75b16e41:
+                providerName: example1_ee7c27dda4c8e01e
+              example1_128ed6e824345145:
+                providerName: example1_02327216cb0dba21
         - name: envoy.filters.http.rbac
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              httproute/default/httproute-1/rule/0/match/0/www_example_com/example1:
+              jwt/provider/example1/02327216cb0dba21:
                 audiences:
                 - two.foo.com
                 forward: true
@@ -35,7 +35,7 @@
                     cluster: two_example_com_443
                     timeout: 10s
                     uri: https://two.example.com/jwt/public-key/jwks.json
-              httproute/default/httproute-2/rule/0/match/0/www_example_com/example1:
+              jwt/provider/example1/ee7c27dda4c8e01e:
                 audiences:
                 - one.foo.com
                 forward: true
@@ -53,10 +53,10 @@
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
             requirementMap:
-              httproute/default/httproute-1/rule/0/match/0/www_example_com:
-                providerName: httproute/default/httproute-1/rule/0/match/0/www_example_com/example1
-              httproute/default/httproute-2/rule/0/match/0/www_example_com:
-                providerName: httproute/default/httproute-2/rule/0/match/0/www_example_com/example1
+              jwt/requirement/f221fc9d2c0259f7:
+                providerName: jwt/provider/example1/02327216cb0dba21
+              jwt/requirement/fcdfd84248345c0e:
+                providerName: jwt/provider/example1/ee7c27dda4c8e01e
         - name: envoy.filters.http.rbac
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example1/02327216cb0dba21:
+              jwt/provider/example1/02327216cb0dba2135b1ac9fdc9ee8353f7469c02f72851a8d0393d44fd1e86b:
                 audiences:
                 - two.foo.com
                 forward: true
@@ -35,7 +35,7 @@
                     cluster: two_example_com_443
                     timeout: 10s
                     uri: https://two.example.com/jwt/public-key/jwks.json
-              jwt/provider/example1/ee7c27dda4c8e01e:
+              jwt/provider/example1/ee7c27dda4c8e01e584ab8ca63089b3f6f5d6da7d8eed2720245256abbf3019d:
                 audiences:
                 - one.foo.com
                 forward: true
@@ -53,10 +53,10 @@
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/f221fc9d2c0259f7:
-                providerName: jwt/provider/example1/02327216cb0dba21
-              jwt/requirement/fcdfd84248345c0e:
-                providerName: jwt/provider/example1/ee7c27dda4c8e01e
+              jwt/requirement/08f241a5e0676684ca923fdce9a8efd3434f0f14a9cdd598b50cb0b470447a4e:
+                providerName: jwt/provider/example1/ee7c27dda4c8e01e584ab8ca63089b3f6f5d6da7d8eed2720245256abbf3019d
+              jwt/requirement/bd10aba78008229742963accf7aa2f3ac242f3c97e632ab6b90dc821773c7deb:
+                providerName: jwt/provider/example1/02327216cb0dba2135b1ac9fdc9ee8353f7469c02f72851a8d0393d44fd1e86b
         - name: envoy.filters.http.rbac
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/f221fc9d2c0259f7
+          requirementName: jwt/requirement/bd10aba78008229742963accf7aa2f3ac242f3c97e632ab6b90dc821773c7deb
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:
@@ -105,7 +105,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/fcdfd84248345c0e
+          requirementName: jwt/requirement/08f241a5e0676684ca923fdce9a8efd3434f0f14a9cdd598b50cb0b470447a4e
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/bd10aba78008229742963accf7aa2f3ac242f3c97e632ab6b90dc821773c7deb
+          requirementName: example1_128ed6e824345145
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:
@@ -105,7 +105,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/08f241a5e0676684ca923fdce9a8efd3434f0f14a9cdd598b50cb0b470447a4e
+          requirementName: example1_3b6358ed75b16e41
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: httproute/default/httproute-1/rule/0/match/0/www_example_com
+          requirementName: jwt/requirement/f221fc9d2c0259f7
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:
@@ -105,7 +105,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: httproute/default/httproute-2/rule/0/match/0/www_example_com
+          requirementName: jwt/requirement/fcdfd84248345c0e
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example1/02327216cb0dba2135b1ac9fdc9ee8353f7469c02f72851a8d0393d44fd1e86b:
+              example1_02327216cb0dba21:
                 audiences:
                 - two.foo.com
                 forward: true
@@ -35,7 +35,7 @@
                     cluster: two_example_com_443
                     timeout: 10s
                     uri: https://two.example.com/jwt/public-key/jwks.json
-              jwt/provider/example1/ee7c27dda4c8e01e584ab8ca63089b3f6f5d6da7d8eed2720245256abbf3019d:
+              example1_ee7c27dda4c8e01e:
                 audiences:
                 - one.foo.com
                 forward: true
@@ -53,10 +53,10 @@
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/08f241a5e0676684ca923fdce9a8efd3434f0f14a9cdd598b50cb0b470447a4e:
-                providerName: jwt/provider/example1/ee7c27dda4c8e01e584ab8ca63089b3f6f5d6da7d8eed2720245256abbf3019d
-              jwt/requirement/bd10aba78008229742963accf7aa2f3ac242f3c97e632ab6b90dc821773c7deb:
-                providerName: jwt/provider/example1/02327216cb0dba2135b1ac9fdc9ee8353f7469c02f72851a8d0393d44fd1e86b
+              example1_3b6358ed75b16e41:
+                providerName: example1_ee7c27dda4c8e01e
+              example1_128ed6e824345145:
+                providerName: example1_02327216cb0dba21
         - name: envoy.filters.http.rbac
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              httproute/default/httproute-1/rule/0/match/0/www_example_com/example1:
+              jwt/provider/example1/02327216cb0dba21:
                 audiences:
                 - two.foo.com
                 forward: true
@@ -35,7 +35,7 @@
                     cluster: two_example_com_443
                     timeout: 10s
                     uri: https://two.example.com/jwt/public-key/jwks.json
-              httproute/default/httproute-2/rule/0/match/0/www_example_com/example1:
+              jwt/provider/example1/ee7c27dda4c8e01e:
                 audiences:
                 - one.foo.com
                 forward: true
@@ -53,10 +53,10 @@
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
             requirementMap:
-              httproute/default/httproute-1/rule/0/match/0/www_example_com:
-                providerName: httproute/default/httproute-1/rule/0/match/0/www_example_com/example1
-              httproute/default/httproute-2/rule/0/match/0/www_example_com:
-                providerName: httproute/default/httproute-2/rule/0/match/0/www_example_com/example1
+              jwt/requirement/f221fc9d2c0259f7:
+                providerName: jwt/provider/example1/02327216cb0dba21
+              jwt/requirement/fcdfd84248345c0e:
+                providerName: jwt/provider/example1/ee7c27dda4c8e01e
         - name: envoy.filters.http.rbac
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example1/02327216cb0dba21:
+              jwt/provider/example1/02327216cb0dba2135b1ac9fdc9ee8353f7469c02f72851a8d0393d44fd1e86b:
                 audiences:
                 - two.foo.com
                 forward: true
@@ -35,7 +35,7 @@
                     cluster: two_example_com_443
                     timeout: 10s
                     uri: https://two.example.com/jwt/public-key/jwks.json
-              jwt/provider/example1/ee7c27dda4c8e01e:
+              jwt/provider/example1/ee7c27dda4c8e01e584ab8ca63089b3f6f5d6da7d8eed2720245256abbf3019d:
                 audiences:
                 - one.foo.com
                 forward: true
@@ -53,10 +53,10 @@
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/f221fc9d2c0259f7:
-                providerName: jwt/provider/example1/02327216cb0dba21
-              jwt/requirement/fcdfd84248345c0e:
-                providerName: jwt/provider/example1/ee7c27dda4c8e01e
+              jwt/requirement/08f241a5e0676684ca923fdce9a8efd3434f0f14a9cdd598b50cb0b470447a4e:
+                providerName: jwt/provider/example1/ee7c27dda4c8e01e584ab8ca63089b3f6f5d6da7d8eed2720245256abbf3019d
+              jwt/requirement/bd10aba78008229742963accf7aa2f3ac242f3c97e632ab6b90dc821773c7deb:
+                providerName: jwt/provider/example1/02327216cb0dba2135b1ac9fdc9ee8353f7469c02f72851a8d0393d44fd1e86b
         - name: envoy.filters.http.rbac
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: httproute/default/httproute-1/rule/0/match/0/www_example_com
+          requirementName: jwt/requirement/f221fc9d2c0259f7
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:
@@ -147,7 +147,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: httproute/default/httproute-2/rule/0/match/0/www_example_com
+          requirementName: jwt/requirement/fcdfd84248345c0e
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/f221fc9d2c0259f7
+          requirementName: jwt/requirement/bd10aba78008229742963accf7aa2f3ac242f3c97e632ab6b90dc821773c7deb
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:
@@ -147,7 +147,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/fcdfd84248345c0e
+          requirementName: jwt/requirement/08f241a5e0676684ca923fdce9a8efd3434f0f14a9cdd598b50cb0b470447a4e
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/bd10aba78008229742963accf7aa2f3ac242f3c97e632ab6b90dc821773c7deb
+          requirementName: example1_128ed6e824345145
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:
@@ -147,7 +147,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/08f241a5e0676684ca923fdce9a8efd3434f0f14a9cdd598b50cb0b470447a4e
+          requirementName: example1_3b6358ed75b16e41
         envoy.filters.http.rbac:
           '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
           rbac:

--- a/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
@@ -65,7 +65,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              httproute/envoy-gateway/httproute-1/rule/0/match/0/www_example_com/example1:
+              jwt/provider/example1/324018c9eaae726a:
                 audiences:
                 - one.foo.com
                 claimToHeaders:
@@ -85,7 +85,7 @@
                     cluster: one_example_com_443
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
-              httproute/envoy-gateway/httproute-1/rule/0/match/0/www_example_com/example2:
+              jwt/provider/example2/b2e71814e87a6562:
                 audiences:
                 - two.foo.com
                 claimToHeaders:
@@ -106,11 +106,11 @@
                     timeout: 10s
                     uri: http://two.example.com/jwt/public-key/jwks.json
             requirementMap:
-              httproute/envoy-gateway/httproute-1/rule/0/match/0/www_example_com:
+              jwt/requirement/2efd9a4d6f64d2ce:
                 requiresAny:
                   requirements:
-                  - providerName: httproute/envoy-gateway/httproute-1/rule/0/match/0/www_example_com/example1
-                  - providerName: httproute/envoy-gateway/httproute-1/rule/0/match/0/www_example_com/example2
+                  - providerName: jwt/provider/example1/324018c9eaae726a
+                  - providerName: jwt/provider/example2/b2e71814e87a6562
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
@@ -65,7 +65,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example1/324018c9eaae726a:
+              jwt/provider/example1/324018c9eaae726a83bab5c117d77649aa8b6ffd1ecb999504b96d740d8892ff:
                 audiences:
                 - one.foo.com
                 claimToHeaders:
@@ -85,7 +85,7 @@
                     cluster: one_example_com_443
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
-              jwt/provider/example2/b2e71814e87a6562:
+              jwt/provider/example2/b2e71814e87a6562eeaa315a6f89b5dba0e3495289c399ca14d372659a7a0071:
                 audiences:
                 - two.foo.com
                 claimToHeaders:
@@ -106,11 +106,11 @@
                     timeout: 10s
                     uri: http://two.example.com/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/2efd9a4d6f64d2ce:
+              jwt/requirement/ab4233a6c948da652b54825e9813a1e2fb7324bb03188c2f64adcf2e8e76d501:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/example1/324018c9eaae726a
-                  - providerName: jwt/provider/example2/b2e71814e87a6562
+                  - providerName: jwt/provider/example1/324018c9eaae726a83bab5c117d77649aa8b6ffd1ecb999504b96d740d8892ff
+                  - providerName: jwt/provider/example2/b2e71814e87a6562eeaa315a6f89b5dba0e3495289c399ca14d372659a7a0071
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.listeners.yaml
@@ -65,7 +65,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example1/324018c9eaae726a83bab5c117d77649aa8b6ffd1ecb999504b96d740d8892ff:
+              example1_324018c9eaae726a:
                 audiences:
                 - one.foo.com
                 claimToHeaders:
@@ -85,7 +85,7 @@
                     cluster: one_example_com_443
                     timeout: 10s
                     uri: https://one.example.com/jwt/public-key/jwks.json
-              jwt/provider/example2/b2e71814e87a6562eeaa315a6f89b5dba0e3495289c399ca14d372659a7a0071:
+              example2_b2e71814e87a6562:
                 audiences:
                 - two.foo.com
                 claimToHeaders:
@@ -106,11 +106,11 @@
                     timeout: 10s
                     uri: http://two.example.com/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/ab4233a6c948da652b54825e9813a1e2fb7324bb03188c2f64adcf2e8e76d501:
+              example1-or-example2_73a070ef6c8ee8ea:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/example1/324018c9eaae726a83bab5c117d77649aa8b6ffd1ecb999504b96d740d8892ff
-                  - providerName: jwt/provider/example2/b2e71814e87a6562eeaa315a6f89b5dba0e3495289c399ca14d372659a7a0071
+                  - providerName: example1_324018c9eaae726a
+                  - providerName: example2_b2e71814e87a6562
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.routes.yaml
@@ -26,7 +26,7 @@
           forwardNotMatchingPreflights: false
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/ab4233a6c948da652b54825e9813a1e2fb7324bb03188c2f64adcf2e8e76d501
+          requirementName: example1-or-example2_73a070ef6c8ee8ea
         envoy.filters.http.wasm/envoyextensionpolicy/envoy-gateway/policy-for-gateway/0:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}

--- a/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.routes.yaml
@@ -26,7 +26,7 @@
           forwardNotMatchingPreflights: false
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: httproute/envoy-gateway/httproute-1/rule/0/match/0/www_example_com
+          requirementName: jwt/requirement/2efd9a4d6f64d2ce
         envoy.filters.http.wasm/envoyextensionpolicy/envoy-gateway/policy-for-gateway/0:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}

--- a/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-filter-order.routes.yaml
@@ -26,7 +26,7 @@
           forwardNotMatchingPreflights: false
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/2efd9a4d6f64d2ce
+          requirementName: jwt/requirement/ab4233a6c948da652b54825e9813a1e2fb7324bb03188c2f64adcf2e8e76d501
         envoy.filters.http.wasm/envoyextensionpolicy/envoy-gateway/policy-for-gateway/0:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/ca5e5bd0966b6a1e:
+              jwt/provider/example/ca5e5bd0966b6a1eec2b90a8cbeb9526da88ccaca08b815c8a24643c6be07c16:
                 audiences:
                 - foo.com
                 forward: true
@@ -43,8 +43,8 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/758e7fc5a524523b:
-                providerName: jwt/provider/example/ca5e5bd0966b6a1e
+              jwt/requirement/da693d2125cf562719cd741425cf1a5b596e4d72b691fdc982e956afa730a902:
+                providerName: jwt/provider/example/ca5e5bd0966b6a1eec2b90a8cbeb9526da88ccaca08b815c8a24643c6be07c16
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/ca5e5bd0966b6a1eec2b90a8cbeb9526da88ccaca08b815c8a24643c6be07c16:
+              example_ca5e5bd0966b6a1e:
                 audiences:
                 - foo.com
                 forward: true
@@ -43,8 +43,8 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/da693d2125cf562719cd741425cf1a5b596e4d72b691fdc982e956afa730a902:
-                providerName: jwt/provider/example/ca5e5bd0966b6a1eec2b90a8cbeb9526da88ccaca08b815c8a24643c6be07c16
+              example_94e1b42a04d0a923:
+                providerName: example_ca5e5bd0966b6a1e
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              first-route/example:
+              jwt/provider/example/ca5e5bd0966b6a1e:
                 audiences:
                 - foo.com
                 forward: true
@@ -43,8 +43,8 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              first-route:
-                providerName: first-route/example
+              jwt/requirement/758e7fc5a524523b:
+                providerName: jwt/provider/example/ca5e5bd0966b6a1e
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/758e7fc5a524523b
+          requirementName: jwt/requirement/da693d2125cf562719cd741425cf1a5b596e4d72b691fdc982e956afa730a902

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/da693d2125cf562719cd741425cf1a5b596e4d72b691fdc982e956afa730a902
+          requirementName: example_94e1b42a04d0a923

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: first-route
+          requirementName: jwt/requirement/758e7fc5a524523b

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.listeners.yaml
@@ -54,7 +54,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/jwt1/cb766da7fa6f1202:
+              jwt/provider/jwt1/cb766da7fa6f120205692a9243e7f6aa199854acd573a66fd2104147534a1b39:
                 forward: true
                 fromCookies:
                 - AccessTokenDomain1
@@ -70,7 +70,7 @@
                     cluster: www_googleapis_com_443
                     timeout: 10s
                     uri: https://www.googleapis.com/oauth2/v3/certs
-              jwt/provider/jwt2/d1e60459ce7ec72c:
+              jwt/provider/jwt2/d1e60459ce7ec72cb019553138e4034f83b39649992278581776b0929c8eae5d:
                 forward: true
                 fromCookies:
                 - AccessTokenDomain2
@@ -87,15 +87,15 @@
                     timeout: 10s
                     uri: https://www.googleapis.com/oauth2/v3/certs
             requirementMap:
-              jwt/requirement/8aaa63102e3c7ac2:
+              jwt/requirement/2e185e0ebcf2694d92db2cffbf9e32d8552a08e06d2701915c01d6eee7619603:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/jwt1/cb766da7fa6f1202
+                  - providerName: jwt/provider/jwt2/d1e60459ce7ec72cb019553138e4034f83b39649992278581776b0929c8eae5d
                   - allowMissing: {}
-              jwt/requirement/5272fd3188a21f1b:
+              jwt/requirement/a84799e66c64ed7c2eb8701b2c0ff3849215572c80290825ebc4c63375a581a4:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/jwt2/d1e60459ce7ec72c
+                  - providerName: jwt/provider/jwt1/cb766da7fa6f120205692a9243e7f6aa199854acd573a66fd2104147534a1b39
                   - allowMissing: {}
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.listeners.yaml
@@ -54,7 +54,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/jwt1/cb766da7fa6f120205692a9243e7f6aa199854acd573a66fd2104147534a1b39:
+              jwt1_cb766da7fa6f1202:
                 forward: true
                 fromCookies:
                 - AccessTokenDomain1
@@ -70,7 +70,7 @@
                     cluster: www_googleapis_com_443
                     timeout: 10s
                     uri: https://www.googleapis.com/oauth2/v3/certs
-              jwt/provider/jwt2/d1e60459ce7ec72cb019553138e4034f83b39649992278581776b0929c8eae5d:
+              jwt2_d1e60459ce7ec72c:
                 forward: true
                 fromCookies:
                 - AccessTokenDomain2
@@ -87,15 +87,15 @@
                     timeout: 10s
                     uri: https://www.googleapis.com/oauth2/v3/certs
             requirementMap:
-              jwt/requirement/2e185e0ebcf2694d92db2cffbf9e32d8552a08e06d2701915c01d6eee7619603:
+              jwt1-or-missing_6f7e920fc2a0617c:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/jwt2/d1e60459ce7ec72cb019553138e4034f83b39649992278581776b0929c8eae5d
+                  - providerName: jwt1_cb766da7fa6f1202
                   - allowMissing: {}
-              jwt/requirement/a84799e66c64ed7c2eb8701b2c0ff3849215572c80290825ebc4c63375a581a4:
+              jwt2-or-missing_554e269f8327a7aa:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/jwt1/cb766da7fa6f120205692a9243e7f6aa199854acd573a66fd2104147534a1b39
+                  - providerName: jwt2_d1e60459ce7ec72c
                   - allowMissing: {}
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.listeners.yaml
@@ -54,7 +54,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              httproute/ns1/domain1/rule/0/match/0/domain1_example_com/jwt1:
+              jwt/provider/jwt1/cb766da7fa6f1202:
                 forward: true
                 fromCookies:
                 - AccessTokenDomain1
@@ -70,7 +70,7 @@
                     cluster: www_googleapis_com_443
                     timeout: 10s
                     uri: https://www.googleapis.com/oauth2/v3/certs
-              httproute/ns2/domain2/rule/0/match/0/domain2_example_com/jwt2:
+              jwt/provider/jwt2/d1e60459ce7ec72c:
                 forward: true
                 fromCookies:
                 - AccessTokenDomain2
@@ -87,15 +87,15 @@
                     timeout: 10s
                     uri: https://www.googleapis.com/oauth2/v3/certs
             requirementMap:
-              httproute/ns1/domain1/rule/0/match/0/domain1_example_com:
+              jwt/requirement/8aaa63102e3c7ac2:
                 requiresAny:
                   requirements:
-                  - providerName: httproute/ns1/domain1/rule/0/match/0/domain1_example_com/jwt1
+                  - providerName: jwt/provider/jwt1/cb766da7fa6f1202
                   - allowMissing: {}
-              httproute/ns2/domain2/rule/0/match/0/domain2_example_com:
+              jwt/requirement/5272fd3188a21f1b:
                 requiresAny:
                   requirements:
-                  - providerName: httproute/ns2/domain2/rule/0/match/0/domain2_example_com/jwt2
+                  - providerName: jwt/provider/jwt2/d1e60459ce7ec72c
                   - allowMissing: {}
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/a84799e66c64ed7c2eb8701b2c0ff3849215572c80290825ebc4c63375a581a4
+          requirementName: jwt1-or-missing_6f7e920fc2a0617c
   - domains:
     - domain2.example.com
     metadata:
@@ -60,4 +60,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/2e185e0ebcf2694d92db2cffbf9e32d8552a08e06d2701915c01d6eee7619603
+          requirementName: jwt2-or-missing_554e269f8327a7aa

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: httproute/ns1/domain1/rule/0/match/0/domain1_example_com
+          requirementName: jwt/requirement/8aaa63102e3c7ac2
   - domains:
     - domain2.example.com
     metadata:
@@ -60,4 +60,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: httproute/ns2/domain2/rule/0/match/0/domain2_example_com
+          requirementName: jwt/requirement/5272fd3188a21f1b

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/8aaa63102e3c7ac2
+          requirementName: jwt/requirement/a84799e66c64ed7c2eb8701b2c0ff3849215572c80290825ebc4c63375a581a4
   - domains:
     - domain2.example.com
     metadata:
@@ -60,4 +60,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/5272fd3188a21f1b
+          requirementName: jwt/requirement/2e185e0ebcf2694d92db2cffbf9e32d8552a08e06d2701915c01d6eee7619603

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/7e0f64f43618ad77d6ef8e083baff5c2fe35e4c99c3d3fe18e13d8c2161b99eb:
+              example_7e0f64f43618ad77:
                 audiences:
                 - foo.com
                 claimToHeaders:
@@ -38,7 +38,7 @@
                     cluster: localhost_80
                     timeout: 10s
                     uri: http://localhost/jwt/public-key/jwks.json
-              jwt/provider/example/c464f1a4e10c61a27e355446e46d4c10b9717e95eff5456f7c0986273204706e:
+              example_c464f1a4e10c61a2:
                 audiences:
                 - foo.com
                 claimToHeaders:
@@ -58,7 +58,7 @@
                     cluster: localhost_80
                     timeout: 10s
                     uri: http://localhost/jwt/public-key/jwks.json
-              jwt/provider/example2/9fb53f4aa4426db0f4d66c27a674850f9f3b5c27475254c396488550d24d96ba:
+              example2_9fb53f4aa4426db0:
                 audiences:
                 - one.foo.com
                 - two.foo.com
@@ -85,7 +85,7 @@
                   - scope
                   - scp
                 payloadInMetadata: example2
-              jwt/provider/example2/e2fe046d949623590cb3476ea5037c17602c80e5b1e7e2c5f4f12c7dad369c5c:
+              example2_e2fe046d94962359:
                 audiences:
                 - one.foo.com
                 - two.foo.com
@@ -104,16 +104,16 @@
                     timeout: 10s
                     uri: https://192.168.1.250:8080/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/1bc45aab169ed46ae459f4389afcf01ef34c24a680f322bd4bf53b6673e90743:
+              example-or-example2_32d8e7367a44f94f:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/example/c464f1a4e10c61a27e355446e46d4c10b9717e95eff5456f7c0986273204706e
-                  - providerName: jwt/provider/example2/9fb53f4aa4426db0f4d66c27a674850f9f3b5c27475254c396488550d24d96ba
-              jwt/requirement/f10504aaed29f87cda860a91e55082670a7be8abd48f08a4710e1d5725d2d164:
+                  - providerName: example_7e0f64f43618ad77
+                  - providerName: example2_e2fe046d94962359
+              example-or-example2_6521f40c1fdcd711:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/example/7e0f64f43618ad77d6ef8e083baff5c2fe35e4c99c3d3fe18e13d8c2161b99eb
-                  - providerName: jwt/provider/example2/e2fe046d949623590cb3476ea5037c17602c80e5b1e7e2c5f4f12c7dad369c5c
+                  - providerName: example_c464f1a4e10c61a2
+                  - providerName: example2_9fb53f4aa4426db0
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/7e0f64f43618ad77:
+              jwt/provider/example/7e0f64f43618ad77d6ef8e083baff5c2fe35e4c99c3d3fe18e13d8c2161b99eb:
                 audiences:
                 - foo.com
                 claimToHeaders:
@@ -38,7 +38,7 @@
                     cluster: localhost_80
                     timeout: 10s
                     uri: http://localhost/jwt/public-key/jwks.json
-              jwt/provider/example/c464f1a4e10c61a2:
+              jwt/provider/example/c464f1a4e10c61a27e355446e46d4c10b9717e95eff5456f7c0986273204706e:
                 audiences:
                 - foo.com
                 claimToHeaders:
@@ -58,7 +58,7 @@
                     cluster: localhost_80
                     timeout: 10s
                     uri: http://localhost/jwt/public-key/jwks.json
-              jwt/provider/example2/9fb53f4aa4426db0:
+              jwt/provider/example2/9fb53f4aa4426db0f4d66c27a674850f9f3b5c27475254c396488550d24d96ba:
                 audiences:
                 - one.foo.com
                 - two.foo.com
@@ -85,7 +85,7 @@
                   - scope
                   - scp
                 payloadInMetadata: example2
-              jwt/provider/example2/e2fe046d94962359:
+              jwt/provider/example2/e2fe046d949623590cb3476ea5037c17602c80e5b1e7e2c5f4f12c7dad369c5c:
                 audiences:
                 - one.foo.com
                 - two.foo.com
@@ -104,16 +104,16 @@
                     timeout: 10s
                     uri: https://192.168.1.250:8080/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/7b9f7dfa2d18b3f1:
+              jwt/requirement/1bc45aab169ed46ae459f4389afcf01ef34c24a680f322bd4bf53b6673e90743:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/example/c464f1a4e10c61a2
-                  - providerName: jwt/provider/example2/9fb53f4aa4426db0
-              jwt/requirement/333e4fca5cdf9227:
+                  - providerName: jwt/provider/example/c464f1a4e10c61a27e355446e46d4c10b9717e95eff5456f7c0986273204706e
+                  - providerName: jwt/provider/example2/9fb53f4aa4426db0f4d66c27a674850f9f3b5c27475254c396488550d24d96ba
+              jwt/requirement/f10504aaed29f87cda860a91e55082670a7be8abd48f08a4710e1d5725d2d164:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/example/7e0f64f43618ad77
-                  - providerName: jwt/provider/example2/e2fe046d94962359
+                  - providerName: jwt/provider/example/7e0f64f43618ad77d6ef8e083baff5c2fe35e4c99c3d3fe18e13d8c2161b99eb
+                  - providerName: jwt/provider/example2/e2fe046d949623590cb3476ea5037c17602c80e5b1e7e2c5f4f12c7dad369c5c
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.listeners.yaml
@@ -18,7 +18,27 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              first-route-www.test.com/example:
+              jwt/provider/example/7e0f64f43618ad77:
+                audiences:
+                - foo.com
+                claimToHeaders:
+                - claimName: claim.neteased.key
+                  headerName: second-route-example-key1
+                forward: true
+                issuer: https://www.example.com
+                normalizePayloadInMetadata:
+                  spaceDelimitedClaims:
+                  - scope
+                  - scp
+                payloadInMetadata: example
+                remoteJwks:
+                  asyncFetch: {}
+                  cacheDuration: 300s
+                  httpUri:
+                    cluster: localhost_80
+                    timeout: 10s
+                    uri: http://localhost/jwt/public-key/jwks.json
+              jwt/provider/example/c464f1a4e10c61a2:
                 audiences:
                 - foo.com
                 claimToHeaders:
@@ -38,7 +58,7 @@
                     cluster: localhost_80
                     timeout: 10s
                     uri: http://localhost/jwt/public-key/jwks.json
-              first-route-www.test.com/example2:
+              jwt/provider/example2/9fb53f4aa4426db0:
                 audiences:
                 - one.foo.com
                 - two.foo.com
@@ -65,27 +85,7 @@
                   - scope
                   - scp
                 payloadInMetadata: example2
-              second-route-www.test.com/example:
-                audiences:
-                - foo.com
-                claimToHeaders:
-                - claimName: claim.neteased.key
-                  headerName: second-route-example-key1
-                forward: true
-                issuer: https://www.example.com
-                normalizePayloadInMetadata:
-                  spaceDelimitedClaims:
-                  - scope
-                  - scp
-                payloadInMetadata: example
-                remoteJwks:
-                  asyncFetch: {}
-                  cacheDuration: 300s
-                  httpUri:
-                    cluster: localhost_80
-                    timeout: 10s
-                    uri: http://localhost/jwt/public-key/jwks.json
-              second-route-www.test.com/example2:
+              jwt/provider/example2/e2fe046d94962359:
                 audiences:
                 - one.foo.com
                 - two.foo.com
@@ -104,16 +104,16 @@
                     timeout: 10s
                     uri: https://192.168.1.250:8080/jwt/public-key/jwks.json
             requirementMap:
-              first-route-www.test.com:
+              jwt/requirement/7b9f7dfa2d18b3f1:
                 requiresAny:
                   requirements:
-                  - providerName: first-route-www.test.com/example
-                  - providerName: first-route-www.test.com/example2
-              second-route-www.test.com:
+                  - providerName: jwt/provider/example/c464f1a4e10c61a2
+                  - providerName: jwt/provider/example2/9fb53f4aa4426db0
+              jwt/requirement/333e4fca5cdf9227:
                 requiresAny:
                   requirements:
-                  - providerName: second-route-www.test.com/example
-                  - providerName: second-route-www.test.com/example2
+                  - providerName: jwt/provider/example/7e0f64f43618ad77
+                  - providerName: jwt/provider/example2/e2fe046d94962359
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/7b9f7dfa2d18b3f1
+          requirementName: jwt/requirement/1bc45aab169ed46ae459f4389afcf01ef34c24a680f322bd4bf53b6673e90743
     - match:
         path: foo/baz
       name: second-route-www.test.com
@@ -26,4 +26,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/333e4fca5cdf9227
+          requirementName: jwt/requirement/f10504aaed29f87cda860a91e55082670a7be8abd48f08a4710e1d5725d2d164

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/1bc45aab169ed46ae459f4389afcf01ef34c24a680f322bd4bf53b6673e90743
+          requirementName: example-or-example2_6521f40c1fdcd711
     - match:
         path: foo/baz
       name: second-route-www.test.com
@@ -26,4 +26,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/f10504aaed29f87cda860a91e55082670a7be8abd48f08a4710e1d5725d2d164
+          requirementName: example-or-example2_32d8e7367a44f94f

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: first-route-www.test.com
+          requirementName: jwt/requirement/7b9f7dfa2d18b3f1
     - match:
         path: foo/baz
       name: second-route-www.test.com
@@ -26,4 +26,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: second-route-www.test.com
+          requirementName: jwt/requirement/333e4fca5cdf9227

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
@@ -40,7 +40,24 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              first-route/example:
+              jwt/provider/example/ced70d98fe975d58:
+                audiences:
+                - foo.com
+                forward: true
+                issuer: https://www.example.com
+                normalizePayloadInMetadata:
+                  spaceDelimitedClaims:
+                  - scope
+                  - scp
+                payloadInMetadata: example
+                remoteJwks:
+                  asyncFetch: {}
+                  cacheDuration: 300s
+                  httpUri:
+                    cluster: localhost_443
+                    timeout: 10s
+                    uri: https://localhost/jwt/public-key/jwks.json
+              jwt/provider/example/ec0cbab21272dbab:
                 audiences:
                 - foo.com
                 claimToHeaders:
@@ -60,28 +77,11 @@
                     cluster: localhost_443
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
-              second-route/example:
-                audiences:
-                - foo.com
-                forward: true
-                issuer: https://www.example.com
-                normalizePayloadInMetadata:
-                  spaceDelimitedClaims:
-                  - scope
-                  - scp
-                payloadInMetadata: example
-                remoteJwks:
-                  asyncFetch: {}
-                  cacheDuration: 300s
-                  httpUri:
-                    cluster: localhost_443
-                    timeout: 10s
-                    uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              first-route:
-                providerName: first-route/example
-              second-route:
-                providerName: second-route/example
+              jwt/requirement/28d048f7ae082488:
+                providerName: jwt/provider/example/ced70d98fe975d58
+              jwt/requirement/26479564a58816cb:
+                providerName: jwt/provider/example/ec0cbab21272dbab
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
@@ -40,7 +40,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/ced70d98fe975d58db12245312161a7ed7089ea07dab4779c9b178c977369bfb:
+              example_ced70d98fe975d58:
                 audiences:
                 - foo.com
                 forward: true
@@ -57,7 +57,7 @@
                     cluster: localhost_443
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
-              jwt/provider/example/ec0cbab21272dbabdf5e90cd07bee495dda0d5c9ec624ca378edd2f13d75f242:
+              example_ec0cbab21272dbab:
                 audiences:
                 - foo.com
                 claimToHeaders:
@@ -78,10 +78,10 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/d6849978f979611f2c5f72aacc63ab40fda64c1115227e95782f03a4a0d914cd:
-                providerName: jwt/provider/example/ec0cbab21272dbabdf5e90cd07bee495dda0d5c9ec624ca378edd2f13d75f242
-              jwt/requirement/fec9e1b50ff77cffddd9657517afbef6c00b0fb28bcc84f3ce38bfefdab173f5:
-                providerName: jwt/provider/example/ced70d98fe975d58db12245312161a7ed7089ea07dab4779c9b178c977369bfb
+              example_670bf892477997dd:
+                providerName: example_ced70d98fe975d58
+              example_c3b3e98f32dd654c:
+                providerName: example_ec0cbab21272dbab
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.listeners.yaml
@@ -40,7 +40,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/ced70d98fe975d58:
+              jwt/provider/example/ced70d98fe975d58db12245312161a7ed7089ea07dab4779c9b178c977369bfb:
                 audiences:
                 - foo.com
                 forward: true
@@ -57,7 +57,7 @@
                     cluster: localhost_443
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
-              jwt/provider/example/ec0cbab21272dbab:
+              jwt/provider/example/ec0cbab21272dbabdf5e90cd07bee495dda0d5c9ec624ca378edd2f13d75f242:
                 audiences:
                 - foo.com
                 claimToHeaders:
@@ -78,10 +78,10 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/28d048f7ae082488:
-                providerName: jwt/provider/example/ced70d98fe975d58
-              jwt/requirement/26479564a58816cb:
-                providerName: jwt/provider/example/ec0cbab21272dbab
+              jwt/requirement/d6849978f979611f2c5f72aacc63ab40fda64c1115227e95782f03a4a0d914cd:
+                providerName: jwt/provider/example/ec0cbab21272dbabdf5e90cd07bee495dda0d5c9ec624ca378edd2f13d75f242
+              jwt/requirement/fec9e1b50ff77cffddd9657517afbef6c00b0fb28bcc84f3ce38bfefdab173f5:
+                providerName: jwt/provider/example/ced70d98fe975d58db12245312161a7ed7089ea07dab4779c9b178c977369bfb
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: first-route
+          requirementName: jwt/requirement/26479564a58816cb
     - match:
         path: foo/baz
       name: second-route
@@ -26,4 +26,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: second-route
+          requirementName: jwt/requirement/28d048f7ae082488

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/26479564a58816cb
+          requirementName: jwt/requirement/d6849978f979611f2c5f72aacc63ab40fda64c1115227e95782f03a4a0d914cd
     - match:
         path: foo/baz
       name: second-route
@@ -26,4 +26,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/28d048f7ae082488
+          requirementName: jwt/requirement/fec9e1b50ff77cffddd9657517afbef6c00b0fb28bcc84f3ce38bfefdab173f5

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/d6849978f979611f2c5f72aacc63ab40fda64c1115227e95782f03a4a0d914cd
+          requirementName: example_c3b3e98f32dd654c
     - match:
         path: foo/baz
       name: second-route
@@ -26,4 +26,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/fec9e1b50ff77cffddd9657517afbef6c00b0fb28bcc84f3ce38bfefdab173f5
+          requirementName: example_670bf892477997dd

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/ca5e5bd0966b6a1eec2b90a8cbeb9526da88ccaca08b815c8a24643c6be07c16:
+              example_ca5e5bd0966b6a1e:
                 audiences:
                 - foo.com
                 forward: true
@@ -43,10 +43,10 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/0cdbc414569dfae46af6b28ef9625163d49f77b346bc8700a42fc59127dafa33:
+              example-or-missing_a9dd8f84acc79c72:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/example/ca5e5bd0966b6a1eec2b90a8cbeb9526da88ccaca08b815c8a24643c6be07c16
+                  - providerName: example_ca5e5bd0966b6a1e
                   - allowMissing: {}
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/ca5e5bd0966b6a1e:
+              jwt/provider/example/ca5e5bd0966b6a1eec2b90a8cbeb9526da88ccaca08b815c8a24643c6be07c16:
                 audiences:
                 - foo.com
                 forward: true
@@ -43,10 +43,10 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/3305d64dd047baf6:
+              jwt/requirement/0cdbc414569dfae46af6b28ef9625163d49f77b346bc8700a42fc59127dafa33:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/example/ca5e5bd0966b6a1e
+                  - providerName: jwt/provider/example/ca5e5bd0966b6a1eec2b90a8cbeb9526da88ccaca08b815c8a24643c6be07c16
                   - allowMissing: {}
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              first-route/example:
+              jwt/provider/example/ca5e5bd0966b6a1e:
                 audiences:
                 - foo.com
                 forward: true
@@ -43,10 +43,10 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              first-route:
+              jwt/requirement/3305d64dd047baf6:
                 requiresAny:
                   requirements:
-                  - providerName: first-route/example
+                  - providerName: jwt/provider/example/ca5e5bd0966b6a1e
                   - allowMissing: {}
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/3305d64dd047baf6
+          requirementName: jwt/requirement/0cdbc414569dfae46af6b28ef9625163d49f77b346bc8700a42fc59127dafa33

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/0cdbc414569dfae46af6b28ef9625163d49f77b346bc8700a42fc59127dafa33
+          requirementName: example-or-missing_a9dd8f84acc79c72

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: first-route
+          requirementName: jwt/requirement/3305d64dd047baf6

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              first-route/example:
+              jwt/provider/example/47556953f591bc2c:
                 audiences:
                 - foo.com
                 forward: true
@@ -36,8 +36,8 @@
                     timeout: 10s
                     uri: https://192.168.1.250/jwt/public-key/jwks.json
             requirementMap:
-              first-route:
-                providerName: first-route/example
+              jwt/requirement/20abdc0b14ee56f7:
+                providerName: jwt/provider/example/47556953f591bc2c
         - name: envoy.filters.http.ratelimit
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/47556953f591bc2ca2c657d430ddb5c58cb0d65c7d08b26db31828d886106c51:
+              example_47556953f591bc2c:
                 audiences:
                 - foo.com
                 forward: true
@@ -36,8 +36,8 @@
                     timeout: 10s
                     uri: https://192.168.1.250/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/75512ffb30f276d01a7d02e03a88d4a33f795cc64f8961cd72ebdaa7bdb90f45:
-                providerName: jwt/provider/example/47556953f591bc2ca2c657d430ddb5c58cb0d65c7d08b26db31828d886106c51
+              example_531080ccb6b88587:
+                providerName: example_47556953f591bc2c
         - name: envoy.filters.http.ratelimit
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/47556953f591bc2c:
+              jwt/provider/example/47556953f591bc2ca2c657d430ddb5c58cb0d65c7d08b26db31828d886106c51:
                 audiences:
                 - foo.com
                 forward: true
@@ -36,8 +36,8 @@
                     timeout: 10s
                     uri: https://192.168.1.250/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/20abdc0b14ee56f7:
-                providerName: jwt/provider/example/47556953f591bc2c
+              jwt/requirement/75512ffb30f276d01a7d02e03a88d4a33f795cc64f8961cd72ebdaa7bdb90f45:
+                providerName: jwt/provider/example/47556953f591bc2ca2c657d430ddb5c58cb0d65c7d08b26db31828d886106c51
         - name: envoy.filters.http.ratelimit
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/75512ffb30f276d01a7d02e03a88d4a33f795cc64f8961cd72ebdaa7bdb90f45
+          requirementName: example_531080ccb6b88587
         envoy.filters.http.ratelimit:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
           domain: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/20abdc0b14ee56f7
+          requirementName: jwt/requirement/75512ffb30f276d01a7d02e03a88d4a33f795cc64f8961cd72ebdaa7bdb90f45
         envoy.filters.http.ratelimit:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
           domain: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: first-route
+          requirementName: jwt/requirement/20abdc0b14ee56f7
         envoy.filters.http.ratelimit:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
           domain: first-listener

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/ced70d98fe975d58:
+              jwt/provider/example/ced70d98fe975d58db12245312161a7ed7089ea07dab4779c9b178c977369bfb:
                 audiences:
                 - foo.com
                 forward: true
@@ -36,8 +36,8 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/28d048f7ae082488:
-                providerName: jwt/provider/example/ced70d98fe975d58
+              jwt/requirement/fec9e1b50ff77cffddd9657517afbef6c00b0fb28bcc84f3ce38bfefdab173f5:
+                providerName: jwt/provider/example/ced70d98fe975d58db12245312161a7ed7089ea07dab4779c9b178c977369bfb
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/ced70d98fe975d58db12245312161a7ed7089ea07dab4779c9b178c977369bfb:
+              example_ced70d98fe975d58:
                 audiences:
                 - foo.com
                 forward: true
@@ -36,8 +36,8 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/fec9e1b50ff77cffddd9657517afbef6c00b0fb28bcc84f3ce38bfefdab173f5:
-                providerName: jwt/provider/example/ced70d98fe975d58db12245312161a7ed7089ea07dab4779c9b178c977369bfb
+              example_670bf892477997dd:
+                providerName: example_ced70d98fe975d58
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              first-route/example:
+              jwt/provider/example/ced70d98fe975d58:
                 audiences:
                 - foo.com
                 forward: true
@@ -36,8 +36,8 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              first-route:
-                providerName: first-route/example
+              jwt/requirement/28d048f7ae082488:
+                providerName: jwt/provider/example/ced70d98fe975d58
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/fec9e1b50ff77cffddd9657517afbef6c00b0fb28bcc84f3ce38bfefdab173f5
+          requirementName: example_670bf892477997dd

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: first-route
+          requirementName: jwt/requirement/28d048f7ae082488

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/28d048f7ae082488
+          requirementName: jwt/requirement/fec9e1b50ff77cffddd9657517afbef6c00b0fb28bcc84f3ce38bfefdab173f5

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/foobar/14d5b09b29e54e968c31c653f7cbc235a31a54c493a34c478f321f396942cbe3:
+              foobar_14d5b09b29e54e96:
                 audiences:
                 - foo.bar.com
                 claimToHeaders:
@@ -46,8 +46,8 @@
                       maxInterval: 5s
                     retryOn: 5xx,gateway-error,reset
             requirementMap:
-              jwt/requirement/b5609eb5c2b748e8eb4d3a072628bca7a7645001802d5e5fed11260bdddc3932:
-                providerName: jwt/provider/foobar/14d5b09b29e54e968c31c653f7cbc235a31a54c493a34c478f321f396942cbe3
+              foobar_d74de7564544aa48:
+                providerName: foobar_14d5b09b29e54e96
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/foobar/14d5b09b29e54e96:
+              jwt/provider/foobar/14d5b09b29e54e968c31c653f7cbc235a31a54c493a34c478f321f396942cbe3:
                 audiences:
                 - foo.bar.com
                 claimToHeaders:
@@ -46,8 +46,8 @@
                       maxInterval: 5s
                     retryOn: 5xx,gateway-error,reset
             requirementMap:
-              jwt/requirement/88f10a87009ca1b9:
-                providerName: jwt/provider/foobar/14d5b09b29e54e96
+              jwt/requirement/b5609eb5c2b748e8eb4d3a072628bca7a7645001802d5e5fed11260bdddc3932:
+                providerName: jwt/provider/foobar/14d5b09b29e54e968c31c653f7cbc235a31a54c493a34c478f321f396942cbe3
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io/foobar:
+              jwt/provider/foobar/14d5b09b29e54e96:
                 audiences:
                 - foo.bar.com
                 claimToHeaders:
@@ -46,8 +46,8 @@
                       maxInterval: 5s
                     retryOn: 5xx,gateway-error,reset
             requirementMap:
-              httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io:
-                providerName: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io/foobar
+              jwt/requirement/88f10a87009ca1b9:
+                providerName: jwt/provider/foobar/14d5b09b29e54e96
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.routes.yaml
@@ -30,4 +30,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/88f10a87009ca1b9
+          requirementName: jwt/requirement/b5609eb5c2b748e8eb4d3a072628bca7a7645001802d5e5fed11260bdddc3932

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.routes.yaml
@@ -30,4 +30,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: httproute/default/httproute-1/rule/0/match/0/gateway_envoyproxy_io
+          requirementName: jwt/requirement/88f10a87009ca1b9

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.routes.yaml
@@ -30,4 +30,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/b5609eb5c2b748e8eb4d3a072628bca7a7645001802d5e5fed11260bdddc3932
+          requirementName: foobar_d74de7564544aa48

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              first-route/example:
+              jwt/provider/example/365c9c9bf2a47d08:
                 audiences:
                 - foo.com
                 forward: true
@@ -35,8 +35,8 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              first-route:
-                providerName: first-route/example
+              jwt/requirement/41c257725d433d33:
+                providerName: jwt/provider/example/365c9c9bf2a47d08
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/365c9c9bf2a47d08:
+              jwt/provider/example/365c9c9bf2a47d08b9c8765475c565ecd0c139f89ca5905e10819653106561d3:
                 audiences:
                 - foo.com
                 forward: true
@@ -35,8 +35,8 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/41c257725d433d33:
-                providerName: jwt/provider/example/365c9c9bf2a47d08
+              jwt/requirement/27feed2254b5708e07db172afd5f8ed3e23256ed3ab24bfe3cf737b84f3e9f2d:
+                providerName: jwt/provider/example/365c9c9bf2a47d08b9c8765475c565ecd0c139f89ca5905e10819653106561d3
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.listeners.yaml
@@ -18,7 +18,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example/365c9c9bf2a47d08b9c8765475c565ecd0c139f89ca5905e10819653106561d3:
+              example_365c9c9bf2a47d08:
                 audiences:
                 - foo.com
                 forward: true
@@ -35,8 +35,8 @@
                     timeout: 10s
                     uri: https://localhost/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/27feed2254b5708e07db172afd5f8ed3e23256ed3ab24bfe3cf737b84f3e9f2d:
-                providerName: jwt/provider/example/365c9c9bf2a47d08b9c8765475c565ecd0c139f89ca5905e10819653106561d3
+              example_fd031fc5645b0535:
+                providerName: example_365c9c9bf2a47d08
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/41c257725d433d33
+          requirementName: jwt/requirement/27feed2254b5708e07db172afd5f8ed3e23256ed3ab24bfe3cf737b84f3e9f2d

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/27feed2254b5708e07db172afd5f8ed3e23256ed3ab24bfe3cf737b84f3e9f2d
+          requirementName: example_fd031fc5645b0535

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.routes.yaml
@@ -15,4 +15,4 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: first-route
+          requirementName: jwt/requirement/41c257725d433d33

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.listeners.yaml
@@ -21,7 +21,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example1/080509a58e5880a9:
+              jwt/provider/example1/080509a58e5880a9e565388095d618178374dfd2e6fe431baa1bbf031cecebcf:
                 forward: true
                 issuer: https://oauth.foo.com
                 normalizePayloadInMetadata:
@@ -36,7 +36,7 @@
                     cluster: oauth_foo_com_443
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
-              jwt/provider/example2/fad2a181f4b0664e:
+              jwt/provider/example2/fad2a181f4b0664eb241625cbf04683d9893347f6359c311a86608072da13914:
                 forward: true
                 fromHeaders:
                 - name: MyHeaderPrefixed
@@ -55,7 +55,7 @@
                     cluster: oauth_foo_com_443
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
-              jwt/provider/example3/2c73957cd9550a84:
+              jwt/provider/example3/2c73957cd9550a84b656d3765ea9d9c8c03637475080d2c41bd131efaa8c30f2:
                 forward: true
                 fromCookies:
                 - Cookie1
@@ -73,7 +73,7 @@
                     cluster: oauth_foo_com_443
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
-              jwt/provider/example4/fd3a3100036e2084:
+              jwt/provider/example4/fd3a3100036e208434ce889ed178091b86e8ae9db66d0d5383881346139aab41:
                 forward: true
                 fromParams:
                 - Param1
@@ -92,13 +92,13 @@
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/db82c3fbf1d72883:
+              jwt/requirement/48f64c1f30ef293d6ab757b230ce3ca51a62ecfb5289bc80d53fa26b95eac86c:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/example1/080509a58e5880a9
-                  - providerName: jwt/provider/example2/fad2a181f4b0664e
-                  - providerName: jwt/provider/example3/2c73957cd9550a84
-                  - providerName: jwt/provider/example4/fd3a3100036e2084
+                  - providerName: jwt/provider/example1/080509a58e5880a9e565388095d618178374dfd2e6fe431baa1bbf031cecebcf
+                  - providerName: jwt/provider/example2/fad2a181f4b0664eb241625cbf04683d9893347f6359c311a86608072da13914
+                  - providerName: jwt/provider/example3/2c73957cd9550a84b656d3765ea9d9c8c03637475080d2c41bd131efaa8c30f2
+                  - providerName: jwt/provider/example4/fd3a3100036e208434ce889ed178091b86e8ae9db66d0d5383881346139aab41
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.listeners.yaml
@@ -21,7 +21,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              httproute/default/httproute-1/rule/0/match/0/www_example_com/example1:
+              jwt/provider/example1/080509a58e5880a9:
                 forward: true
                 issuer: https://oauth.foo.com
                 normalizePayloadInMetadata:
@@ -36,7 +36,7 @@
                     cluster: oauth_foo_com_443
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
-              httproute/default/httproute-1/rule/0/match/0/www_example_com/example2:
+              jwt/provider/example2/fad2a181f4b0664e:
                 forward: true
                 fromHeaders:
                 - name: MyHeaderPrefixed
@@ -55,7 +55,7 @@
                     cluster: oauth_foo_com_443
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
-              httproute/default/httproute-1/rule/0/match/0/www_example_com/example3:
+              jwt/provider/example3/2c73957cd9550a84:
                 forward: true
                 fromCookies:
                 - Cookie1
@@ -73,7 +73,7 @@
                     cluster: oauth_foo_com_443
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
-              httproute/default/httproute-1/rule/0/match/0/www_example_com/example4:
+              jwt/provider/example4/fd3a3100036e2084:
                 forward: true
                 fromParams:
                 - Param1
@@ -92,13 +92,13 @@
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
             requirementMap:
-              httproute/default/httproute-1/rule/0/match/0/www_example_com:
+              jwt/requirement/db82c3fbf1d72883:
                 requiresAny:
                   requirements:
-                  - providerName: httproute/default/httproute-1/rule/0/match/0/www_example_com/example1
-                  - providerName: httproute/default/httproute-1/rule/0/match/0/www_example_com/example2
-                  - providerName: httproute/default/httproute-1/rule/0/match/0/www_example_com/example3
-                  - providerName: httproute/default/httproute-1/rule/0/match/0/www_example_com/example4
+                  - providerName: jwt/provider/example1/080509a58e5880a9
+                  - providerName: jwt/provider/example2/fad2a181f4b0664e
+                  - providerName: jwt/provider/example3/2c73957cd9550a84
+                  - providerName: jwt/provider/example4/fd3a3100036e2084
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.listeners.yaml
@@ -21,7 +21,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/example1/080509a58e5880a9e565388095d618178374dfd2e6fe431baa1bbf031cecebcf:
+              example1_080509a58e5880a9:
                 forward: true
                 issuer: https://oauth.foo.com
                 normalizePayloadInMetadata:
@@ -36,7 +36,7 @@
                     cluster: oauth_foo_com_443
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
-              jwt/provider/example2/fad2a181f4b0664eb241625cbf04683d9893347f6359c311a86608072da13914:
+              example2_fad2a181f4b0664e:
                 forward: true
                 fromHeaders:
                 - name: MyHeaderPrefixed
@@ -55,7 +55,7 @@
                     cluster: oauth_foo_com_443
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
-              jwt/provider/example3/2c73957cd9550a84b656d3765ea9d9c8c03637475080d2c41bd131efaa8c30f2:
+              example3_2c73957cd9550a84:
                 forward: true
                 fromCookies:
                 - Cookie1
@@ -73,7 +73,7 @@
                     cluster: oauth_foo_com_443
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
-              jwt/provider/example4/fd3a3100036e208434ce889ed178091b86e8ae9db66d0d5383881346139aab41:
+              example4_fd3a3100036e2084:
                 forward: true
                 fromParams:
                 - Param1
@@ -92,13 +92,13 @@
                     timeout: 10s
                     uri: https://oauth.foo.com/jwt/public-key/jwks.json
             requirementMap:
-              jwt/requirement/48f64c1f30ef293d6ab757b230ce3ca51a62ecfb5289bc80d53fa26b95eac86c:
+              example1-or-example2-or-example3-or-example4_f1dce4fcb58e4627:
                 requiresAny:
                   requirements:
-                  - providerName: jwt/provider/example1/080509a58e5880a9e565388095d618178374dfd2e6fe431baa1bbf031cecebcf
-                  - providerName: jwt/provider/example2/fad2a181f4b0664eb241625cbf04683d9893347f6359c311a86608072da13914
-                  - providerName: jwt/provider/example3/2c73957cd9550a84b656d3765ea9d9c8c03637475080d2c41bd131efaa8c30f2
-                  - providerName: jwt/provider/example4/fd3a3100036e208434ce889ed178091b86e8ae9db66d0d5383881346139aab41
+                  - providerName: example1_080509a58e5880a9
+                  - providerName: example2_fad2a181f4b0664e
+                  - providerName: example3_2c73957cd9550a84
+                  - providerName: example4_fd3a3100036e2084
         - name: envoy.filters.http.router
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/48f64c1f30ef293d6ab757b230ce3ca51a62ecfb5289bc80d53fa26b95eac86c
+          requirementName: example1-or-example2-or-example3-or-example4_f1dce4fcb58e4627
         envoy.filters.http.oauth2:
           '@type': type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2PerRoute
           config:

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/db82c3fbf1d72883
+          requirementName: jwt/requirement/48f64c1f30ef293d6ab757b230ce3ca51a62ecfb5289bc80d53fa26b95eac86c
         envoy.filters.http.oauth2:
           '@type': type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2PerRoute
           config:

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.routes.yaml
@@ -15,7 +15,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: httproute/default/httproute-1/rule/0/match/0/www_example_com
+          requirementName: jwt/requirement/db82c3fbf1d72883
         envoy.filters.http.oauth2:
           '@type': type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2PerRoute
           config:

--- a/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.listeners.yaml
@@ -21,7 +21,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              httproute/default/httproute-1/rule/0/match/0/www_example_com/exjwt:
+              jwt/provider/exjwt/7e856c9609a79109:
                 claimToHeaders:
                 - claimName: email
                   headerName: x-user-email
@@ -42,8 +42,8 @@
                     timeout: 10s
                     uri: https://oidc.example.com/auth/realms/example/protocol/openid-connect/certs
             requirementMap:
-              httproute/default/httproute-1/rule/0/match/0/www_example_com:
-                providerName: httproute/default/httproute-1/rule/0/match/0/www_example_com/exjwt
+              jwt/requirement/fea3876a8438696a:
+                providerName: jwt/provider/exjwt/7e856c9609a79109
         - name: envoy.filters.http.rbac
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC

--- a/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.listeners.yaml
@@ -21,7 +21,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/exjwt/7e856c9609a791096338a438e1d0d88ee9b6002cc9634b4a26d9e08a514b082c:
+              exjwt_7e856c9609a79109:
                 claimToHeaders:
                 - claimName: email
                   headerName: x-user-email
@@ -42,8 +42,8 @@
                     timeout: 10s
                     uri: https://oidc.example.com/auth/realms/example/protocol/openid-connect/certs
             requirementMap:
-              jwt/requirement/b81c72c87497359193233ab65f3301b0f827adab6526b49e1c06734b5b43ba44:
-                providerName: jwt/provider/exjwt/7e856c9609a791096338a438e1d0d88ee9b6002cc9634b4a26d9e08a514b082c
+              exjwt_0c84dc547de3534c:
+                providerName: exjwt_7e856c9609a79109
         - name: envoy.filters.http.rbac
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC

--- a/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.listeners.yaml
@@ -21,7 +21,7 @@
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
             providers:
-              jwt/provider/exjwt/7e856c9609a79109:
+              jwt/provider/exjwt/7e856c9609a791096338a438e1d0d88ee9b6002cc9634b4a26d9e08a514b082c:
                 claimToHeaders:
                 - claimName: email
                   headerName: x-user-email
@@ -42,8 +42,8 @@
                     timeout: 10s
                     uri: https://oidc.example.com/auth/realms/example/protocol/openid-connect/certs
             requirementMap:
-              jwt/requirement/fea3876a8438696a:
-                providerName: jwt/provider/exjwt/7e856c9609a79109
+              jwt/requirement/b81c72c87497359193233ab65f3301b0f827adab6526b49e1c06734b5b43ba44:
+                providerName: jwt/provider/exjwt/7e856c9609a791096338a438e1d0d88ee9b6002cc9634b4a26d9e08a514b082c
         - name: envoy.filters.http.rbac
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC

--- a/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: httproute/default/httproute-1/rule/0/match/0/www_example_com
+          requirementName: jwt/requirement/fea3876a8438696a
         envoy.filters.http.oauth2:
           '@type': type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2PerRoute
           config:

--- a/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/b81c72c87497359193233ab65f3301b0f827adab6526b49e1c06734b5b43ba44
+          requirementName: exjwt_0c84dc547de3534c
         envoy.filters.http.oauth2:
           '@type': type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2PerRoute
           config:

--- a/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.routes.yaml
@@ -30,7 +30,7 @@
       typedPerFilterConfig:
         envoy.filters.http.jwt_authn:
           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt/requirement/fea3876a8438696a
+          requirementName: jwt/requirement/b81c72c87497359193233ab65f3301b0f827adab6526b49e1c06734b5b43ba44
         envoy.filters.http.oauth2:
           '@type': type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2PerRoute
           config:

--- a/release-notes/current/breaking_changes/9103-dedupe-jwt-authn-providers.md
+++ b/release-notes/current/breaking_changes/9103-dedupe-jwt-authn-providers.md
@@ -1,0 +1,1 @@
+JWT authentication provider and requirement names in generated listener xDS now use stable, content-derived names so identical providers can be deduplicated across routes. EnvoyPatchPolicy or extension-server integrations that match previous route-derived `jwt_authn.providers` or `requirementMap` keys must update those references.

--- a/release-notes/current/performance_improvements/9103-dedupe-jwt-authn-providers.md
+++ b/release-notes/current/performance_improvements/9103-dedupe-jwt-authn-providers.md
@@ -1,1 +1,0 @@
-Deduplicated identical JWT authentication providers and requirements in listener xDS config so adding routes that reuse an existing JWT provider no longer changes LDS solely to add duplicate `jwt_authn` entries.

--- a/release-notes/current/performance_improvements/9103-dedupe-jwt-authn-providers.md
+++ b/release-notes/current/performance_improvements/9103-dedupe-jwt-authn-providers.md
@@ -1,0 +1,1 @@
+Deduplicated identical JWT authentication providers and requirements in listener xDS config so adding routes that reuse an existing JWT provider no longer changes LDS solely to add duplicate `jwt_authn` entries.


### PR DESCRIPTION
**What this PR does / why we need it**

Fixes #9103 by deduplicating identical JWT authentication providers and requirements in listener xDS config. Routes that reuse the same JWT provider now point at a shared `jwt_authn` requirement, avoiding LDS changes that only add duplicate provider/requirement entries.

**Which issue(s) this PR fixes**

Fixes #9103

**Special notes for your reviewer**

The provider and requirement names are now derived from deterministic protobuf serialization hashes of the generated Envoy JWT config. This keeps providers with different settings separate while allowing identical ones to share listener-level config.

**Does this PR introduce a user-facing change?**

```release-note
Deduplicated identical JWT authentication providers and requirements in listener xDS config so adding routes that reuse an existing JWT provider no longer changes LDS solely to add duplicate jwt_authn entries.
```

**Testing**

- `go test ./internal/xds/translator -run 'TestJWTAuthnDeduplicatesIdenticalRouteProviders|TestTranslateXds' -count=1`\n- `go test ./internal/xds/translator -count=1`\n- `go test ./internal/xds/... -count=1`\n- `bash tools/hack/check-release-notes-filenames.sh`\n\n**DCO**\n\nCommit was created with `git commit -s`.\n