### PR TITLE
conformance: fix GatewayListenerUnsupportedProtocol test

### DIFF
--- a/internal/gatewayapi/status/gateway.go
+++ b/internal/gatewayapi/status/gateway.go
@@ -8,6 +8,7 @@ package status
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +39,7 @@ func UpdateGatewayStatusAccepted(gw *gwapiv1.Gateway) *gwapiv1.Gateway {
 func computeGatewayAcceptedFromListeners(listeners []gwapiv1.ListenerStatus) (metav1.ConditionStatus, gwapiv1.GatewayConditionReason, string) {
 	allAccepted := true
 	anyAccepted := false
+	notAcceptedNames := make([]string, 0, len(listeners))
 	for _, l := range listeners {
 		accepted := false
 		for _, cond := range l.Conditions {
@@ -48,16 +50,22 @@ func computeGatewayAcceptedFromListeners(listeners []gwapiv1.ListenerStatus) (me
 		}
 		anyAccepted = anyAccepted || accepted
 		allAccepted = allAccepted && accepted
+		if !accepted {
+			notAcceptedNames = append(notAcceptedNames, string(l.Name))
+		}
 	}
+	slices.Sort(notAcceptedNames)
 
 	switch {
 	case allAccepted:
 		return metav1.ConditionTrue, gwapiv1.GatewayReasonAccepted, "The Gateway has been scheduled by Envoy Gateway"
 	case anyAccepted:
 		// Gateway with at least one accepted listeners should be accepted and the listeners should have the Accepted condition set accordingly
-		return metav1.ConditionTrue, gwapiv1.GatewayReasonListenersNotValid, "Some listeners are invalid"
+		return metav1.ConditionTrue, gwapiv1.GatewayReasonListenersNotValid,
+			fmt.Sprintf("Listeners not valid: %s", strings.Join(notAcceptedNames, ", "))
 	default:
-		return metav1.ConditionFalse, gwapiv1.GatewayReasonListenersNotValid, "No listeners are valid"
+		return metav1.ConditionFalse, gwapiv1.GatewayReasonListenersNotValid,
+			fmt.Sprintf("No listeners are valid: %s", strings.Join(notAcceptedNames, ", "))
 	}
 }
 

--- a/internal/gatewayapi/status/gateway.go
+++ b/internal/gatewayapi/status/gateway.go
@@ -22,11 +22,43 @@ func UpdateGatewayStatusNotAccepted(gw *gwapiv1.Gateway, reason gwapiv1.GatewayC
 	return gw
 }
 
+// UpdateGatewayStatusAccepted sets the Gateway's Accepted condition based on the
+// Accepted condition of its listeners: True/Accepted if all listeners are accepted,
+// True/ListenersNotValid if only some are accepted, and False/ListenersNotValid if
+// none are, matching the upstream Gateway API contract for GatewayReasonListenersNotValid.
 func UpdateGatewayStatusAccepted(gw *gwapiv1.Gateway) *gwapiv1.Gateway {
-	cond := newCondition(string(gwapiv1.GatewayConditionAccepted), metav1.ConditionTrue,
-		string(gwapiv1.GatewayReasonAccepted), "The Gateway has been scheduled by Envoy Gateway", gw.Generation)
+	condStatus, reason, msg := computeGatewayAcceptedFromListeners(gw.Status.Listeners)
+	cond := newCondition(string(gwapiv1.GatewayConditionAccepted), condStatus, string(reason), msg, gw.Generation)
 	gw.Status.Conditions = MergeConditions(gw.Status.Conditions, cond)
 	return gw
+}
+
+// computeGatewayAcceptedFromListeners derives the Gateway-level Accepted status/reason/message
+// from the Accepted condition already set on each of its listeners.
+func computeGatewayAcceptedFromListeners(listeners []gwapiv1.ListenerStatus) (metav1.ConditionStatus, gwapiv1.GatewayConditionReason, string) {
+	allAccepted := true
+	anyAccepted := false
+	for _, l := range listeners {
+		accepted := false
+		for _, cond := range l.Conditions {
+			if cond.Type == string(gwapiv1.ListenerConditionAccepted) && cond.Status == metav1.ConditionTrue {
+				accepted = true
+				break
+			}
+		}
+		anyAccepted = anyAccepted || accepted
+		allAccepted = allAccepted && accepted
+	}
+
+	switch {
+	case allAccepted:
+		return metav1.ConditionTrue, gwapiv1.GatewayReasonAccepted, "The Gateway has been scheduled by Envoy Gateway"
+	case anyAccepted:
+		// Gateway with at least one accepted listeners should be accepted and the listeners should have the Accepted condition set accordingly
+		return metav1.ConditionTrue, gwapiv1.GatewayReasonListenersNotValid, "Some listeners are invalid"
+	default:
+		return metav1.ConditionFalse, gwapiv1.GatewayReasonListenersNotValid, "No listeners are valid"
+	}
 }
 
 func UpdateGatewayStatusResolvedRefsCondition(gw *gwapiv1.Gateway, status metav1.ConditionStatus, reason gwapiv1.GatewayConditionReason, msg string) {

--- a/internal/gatewayapi/status/gateway_test.go
+++ b/internal/gatewayapi/status/gateway_test.go
@@ -489,7 +489,7 @@ func TestUpdateGatewayStatusAccepted(t *testing.T) {
 				Type:    string(gwapiv1.GatewayConditionAccepted),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(gwapiv1.GatewayReasonListenersNotValid),
-				Message: "No listeners are valid",
+				Message: "No listeners are valid: invalid",
 			},
 		},
 		{
@@ -499,7 +499,7 @@ func TestUpdateGatewayStatusAccepted(t *testing.T) {
 				Type:    string(gwapiv1.GatewayConditionAccepted),
 				Status:  metav1.ConditionTrue,
 				Reason:  string(gwapiv1.GatewayReasonListenersNotValid),
-				Message: "Some listeners are invalid",
+				Message: "Listeners not valid: invalid",
 			},
 		},
 	}

--- a/internal/gatewayapi/status/gateway_test.go
+++ b/internal/gatewayapi/status/gateway_test.go
@@ -443,6 +443,79 @@ func TestUpdateGatewayStatusProgrammedCondition(t *testing.T) {
 	}
 }
 
+func TestUpdateGatewayStatusAccepted(t *testing.T) {
+	acceptedListener := gwapiv1.ListenerStatus{
+		Name: "http",
+		Conditions: []metav1.Condition{
+			{Type: string(gwapiv1.ListenerConditionAccepted), Status: metav1.ConditionTrue, Reason: string(gwapiv1.ListenerReasonAccepted)},
+		},
+	}
+	unsupportedProtocolListener := gwapiv1.ListenerStatus{
+		Name: "invalid",
+		Conditions: []metav1.Condition{
+			{Type: string(gwapiv1.ListenerConditionAccepted), Status: metav1.ConditionFalse, Reason: string(gwapiv1.ListenerReasonUnsupportedProtocol)},
+		},
+	}
+
+	testCases := []struct {
+		name            string
+		listeners       []gwapiv1.ListenerStatus
+		expectCondition metav1.Condition
+	}{
+		{
+			name:      "no listeners",
+			listeners: nil,
+			expectCondition: metav1.Condition{
+				Type:    string(gwapiv1.GatewayConditionAccepted),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(gwapiv1.GatewayReasonAccepted),
+				Message: "The Gateway has been scheduled by Envoy Gateway",
+			},
+		},
+		{
+			name:      "all listeners accepted",
+			listeners: []gwapiv1.ListenerStatus{acceptedListener},
+			expectCondition: metav1.Condition{
+				Type:    string(gwapiv1.GatewayConditionAccepted),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(gwapiv1.GatewayReasonAccepted),
+				Message: "The Gateway has been scheduled by Envoy Gateway",
+			},
+		},
+		{
+			name:      "no listeners accepted",
+			listeners: []gwapiv1.ListenerStatus{unsupportedProtocolListener},
+			expectCondition: metav1.Condition{
+				Type:    string(gwapiv1.GatewayConditionAccepted),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(gwapiv1.GatewayReasonListenersNotValid),
+				Message: "No listeners are valid",
+			},
+		},
+		{
+			name:      "some listeners accepted",
+			listeners: []gwapiv1.ListenerStatus{acceptedListener, unsupportedProtocolListener},
+			expectCondition: metav1.Condition{
+				Type:    string(gwapiv1.GatewayConditionAccepted),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(gwapiv1.GatewayReasonListenersNotValid),
+				Message: "Some listeners are invalid",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gtw := &gwapiv1.Gateway{Status: gwapiv1.GatewayStatus{Listeners: tc.listeners}}
+			UpdateGatewayStatusAccepted(gtw)
+
+			if d := cmp.Diff([]metav1.Condition{tc.expectCondition}, gtw.Status.Conditions, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")); d != "" {
+				t.Errorf("unexpected condition diff: %s", d)
+			}
+		})
+	}
+}
+
 func TestUpdateGatewayProgrammedCondition(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/internal/provider/kubernetes/status.go
+++ b/internal/provider/kubernetes/status.go
@@ -753,8 +753,8 @@ func (r *gatewayAPIReconciler) updateStatusForGateway(ctx context.Context, gtw *
 	}
 
 	if status.GatewayAccepted(gtw) {
-		// update accepted condition to true if it is not false
-		// this is needed because the accepted condition is not set to true by the Gateway API translator
+		// Not already explicitly rejected (e.g. invalid EnvoyProxy/address) earlier in translation,
+		// so derive Accepted from the per-listener Accepted conditions the translator already set.
 		// TODO (huabing): this is tricky and confusing for later readers, we should remove this and set the accepted condition
 		// to true in the Gateway API translator
 		status.UpdateGatewayStatusAccepted(gtw)

--- a/test/conformance/suite.go
+++ b/test/conformance/suite.go
@@ -48,11 +48,6 @@ func conformanceOpts(t *testing.T) suite.ConformanceOptions {
 		)
 	}
 
-	opts.SkipTests = append(opts.SkipTests,
-		// TODO: retry after https://github.com/envoyproxy/gateway/pull/9196 merged
-		tests.GatewayListenerUnsupportedProtocol.ShortName,
-	)
-
 	opts.Hook = e2e.Hook
 	opts.FailFast = true
 


### PR DESCRIPTION
- Gateway with no accepted listeners should not be accepted and the listener should have the Accepted condition set to False with reason UnsupportedProtocol
- Gateway with at least one accepted listeners should be accepted and the listeners should have the Accepted condition set accordingly