### PR TITLE
fix(logs): restore ISO 8601 timestamp format

### DIFF
--- a/internal/logging/log.go
+++ b/internal/logging/log.go
@@ -136,6 +136,7 @@ func (l Logger) Sugar() *zap.SugaredLogger {
 func initZapLogger(w io.Writer, logging *egv1a1.EnvoyGatewayLogging, level egv1a1.LogLevel) *zap.Logger {
 	parseLevel, _ := zapcore.ParseLevel(string(logging.DefaultEnvoyGatewayLoggingLevel(level)))
 	cfg := zap.NewProductionEncoderConfig()
+	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
 	var encoder zapcore.Encoder
 	logEncoder := egv1a1.EnvoyGatewayLogEncoderText
 	if logging != nil && logging.Encoder != nil {

--- a/release-notes/current/bug_fixes/9492-logs-restore-iso8601-timestamp-format.md
+++ b/release-notes/current/bug_fixes/9492-logs-restore-iso8601-timestamp-format.md
@@ -1,0 +1,1 @@
+Fixed log timestamps regressing to Unix epoch floats (e.g. `1.784e+09`) since v1.8.0 by explicitly setting `ISO8601TimeEncoder` on the production zap encoder config, restoring the expected ISO 8601 format (e.g. `2026-07-14T17:44:06.617Z`).


### PR DESCRIPTION
**What this PR does / why we need it**:

  Since v1.8.0, log timestamps regressed from ISO 8601 format (e.g. `2026-07-14T17:44:06.617Z`) to Unix epoch floats in scientific notation (e.g. `1.7840510610168722e+09`). This happened
  because PR #8555 switched from `zap.NewDevelopmentEncoderConfig()` to `zap.NewProductionEncoderConfig()`, which defaults to `zapcore.EpochTimeEncoder`. The fix explicitly sets
  `cfg.EncodeTime = zapcore.ISO8601TimeEncoder` after constructing the production encoder config.

  **Which issue(s) this PR fixes**:

  Fixes #9492

  ---

  **PR Checklist**

  - [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full
  responsibility for this PR. I have not submitted generated output I do not understand.
  - [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
  - [x] **API agreed first**: N/A — no API changes.
  - [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass.
  - [x] **Tests added/updated**: Existing tests in `internal/logging` cover the logger; no new logic to test beyond the encoder config line.
  - [x] **Docs**: N/A — no user-facing behaviour change beyond restoring the pre-regression format.
  - [x] **Release notes**: Added `release-notes/current/bug_fixes/9492-logs-restore-iso8601-timestamp-format.md`.
  - [x] **Generated files committed**: N/A — no API/helm changes.
  - [x] **Scope & compatibility**: Single-line fix, fully backward-compatible (restores prior behaviour).
  - [x] **Codex review**: Requested a Codex review and addressed all of its comments.
  - [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.