### PR TITLE
docs: explain backend protocol selection

### DIFF
--- a/site/content/en/latest/concepts/gateway_api_extensions/backend-traffic-policy.md
+++ b/site/content/en/latest/concepts/gateway_api_extensions/backend-traffic-policy.md
@@ -149,6 +149,72 @@ In this example, `alpha-policy` would take precedence due to its earlier creatio
 
 When the `mergeType` field is unset, no merging occurs and only the most specific configuration takes effect. However, policies can be configured to merge with parent policies using the `mergeType` field (see [Policy Merging](#policy-merging) section below).
 
+## Backend Protocol Selection
+
+`BackendTrafficPolicy` configures an upstream connection after Envoy Gateway
+selects its protocol. For example, the `http2` field tunes an HTTP/2 connection
+but does not select HTTP/2 by itself.
+
+Envoy Gateway can select HTTP/2 for an upstream connection in the following
+ways:
+
+- Set the Kubernetes Service port's
+  [`appProtocol`][Kubernetes Service appProtocol] to `kubernetes.io/h2c` for
+  cleartext HTTP/2.
+- Use a [`GRPCRoute`][GRPC Routing]. Because gRPC uses HTTP/2, its backend
+  connections use HTTP/2 automatically.
+- Configure backend TLS with a [`BackendTLSPolicy`][Backend TLS]. For
+  HTTP-based routes, Envoy can negotiate HTTP/2 with the backend through ALPN.
+- Set `useClientProtocol: true` in a `BackendTrafficPolicy` to use the same
+  protocol for the upstream connection as the downstream request. This selects
+  HTTP/2 only when the downstream request uses HTTP/2.
+
+{{% alert title="HTTP/2 settings do not select HTTP/2" color="warning" %}}
+
+Setting `spec.http2`, including `http2: {}`, does not enable HTTP/2 for a
+backend. Envoy Gateway applies these settings only when one of the mechanisms
+above selects HTTP/2.
+
+{{% /alert %}}
+
+This separation lets a platform team define HTTP/2 connection defaults at the
+Gateway level without forcing every application backend to use HTTP/2.
+Application teams can opt in per backend by setting `appProtocol` on their
+Service port or by using a `GRPCRoute`.
+
+In the following example, the Gateway-level policy sets HTTP/2 defaults. The
+Service selects cleartext HTTP/2 for routes that reference its `grpc` port:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-backend
+spec:
+  selector:
+    app: example-backend
+  ports:
+  - name: grpc
+    port: 8080
+    targetPort: 8080
+    appProtocol: kubernetes.io/h2c
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: gateway-http2-defaults
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: eg
+  http2:
+    maxConcurrentStreams: 200
+    connectionKeepalive:
+      interval: 30s
+      timeout: 10s
+```
+
 ## Policy Merging
 
 BackendTrafficPolicy supports merging configurations using the `mergeType` field, which allows route-level or route rule-level policies to combine with gateway-level or listener-level policies rather than completely overriding them. This enables layered policy strategies where platform teams can set baseline configurations at the Gateway level, while application teams can add specific policies for their routes.
@@ -231,3 +297,7 @@ In this example, the route-level policy merges with the gateway-level policy, re
 - [Response Compression](../../tasks/traffic/response-compression)
 - [Response Override](../../tasks/traffic/response-override)
 - [BackendTrafficPolicy API Reference](../../api/extension_types#backendtrafficpolicy)
+
+[Backend TLS]: ../../tasks/security/backend-tls
+[GRPC Routing]: ../../tasks/traffic/grpc-routing
+[Kubernetes Service appProtocol]: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol


### PR DESCRIPTION
**What this PR does / why we need it**:

Envoy Gateway documents HTTP/2 settings on `BackendTrafficPolicy`, but the concept page does not explain how the upstream protocol is selected. That can make `spec.http2` look like an HTTP/2 enablement switch even though it only tunes an already-selected HTTP/2 connection.

This PR:

- documents the four protocol-selection paths confirmed in #8648: Service `appProtocol`, `GRPCRoute`, backend TLS with ALPN, and `useClientProtocol`
- adds a warning that `spec.http2`, including `http2: {}`, does not enable HTTP/2
- shows a Gateway-level HTTP/2 defaults policy combined with a Service-level h2c opt-in
- links to the relevant backend TLS, gRPC routing, and Kubernetes Service documentation

The result gives platform teams a reusable connection policy without forcing every application backend onto HTTP/2.

Validation:

- `git diff --check`
- changed-file Markdown lint with the repository configuration
- `make docs` using the Node LTS version selected by `site/.nvmrc`
- `make docs-check-links` scanned 2,199 links; it exited non-zero only for five unrelated ReadTheDocs URLs returning HTTP 429, and reported no link introduced by this page
- all hosted actionable gates pass on `12202063`: docs lint/build, repository lint, generated-file check, license check, aggregate CI, CodeQL, OSV, DCO, and the Netlify preview
- [Codex reviewed exact head `12202063` and found no major issues](https://github.com/envoyproxy/gateway/pull/9574#issuecomment-5112286323)

AI tooling assisted with repository navigation and drafting. I reviewed the current implementation paths, validated every example field, and take responsibility for the change.

---

**PR Checklist**

- [x] **Authorship & ownership**: I reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR.
- [x] **DCO**: All commits are signed off (`git commit -s`).
- [x] **API agreed first**: N/A: this PR does not change files under `/api`.
- [x] **Required checks pass**: All applicable hosted checks pass; code-only and publish jobs are skipped as expected for this documentation-only patch.
- [x] **Tests added/updated**: N/A: this PR changes documentation only.
- [x] **Docs**: This PR directly updates the user-facing concept documentation.
- [x] **Release notes**: N/A: this is a documentation clarification with no runtime behavior change.
- [x] **Generated files committed**: N/A: no API, Helm chart, or module input changed; `make docs` left the tracked tree clean.
- [x] **Scope & compatibility**: The PR changes one concept page and does not change runtime behavior or compatibility.
- [x] **Codex review**: Requested on exact head `12202063`; no major issues were found.
- [ ] **Copilot review**: GitHub rejected the fork author's review request because this account lacks repository review-request permission; a maintainer may request it if desired.

**Which issue(s) this PR fixes**:

Fixes #8773