### PR TITLE
gatewayapi: deduplicate upstream TLS clusters

### DIFF
--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -2333,13 +2333,13 @@ func stableTLSUpstreamConfig(tlsConfig *ir.TLSUpstreamConfig) *stableTLSUpstream
 		SubjectAltNames:             tlsConfig.SubjectAltNames,
 		InsecureSkipVerify:          tlsConfig.InsecureSkipVerify,
 	}
-	for _, cert := range tlsConfig.ClientCertificates {
-		out.ClientCertificates = append(out.ClientCertificates, stableTLSCertificateConfig(cert))
+	for idx := range tlsConfig.ClientCertificates {
+		out.ClientCertificates = append(out.ClientCertificates, stableTLSCertificateConfig(&tlsConfig.ClientCertificates[idx]))
 	}
 	return out
 }
 
-func stableTLSCertificateConfig(cert ir.TLSCertificate) stableTLSCertificate {
+func stableTLSCertificateConfig(cert *ir.TLSCertificate) stableTLSCertificate {
 	return stableTLSCertificate{
 		Name:        cert.Name,
 		SDS:         cert.SDS,

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -2084,16 +2084,29 @@ func stableClusterRouteDestination(
 		return destination
 	}
 
+	settingNames := make([]string, 0, len(copiedSettings))
 	for _, setting := range copiedSettings {
-		setting.Name = stableClusterName(routeType, []*ir.DestinationSetting{setting}, traffic, useClientProtocol, options)
+		name, ok := stableClusterName(routeType, []*ir.DestinationSetting{setting}, traffic, useClientProtocol, options)
+		if !ok {
+			return destination
+		}
+		settingNames = append(settingNames, name)
 	}
 
 	if len(copiedSettings) == 1 {
-		destination.Name = copiedSettings[0].Name
+		copiedSettings[0].Name = settingNames[0]
+		destination.Name = settingNames[0]
 		return destination
 	}
 
-	destination.Name = stableClusterName(routeType, copiedSettings, traffic, useClientProtocol, options)
+	name, ok := stableClusterName(routeType, copiedSettings, traffic, useClientProtocol, options)
+	if !ok {
+		return destination
+	}
+	for idx, setting := range copiedSettings {
+		setting.Name = settingNames[idx]
+	}
+	destination.Name = name
 	return destination
 }
 
@@ -2126,7 +2139,7 @@ func stableClusterName(
 	traffic *ir.TrafficFeatures,
 	useClientProtocol *bool,
 	options stableClusterRouteDestinationOptions,
-) string {
+) (string, bool) {
 	input := stableClusterNameInput{
 		RouteType:         routeType,
 		Settings:          make([]stableDestinationSetting, 0, len(settings)),
@@ -2154,10 +2167,10 @@ func stableClusterName(
 
 	data, err := json.Marshal(input)
 	if err != nil {
-		return ""
+		return "", false
 	}
 	sum := sha256.Sum256(data)
-	return "backend/" + hex.EncodeToString(sum[:8])
+	return "backend/" + hex.EncodeToString(sum[:8]), true
 }
 
 func routeDestinationStatName(pattern string, route RouteContext, ruleName *gwapiv1.SectionName, ruleIdx int, backendRefNames []string) *string {
@@ -2261,7 +2274,7 @@ type stableTLSUpstream struct {
 	Ciphers                     []string                `json:"ciphers,omitempty"`
 	ECDHCurves                  []string                `json:"ecdhCurves,omitempty"`
 	SignatureAlgorithms         []string                `json:"signatureAlgorithms,omitempty"`
-	ALPNProtocols               []string                `json:"alpnProtocols,omitempty"`
+	ALPNProtocols               []string                `json:"alpnProtocols"`
 	StatelessSessionResumption  bool                    `json:"statelessSessionResumption,omitempty"`
 	StatefulSessionResumption   bool                    `json:"statefulSessionResumption,omitempty"`
 	Fingerprints                []ir.TLSFingerprintType `json:"fingerprints,omitempty"`

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -6,6 +6,9 @@
 package gatewayapi
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -426,11 +429,20 @@ func (t *Translator) processHTTPRouteRules(httpRoute *HTTPRouteContext, parentRe
 				if irRoute.DirectResponse != nil || irRoute.Redirect != nil {
 					continue
 				}
-				destination := &ir.RouteDestination{
-					Name:     destName,
-					Settings: allDs,
-					Metadata: routeRuleMetadata,
-				}
+				statName := routeDestinationStatName(pattern, httpRoute, rule.Name, ruleIdx, backendRefNames)
+				destination := stableClusterRouteDestination(
+					resource.KindHTTPRoute,
+					destName,
+					allDs,
+					irRoute.Traffic,
+					irRoute.UseClientProtocol,
+					routeRuleMetadata,
+					stableClusterRouteDestinationOptions{
+						StatName:         statName,
+						RouteHostname:    irRoute.Hostname,
+						HasExtensionRefs: len(irRoute.ExtensionRefs) > 0 || len(backendCustomRefs) > 0,
+					},
+				)
 				irRoute.Destination = destination
 			}
 		}
@@ -440,11 +452,6 @@ func (t *Translator) processHTTPRouteRules(httpRoute *HTTPRouteContext, parentRe
 			// add custom backend refs if any
 			if len(backendCustomRefs) > 0 {
 				irRoute.ExtensionRefs = append(irRoute.ExtensionRefs, backendCustomRefs...)
-			}
-
-			// set the stat name for this route
-			if irRoute.Destination != nil && pattern != "" {
-				irRoute.Destination.StatName = new(buildStatName(pattern, httpRoute, rule.Name, ruleIdx, backendRefNames))
 			}
 		}
 
@@ -1127,11 +1134,21 @@ func (t *Translator) processGRPCRouteRules(grpcRoute *GRPCRouteContext, parentRe
 				if irRoute.DirectResponse != nil || irRoute.Redirect != nil {
 					continue
 				}
-				destination := &ir.RouteDestination{
-					Name:     destName,
-					Settings: allDs,
-					Metadata: buildResourceMetadata(grpcRoute, rule.Name),
-				}
+				routeRuleMetadata := buildResourceMetadata(grpcRoute, rule.Name)
+				statName := routeDestinationStatName(pattern, grpcRoute, rule.Name, ruleIdx, backendRefNames)
+				destination := stableClusterRouteDestination(
+					resource.KindGRPCRoute,
+					destName,
+					allDs,
+					irRoute.Traffic,
+					irRoute.UseClientProtocol,
+					routeRuleMetadata,
+					stableClusterRouteDestinationOptions{
+						StatName:         statName,
+						RouteHostname:    irRoute.Hostname,
+						HasExtensionRefs: len(irRoute.ExtensionRefs) > 0,
+					},
+				)
 				irRoute.Destination = destination
 			}
 
@@ -1140,11 +1157,6 @@ func (t *Translator) processGRPCRouteRules(grpcRoute *GRPCRouteContext, parentRe
 		// finalize the IR routes for this rule
 		for _, irRoute := range ruleRoutes {
 			irRoute.IsHTTP2 = true
-
-			// set the stat name for this route
-			if irRoute.Destination != nil && pattern != "" {
-				irRoute.Destination.StatName = new(buildStatName(pattern, grpcRoute, rule.Name, ruleIdx, backendRefNames))
-			}
 		}
 
 		irRoutes = append(irRoutes, ruleRoutes...)
@@ -2041,6 +2053,317 @@ func (t *Translator) processDestination(name string, backendRefContext BackendRe
 
 	ds.Weight = &weight
 	return ds, nil, nil
+}
+
+func stableClusterRouteDestination(
+	routeType gwapiv1.Kind,
+	fallbackName string,
+	settings []*ir.DestinationSetting,
+	traffic *ir.TrafficFeatures,
+	useClientProtocol *bool,
+	metadata *ir.ResourceMetadata,
+	options stableClusterRouteDestinationOptions,
+) *ir.RouteDestination {
+	copiedSettings := make([]*ir.DestinationSetting, 0, len(settings))
+	for _, setting := range settings {
+		if setting == nil {
+			copiedSettings = append(copiedSettings, nil)
+			continue
+		}
+		copiedSettings = append(copiedSettings, setting.DeepCopy())
+	}
+
+	destination := &ir.RouteDestination{
+		Name:     fallbackName,
+		StatName: options.StatName,
+		Settings: copiedSettings,
+		Metadata: metadata,
+	}
+
+	if !canUseStableClusterName(copiedSettings, options) {
+		return destination
+	}
+
+	for _, setting := range copiedSettings {
+		setting.Name = stableClusterName(routeType, []*ir.DestinationSetting{setting}, traffic, useClientProtocol, options)
+	}
+
+	if len(copiedSettings) == 1 {
+		destination.Name = copiedSettings[0].Name
+		return destination
+	}
+
+	destination.Name = stableClusterName(routeType, copiedSettings, traffic, useClientProtocol, options)
+	return destination
+}
+
+type stableClusterRouteDestinationOptions struct {
+	StatName         *string
+	RouteHostname    string
+	HasExtensionRefs bool
+}
+
+func canUseStableClusterName(settings []*ir.DestinationSetting, options stableClusterRouteDestinationOptions) bool {
+	if options.HasExtensionRefs {
+		return false
+	}
+
+	for _, setting := range settings {
+		if setting == nil ||
+			setting.Invalid ||
+			setting.IsCustomBackend ||
+			setting.TLS == nil ||
+			setting.Filters != nil {
+			return false
+		}
+	}
+	return len(settings) > 0
+}
+
+func stableClusterName(
+	routeType gwapiv1.Kind,
+	settings []*ir.DestinationSetting,
+	traffic *ir.TrafficFeatures,
+	useClientProtocol *bool,
+	options stableClusterRouteDestinationOptions,
+) string {
+	input := stableClusterNameInput{
+		RouteType:         routeType,
+		Settings:          make([]stableDestinationSetting, 0, len(settings)),
+		Traffic:           stableClusterTrafficConfig(traffic),
+		UseClientProtocol: useClientProtocol,
+		StatName:          options.StatName,
+	}
+	if healthCheckUsesRouteHostname(traffic) {
+		input.RouteHostname = options.RouteHostname
+	}
+	for _, setting := range settings {
+		input.Settings = append(input.Settings, stableDestinationSetting{
+			IsDynamicResolver: setting.IsDynamicResolver,
+			Weight:            setting.Weight,
+			Priority:          setting.Priority,
+			Protocol:          setting.Protocol,
+			ForceHTTP1:        setting.ForceHTTP1Upstream,
+			AddressType:       setting.AddressType,
+			IPFamily:          setting.IPFamily,
+			TLS:               stableTLSUpstreamConfig(setting.TLS),
+			PreferLocal:       setting.PreferLocal,
+			Metadata:          setting.Metadata,
+		})
+	}
+
+	data, err := json.Marshal(input)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return "backend/" + hex.EncodeToString(sum[:8])
+}
+
+func routeDestinationStatName(pattern string, route RouteContext, ruleName *gwapiv1.SectionName, ruleIdx int, backendRefNames []string) *string {
+	if pattern == "" {
+		return nil
+	}
+	statName := buildStatName(pattern, route, ruleName, ruleIdx, backendRefNames)
+	return &statName
+}
+
+func healthCheckUsesRouteHostname(traffic *ir.TrafficFeatures) bool {
+	return traffic != nil &&
+		traffic.HealthCheck != nil &&
+		traffic.HealthCheck.Active != nil &&
+		traffic.HealthCheck.Active.HTTP != nil &&
+		traffic.HealthCheck.Active.HTTP.Host == ""
+}
+
+type stableClusterNameInput struct {
+	RouteType         gwapiv1.Kind               `json:"routeType"`
+	Settings          []stableDestinationSetting `json:"settings"`
+	Traffic           *stableClusterTraffic      `json:"traffic,omitempty"`
+	UseClientProtocol *bool                      `json:"useClientProtocol,omitempty"`
+	StatName          *string                    `json:"statName,omitempty"`
+	RouteHostname     string                     `json:"routeHostname,omitempty"`
+}
+
+type stableClusterTraffic struct {
+	LoadBalancer      *ir.LoadBalancer      `json:"loadBalancer,omitempty"`
+	ProxyProtocol     *ir.ProxyProtocol     `json:"proxyProtocol,omitempty"`
+	CircuitBreaker    *ir.CircuitBreaker    `json:"circuitBreaker,omitempty"`
+	HealthCheck       *ir.HealthCheck       `json:"healthCheck,omitempty"`
+	Timeout           *ir.Timeout           `json:"timeout,omitempty"`
+	TCPKeepalive      *ir.TCPKeepalive      `json:"tcpKeepalive,omitempty"`
+	BackendConnection *ir.BackendConnection `json:"backendConnection,omitempty"`
+	DNS               *ir.DNS               `json:"dns,omitempty"`
+	HTTP2             *ir.HTTP2Settings     `json:"http2,omitempty"`
+	AdmissionControl  *ir.AdmissionControl  `json:"admissionControl,omitempty"`
+}
+
+func stableClusterTrafficConfig(traffic *ir.TrafficFeatures) *stableClusterTraffic {
+	if traffic == nil {
+		return nil
+	}
+	clusterTraffic := &stableClusterTraffic{
+		LoadBalancer:      traffic.LoadBalancer,
+		ProxyProtocol:     traffic.ProxyProtocol,
+		CircuitBreaker:    traffic.CircuitBreaker,
+		HealthCheck:       traffic.HealthCheck,
+		Timeout:           traffic.Timeout,
+		TCPKeepalive:      traffic.TCPKeepalive,
+		BackendConnection: traffic.BackendConnection,
+		DNS:               traffic.DNS,
+		HTTP2:             traffic.HTTP2,
+		AdmissionControl:  traffic.AdmissionControl,
+	}
+	if clusterTraffic.LoadBalancer == nil &&
+		clusterTraffic.ProxyProtocol == nil &&
+		clusterTraffic.CircuitBreaker == nil &&
+		clusterTraffic.HealthCheck == nil &&
+		clusterTraffic.Timeout == nil &&
+		clusterTraffic.TCPKeepalive == nil &&
+		clusterTraffic.BackendConnection == nil &&
+		clusterTraffic.DNS == nil &&
+		clusterTraffic.HTTP2 == nil &&
+		clusterTraffic.AdmissionControl == nil {
+		return nil
+	}
+	return clusterTraffic
+}
+
+type stableDestinationSetting struct {
+	IsDynamicResolver bool                       `json:"isDynamicResolver,omitempty"`
+	Weight            *uint32                    `json:"weight,omitempty"`
+	Priority          *uint32                    `json:"priority,omitempty"`
+	Protocol          ir.AppProtocol             `json:"protocol,omitempty"`
+	ForceHTTP1        bool                       `json:"forceHTTP1,omitempty"`
+	AddressType       *ir.DestinationAddressType `json:"addressType,omitempty"`
+	IPFamily          *egv1a1.IPFamily           `json:"ipFamily,omitempty"`
+	TLS               *stableTLSUpstream         `json:"tls,omitempty"`
+	PreferLocal       *ir.PreferLocalZone        `json:"preferLocal,omitempty"`
+	Metadata          *ir.ResourceMetadata       `json:"metadata,omitempty"`
+}
+
+type stableTLSUpstream struct {
+	SNI                         *string                 `json:"sni,omitempty"`
+	AutoSNIFromEndpointHostname bool                    `json:"autoSNIFromEndpointHostname,omitempty"`
+	UseSystemTrustStore         bool                    `json:"useSystemTrustStore,omitempty"`
+	CACertificate               *stableTLSCACertificate `json:"caCertificate,omitempty"`
+	ClientCertificates          []stableTLSCertificate  `json:"clientCertificates,omitempty"`
+	RequireClientCertificate    bool                    `json:"requireClientCertificate,omitempty"`
+	ClientValidationEnabled     bool                    `json:"clientValidationEnabled,omitempty"`
+	AcceptUntrusted             bool                    `json:"acceptUntrusted,omitempty"`
+	AllowExpiredCertificate     bool                    `json:"allowExpiredCertificate,omitempty"`
+	VerifyCertificateSpki       []string                `json:"verifyCertificateSpki,omitempty"`
+	VerifyCertificateHash       []string                `json:"verifyCertificateHash,omitempty"`
+	Crl                         *stableTLSCrl           `json:"crl,omitempty"`
+	MatchTypedSubjectAltNames   []*ir.StringMatch       `json:"matchTypedSubjectAltNames,omitempty"`
+	MinVersion                  *ir.TLSVersion          `json:"minVersion,omitempty"`
+	MaxVersion                  *ir.TLSVersion          `json:"maxVersion,omitempty"`
+	Ciphers                     []string                `json:"ciphers,omitempty"`
+	ECDHCurves                  []string                `json:"ecdhCurves,omitempty"`
+	SignatureAlgorithms         []string                `json:"signatureAlgorithms,omitempty"`
+	ALPNProtocols               []string                `json:"alpnProtocols,omitempty"`
+	StatelessSessionResumption  bool                    `json:"statelessSessionResumption,omitempty"`
+	StatefulSessionResumption   bool                    `json:"statefulSessionResumption,omitempty"`
+	Fingerprints                []ir.TLSFingerprintType `json:"fingerprints,omitempty"`
+	SubjectAltNames             []ir.SubjectAltName     `json:"subjectAltNames,omitempty"`
+	InsecureSkipVerify          bool                    `json:"insecureSkipVerify,omitempty"`
+}
+
+type stableTLSCertificate struct {
+	Name        string        `json:"name,omitempty"`
+	SDS         *ir.SDSConfig `json:"sds,omitempty"`
+	Certificate string        `json:"certificate,omitempty"`
+	PrivateKey  string        `json:"privateKey,omitempty"`
+	OCSPStaple  string        `json:"ocspStaple,omitempty"`
+}
+
+type stableTLSCACertificate struct {
+	Name        string        `json:"name,omitempty"`
+	Certificate string        `json:"certificate,omitempty"`
+	SDS         *ir.SDSConfig `json:"sds,omitempty"`
+}
+
+type stableTLSCrl struct {
+	Name                      string `json:"name,omitempty"`
+	Data                      string `json:"data,omitempty"`
+	OnlyVerifyLeafCertificate bool   `json:"onlyVerifyLeafCertificate,omitempty"`
+}
+
+func stableTLSUpstreamConfig(tlsConfig *ir.TLSUpstreamConfig) *stableTLSUpstream {
+	if tlsConfig == nil {
+		return nil
+	}
+
+	out := &stableTLSUpstream{
+		SNI:                         tlsConfig.SNI,
+		AutoSNIFromEndpointHostname: tlsConfig.AutoSNIFromEndpointHostname,
+		UseSystemTrustStore:         tlsConfig.UseSystemTrustStore,
+		CACertificate:               stableTLSCACertificateConfig(tlsConfig.CACertificate),
+		ClientCertificates:          make([]stableTLSCertificate, 0, len(tlsConfig.ClientCertificates)),
+		RequireClientCertificate:    tlsConfig.RequireClientCertificate,
+		ClientValidationEnabled:     tlsConfig.ClientValidationEnabled,
+		AcceptUntrusted:             tlsConfig.AcceptUntrusted,
+		AllowExpiredCertificate:     tlsConfig.AllowExpiredCertificate,
+		VerifyCertificateSpki:       tlsConfig.VerifyCertificateSpki,
+		VerifyCertificateHash:       tlsConfig.VerifyCertificateHash,
+		Crl:                         stableTLSCrlConfig(tlsConfig.Crl),
+		MatchTypedSubjectAltNames:   tlsConfig.MatchTypedSubjectAltNames,
+		MinVersion:                  tlsConfig.MinVersion,
+		MaxVersion:                  tlsConfig.MaxVersion,
+		Ciphers:                     tlsConfig.Ciphers,
+		ECDHCurves:                  tlsConfig.ECDHCurves,
+		SignatureAlgorithms:         tlsConfig.SignatureAlgorithms,
+		ALPNProtocols:               tlsConfig.ALPNProtocols,
+		StatelessSessionResumption:  tlsConfig.StatelessSessionResumption,
+		StatefulSessionResumption:   tlsConfig.StatefulSessionResumption,
+		Fingerprints:                tlsConfig.Fingerprints,
+		SubjectAltNames:             tlsConfig.SubjectAltNames,
+		InsecureSkipVerify:          tlsConfig.InsecureSkipVerify,
+	}
+	for _, cert := range tlsConfig.ClientCertificates {
+		out.ClientCertificates = append(out.ClientCertificates, stableTLSCertificateConfig(cert))
+	}
+	return out
+}
+
+func stableTLSCertificateConfig(cert ir.TLSCertificate) stableTLSCertificate {
+	return stableTLSCertificate{
+		Name:        cert.Name,
+		SDS:         cert.SDS,
+		Certificate: hashBytes(cert.Certificate),
+		PrivateKey:  hashBytes(cert.PrivateKey),
+		OCSPStaple:  hashBytes(cert.OCSPStaple),
+	}
+}
+
+func stableTLSCACertificateConfig(cert *ir.TLSCACertificate) *stableTLSCACertificate {
+	if cert == nil {
+		return nil
+	}
+	return &stableTLSCACertificate{
+		Name:        cert.Name,
+		Certificate: hashBytes(cert.Certificate),
+		SDS:         cert.SDS,
+	}
+}
+
+func stableTLSCrlConfig(crl *ir.TLSCrl) *stableTLSCrl {
+	if crl == nil {
+		return nil
+	}
+	return &stableTLSCrl{
+		Name:                      crl.Name,
+		Data:                      hashBytes(crl.Data),
+		OnlyVerifyLeafCertificate: crl.OnlyVerifyLeafCertificate,
+	}
+}
+
+func hashBytes(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
 func validateDestinationSettings(destinationSettings *ir.DestinationSetting, isServiceRouting bool, kind *gwapiv1.Kind) status.Error {

--- a/internal/gatewayapi/route_test.go
+++ b/internal/gatewayapi/route_test.go
@@ -158,7 +158,7 @@ func TestStableClusterRouteDestinationReusesSameTLSBackend(t *testing.T) {
 	require.Equal(t, first.Name, third.Name)
 	require.Equal(t, first.Settings[0].Name, second.Settings[0].Name)
 	require.NotEqual(t, "httproute/default/route-a/rule/0", first.Name)
-	require.Equal(t, settings[0].Name, "httproute/default/route-a/rule/0/backend/0")
+	require.Equal(t, "httproute/default/route-a/rule/0/backend/0", settings[0].Name)
 }
 
 func TestStableClusterRouteDestinationUsesXDSClusterInputs(t *testing.T) {

--- a/internal/gatewayapi/route_test.go
+++ b/internal/gatewayapi/route_test.go
@@ -106,6 +106,125 @@ func TestAppProtocolToIRAppProtocol(t *testing.T) {
 	}
 }
 
+func TestStableClusterRouteDestinationReusesSameTLSBackend(t *testing.T) {
+	weight := uint32(1)
+	addressType := ir.IP
+	sni := "backend.example.com"
+	metadata := &ir.ResourceMetadata{
+		Kind:      "Service",
+		Name:      "backend",
+		Namespace: "default",
+	}
+	settings := []*ir.DestinationSetting{
+		{
+			Name:        "httproute/default/route-a/rule/0/backend/0",
+			Weight:      &weight,
+			Protocol:    ir.HTTP,
+			AddressType: &addressType,
+			Endpoints: []*ir.DestinationEndpoint{
+				ir.NewDestEndpoint(nil, "10.0.0.1", 8080, false, nil),
+			},
+			TLS: &ir.TLSUpstreamConfig{
+				SNI: &sni,
+				CACertificate: &ir.TLSCACertificate{
+					Name:        "backend-ca",
+					Certificate: []byte("ca-bundle"),
+				},
+			},
+			Metadata: metadata,
+		},
+	}
+
+	routeMetadata := &ir.ResourceMetadata{
+		Kind:      "HTTPRoute",
+		Name:      "route-a",
+		Namespace: "default",
+	}
+	otherRouteMetadata := &ir.ResourceMetadata{
+		Kind:      "HTTPRoute",
+		Name:      "route-b",
+		Namespace: "default",
+	}
+	first := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-a/rule/0", settings, nil, nil, routeMetadata, stableClusterRouteDestinationOptions{})
+	second := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-b/rule/0", settings, nil, nil, otherRouteMetadata, stableClusterRouteDestinationOptions{})
+	routeOnlyTraffic := &ir.TrafficFeatures{
+		Retry: &ir.Retry{
+			NumRetries: new(uint32),
+		},
+	}
+	third := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-c/rule/0", settings, routeOnlyTraffic, nil, routeMetadata, stableClusterRouteDestinationOptions{})
+
+	require.Equal(t, first.Name, second.Name)
+	require.Equal(t, first.Name, third.Name)
+	require.Equal(t, first.Settings[0].Name, second.Settings[0].Name)
+	require.NotEqual(t, "httproute/default/route-a/rule/0", first.Name)
+	require.Equal(t, settings[0].Name, "httproute/default/route-a/rule/0/backend/0")
+}
+
+func TestStableClusterRouteDestinationUsesXDSClusterInputs(t *testing.T) {
+	weight := uint32(1)
+	addressType := ir.IP
+	settings := []*ir.DestinationSetting{
+		{
+			Name:        "httproute/default/route-a/rule/0/backend/0",
+			Weight:      &weight,
+			Protocol:    ir.HTTP,
+			AddressType: &addressType,
+			Endpoints: []*ir.DestinationEndpoint{
+				ir.NewDestEndpoint(nil, "10.0.0.1", 8080, false, nil),
+			},
+			TLS: &ir.TLSUpstreamConfig{
+				CACertificate: &ir.TLSCACertificate{
+					Name:        "backend-ca",
+					Certificate: []byte("ca-bundle"),
+				},
+			},
+			Metadata: &ir.ResourceMetadata{
+				Kind:      "Service",
+				Name:      "backend",
+				Namespace: "default",
+			},
+		},
+	}
+
+	routeAMetadata := &ir.ResourceMetadata{Kind: "HTTPRoute", Name: "route-a", Namespace: "default"}
+	routeBMetadata := &ir.ResourceMetadata{Kind: "HTTPRoute", Name: "route-b", Namespace: "default"}
+	routeAStatName := "route-a-cluster"
+	routeBStatName := "route-b-cluster"
+
+	routeMetadataOnly := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-b/rule/0", settings, nil, nil, routeBMetadata, stableClusterRouteDestinationOptions{})
+	sameRouteMetadataOnly := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-a/rule/0", settings, nil, nil, routeAMetadata, stableClusterRouteDestinationOptions{})
+	first := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-a/rule/0", settings, nil, nil, routeAMetadata, stableClusterRouteDestinationOptions{
+		StatName: &routeAStatName,
+	})
+	second := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-b/rule/0", settings, nil, nil, routeBMetadata, stableClusterRouteDestinationOptions{
+		StatName: &routeBStatName,
+	})
+	withExtensionRef := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-c/rule/0", settings, nil, nil, routeAMetadata, stableClusterRouteDestinationOptions{
+		HasExtensionRefs: true,
+	})
+
+	require.Equal(t, sameRouteMetadataOnly.Name, routeMetadataOnly.Name)
+	require.NotEqual(t, first.Name, second.Name)
+	require.Equal(t, "httproute/default/route-c/rule/0", withExtensionRef.Name)
+	require.Equal(t, "httproute/default/route-a/rule/0/backend/0", settings[0].Name)
+
+	healthCheckTraffic := &ir.TrafficFeatures{
+		HealthCheck: &ir.HealthCheck{
+			Active: &ir.ActiveHealthCheck{
+				HTTP: &ir.HTTPHealthChecker{},
+			},
+		},
+	}
+	routeHostA := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-a/rule/0", settings, healthCheckTraffic, nil, routeAMetadata, stableClusterRouteDestinationOptions{
+		RouteHostname: "route-a.example.com",
+	})
+	routeHostB := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-a/rule/0", settings, healthCheckTraffic, nil, routeAMetadata, stableClusterRouteDestinationOptions{
+		RouteHostname: "route-b.example.com",
+	})
+	require.NotEqual(t, routeHostA.Name, routeHostB.Name)
+}
+
 func TestGetIREndpointsFromEndpointSlices(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/internal/gatewayapi/route_test.go
+++ b/internal/gatewayapi/route_test.go
@@ -223,6 +223,12 @@ func TestStableClusterRouteDestinationUsesXDSClusterInputs(t *testing.T) {
 		RouteHostname: "route-b.example.com",
 	})
 	require.NotEqual(t, routeHostA.Name, routeHostB.Name)
+
+	emptyALPNSettings := []*ir.DestinationSetting{settings[0].DeepCopy()}
+	emptyALPNSettings[0].TLS.ALPNProtocols = []string{}
+	nilALPN := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-a/rule/0", settings, nil, nil, routeAMetadata, stableClusterRouteDestinationOptions{})
+	emptyALPN := stableClusterRouteDestination(resource.KindHTTPRoute, "httproute/default/route-a/rule/0", emptyALPNSettings, nil, nil, routeAMetadata, stableClusterRouteDestinationOptions{})
+	require.NotEqual(t, nilALPN.Name, emptyALPN.Name)
 }
 
 func TestGetIREndpointsFromEndpointSlices(t *testing.T) {

--- a/internal/gatewayapi/testdata/backend-tls-auto-host-sni.out.yaml
+++ b/internal/gatewayapi/testdata/backend-tls-auto-host-sni.out.yaml
@@ -168,7 +168,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls/rule/0
+          name: backend/994fb6e47b738d41
           settings:
           - addressType: FQDN
             endpoints:
@@ -178,7 +178,7 @@ xdsIR:
               kind: Backend
               name: backend-1
               namespace: backends
-            name: httproute/envoy-gateway/httproute-btls/rule/0/backend/0
+            name: backend/994fb6e47b738d41
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backend-tls-auto-host-sni.out.yaml
+++ b/internal/gatewayapi/testdata/backend-tls-auto-host-sni.out.yaml
@@ -168,7 +168,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: backend/994fb6e47b738d41
+          name: backend/a74deb8d933d0307
           settings:
           - addressType: FQDN
             endpoints:
@@ -178,7 +178,7 @@ xdsIR:
               kind: Backend
               name: backend-1
               namespace: backends
-            name: backend/994fb6e47b738d41
+            name: backend/a74deb8d933d0307
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backend-tls-settings.out.yaml
+++ b/internal/gatewayapi/testdata/backend-tls-settings.out.yaml
@@ -1038,7 +1038,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: default
-          name: httproute/default/httproute-1/rule/0
+          name: backend/584820c6b91472ff
           settings:
           - addressType: IP
             endpoints:
@@ -1048,7 +1048,7 @@ xdsIR:
               kind: Backend
               name: backend-1
               namespace: default
-            name: httproute/default/httproute-1/rule/0/backend/0
+            name: backend/584820c6b91472ff
             protocol: HTTP
             tls:
               alpnProtocols:
@@ -1093,7 +1093,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-2
             namespace: default
-          name: httproute/default/httproute-2/rule/0
+          name: backend/3c80e82dc63992bc
           settings:
           - addressType: IP
             endpoints:
@@ -1103,7 +1103,7 @@ xdsIR:
               kind: Backend
               name: backend-2
               namespace: default
-            name: httproute/default/httproute-2/rule/0/backend/0
+            name: backend/3c80e82dc63992bc
             protocol: HTTP
             tls:
               alpnProtocols:
@@ -1144,7 +1144,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-3
             namespace: default
-          name: httproute/default/httproute-3/rule/0
+          name: backend/0d9bb2ec9cfda007
           settings:
           - addressType: IP
             endpoints:
@@ -1154,7 +1154,7 @@ xdsIR:
               kind: Backend
               name: backend-3
               namespace: default
-            name: httproute/default/httproute-3/rule/0/backend/0
+            name: backend/0d9bb2ec9cfda007
             protocol: HTTP
             tls:
               alpnProtocols:
@@ -1196,7 +1196,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-4
             namespace: default
-          name: httproute/default/httproute-4/rule/0
+          name: backend/2eb216de2f1ddc1f
           settings:
           - addressType: IP
             endpoints:
@@ -1206,7 +1206,7 @@ xdsIR:
               kind: Backend
               name: backend-4
               namespace: default
-            name: httproute/default/httproute-4/rule/0/backend/0
+            name: backend/2eb216de2f1ddc1f
             protocol: HTTP
             tls:
               alpnProtocols:
@@ -1274,7 +1274,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-7-override-client-tls-settings
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-7-override-client-tls-settings/rule/0
+          name: backend/b34c7fbddf5e496a
           settings:
           - addressType: IP
             endpoints:
@@ -1284,7 +1284,7 @@ xdsIR:
               kind: Backend
               name: backend-7
               namespace: envoy-gateway
-            name: httproute/envoy-gateway/httproute-7-override-client-tls-settings/rule/0/backend/0
+            name: backend/b34c7fbddf5e496a
             protocol: HTTP
             tls:
               alpnProtocols:
@@ -1324,7 +1324,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-9-override-client-tls-settings-disable-alpn
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-9-override-client-tls-settings-disable-alpn/rule/0
+          name: backend/1dc76463cd0c7470
           settings:
           - addressType: IP
             endpoints:
@@ -1334,7 +1334,7 @@ xdsIR:
               kind: Backend
               name: backend-9
               namespace: envoy-gateway
-            name: httproute/envoy-gateway/httproute-9-override-client-tls-settings-disable-alpn/rule/0/backend/0
+            name: backend/1dc76463cd0c7470
             protocol: HTTP
             tls:
               alpnProtocols: []
@@ -1419,7 +1419,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-8-gateway-backend-tls-precedence
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-8-gateway-backend-tls-precedence/rule/0
+          name: backend/3ad6190c2de764f7
           settings:
           - addressType: IP
             endpoints:
@@ -1429,7 +1429,7 @@ xdsIR:
               kind: Backend
               name: backend-8
               namespace: envoy-gateway
-            name: httproute/envoy-gateway/httproute-8-gateway-backend-tls-precedence/rule/0/backend/0
+            name: backend/3ad6190c2de764f7
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -1509,7 +1509,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-10-no-client-tls-settings
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-10-no-client-tls-settings/rule/0
+          name: backend/3c025280b9f192c1
           settings:
           - addressType: IP
             endpoints:
@@ -1519,7 +1519,7 @@ xdsIR:
               kind: Backend
               name: backend-10
               namespace: envoy-gateway
-            name: httproute/envoy-gateway/httproute-10-no-client-tls-settings/rule/0/backend/0
+            name: backend/3c025280b9f192c1
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backend-tls-settings.out.yaml
+++ b/internal/gatewayapi/testdata/backend-tls-settings.out.yaml
@@ -1324,7 +1324,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-9-override-client-tls-settings-disable-alpn
             namespace: envoy-gateway
-          name: backend/1dc76463cd0c7470
+          name: backend/cee3446a71c5851d
           settings:
           - addressType: IP
             endpoints:
@@ -1334,7 +1334,7 @@ xdsIR:
               kind: Backend
               name: backend-9
               namespace: envoy-gateway
-            name: backend/1dc76463cd0c7470
+            name: backend/cee3446a71c5851d
             protocol: HTTP
             tls:
               alpnProtocols: []
@@ -1419,7 +1419,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-8-gateway-backend-tls-precedence
             namespace: envoy-gateway
-          name: backend/3ad6190c2de764f7
+          name: backend/bcc469569e8f3c10
           settings:
           - addressType: IP
             endpoints:
@@ -1429,7 +1429,7 @@ xdsIR:
               kind: Backend
               name: backend-8
               namespace: envoy-gateway
-            name: backend/3ad6190c2de764f7
+            name: backend/bcc469569e8f3c10
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -1509,7 +1509,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-10-no-client-tls-settings
             namespace: envoy-gateway
-          name: backend/3c025280b9f192c1
+          name: backend/30292a3421d8ef6d
           settings:
           - addressType: IP
             endpoints:
@@ -1519,7 +1519,7 @@ xdsIR:
               kind: Backend
               name: backend-10
               namespace: envoy-gateway
-            name: backend/3c025280b9f192c1
+            name: backend/30292a3421d8ef6d
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backend-with-auto-san-sni.out.yaml
+++ b/internal/gatewayapi/testdata/backend-with-auto-san-sni.out.yaml
@@ -403,7 +403,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-backend-without-sni-and-btlsp
             namespace: envoy-gateway
-          name: backend/7709880768ff8b78
+          name: backend/d19836bf4df279ad
           settings:
           - addressType: IP
             endpoints:
@@ -413,7 +413,7 @@ xdsIR:
               kind: Backend
               name: backend-without-sni-and-btlsp
               namespace: backends
-            name: backend/7709880768ff8b78
+            name: backend/d19836bf4df279ad
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -442,7 +442,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-backend-with-sni-and-btlsp
             namespace: envoy-gateway
-          name: backend/a59b4281e3a61a9f
+          name: backend/8c2f4b3afbcf010f
           settings:
           - addressType: IP
             endpoints:
@@ -452,7 +452,7 @@ xdsIR:
               kind: Backend
               name: backend-with-sni-and-btlsp
               namespace: backends
-            name: backend/a59b4281e3a61a9f
+            name: backend/8c2f4b3afbcf010f
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -481,7 +481,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-backend-without-sni
             namespace: envoy-gateway
-          name: backend/57cd4794d49739d7
+          name: backend/cebb98a9bb4904c1
           settings:
           - addressType: IP
             endpoints:
@@ -491,7 +491,7 @@ xdsIR:
               kind: Backend
               name: backend-without-sni
               namespace: backends
-            name: backend/57cd4794d49739d7
+            name: backend/cebb98a9bb4904c1
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -517,7 +517,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-backend-with-sni
             namespace: envoy-gateway
-          name: backend/7d4f153a36c418c0
+          name: backend/fdb1dc30d10c584d
           settings:
           - addressType: IP
             endpoints:
@@ -527,7 +527,7 @@ xdsIR:
               kind: Backend
               name: backend-with-sni
               namespace: backends
-            name: backend/7d4f153a36c418c0
+            name: backend/fdb1dc30d10c584d
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backend-with-auto-san-sni.out.yaml
+++ b/internal/gatewayapi/testdata/backend-with-auto-san-sni.out.yaml
@@ -403,7 +403,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-backend-without-sni-and-btlsp
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-backend-without-sni-and-btlsp/rule/0
+          name: backend/7709880768ff8b78
           settings:
           - addressType: IP
             endpoints:
@@ -413,7 +413,7 @@ xdsIR:
               kind: Backend
               name: backend-without-sni-and-btlsp
               namespace: backends
-            name: httproute/envoy-gateway/httproute-backend-without-sni-and-btlsp/rule/0/backend/0
+            name: backend/7709880768ff8b78
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -442,7 +442,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-backend-with-sni-and-btlsp
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-backend-with-sni-and-btlsp/rule/0
+          name: backend/a59b4281e3a61a9f
           settings:
           - addressType: IP
             endpoints:
@@ -452,7 +452,7 @@ xdsIR:
               kind: Backend
               name: backend-with-sni-and-btlsp
               namespace: backends
-            name: httproute/envoy-gateway/httproute-backend-with-sni-and-btlsp/rule/0/backend/0
+            name: backend/a59b4281e3a61a9f
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -481,7 +481,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-backend-without-sni
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-backend-without-sni/rule/0
+          name: backend/57cd4794d49739d7
           settings:
           - addressType: IP
             endpoints:
@@ -491,7 +491,7 @@ xdsIR:
               kind: Backend
               name: backend-without-sni
               namespace: backends
-            name: httproute/envoy-gateway/httproute-backend-without-sni/rule/0/backend/0
+            name: backend/57cd4794d49739d7
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -517,7 +517,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-backend-with-sni
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-backend-with-sni/rule/0
+          name: backend/7d4f153a36c418c0
           settings:
           - addressType: IP
             endpoints:
@@ -527,7 +527,7 @@ xdsIR:
               kind: Backend
               name: backend-with-sni
               namespace: backends
-            name: httproute/envoy-gateway/httproute-backend-with-sni/rule/0/backend/0
+            name: backend/7d4f153a36c418c0
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backend-with-skip-tls-verify.out.yaml
+++ b/internal/gatewayapi/testdata/backend-with-skip-tls-verify.out.yaml
@@ -199,7 +199,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: backend/af80659051696cf7
+          name: backend/1fb24d0e632fc76f
           settings:
           - addressType: IP
             endpoints:
@@ -209,7 +209,7 @@ xdsIR:
               kind: Backend
               name: backend-1
               namespace: backends
-            name: backend/af80659051696cf7
+            name: backend/1fb24d0e632fc76f
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backend-with-skip-tls-verify.out.yaml
+++ b/internal/gatewayapi/testdata/backend-with-skip-tls-verify.out.yaml
@@ -199,7 +199,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls/rule/0
+          name: backend/af80659051696cf7
           settings:
           - addressType: IP
             endpoints:
@@ -209,7 +209,7 @@ xdsIR:
               kind: Backend
               name: backend-1
               namespace: backends
-            name: httproute/envoy-gateway/httproute-btls/rule/0/backend/0
+            name: backend/af80659051696cf7
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-ca-clustertrustbundle.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-ca-clustertrustbundle.out.yaml
@@ -178,7 +178,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: backend/c3c0a779878febaa
+          name: backend/9741bf30cf318379
           settings:
           - addressType: IP
             endpoints:
@@ -189,7 +189,7 @@ xdsIR:
               name: http-backend
               namespace: backends
               sectionName: "8080"
-            name: backend/c3c0a779878febaa
+            name: backend/9741bf30cf318379
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-ca-clustertrustbundle.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-ca-clustertrustbundle.out.yaml
@@ -178,7 +178,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls/rule/0
+          name: backend/c3c0a779878febaa
           settings:
           - addressType: IP
             endpoints:
@@ -189,7 +189,7 @@ xdsIR:
               name: http-backend
               namespace: backends
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls/rule/0/backend/0
+            name: backend/c3c0a779878febaa
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-ca-only-secret.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-ca-only-secret.out.yaml
@@ -178,7 +178,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: backend/d462e2beb0d1e5f3
+          name: backend/2515bf8868fc2f0a
           settings:
           - addressType: IP
             endpoints:
@@ -189,7 +189,7 @@ xdsIR:
               name: http-backend
               namespace: backends
               sectionName: "8080"
-            name: backend/d462e2beb0d1e5f3
+            name: backend/2515bf8868fc2f0a
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-ca-only-secret.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-ca-only-secret.out.yaml
@@ -178,7 +178,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls/rule/0
+          name: backend/d462e2beb0d1e5f3
           settings:
           - addressType: IP
             endpoints:
@@ -189,7 +189,7 @@ xdsIR:
               name: http-backend
               namespace: backends
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls/rule/0/backend/0
+            name: backend/d462e2beb0d1e5f3
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-ca-only.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-ca-only.out.yaml
@@ -178,7 +178,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: backend/d462e2beb0d1e5f3
+          name: backend/2515bf8868fc2f0a
           settings:
           - addressType: IP
             endpoints:
@@ -189,7 +189,7 @@ xdsIR:
               name: http-backend
               namespace: backends
               sectionName: "8080"
-            name: backend/d462e2beb0d1e5f3
+            name: backend/2515bf8868fc2f0a
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-ca-only.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-ca-only.out.yaml
@@ -178,7 +178,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls/rule/0
+          name: backend/d462e2beb0d1e5f3
           settings:
           - addressType: IP
             endpoints:
@@ -189,7 +189,7 @@ xdsIR:
               name: http-backend
               namespace: backends
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls/rule/0/backend/0
+            name: backend/d462e2beb0d1e5f3
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-conflict.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-conflict.out.yaml
@@ -253,7 +253,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-1
             namespace: envoy-gateway
-          name: backend/257bb0e6d9a10beb
+          name: backend/f0c0c4694a129c01
           settings:
           - addressType: IP
             endpoints:
@@ -264,7 +264,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8080"
-            name: backend/257bb0e6d9a10beb
+            name: backend/f0c0c4694a129c01
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -291,7 +291,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-2
             namespace: envoy-gateway
-          name: backend/f6fe862eacda25e5
+          name: backend/5d875107b7588207
           settings:
           - addressType: IP
             endpoints:
@@ -302,7 +302,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8081"
-            name: backend/f6fe862eacda25e5
+            name: backend/5d875107b7588207
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-conflict.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-conflict.out.yaml
@@ -253,7 +253,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls-1/rule/0
+          name: backend/257bb0e6d9a10beb
           settings:
           - addressType: IP
             endpoints:
@@ -264,7 +264,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls-1/rule/0/backend/0
+            name: backend/257bb0e6d9a10beb
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -291,7 +291,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-2
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls-2/rule/0
+          name: backend/f6fe862eacda25e5
           settings:
           - addressType: IP
             endpoints:
@@ -302,7 +302,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8081"
-            name: httproute/envoy-gateway/httproute-btls-2/rule/0/backend/0
+            name: backend/f6fe862eacda25e5
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-default-ns-targetrefs.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-default-ns-targetrefs.out.yaml
@@ -317,7 +317,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: backend/3171b2e69f3682dc
+          name: backend/15cc5c5909d05d39
           settings:
           - addressType: IP
             endpoints:
@@ -328,7 +328,7 @@ xdsIR:
               name: http-backend
               namespace: default
               sectionName: "8080"
-            name: backend/e7f3f760a4bfcdc6
+            name: backend/eed8e25f9f0d68e0
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -347,7 +347,7 @@ xdsIR:
               kind: Backend
               name: backend-ip-tls
               namespace: default
-            name: backend/318423ce46304d70
+            name: backend/fbd4870d5447b5ae
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -420,7 +420,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls2
             namespace: envoy-gateway
-          name: backend/3171b2e69f3682dc
+          name: backend/15cc5c5909d05d39
           settings:
           - addressType: IP
             endpoints:
@@ -431,7 +431,7 @@ xdsIR:
               name: http-backend
               namespace: default
               sectionName: "8080"
-            name: backend/e7f3f760a4bfcdc6
+            name: backend/eed8e25f9f0d68e0
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -450,7 +450,7 @@ xdsIR:
               kind: Backend
               name: backend-ip-tls
               namespace: default
-            name: backend/318423ce46304d70
+            name: backend/fbd4870d5447b5ae
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-default-ns-targetrefs.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-default-ns-targetrefs.out.yaml
@@ -317,7 +317,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls/rule/0
+          name: backend/3171b2e69f3682dc
           settings:
           - addressType: IP
             endpoints:
@@ -328,7 +328,7 @@ xdsIR:
               name: http-backend
               namespace: default
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls/rule/0/backend/0
+            name: backend/e7f3f760a4bfcdc6
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -347,7 +347,7 @@ xdsIR:
               kind: Backend
               name: backend-ip-tls
               namespace: default
-            name: httproute/envoy-gateway/httproute-btls/rule/0/backend/1
+            name: backend/318423ce46304d70
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -420,7 +420,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls2
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls2/rule/0
+          name: backend/3171b2e69f3682dc
           settings:
           - addressType: IP
             endpoints:
@@ -431,7 +431,7 @@ xdsIR:
               name: http-backend
               namespace: default
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls2/rule/0/backend/0
+            name: backend/e7f3f760a4bfcdc6
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -450,7 +450,7 @@ xdsIR:
               kind: Backend
               name: backend-ip-tls
               namespace: default
-            name: httproute/envoy-gateway/httproute-btls2/rule/0/backend/1
+            name: backend/318423ce46304d70
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-multiple-targets.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-multiple-targets.out.yaml
@@ -219,7 +219,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-1
             namespace: envoy-gateway
-          name: backend/afea83ac11ab1dd9
+          name: backend/f70bd8cc046a5488
           settings:
           - addressType: IP
             endpoints:
@@ -230,7 +230,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8080"
-            name: backend/afea83ac11ab1dd9
+            name: backend/f70bd8cc046a5488
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -257,7 +257,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-2
             namespace: envoy-gateway
-          name: backend/d0ff4b57fa5220bc
+          name: backend/05efd00fcfdb0845
           settings:
           - addressType: IP
             endpoints:
@@ -268,7 +268,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8081"
-            name: backend/d0ff4b57fa5220bc
+            name: backend/05efd00fcfdb0845
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-multiple-targets.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-multiple-targets.out.yaml
@@ -219,7 +219,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls-1/rule/0
+          name: backend/afea83ac11ab1dd9
           settings:
           - addressType: IP
             endpoints:
@@ -230,7 +230,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls-1/rule/0/backend/0
+            name: backend/afea83ac11ab1dd9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -257,7 +257,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-2
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls-2/rule/0
+          name: backend/d0ff4b57fa5220bc
           settings:
           - addressType: IP
             endpoints:
@@ -268,7 +268,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8081"
-            name: httproute/envoy-gateway/httproute-btls-2/rule/0/backend/0
+            name: backend/d0ff4b57fa5220bc
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-not-conflict-service.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-not-conflict-service.out.yaml
@@ -249,7 +249,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls-1/rule/0
+          name: backend/257bb0e6d9a10beb
           settings:
           - addressType: IP
             endpoints:
@@ -260,7 +260,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls-1/rule/0/backend/0
+            name: backend/257bb0e6d9a10beb
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -287,7 +287,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-2
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls-2/rule/0
+          name: backend/f6fe862eacda25e5
           settings:
           - addressType: IP
             endpoints:
@@ -298,7 +298,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8081"
-            name: httproute/envoy-gateway/httproute-btls-2/rule/0/backend/0
+            name: backend/f6fe862eacda25e5
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-not-conflict-service.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-not-conflict-service.out.yaml
@@ -249,7 +249,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-1
             namespace: envoy-gateway
-          name: backend/257bb0e6d9a10beb
+          name: backend/f0c0c4694a129c01
           settings:
           - addressType: IP
             endpoints:
@@ -260,7 +260,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8080"
-            name: backend/257bb0e6d9a10beb
+            name: backend/f0c0c4694a129c01
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -287,7 +287,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-2
             namespace: envoy-gateway
-          name: backend/f6fe862eacda25e5
+          name: backend/5d875107b7588207
           settings:
           - addressType: IP
             endpoints:
@@ -298,7 +298,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8081"
-            name: backend/f6fe862eacda25e5
+            name: backend/5d875107b7588207
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-not-conflict.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-not-conflict.out.yaml
@@ -250,7 +250,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls-1/rule/0
+          name: backend/257bb0e6d9a10beb
           settings:
           - addressType: IP
             endpoints:
@@ -261,7 +261,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls-1/rule/0/backend/0
+            name: backend/257bb0e6d9a10beb
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -288,7 +288,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-2
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls-2/rule/0
+          name: backend/bc28fa68d1eae760
           settings:
           - addressType: IP
             endpoints:
@@ -299,7 +299,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8081"
-            name: httproute/envoy-gateway/httproute-btls-2/rule/0/backend/0
+            name: backend/bc28fa68d1eae760
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-not-conflict.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-not-conflict.out.yaml
@@ -250,7 +250,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-1
             namespace: envoy-gateway
-          name: backend/257bb0e6d9a10beb
+          name: backend/f0c0c4694a129c01
           settings:
           - addressType: IP
             endpoints:
@@ -261,7 +261,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8080"
-            name: backend/257bb0e6d9a10beb
+            name: backend/f0c0c4694a129c01
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -288,7 +288,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-2
             namespace: envoy-gateway
-          name: backend/bc28fa68d1eae760
+          name: backend/912deaea210b6232
           settings:
           - addressType: IP
             endpoints:
@@ -299,7 +299,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8081"
-            name: backend/bc28fa68d1eae760
+            name: backend/912deaea210b6232
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
@@ -186,7 +186,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: backend/613d82e8f5158ac6
+          name: backend/3804884682a91024
           settings:
           - addressType: IP
             endpoints:
@@ -197,7 +197,7 @@ xdsIR:
               name: service-import-1
               namespace: default
               sectionName: "8080"
-            name: backend/6261c76a94496ec3
+            name: backend/9f18f3dbdb00bf26
             protocol: HTTP2
             tls:
               alpnProtocols: null
@@ -217,7 +217,7 @@ xdsIR:
               name: service-import-1
               namespace: default
               sectionName: "9000"
-            name: backend/eca4696c53d6447f
+            name: backend/03e79cc16fb15d3e
             protocol: GRPC
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-serviceimport-target.out.yaml
@@ -186,7 +186,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls/rule/0
+          name: backend/613d82e8f5158ac6
           settings:
           - addressType: IP
             endpoints:
@@ -197,7 +197,7 @@ xdsIR:
               name: service-import-1
               namespace: default
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls/rule/0/backend/0
+            name: backend/6261c76a94496ec3
             protocol: HTTP2
             tls:
               alpnProtocols: null
@@ -217,7 +217,7 @@ xdsIR:
               name: service-import-1
               namespace: default
               sectionName: "9000"
-            name: httproute/envoy-gateway/httproute-btls/rule/0/backend/1
+            name: backend/eca4696c53d6447f
             protocol: GRPC
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-status-conditions-truncated.out.yaml
@@ -2267,7 +2267,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -2278,7 +2278,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2364,7 +2364,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -2375,7 +2375,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2461,7 +2461,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -2472,7 +2472,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2558,7 +2558,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -2569,7 +2569,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2655,7 +2655,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -2666,7 +2666,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2752,7 +2752,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -2763,7 +2763,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2849,7 +2849,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -2860,7 +2860,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2946,7 +2946,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -2957,7 +2957,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3043,7 +3043,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -3054,7 +3054,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3140,7 +3140,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -3151,7 +3151,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3237,7 +3237,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -3248,7 +3248,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3334,7 +3334,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -3345,7 +3345,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3431,7 +3431,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -3442,7 +3442,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3528,7 +3528,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -3539,7 +3539,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3625,7 +3625,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -3636,7 +3636,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3722,7 +3722,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -3733,7 +3733,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3819,7 +3819,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -3830,7 +3830,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3916,7 +3916,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-1/rule/0
+          name: backend/74cc16b1930bc5a9
           settings:
           - addressType: IP
             endpoints:
@@ -3927,7 +3927,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: httproute/envoy-gateway/httproute-1/rule/0/backend/0
+            name: backend/74cc16b1930bc5a9
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-status-conditions-truncated.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-status-conditions-truncated.out.yaml
@@ -2267,7 +2267,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -2278,7 +2278,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2364,7 +2364,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -2375,7 +2375,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2461,7 +2461,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -2472,7 +2472,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2558,7 +2558,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -2569,7 +2569,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2655,7 +2655,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -2666,7 +2666,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2752,7 +2752,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -2763,7 +2763,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2849,7 +2849,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -2860,7 +2860,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -2946,7 +2946,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -2957,7 +2957,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3043,7 +3043,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -3054,7 +3054,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3140,7 +3140,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -3151,7 +3151,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3237,7 +3237,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -3248,7 +3248,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3334,7 +3334,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -3345,7 +3345,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3431,7 +3431,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -3442,7 +3442,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3528,7 +3528,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -3539,7 +3539,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3625,7 +3625,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -3636,7 +3636,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3722,7 +3722,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -3733,7 +3733,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3819,7 +3819,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -3830,7 +3830,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -3916,7 +3916,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: envoy-gateway
-          name: backend/74cc16b1930bc5a9
+          name: backend/e0db738af011fed3
           settings:
           - addressType: IP
             endpoints:
@@ -3927,7 +3927,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8443"
-            name: backend/74cc16b1930bc5a9
+            name: backend/e0db738af011fed3
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-subjectaltnames.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-subjectaltnames.out.yaml
@@ -183,7 +183,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls/rule/0
+          name: backend/e7b97b04fcda62e8
           settings:
           - addressType: IP
             endpoints:
@@ -194,7 +194,7 @@ xdsIR:
               name: http-backend
               namespace: backends
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls/rule/0/backend/0
+            name: backend/e7b97b04fcda62e8
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-subjectaltnames.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-subjectaltnames.out.yaml
@@ -183,7 +183,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: backend/e7b97b04fcda62e8
+          name: backend/7cfc0b3f7690a17b
           settings:
           - addressType: IP
             endpoints:
@@ -194,7 +194,7 @@ xdsIR:
               name: http-backend
               namespace: backends
               sectionName: "8080"
-            name: backend/e7b97b04fcda62e8
+            name: backend/7cfc0b3f7690a17b
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-system-truststore.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-system-truststore.out.yaml
@@ -175,7 +175,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls/rule/0
+          name: backend/8a1cbc099645cd3a
           settings:
           - addressType: IP
             endpoints:
@@ -186,7 +186,7 @@ xdsIR:
               name: http-backend
               namespace: default
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls/rule/0/backend/0
+            name: backend/8a1cbc099645cd3a
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-system-truststore.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-system-truststore.out.yaml
@@ -175,7 +175,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls
             namespace: envoy-gateway
-          name: backend/8a1cbc099645cd3a
+          name: backend/e9d255f2b4df93a3
           settings:
           - addressType: IP
             endpoints:
@@ -186,7 +186,7 @@ xdsIR:
               name: http-backend
               namespace: default
               sectionName: "8080"
-            name: backend/8a1cbc099645cd3a
+            name: backend/e9d255f2b4df93a3
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-wildcard-older-than-sectioned.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-wildcard-older-than-sectioned.out.yaml
@@ -251,7 +251,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-port1
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls-port1/rule/0
+          name: backend/4bc5fe06d90e885a
           settings:
           - addressType: IP
             endpoints:
@@ -262,7 +262,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8080"
-            name: httproute/envoy-gateway/httproute-btls-port1/rule/0/backend/0
+            name: backend/4bc5fe06d90e885a
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -289,7 +289,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-port2
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-btls-port2/rule/0
+          name: backend/fa1b251b614bd825
           settings:
           - addressType: IP
             endpoints:
@@ -300,7 +300,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8081"
-            name: httproute/envoy-gateway/httproute-btls-port2/rule/0/backend/0
+            name: backend/fa1b251b614bd825
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/backendtlspolicy-wildcard-older-than-sectioned.out.yaml
+++ b/internal/gatewayapi/testdata/backendtlspolicy-wildcard-older-than-sectioned.out.yaml
@@ -251,7 +251,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-port1
             namespace: envoy-gateway
-          name: backend/4bc5fe06d90e885a
+          name: backend/5470d3715ffacccd
           settings:
           - addressType: IP
             endpoints:
@@ -262,7 +262,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8080"
-            name: backend/4bc5fe06d90e885a
+            name: backend/5470d3715ffacccd
             protocol: HTTP
             tls:
               alpnProtocols: null
@@ -289,7 +289,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-btls-port2
             namespace: envoy-gateway
-          name: backend/fa1b251b614bd825
+          name: backend/b5eed421ea39456f
           settings:
           - addressType: IP
             endpoints:
@@ -300,7 +300,7 @@ xdsIR:
               name: http-backend
               namespace: envoy-gateway
               sectionName: "8081"
-            name: backend/fa1b251b614bd825
+            name: backend/b5eed421ea39456f
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/envoyproxy-tls-settings.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-tls-settings.out.yaml
@@ -270,7 +270,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-tls
             namespace: envoy-gateway
-          name: httproute/envoy-gateway/httproute-tls/rule/0
+          name: backend/fcd33b6514a2c856
           settings:
           - addressType: IP
             endpoints:
@@ -281,7 +281,7 @@ xdsIR:
               name: https-backend
               namespace: default
               sectionName: "443"
-            name: httproute/envoy-gateway/httproute-tls/rule/0/backend/0
+            name: backend/fcd33b6514a2c856
             protocol: HTTP
             tls:
               alpnProtocols:

--- a/internal/gatewayapi/testdata/gateway-tls-frontend-backend.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-tls-frontend-backend.out.yaml
@@ -1831,7 +1831,7 @@ xdsIR:
             kind: HTTPRoute
             name: invalid-gateway-backend-client-cert-no-fallback
             namespace: default
-          name: backend/c20714977179ae8e
+          name: backend/01390b39ea208959
           settings:
           - addressType: IP
             endpoints:
@@ -1842,7 +1842,7 @@ xdsIR:
               name: tls-backend
               namespace: default
               sectionName: "443"
-            name: backend/c20714977179ae8e
+            name: backend/01390b39ea208959
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/gateway-tls-frontend-backend.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-tls-frontend-backend.out.yaml
@@ -1831,7 +1831,7 @@ xdsIR:
             kind: HTTPRoute
             name: invalid-gateway-backend-client-cert-no-fallback
             namespace: default
-          name: httproute/default/invalid-gateway-backend-client-cert-no-fallback/rule/0
+          name: backend/c20714977179ae8e
           settings:
           - addressType: IP
             endpoints:
@@ -1842,7 +1842,7 @@ xdsIR:
               name: tls-backend
               namespace: default
               sectionName: "443"
-            name: httproute/default/invalid-gateway-backend-client-cert-no-fallback/rule/0/backend/0
+            name: backend/c20714977179ae8e
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/httproute-dynamic-resolver-host-rewriting.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-dynamic-resolver-host-rewriting.out.yaml
@@ -343,10 +343,10 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: default
-          name: backend/55fd63152e582baa
+          name: backend/e411993e8e438ccc
           settings:
           - isDynamicResolver: true
-            name: backend/55fd63152e582baa
+            name: backend/e411993e8e438ccc
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/httproute-dynamic-resolver-host-rewriting.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-dynamic-resolver-host-rewriting.out.yaml
@@ -343,10 +343,10 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: default
-          name: httproute/default/httproute-1/rule/1
+          name: backend/55fd63152e582baa
           settings:
           - isDynamicResolver: true
-            name: httproute/default/httproute-1/rule/1/backend/0
+            name: backend/55fd63152e582baa
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/httproute-dynamic-resolver.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-dynamic-resolver.out.yaml
@@ -213,10 +213,10 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: default
-          name: httproute/default/httproute-1/rule/0
+          name: backend/cd8835c806cb52d7
           settings:
           - isDynamicResolver: true
-            name: httproute/default/httproute-1/rule/0/backend/0
+            name: backend/cd8835c806cb52d7
             protocol: HTTP2
             tls:
               alpnProtocols: null
@@ -238,10 +238,10 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-2
             namespace: default
-          name: httproute/default/httproute-2/rule/0
+          name: backend/55fd63152e582baa
           settings:
           - isDynamicResolver: true
-            name: httproute/default/httproute-2/rule/0/backend/0
+            name: backend/55fd63152e582baa
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/httproute-dynamic-resolver.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-dynamic-resolver.out.yaml
@@ -213,10 +213,10 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: default
-          name: backend/cd8835c806cb52d7
+          name: backend/ac6e707e795a4197
           settings:
           - isDynamicResolver: true
-            name: backend/cd8835c806cb52d7
+            name: backend/ac6e707e795a4197
             protocol: HTTP2
             tls:
               alpnProtocols: null
@@ -238,10 +238,10 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-2
             namespace: default
-          name: backend/55fd63152e582baa
+          name: backend/e411993e8e438ccc
           settings:
           - isDynamicResolver: true
-            name: backend/55fd63152e582baa
+            name: backend/e411993e8e438ccc
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/httproute-rule-with-non-service-backends-and-websocket-app-protocols.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-non-service-backends-and-websocket-app-protocols.out.yaml
@@ -268,7 +268,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-wss
             namespace: default
-          name: httproute/default/httproute-wss/rule/0
+          name: backend/7615f8a554e14fe6
           settings:
           - addressType: FQDN
             endpoints:
@@ -279,7 +279,7 @@ xdsIR:
               kind: Backend
               name: backend-wss
               namespace: default
-            name: httproute/default/httproute-wss/rule/0/backend/0
+            name: backend/7615f8a554e14fe6
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/httproute-rule-with-non-service-backends-and-websocket-app-protocols.out.yaml
+++ b/internal/gatewayapi/testdata/httproute-rule-with-non-service-backends-and-websocket-app-protocols.out.yaml
@@ -268,7 +268,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-wss
             namespace: default
-          name: backend/7615f8a554e14fe6
+          name: backend/e52571ea68020e59
           settings:
           - addressType: FQDN
             endpoints:
@@ -279,7 +279,7 @@ xdsIR:
               kind: Backend
               name: backend-wss
               namespace: default
-            name: backend/7615f8a554e14fe6
+            name: backend/e52571ea68020e59
             protocol: HTTP
             tls:
               alpnProtocols: null

--- a/internal/gatewayapi/testdata/sds.out.yaml
+++ b/internal/gatewayapi/testdata/sds.out.yaml
@@ -209,7 +209,7 @@ xdsIR:
             kind: HTTPRoute
             name: httproute-1
             namespace: default
-          name: httproute/default/httproute-1/rule/0
+          name: backend/cbcefd28840669c5
           settings:
           - addressType: IP
             endpoints:
@@ -220,7 +220,7 @@ xdsIR:
               name: service-1
               namespace: default
               sectionName: "8080"
-            name: httproute/default/httproute-1/rule/0/backend/0
+            name: backend/cbcefd28840669c5
             protocol: HTTP
             tls:
               alpnProtocols:

--- a/internal/gatewayapi/translator_test.go
+++ b/internal/gatewayapi/translator_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	xdsresource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +43,7 @@ import (
 	"github.com/envoyproxy/gateway/internal/utils/file"
 	"github.com/envoyproxy/gateway/internal/utils/test"
 	"github.com/envoyproxy/gateway/internal/wasm"
+	xdstranslator "github.com/envoyproxy/gateway/internal/xds/translator"
 )
 
 func mustUnmarshal(t *testing.T, val []byte, out any) {
@@ -509,6 +512,83 @@ func TestTranslate(t *testing.T) {
 			require.Empty(t, cmp.Diff(want, got, opts...))
 		})
 	}
+}
+
+func TestTranslateReusesUpstreamTLSClusterForSameBackend(t *testing.T) {
+	input, err := os.ReadFile(filepath.Join("testdata", "backendtlspolicy-ca-only.in.yaml"))
+	require.NoError(t, err)
+
+	resources := &resource.Resources{}
+	mustUnmarshal(t, input, resources)
+	base, err := os.ReadFile(filepath.Join("testdata", "base", "base.yaml"))
+	require.NoError(t, err)
+	baseResources := &resource.Resources{}
+	mustUnmarshal(t, base, baseResources)
+	resources.Secrets = append(resources.Secrets, baseResources.Secrets...)
+	resources.Namespaces = append(resources.Namespaces,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "envoy-gateway"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "backends"}},
+	)
+
+	secondRoute := resources.HTTPRoutes[0].DeepCopy()
+	secondRoute.Name = "httproute-btls-2"
+	secondPath := "/exact-2"
+	secondRoute.Spec.Rules[0].Matches[0].Path.Value = &secondPath
+	resources.HTTPRoutes = append(resources.HTTPRoutes, secondRoute)
+
+	translator := &Translator{
+		GatewayControllerName:  egv1a1.GatewayControllerName,
+		GatewayClassName:       "envoy-gateway-class",
+		GlobalRateLimitEnabled: true,
+		BackendEnabled:         true,
+		MergeGateways:          IsMergeGatewaysEnabled(resources),
+		ControllerNamespace:    "envoy-gateway-system",
+		WasmCache:              &mockWasmCache{},
+		Logger:                 logging.DefaultLogger(os.Stdout, egv1a1.LogLevelInfo),
+	}
+
+	got, err := translator.Translate(resources)
+	require.NoError(t, err)
+
+	xdsIR := got.XdsIR["envoy-gateway/gateway-btls"]
+	require.NotNil(t, xdsIR)
+	require.Len(t, xdsIR.HTTP, 1)
+	require.Len(t, xdsIR.HTTP[0].Routes, 2)
+
+	firstDestination := xdsIR.HTTP[0].Routes[0].Destination
+	secondDestination := xdsIR.HTTP[0].Routes[1].Destination
+	require.NotNil(t, firstDestination)
+	require.NotNil(t, secondDestination)
+	require.Equal(t, firstDestination.Name, secondDestination.Name)
+	require.Equal(t, firstDestination.Settings[0].Name, secondDestination.Settings[0].Name)
+
+	xdsTranslator := &xdstranslator.Translator{
+		ControllerNamespace: "envoy-gateway-system",
+		FilterOrder:         xdsIR.FilterOrder,
+	}
+	tCtx, err := xdsTranslator.Translate(xdsIR)
+	require.NoError(t, err)
+
+	clusterCount := 0
+	var matchedCluster *clusterv3.Cluster
+	for _, xdsResource := range tCtx.XdsResources[xdsresource.ClusterType] {
+		cluster, ok := xdsResource.(*clusterv3.Cluster)
+		if ok && cluster.Name == firstDestination.Name {
+			clusterCount++
+			matchedCluster = cluster
+		}
+	}
+	require.Equal(t, 1, clusterCount)
+	require.NotNil(t, matchedCluster)
+	metadata := matchedCluster.GetMetadata().GetFilterMetadata()["envoy-gateway"]
+	require.NotNil(t, metadata)
+	metadataResources := metadata.GetFields()["resources"].GetListValue().GetValues()
+	require.Len(t, metadataResources, 1)
+	resourceMetadata := metadataResources[0].GetStructValue().GetFields()
+	require.Equal(t, "Service", resourceMetadata["kind"].GetStringValue())
+	require.Equal(t, "http-backend", resourceMetadata["name"].GetStringValue())
+	require.Equal(t, "backends", resourceMetadata["namespace"].GetStringValue())
 }
 
 func TestTranslateWithExtensionKinds(t *testing.T) {

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -616,7 +616,7 @@ func (t *Translator) addRouteToRouteConfig(
 					httpRoute.Destination.Settings,
 					&HTTPRouteTranslator{httpRoute},
 					ea,
-					httpRoute.Destination.Metadata,
+					clusterMetadata(httpRoute.Destination, nil),
 				)
 				if err != nil {
 					errs = errors.Join(errs, err)
@@ -630,7 +630,7 @@ func (t *Translator) addRouteToRouteConfig(
 						tSettings,
 						&HTTPRouteTranslator{httpRoute},
 						ea,
-						httpRoute.Destination.Metadata)
+						clusterMetadata(httpRoute.Destination, setting))
 					if err != nil {
 						errs = errors.Join(errs, err)
 					}
@@ -1068,6 +1068,23 @@ func processXdsCluster(tCtx *types.ResourceVersionTable,
 	metadata *ir.ResourceMetadata,
 ) error {
 	return addXdsCluster(tCtx, route.asClusterArgs(name, settings, extras, metadata))
+}
+
+func clusterMetadata(destination *ir.RouteDestination, setting *ir.DestinationSetting) *ir.ResourceMetadata {
+	if destination == nil {
+		return nil
+	}
+	if setting != nil && isStableBackendClusterName(setting.Name) {
+		return setting.Metadata
+	}
+	if setting == nil && isStableBackendClusterName(destination.Name) && len(destination.Settings) == 1 {
+		return destination.Settings[0].Metadata
+	}
+	return destination.Metadata
+}
+
+func isStableBackendClusterName(name string) bool {
+	return strings.HasPrefix(name, "backend/")
 }
 
 // findXdsSecret finds a xds secret with the same name, and returns nil if there is no match.

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -6,6 +6,9 @@
 package translator
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -508,6 +511,8 @@ func (t *Translator) addRouteToRouteConfig(
 
 	// Check if an extension is loaded that wants to modify xDS Routes after they have been generated
 	for _, httpRoute := range httpListener.Routes {
+		httpRoute = httpRouteWithListenerHTTP1ClusterName(httpRoute, httpListener.HTTP1)
+
 		// 1:1 between IR HTTPRoute Hostname and xDS VirtualHost.
 		vHost := vHosts[httpRoute.Hostname]
 		if vHost == nil {
@@ -1085,6 +1090,51 @@ func clusterMetadata(destination *ir.RouteDestination, setting *ir.DestinationSe
 
 func isStableBackendClusterName(name string) bool {
 	return strings.HasPrefix(name, "backend/")
+}
+
+func httpRouteWithListenerHTTP1ClusterName(route *ir.HTTPRoute, http1 *ir.HTTP1Settings) *ir.HTTPRoute {
+	suffix, ok := listenerHTTP1ClusterNameSuffix(http1)
+	if !ok || route == nil || route.Destination == nil {
+		return route
+	}
+
+	destination := route.Destination
+	if !isStableBackendClusterName(destination.Name) {
+		return route
+	}
+
+	route = route.DeepCopy()
+	route.Destination.Name += suffix
+	for _, setting := range route.Destination.Settings {
+		if setting != nil && isStableBackendClusterName(setting.Name) {
+			setting.Name += suffix
+		}
+	}
+	return route
+}
+
+type stableListenerHTTP1Settings struct {
+	EnableTrailers     bool               `json:"enableTrailers,omitempty"`
+	PreserveHeaderCase bool               `json:"preserveHeaderCase,omitempty"`
+	HTTP10             *ir.HTTP10Settings `json:"http10,omitempty"`
+}
+
+func listenerHTTP1ClusterNameSuffix(http1 *ir.HTTP1Settings) (string, bool) {
+	if http1 == nil || (!http1.EnableTrailers && !http1.PreserveHeaderCase && http1.HTTP10 == nil) {
+		return "", false
+	}
+
+	input := stableListenerHTTP1Settings{
+		EnableTrailers:     http1.EnableTrailers,
+		PreserveHeaderCase: http1.PreserveHeaderCase,
+		HTTP10:             http1.HTTP10,
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		return "", false
+	}
+	sum := sha256.Sum256(data)
+	return "/http1/" + hex.EncodeToString(sum[:8]), true
 }
 
 // findXdsSecret finds a xds secret with the same name, and returns nil if there is no match.

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -511,7 +511,7 @@ func (t *Translator) addRouteToRouteConfig(
 
 	// Check if an extension is loaded that wants to modify xDS Routes after they have been generated
 	for _, httpRoute := range httpListener.Routes {
-		httpRoute = httpRouteWithListenerHTTP1ClusterName(httpRoute, httpListener.HTTP1)
+		httpRoute = httpRouteWithXDSClusterNameInputs(httpRoute, httpListener.HTTP1)
 
 		// 1:1 between IR HTTPRoute Hostname and xDS VirtualHost.
 		vHost := vHosts[httpRoute.Hostname]
@@ -1092,25 +1092,104 @@ func isStableBackendClusterName(name string) bool {
 	return strings.HasPrefix(name, "backend/")
 }
 
-func httpRouteWithListenerHTTP1ClusterName(route *ir.HTTPRoute, http1 *ir.HTTP1Settings) *ir.HTTPRoute {
-	suffix, ok := listenerHTTP1ClusterNameSuffix(http1)
-	if !ok || route == nil || route.Destination == nil {
+func httpRouteWithXDSClusterNameInputs(route *ir.HTTPRoute, http1 *ir.HTTP1Settings) *ir.HTTPRoute {
+	if route == nil || route.Destination == nil {
 		return route
 	}
-
 	destination := route.Destination
 	if !isStableBackendClusterName(destination.Name) {
 		return route
 	}
 
+	var suffix strings.Builder
+	if routeSuffix, ok := routeClusterNameSuffix(route); ok {
+		suffix.WriteString(routeSuffix)
+	}
+	if http1Suffix, ok := listenerHTTP1ClusterNameSuffix(http1); ok {
+		suffix.WriteString(http1Suffix)
+	}
+	if suffix.Len() == 0 {
+		return route
+	}
+
 	route = route.DeepCopy()
-	route.Destination.Name += suffix
+	route.Destination.Name += suffix.String()
 	for _, setting := range route.Destination.Settings {
 		if setting != nil && isStableBackendClusterName(setting.Name) {
-			setting.Name += suffix
+			setting.Name += suffix.String()
 		}
 	}
 	return route
+}
+
+type stableHTTPRouteClusterSettings struct {
+	Traffic           *stableXDSClusterTraffic `json:"traffic,omitempty"`
+	UseClientProtocol bool                     `json:"useClientProtocol,omitempty"`
+}
+
+type stableXDSClusterTraffic struct {
+	LoadBalancer      *ir.LoadBalancer      `json:"loadBalancer,omitempty"`
+	ProxyProtocol     *ir.ProxyProtocol     `json:"proxyProtocol,omitempty"`
+	CircuitBreaker    *ir.CircuitBreaker    `json:"circuitBreaker,omitempty"`
+	HealthCheck       *ir.HealthCheck       `json:"healthCheck,omitempty"`
+	Timeout           *ir.Timeout           `json:"timeout,omitempty"`
+	TCPKeepalive      *ir.TCPKeepalive      `json:"tcpKeepalive,omitempty"`
+	BackendConnection *ir.BackendConnection `json:"backendConnection,omitempty"`
+	DNS               *ir.DNS               `json:"dns,omitempty"`
+	HTTP2             *ir.HTTP2Settings     `json:"http2,omitempty"`
+	AdmissionControl  *ir.AdmissionControl  `json:"admissionControl,omitempty"`
+}
+
+func routeClusterNameSuffix(route *ir.HTTPRoute) (string, bool) {
+	if route == nil {
+		return "", false
+	}
+
+	input := stableHTTPRouteClusterSettings{
+		Traffic:           stableXDSClusterTrafficConfig(route.Traffic),
+		UseClientProtocol: ptr.Deref(route.UseClientProtocol, false),
+	}
+	if input.Traffic == nil && !input.UseClientProtocol {
+		return "", false
+	}
+
+	data, err := json.Marshal(input)
+	if err != nil {
+		return "", false
+	}
+	sum := sha256.Sum256(data)
+	return "/route/" + hex.EncodeToString(sum[:8]), true
+}
+
+func stableXDSClusterTrafficConfig(traffic *ir.TrafficFeatures) *stableXDSClusterTraffic {
+	if traffic == nil {
+		return nil
+	}
+	clusterTraffic := &stableXDSClusterTraffic{
+		LoadBalancer:      traffic.LoadBalancer,
+		ProxyProtocol:     traffic.ProxyProtocol,
+		CircuitBreaker:    traffic.CircuitBreaker,
+		HealthCheck:       traffic.HealthCheck,
+		Timeout:           traffic.Timeout,
+		TCPKeepalive:      traffic.TCPKeepalive,
+		BackendConnection: traffic.BackendConnection,
+		DNS:               traffic.DNS,
+		HTTP2:             traffic.HTTP2,
+		AdmissionControl:  traffic.AdmissionControl,
+	}
+	if clusterTraffic.LoadBalancer == nil &&
+		clusterTraffic.ProxyProtocol == nil &&
+		clusterTraffic.CircuitBreaker == nil &&
+		clusterTraffic.HealthCheck == nil &&
+		clusterTraffic.Timeout == nil &&
+		clusterTraffic.TCPKeepalive == nil &&
+		clusterTraffic.BackendConnection == nil &&
+		clusterTraffic.DNS == nil &&
+		clusterTraffic.HTTP2 == nil &&
+		clusterTraffic.AdmissionControl == nil {
+		return nil
+	}
+	return clusterTraffic
 }
 
 type stableListenerHTTP1Settings struct {

--- a/internal/xds/translator/translator_test.go
+++ b/internal/xds/translator/translator_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
@@ -217,6 +218,101 @@ func TestTranslateXds(t *testing.T) {
 	if test.OverrideTestData() {
 		cleanupOutdatedTestData(t, filepath.Join("testdata", "out", "xds-ir"), keep)
 	}
+}
+
+func TestTranslateXdsStableBackendClusterNameIncludesListenerHTTP1(t *testing.T) {
+	weight := uint32(1)
+	addressType := ir.IP
+	pathPrefix := "/"
+	routeDestination := func() *ir.RouteDestination {
+		return &ir.RouteDestination{
+			Name: "backend/shared",
+			Settings: []*ir.DestinationSetting{
+				{
+					Name:        "backend/shared",
+					Weight:      &weight,
+					Protocol:    ir.HTTP,
+					AddressType: &addressType,
+					Endpoints: []*ir.DestinationEndpoint{
+						ir.NewDestEndpoint(nil, "10.0.0.1", 8080, false, nil),
+					},
+				},
+			},
+		}
+	}
+
+	xdsIR := &ir.Xds{
+		HTTP: []*ir.HTTPListener{
+			{
+				CoreListenerDetails: ir.CoreListenerDetails{
+					Name:    "listener-a",
+					Address: "0.0.0.0",
+					Port:    10080,
+				},
+				Hostnames: []string{"a.example.com"},
+				HTTP1: &ir.HTTP1Settings{
+					EnableTrailers: true,
+				},
+				Routes: []*ir.HTTPRoute{
+					{
+						Name:        "route-a",
+						Hostname:    "a.example.com",
+						PathMatch:   &ir.StringMatch{Prefix: &pathPrefix},
+						Destination: routeDestination(),
+					},
+				},
+			},
+			{
+				CoreListenerDetails: ir.CoreListenerDetails{
+					Name:    "listener-b",
+					Address: "0.0.0.0",
+					Port:    10081,
+				},
+				Hostnames: []string{"b.example.com"},
+				HTTP1: &ir.HTTP1Settings{
+					PreserveHeaderCase: true,
+				},
+				Routes: []*ir.HTTPRoute{
+					{
+						Name:        "route-b",
+						Hostname:    "b.example.com",
+						PathMatch:   &ir.StringMatch{Prefix: &pathPrefix},
+						Destination: routeDestination(),
+					},
+				},
+			},
+		},
+	}
+
+	translator := &Translator{}
+	tCtx, err := translator.Translate(xdsIR)
+	require.NoError(t, err)
+
+	var clusterNames []string
+	for _, xdsResource := range tCtx.XdsResources[resourcev3.ClusterType] {
+		cluster, ok := xdsResource.(*clusterv3.Cluster)
+		if ok && strings.HasPrefix(cluster.Name, "backend/shared/http1/") {
+			clusterNames = append(clusterNames, cluster.Name)
+		}
+	}
+	require.Len(t, clusterNames, 2)
+	require.NotEqual(t, clusterNames[0], clusterNames[1])
+
+	var routeClusterNames []string
+	for _, xdsResource := range tCtx.XdsResources[resourcev3.RouteType] {
+		routeConfig, ok := xdsResource.(*routev3.RouteConfiguration)
+		if !ok {
+			continue
+		}
+		for _, virtualHost := range routeConfig.VirtualHosts {
+			for _, route := range virtualHost.Routes {
+				routeClusterNames = append(routeClusterNames, route.GetRoute().GetCluster())
+			}
+		}
+	}
+	require.ElementsMatch(t, clusterNames, routeClusterNames)
+	require.Equal(t, "backend/shared", xdsIR.HTTP[0].Routes[0].Destination.Name)
+	require.Equal(t, "backend/shared", xdsIR.HTTP[1].Routes[0].Destination.Name)
 }
 
 func cleanupOutdatedTestData(t *testing.T, dir string, keep sets.Set[string]) {

--- a/internal/xds/translator/translator_test.go
+++ b/internal/xds/translator/translator_test.go
@@ -315,6 +315,96 @@ func TestTranslateXdsStableBackendClusterNameIncludesListenerHTTP1(t *testing.T)
 	require.Equal(t, "backend/shared", xdsIR.HTTP[1].Routes[0].Destination.Name)
 }
 
+func TestTranslateXdsStableBackendClusterNameIncludesRouteClusterInputs(t *testing.T) {
+	weight := uint32(1)
+	addressType := ir.IP
+	pathA := "/a"
+	pathB := "/b"
+	useClientProtocol := true
+	connectionIdleTimeout := metav1.Duration{Duration: time.Second}
+	routeDestination := func() *ir.RouteDestination {
+		return &ir.RouteDestination{
+			Name: "backend/shared",
+			Settings: []*ir.DestinationSetting{
+				{
+					Name:        "backend/shared",
+					Weight:      &weight,
+					Protocol:    ir.HTTP,
+					AddressType: &addressType,
+					Endpoints: []*ir.DestinationEndpoint{
+						ir.NewDestEndpoint(nil, "10.0.0.1", 8080, false, nil),
+					},
+				},
+			},
+		}
+	}
+
+	xdsIR := &ir.Xds{
+		HTTP: []*ir.HTTPListener{
+			{
+				CoreListenerDetails: ir.CoreListenerDetails{
+					Name:    "listener",
+					Address: "0.0.0.0",
+					Port:    10080,
+				},
+				Hostnames: []string{"example.com"},
+				Routes: []*ir.HTTPRoute{
+					{
+						Name:        "route-a",
+						Hostname:    "example.com",
+						PathMatch:   &ir.StringMatch{Prefix: &pathA},
+						Destination: routeDestination(),
+					},
+					{
+						Name:        "route-b",
+						Hostname:    "example.com",
+						PathMatch:   &ir.StringMatch{Prefix: &pathB},
+						Destination: routeDestination(),
+						Traffic: &ir.TrafficFeatures{
+							Timeout: &ir.Timeout{
+								HTTP: &ir.HTTPTimeout{
+									ConnectionIdleTimeout: &connectionIdleTimeout,
+								},
+							},
+						},
+						UseClientProtocol: &useClientProtocol,
+					},
+				},
+			},
+		},
+	}
+
+	translator := &Translator{}
+	tCtx, err := translator.Translate(xdsIR)
+	require.NoError(t, err)
+
+	var clusterNames []string
+	for _, xdsResource := range tCtx.XdsResources[resourcev3.ClusterType] {
+		cluster, ok := xdsResource.(*clusterv3.Cluster)
+		if ok && strings.HasPrefix(cluster.Name, "backend/shared") {
+			clusterNames = append(clusterNames, cluster.Name)
+		}
+	}
+	require.Len(t, clusterNames, 2)
+	require.Contains(t, clusterNames, "backend/shared")
+
+	var routeClusterNames []string
+	for _, xdsResource := range tCtx.XdsResources[resourcev3.RouteType] {
+		routeConfig, ok := xdsResource.(*routev3.RouteConfiguration)
+		if !ok {
+			continue
+		}
+		for _, virtualHost := range routeConfig.VirtualHosts {
+			for _, route := range virtualHost.Routes {
+				routeClusterNames = append(routeClusterNames, route.GetRoute().GetCluster())
+			}
+		}
+	}
+	require.ElementsMatch(t, clusterNames, routeClusterNames)
+	require.Equal(t, "backend/shared", xdsIR.HTTP[0].Routes[0].Destination.Name)
+	require.Equal(t, "backend/shared", xdsIR.HTTP[0].Routes[1].Destination.Name)
+}
+
 func cleanupOutdatedTestData(t *testing.T, dir string, keep sets.Set[string]) {
 	t.Helper()
 	entries, err := os.ReadDir(dir)

--- a/release-notes/current/breaking_changes/9489-upstream-tls-cluster-deduplication.md
+++ b/release-notes/current/breaking_changes/9489-upstream-tls-cluster-deduplication.md
@@ -1,0 +1,1 @@
+Deduplicated generated upstream TLS xDS clusters that share the same backend and cluster-level configuration, which changes affected cluster names from route-derived names to stable backend hash names; EnvoyPatchPolicies and extension servers that match the previous route-derived cluster names must be updated.


### PR DESCRIPTION
Fixes #9489.

## Summary
- reuse stable backend hash cluster names for HTTPRoute/GRPCRoute upstream TLS destinations when the backend and cluster-level configuration match
- keep route metadata on the IR while using backend metadata for stable xDS clusters
- add regression coverage for cross-route upstream TLS cluster reuse and refresh affected gatewayapi golden outputs
- add a breaking-change release note for generated xDS cluster name changes

## Tests
- `git diff --check`
- `go test ./internal/gatewayapi -run 'TestStableClusterRouteDestinationReusesSameTLSBackend|TestStableClusterRouteDestinationUsesXDSClusterInputs|TestTranslateReusesUpstreamTLSClusterForSameBackend|TestTranslate/(backend-tls-auto-host-sni|backend-tls-settings|backend-with-auto-san-sni|backend-with-skip-tls-verify|backendtlspolicy-ca-clustertrustbundle|backendtlspolicy-ca-only-secret|backendtlspolicy-ca-only|backendtlspolicy-conflict|backendtlspolicy-default-ns-targetrefs|backendtlspolicy-multiple-targets|backendtlspolicy-not-conflict-service|backendtlspolicy-not-conflict|backendtlspolicy-serviceimport-target|backendtlspolicy-status-conditions-truncated|backendtlspolicy-subjectaltnames|backendtlspolicy-system-truststore|backendtlspolicy-wildcard-older-than-sectioned|envoyproxy-tls-settings|gateway-tls-frontend-backend|httproute-dynamic-resolver-host-rewriting|httproute-dynamic-resolver|httproute-rule-with-non-service-backends-and-websocket-app-protocols|sds)$'`\n- `go test ./internal/xds/translator`\n- `go test ./...` fails only in `TestTranslate/securitypolicy-with-oidc` because `https://accounts.google.com/.well-known/openid-configuration` times out in this environment\n