### PR TITLE
docs: point community meeting calendar to LFX platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,13 @@ If you've found a security vulnerability or a process crash, please follow the i
 
 Envoy Gateway contributor meetings are held on Thursdays and alternate weekly between EU-friendly and APAC-friendly times.
 
-* EU-friendly: Thursdays at 7:00 AM PST / 10:00 AM EST / 4:00 PM CET. [Add to your calendar][eu-calendar]
-* APAC-friendly: Thursdays at 4:00 PM PST / 7:00 PM EST / 8:00 AM CST. [Add to your calendar][apac-calendar]
-* Full Envoy community calendar is available [here][community-calendar].
+* EU-friendly: Thursdays at 7:00 AM PST / 10:00 AM EST / 4:00 PM CET.
+* APAC-friendly: Thursdays at 4:00 PM PST / 7:00 PM EST / 8:00 AM CST.
+* Full Envoy community calendar is available [here][community-calendar], where you can view meeting details and add them to your calendar.
 * Meeting notes and agenda: [Meeting details][meeting]
 
 [meeting]: https://docs.google.com/document/d/1i5wa1VsxIbQw7jbWvGmvy8C4Zpp7SGV1aVViSLgqU4M/edit?usp=sharing
-[eu-calendar]: https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=djQ1NWRhM2xjbG5vdGdpbXZibHM5MWxiOWdfMjAyNTEyMTFUMTUwMDAwWiA4YnNmYzhtMmRmOG1hZDJqdGdmNmY4b25qNEBn&tmsrc=8bsfc8m2df8mad2jtgf6f8onj4%40group.calendar.google.com&scp=ALL
-[apac-calendar]: https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MW80N2FmZDhyZmZoNnBrbTdnbnN1Y3M0dGJfMjAyNTEyMTlUMDAwMDAwWiA4YnNmYzhtMmRmOG1hZDJqdGdmNmY4b25qNEBn&tmsrc=8bsfc8m2df8mad2jtgf6f8onj4%40group.calendar.google.com&scp=ALL
-[community-calendar]: https://calendar.google.com/calendar/u/0/embed?src=8bsfc8m2df8mad2jtgf6f8onj4@group.calendar.google.com&ctz=America/Chicago
+[community-calendar]: https://zoom-lfx.platform.linuxfoundation.org/meetings/envoy?view=week
 [blog]: https://blog.envoyproxy.io/introducing-envoy-gateway-ad385cc59532
 [Envoy Slack workspace]: https://communityinviter.com/apps/envoyproxy/envoy
 [Envoy Gateway channel]: https://envoyproxy.slack.com/archives/C03E6NHLESV


### PR DESCRIPTION
## Description

The Envoy community calendar has moved to the [LFX meetings platform](https://zoom-lfx.platform.linuxfoundation.org/meetings/envoy?view=week). The old Google group calendar linked in the README was no longer being scheduled (its last occurrence was June 25), and the per-timezone "Add to your calendar" links were pinned to stale one-off occurrences that have no equivalent on LFX.

This PR repoints the community calendar link to the LFX Envoy meetings page and drops the stale Google template links.

## Notes

- The LFX page lists all Envoy project meetings, so contributors may need to locate the Gateway meeting among them.
- Meeting times were left unchanged, as only the platform moved.