### PR TITLE
docs: add without-LoadBalancer testing instructions to traffic pages

### DIFF
--- a/site/content/en/latest/tasks/quickstart.md
+++ b/site/content/en/latest/tasks/quickstart.md
@@ -87,10 +87,14 @@ Port forward to the Envoy service:
 kubectl -n envoy-gateway-system port-forward service/${ENVOY_SERVICE} 8888:80 &
 ```
 
+```shell
+export GATEWAY_HOST=localhost:8888
+```
+
 Curl the example app through Envoy proxy:
 
 ```shell
-curl --verbose --header "Host: www.example.com" http://localhost:8888/get
+curl --verbose --header "Host: www.example.com" http://$GATEWAY_HOST/get
 ```
 
 {{% /tab %}}

--- a/site/content/en/latest/tasks/traffic/grpc-routing.md
+++ b/site/content/en/latest/tasks/traffic/grpc-routing.md
@@ -57,14 +57,39 @@ The `example-route` matches any traffic for "grpc-example.com" and forwards it t
 
 Before testing GRPC routing to the `yages` backend, get the Gateway's address.
 
+{{< tabpane text=true >}}
+{{% tab header="With External LoadBalancer Support" %}}
+
 ```shell
-export GATEWAY_HOST=$(kubectl get gateway/example-gateway -o jsonpath='{.status.addresses[0].value}')
+export GATEWAY_HOST=$(kubectl get gateway/example-gateway -o jsonpath='{.status.addresses[0].value}'):80
 ```
+
+{{% /tab %}}
+{{% tab header="Without LoadBalancer Support" %}}
+
+Get the name of the Envoy service created by the example Gateway:
+
+```shell
+export ENVOY_SERVICE=$(kubectl get svc -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-namespace=default,gateway.envoyproxy.io/owning-gateway-name=example-gateway -o jsonpath='{.items[0].metadata.name}')
+```
+
+Port forward to the Envoy service:
+
+```shell
+kubectl -n envoy-gateway-system port-forward service/${ENVOY_SERVICE} 8888:80 &
+```
+
+```shell
+export GATEWAY_HOST=localhost:8888
+```
+
+{{% /tab %}}
+{{< /tabpane >}}
 
 Test GRPC routing to the `yages` backend using the [grpcurl][] command.
 
 ```shell
-grpcurl -plaintext -authority=grpc-example.com ${GATEWAY_HOST}:80 yages.Echo/Ping
+grpcurl -plaintext -authority=grpc-example.com ${GATEWAY_HOST} yages.Echo/Ping
 ```
 
 You should see the below response
@@ -80,7 +105,7 @@ Envoy Gateway also supports [gRPC-Web][] requests for this configuration. The be
 The data in the body `AAAAAAA=` is a base64 encoded representation of an empty message (data length 0) that the Ping RPC accepts.
 
 ```shell
-curl --http2-prior-knowledge -s ${GATEWAY_HOST}:80/yages.Echo/Ping -H 'Host: grpc-example.com'   -H 'Content-Type: application/grpc-web-text'   -H 'Accept: application/grpc-web-text' -XPOST -d'AAAAAAA=' | base64 -d
+curl --http2-prior-knowledge -s ${GATEWAY_HOST}/yages.Echo/Ping -H 'Host: grpc-example.com'   -H 'Content-Type: application/grpc-web-text'   -H 'Accept: application/grpc-web-text' -XPOST -d'AAAAAAA=' | base64 -d
 ```
 
 ## GRPCRoute Match
@@ -171,7 +196,7 @@ kubectl get grpcroutes --selector=example=grpc-routing -o yaml
 Test GRPC routing to the `yages` backend using the [grpcurl][] command.
 
 ```shell
-grpcurl -plaintext -authority=grpc-example.com ${GATEWAY_HOST}:80 yages.Echo/Ping
+grpcurl -plaintext -authority=grpc-example.com ${GATEWAY_HOST} yages.Echo/Ping
 ```
 
 ### RegularExpression
@@ -260,7 +285,7 @@ kubectl get grpcroutes --selector=example=grpc-routing -o yaml
 Test GRPC routing to the `yages` backend using the [grpcurl][] command.
 
 ```shell
-grpcurl -plaintext -authority=grpc-example.com ${GATEWAY_HOST}:80 yages.Echo/Ping
+grpcurl -plaintext -authority=grpc-example.com ${GATEWAY_HOST} yages.Echo/Ping
 ```
 
 ## Configuring or disabling timeouts with `BackendTrafficPolicy`

--- a/site/content/en/latest/tasks/traffic/http-redirect.md
+++ b/site/content/en/latest/tasks/traffic/http-redirect.md
@@ -75,10 +75,11 @@ The HTTPRoute status should indicate that it has been accepted and is bound to t
 kubectl get httproute/http-to-https-filter-redirect -o yaml
 ```
 
-Get the Gateway's address:
+Ensure the `GATEWAY_HOST` environment variable from the [Quickstart](../../quickstart) is set. If not, follow the
+Quickstart instructions to set the variable.
 
 ```shell
-export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
+echo $GATEWAY_HOST
 ```
 
 Querying `redirect.example/get` should result in a `301` response from the example Gateway and redirecting to the

--- a/site/content/en/latest/tasks/traffic/http-routing.md
+++ b/site/content/en/latest/tasks/traffic/http-routing.md
@@ -66,9 +66,34 @@ The `example-route` matches any traffic for "example.com" and forwards it to the
 
 Before testing HTTP routing to the `example-svc` backend, get the Gateway's address.
 
+{{< tabpane text=true >}}
+{{% tab header="With External LoadBalancer Support" %}}
+
 ```shell
 export GATEWAY_HOST=$(kubectl get gateway/example-gateway -o jsonpath='{.status.addresses[0].value}')
 ```
+
+{{% /tab %}}
+{{% tab header="Without LoadBalancer Support" %}}
+
+Get the name of the Envoy service created by the example Gateway:
+
+```shell
+export ENVOY_SERVICE=$(kubectl get svc -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-namespace=default,gateway.envoyproxy.io/owning-gateway-name=example-gateway -o jsonpath='{.items[0].metadata.name}')
+```
+
+Port forward to the Envoy service:
+
+```shell
+kubectl -n envoy-gateway-system port-forward service/${ENVOY_SERVICE} 8888:80 &
+```
+
+```shell
+export GATEWAY_HOST=localhost:8888
+```
+
+{{% /tab %}}
+{{< /tabpane >}}
 
 Test HTTP routing to the `example-svc` backend.
 

--- a/site/content/en/latest/tasks/traffic/http-timeouts.md
+++ b/site/content/en/latest/tasks/traffic/http-timeouts.md
@@ -18,6 +18,13 @@ __Note:__  The Request duration must be >= BackendRequest duration
 
 ## Verification
 
+Ensure the `GATEWAY_HOST` environment variable from the [Quickstart](../../quickstart) is set. If not, follow the
+Quickstart instructions to set the variable.
+
+```shell
+echo $GATEWAY_HOST
+```
+
 backend has the ability to delay responses; we use it as the backend to control response time.
 
 ### request timeout

--- a/site/content/en/latest/tasks/traffic/http-urlrewrite.md
+++ b/site/content/en/latest/tasks/traffic/http-urlrewrite.md
@@ -87,10 +87,11 @@ The HTTPRoute status should indicate that it has been accepted and is bound to t
 kubectl get httproute/http-filter-url-rewrite -o yaml
 ```
 
-Get the Gateway's address:
+Ensure the `GATEWAY_HOST` environment variable from the [Quickstart](../../quickstart) is set. If not, follow the
+Quickstart instructions to set the variable.
 
 ```shell
-export GATEWAY_HOST=$(kubectl get gateway/eg -o jsonpath='{.status.addresses[0].value}')
+echo $GATEWAY_HOST
 ```
 
 Querying `http://${GATEWAY_HOST}/get/origin/path` should rewrite to

--- a/site/content/en/latest/tasks/traffic/tcp-routing.md
+++ b/site/content/en/latest/tasks/traffic/tcp-routing.md
@@ -402,9 +402,34 @@ is taking traffic for port `8088` from outside the cluster and `bar` service tak
 
 Before testing, please get the tcp-gateway [Gateway][]'s address first:
 
+{{< tabpane text=true >}}
+{{% tab header="With External LoadBalancer Support" %}}
+
 ```shell
 export GATEWAY_HOST=$(kubectl get gateway/tcp-gateway -o jsonpath='{.status.addresses[0].value}')
 ```
+
+{{% /tab %}}
+{{% tab header="Without LoadBalancer Support" %}}
+
+Get the name of the Envoy service created by the tcp-gateway Gateway:
+
+```shell
+export ENVOY_SERVICE=$(kubectl get svc -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-namespace=default,gateway.envoyproxy.io/owning-gateway-name=tcp-gateway -o jsonpath='{.items[0].metadata.name}')
+```
+
+Port forward to the Envoy service:
+
+```shell
+kubectl -n envoy-gateway-system port-forward service/${ENVOY_SERVICE} 8088:8088 8089:8089 &
+```
+
+```shell
+export GATEWAY_HOST=localhost
+```
+
+{{% /tab %}}
+{{< /tabpane >}}
 
 You can try to use nc to test the TCP connections of envoy gateway with different ports, and you can see them succeeded:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

HTTP Routing, GRPC Routing, HTTP Timeouts, HTTP Redirects, HTTP URL Rewrite, and TCP Routing only showed how to test through an external LoadBalancer address, so clusters without one (e.g. kind) had no way to follow along.

Adds a port-forward alternative for the pages with their own Gateway (HTTP Routing, GRPC Routing, TCP Routing), and points the pages that reuse the default `eg` Gateway (HTTP Redirects, HTTP URL Rewrite, HTTP Timeouts) at the `GATEWAY_HOST` already set up in Quickstart - same pattern used in the docs elsewhere (e.g. External Processing, Wasm Extensions).

**Which issue(s) this PR fixes**:

Part of #5799 (traffic-routing batch)

Release Notes: No