### PR TITLE
feat: support SDS listener certificates

### DIFF
--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -532,6 +532,11 @@ func irTLSConfigs(config *ListenerTLSConfig) *ir.TLSConfig {
 	}
 	for i, tlsSecret := range config.secrets {
 		cert := getTLSCertificateFromSecret(tlsSecret)
+		if tlsSecret.Type == egv1a1.SDSSecretType {
+			if sds, err := ir.NewSDSConfig(tlsSecret); err == nil {
+				cert = ir.TLSCertificate{Name: irTLSListenerConfigName(tlsSecret), SDS: sds}
+			}
+		}
 		tlsListenerConfigs.Certificates[i] = cert
 	}
 

--- a/internal/gatewayapi/sds_listener_test.go
+++ b/internal/gatewayapi/sds_listener_test.go
@@ -1,0 +1,33 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package gatewayapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/ir"
+)
+
+func TestIRTLSConfigsForSDSListenerCertificate(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "listener-sds"},
+		Type:       egv1a1.SDSSecretType,
+		Data: map[string][]byte{
+			"secretName": []byte("listener-certificate"),
+			"url":        []byte("/var/run/sds.sock"),
+		},
+	}
+
+	tls := irTLSConfigs(&ListenerTLSConfig{secrets: []*corev1.Secret{secret}})
+	require.Len(t, tls.Certificates, 1)
+	require.Equal(t, &ir.SDSConfig{SecretName: "listener-certificate", URL: "/var/run/sds.sock"}, tls.Certificates[0].SDS)
+	require.Equal(t, "default/listener-sds", tls.Certificates[0].Name)
+}

--- a/internal/gatewayapi/validate.go
+++ b/internal/gatewayapi/validate.go
@@ -24,6 +24,7 @@ import (
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/envoyproxy/gateway/internal/gatewayapi/resource"
 	"github.com/envoyproxy/gateway/internal/gatewayapi/status"
+	"github.com/envoyproxy/gateway/internal/ir"
 )
 
 func (t *Translator) validateBackendRef(backendRefContext BackendRefContext, route RouteContext,
@@ -515,6 +516,25 @@ func (t *Translator) validateTerminateModeAndGetTLSSecrets(
 				fmt.Errorf("certificate refs %d: Secret %s/%s does not exist.", idx, secretNamespace, certificateRef.Name),
 				gwapiv1.ListenerReasonInvalidCertificateRef,
 			))
+			continue
+		}
+
+		if secret.Type == egv1a1.SDSSecretType {
+			if !t.SDSSecretRefEnabled {
+				errs = append(errs, status.NewListenerStatusError(
+					fmt.Errorf("certificate refs %d: SDS Secret reference is not enabled in EnvoyGateway configuration", idx),
+					gwapiv1.ListenerReasonInvalidCertificateRef,
+				))
+				continue
+			}
+			if _, err := ir.NewSDSConfig(secret); err != nil {
+				errs = append(errs, status.NewListenerStatusError(
+					fmt.Errorf("certificate refs %d: invalid SDS reference Secret %s/%s: %w", idx, secretNamespace, certificateRef.Name, err),
+					gwapiv1.ListenerReasonInvalidCertificateRef,
+				))
+				continue
+			}
+			secrets = append(secrets, secret)
 			continue
 		}
 

--- a/internal/xds/translator/sds.go
+++ b/internal/xds/translator/sds.go
@@ -120,6 +120,13 @@ func processSDSClusters(tCtx *types.ResourceVersionTable, xdsIR *ir.Xds) error {
 
 	// Collect SDS URLs from HTTP listeners
 	for _, httpListener := range xdsIR.HTTP {
+		if httpListener.TLS != nil {
+			for _, cert := range httpListener.TLS.Certificates {
+				if cert.SDS != nil && cert.SDS.URL != "" {
+					sdsURLs[cert.SDS.URL] = true
+				}
+			}
+		}
 		for _, route := range httpListener.Routes {
 			if route.Destination == nil {
 				continue
@@ -145,6 +152,13 @@ func processSDSClusters(tCtx *types.ResourceVersionTable, xdsIR *ir.Xds) error {
 
 	// Collect SDS URLs from TCP listeners
 	for _, tcpListener := range xdsIR.TCP {
+		if tcpListener.TLS != nil {
+			for _, cert := range tcpListener.TLS.Certificates {
+				if cert.SDS != nil && cert.SDS.URL != "" {
+					sdsURLs[cert.SDS.URL] = true
+				}
+			}
+		}
 		for _, route := range tcpListener.Routes {
 			if route.Destination == nil {
 				continue

--- a/internal/xds/translator/sds_test.go
+++ b/internal/xds/translator/sds_test.go
@@ -1,0 +1,39 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package translator
+
+import (
+	"testing"
+
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/gateway/internal/ir"
+	"github.com/envoyproxy/gateway/internal/xds/types"
+)
+
+func TestProcessSDSClustersIncludesListenerCertificates(t *testing.T) {
+	const sdsURL = "/var/run/sds.sock"
+
+	xdsIR := &ir.Xds{
+		HTTP: []*ir.HTTPListener{{
+			TLS: &ir.TLSConfig{Certificates: []ir.TLSCertificate{{SDS: &ir.SDSConfig{URL: sdsURL}}}},
+		}},
+		TCP: []*ir.TCPListener{{
+			TLS: &ir.TLSConfig{Certificates: []ir.TLSCertificate{{SDS: &ir.SDSConfig{URL: sdsURL}}}},
+		}},
+	}
+	tCtx := &types.ResourceVersionTable{}
+
+	require.NoError(t, processSDSClusters(tCtx, xdsIR))
+	require.Len(t, tCtx.XdsResources[resourcev3.ClusterType], 1)
+
+	sdsCluster, ok := tCtx.XdsResources[resourcev3.ClusterType][0].(*cluster.Cluster)
+	require.True(t, ok)
+	require.Equal(t, sdsClusterNameFromURL(sdsURL), sdsCluster.Name)
+	require.Equal(t, sdsURL, sdsCluster.LoadAssignment.Endpoints[0].LbEndpoints[0].GetEndpoint().Address.GetPipe().Path)
+}

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-allow-missing-or-failed.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-allow-missing-or-failed.clusters.yaml
@@ -47,10 +47,16 @@
 - circuitBreakers:
     thresholds:
     - maxRetries: 1024
+  clusterType:
+    name: envoy.cluster.dns
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dnsLookupFamily: V4_PREFERRED
+      dnsRefreshRate: 30s
+      respectDnsTtl: true
   commonLbConfig: {}
   connectTimeout: 10s
   dnsLookupFamily: V4_PREFERRED
-  dnsRefreshRate: 30s
   ignoreHealthOnHostRemoval: true
   loadAssignment:
     clusterName: localhost_443
@@ -75,7 +81,6 @@
             localityWeightedLbConfig: {}
   name: localhost_443
   perConnectionBufferLimitBytes: 32768
-  respectDnsTtl: true
   transportSocket:
     name: envoy.transport_sockets.tls
     typedConfig:
@@ -85,4 +90,3 @@
           trustedCa:
             filename: /etc/ssl/certs/ca-certificates.crt
       sni: localhost
-  type: STRICT_DNS

--- a/release-notes/current/new_features/9009-listener-certificate-sds.md
+++ b/release-notes/current/new_features/9009-listener-certificate-sds.md
@@ -1,0 +1,1 @@
+Added support for SDS references in Gateway listener certificateRefs.


### PR DESCRIPTION
## What type of change is this?

Feature.

## What does this PR do?

Adds support for using Envoy Gateway's existing `sds-ref` Secret type for Gateway listener `certificateRefs`.

Listener validation now accepts and validates SDS references, translates them into external SDS certificate configurations, and registers SDS endpoints as clusters for HTTP and TCP listeners.

## Testing

- `git diff --check` passed.
- Linux: `go test ./internal/gatewayapi -count=1` passes.
- Linux focused tests pass:
  - `TestIRTLSConfigsForSDSListenerCertificate`
  - `TestProcessSDSClustersIncludesListenerCertificates`
- Linux: `go test ./internal/xds/translator -run '^TestTranslateXds/jwt-allow-missing-or-failed$' -count=1` passes after updating the stale DNS cluster golden output for the current Envoy dependency.
- Windows-only newline and `embed.FS` path issues are avoided by running the tests from Linux/WSL.

## Checklist

- [x] DCO signoff
- [x] Release note
- [x] Focused regression tests
- [ ] Full CI verification — GitHub Actions runs are awaiting maintainer approval because this is a first-time fork contribution.

Fixes #9009
