### PR TITLE
fix: eliminate port race in setupFakeEnvoyStats test helper

### DIFF
--- a/internal/cmd/envoy/shutdown_manager_test.go
+++ b/internal/cmd/envoy/shutdown_manager_test.go
@@ -21,9 +21,9 @@ import (
 
 // setupFakeEnvoyStats set up an HTTP server return content
 func setupFakeEnvoyStats(t *testing.T, content string) *http.Server {
+	// Reuse the bound listener instead of closing and re-binding the port.
 	l, err := net.Listen("tcp", ":0") //nolint: gosec
 	require.NoError(t, err)
-	require.NoError(t, l.Close())
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
@@ -39,7 +39,7 @@ func setupFakeEnvoyStats(t *testing.T, content string) *http.Server {
 	}
 	t.Logf("start to listen at %s ", addr)
 	go func() {
-		if err := s.ListenAndServe(); err != nil {
+		if err := s.Serve(l); err != nil {
 			fmt.Println("fail to listen: ", err)
 		}
 	}()


### PR DESCRIPTION
## Summary
`setupFakeEnvoyStats` in `internal/cmd/envoy/shutdown_manager_test.go` binds an ephemeral port with `net.Listen(":0")`, immediately closes that listener, and later re-binds to the same port number via `s.ListenAndServe()`. This is a classic time-of-check-to-time-of-use race: between `l.Close()` and the goroutine's `ListenAndServe()` actually completing its bind, another process (or a concurrently running test) can grab that exact port number, causing `TestGetTotalConnections` to fail intermittently on loaded machines with errors like `error getting listener downstream_cx_active stat: Get ...`, while the real cause (`fail to listen: ...`) is only printed to stdout rather than failing the test directly.

## Fix
Keep the original `net.Listener` and call `s.Serve(l)` instead of `s.ListenAndServe()`, so the already-bound listener is reused and the port is never released and re-acquired.

## Test plan
- [x] `go build ./...`
- [x] `go test -race -run TestGetTotalConnections -count=200 ./internal/cmd/envoy/...` — clean