### PR TITLE
docs: recommend ListenerSet over mergeGateways

### DIFF
--- a/site/content/en/latest/tasks/operations/deployment-mode.md
+++ b/site/content/en/latest/tasks/operations/deployment-mode.md
@@ -1100,4 +1100,5 @@ curl --header "Host: www.merged3.com" http://$GATEWAY_HOST:8082/example3
 [issue1231]: https://github.com/envoyproxy/gateway/issues/1231
 [issue2629]: https://github.com/envoyproxy/gateway/issues/2629
 [issue 1230]: https://github.com/envoyproxy/gateway/issues/1230
-[ListenerSet]: https://gateway-api.sigs.k8s.io/guides/user-guides/listener-set/
+[ListenerSet]: https://gateway-api.sigs.k8s.io/reference/api-types/listenerset/
+[ListenerSet user guide]: https://gateway-api.sigs.k8s.io/guides/user-guides/listener-set/

--- a/site/content/en/latest/tasks/operations/deployment-mode.md
+++ b/site/content/en/latest/tasks/operations/deployment-mode.md
@@ -20,6 +20,16 @@ Please follow the example [Multi-tenancy](#multi-tenancy).
 
 ### Merged Gateways onto a single EnvoyProxy fleet
 
+{{% alert title="Recommendation" color="primary" %}}
+
+The `mergeGateways` feature was introduced before the Gateway API supported [ListenerSet][]. For splitting listeners
+across multiple resources, prefer [ListenerSet][]: it is the Gateway API-native mechanism, it removes the
+single-Gateway 64-listener limit, and it enables a delegated management model where a platform team owns the Gateway
+and application teams define ports, hostnames, and TLS certificates in their own ListenerSets, suitable for
+high-scale, multi-tenant environments. See the [ListenerSet user guide][] and [issue 1230][] for details.
+
+{{% /alert %}}
+
 By default, each Gateway has its own dedicated set of Envoy Proxy and its configurations.
 However, for some deployments, it may be more convenient to merge listeners across multiple Gateways and deploy a single Envoy Proxy fleet.
 
@@ -659,6 +669,12 @@ Handling connection for 8889
 
 ### Merged gateways deployment
 
+{{% alert title="Recommendation" color="primary" %}}
+
+For new deployments, consider using [ListenerSet][] instead of `mergeGateways`.
+
+{{% /alert %}}
+
 In this example, we will deploy GatewayClass
 
 ```shell
@@ -1083,3 +1099,5 @@ curl --header "Host: www.merged3.com" http://$GATEWAY_HOST:8082/example3
 [Gateway Namespace Mode]: ./gateway-namespace-mode
 [issue1231]: https://github.com/envoyproxy/gateway/issues/1231
 [issue2629]: https://github.com/envoyproxy/gateway/issues/2629
+[issue 1230]: https://github.com/envoyproxy/gateway/issues/1230
+[ListenerSet]: https://gateway-api.sigs.k8s.io/guides/user-guides/listener-set/


### PR DESCRIPTION
## Description

This PR updates the deployment-mode docs to recommend `ListenerSet` over `mergeGateways` for new deployments, adding recommendation alerts that link to the upstream ListenerSet user guide and to #1230.

## Background

The `mergeGateways` feature was introduced before the Gateway API supported [ListenerSet](https://gateway-api.sigs.k8s.io/guides/user-guides/listener-set/). `ListenerSet` is the Gateway API-native way to split listener configuration across resources: teams define ports, hostnames, and TLS certificates in separate resources rather than cramming everything into one giant Gateway object (which is limited to 64 listeners). This enables a delegated management model suitable for high-scale, multi-tenant environments.

