### PR TITLE
[release-1.8] fix: update ratelimit image fallback tag in helm helpers

### DIFF
--- a/charts/gateway-helm/templates/_helpers.tpl
+++ b/charts/gateway-helm/templates/_helpers.tpl
@@ -139,7 +139,7 @@ The name of the Envoy Ratelimit image.
 {{-   $repositoryTag := $imageParts._1 -}}
 {{-   $repositoryParts := splitn ":" 2 $repositoryTag -}}
 {{-   $repositoryName := $repositoryParts._0 -}}
-{{-   $imageTag := default "ff287602" $repositoryParts._1 -}}
+{{-   $imageTag := default "1e50889b" $repositoryParts._1 -}}
 {{-   printf "%s/%s:%s" $registryName $repositoryName $imageTag -}}
 {{- end -}}
 

--- a/release-notes/v1.8.3.yaml
+++ b/release-notes/v1.8.3.yaml
@@ -19,6 +19,7 @@ bug fixes: |
   Fixed Wasm extensions remaining permanently failed after transient errors fetching the Wasm module. Envoy's built-in behavior only retried the fetch once after ~1 second and never re-attempted it, leaving the filter failed until the next configuration update. Envoy Gateway now configures the fetch with up to 10 retries using jittered exponential backoff (1s base interval, 30s max interval).
   Fixed log timestamps regressing to Unix epoch floats (e.g. `1.784e+09`) since v1.8.0 by explicitly setting `ISO8601TimeEncoder` on the production zap encoder config, restoring the expected ISO 8601 format (e.g. `2026-07-14T17:44:06.617Z`).
   Fixed IPv6 literal hosts (e.g. `[::1]`, `[2001:db8::1]`) not being detected in OIDC token/JWKS endpoints, which caused them to be built as STRICT_DNS clusters instead of static ones and bypassed the IP-literal check on the SecurityPolicy token endpoint.
+  Fixed the gateway-helm chart resolving the ratelimit image to an outdated build (`ff287602` instead of `1e50889b`) when `global.images.ratelimit.image` is set without a tag.
 
 # Enhancements that improve performance.
 performance improvements: |


### PR DESCRIPTION
**What this PR does / why we need it**:

The v1.8.2 cherry-picks (#9376) bumped `DefaultRateLimitImage` and `values.tmpl.yaml` to `ratelimit:1e50889b`, but the hardcoded fallback tag in the `eg.ratelimit.image` helper was left at `ff287602` (the envoy proxy fallback was updated in #9364, the ratelimit one was missed). The fallback fires when chart users override `global.images.ratelimit.image` without a tag, so they'd pull the wrong ratelimit build.

One-line fix to `charts/gateway-helm/templates/_helpers.tpl` to realign the fallback with the pinned release tag, targeted for v1.8.3.