### PR TITLE
fix: eliminate cfg.Logger data race in server()'s reload/shutdown path

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -88,6 +88,10 @@ func server(ctx context.Context, stdout, stderr io.Writer, cfgPath string, hook 
 		return err
 	}
 
+	// cfg.Logger is mutated concurrently on reload, so keep our own reference
+	// and update it only via l.LoggerUpdates() below, never read cfg.Logger again.
+	logger := cfg.Logger
+
 	l := loader.New(cfgPath, cfg, hook)
 	if err := l.Start(ctx, stdout); err != nil {
 		return err
@@ -99,17 +103,20 @@ func server(ctx context.Context, stdout, stderr io.Writer, cfgPath string, hook 
 
 	for {
 		select {
+		// Pick up the latest logger whenever a config reload replaces it.
+		case newLogger := <-l.LoggerUpdates():
+			logger = newLogger
 		// Exit if the config loader fails to start the runners.
 		// Continuing with failed runners would cause EG to function incorrectly.
 		case err := <-l.Errors():
-			cfg.Logger.Error(err, "failed to start runners")
+			logger.Error(err, "failed to start runners")
 			// Wait for runners to finish before shutting down.
 			// This is to make sure no orphaned runner process is left running in standalone mode.
 			l.Wait()
 			return err
 		// Wait for the context to be done, which usually happens the process receives a SIGTERM or SIGINT.
 		case <-ctx.Done():
-			cfg.Logger.Info("shutting down")
+			logger.Info("shutting down")
 			// Wait for runners to finish before shutting down.
 			// This is to make sure no orphaned runner process is left running in standalone mode.
 			l.Wait()

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -88,10 +88,6 @@ func server(ctx context.Context, stdout, stderr io.Writer, cfgPath string, hook 
 		return err
 	}
 
-	// cfg.Logger is mutated concurrently on reload, so keep our own reference
-	// and update it only via l.LoggerUpdates() below, never read cfg.Logger again.
-	logger := cfg.Logger
-
 	l := loader.New(cfgPath, cfg, hook)
 	if err := l.Start(ctx, stdout); err != nil {
 		return err
@@ -103,20 +99,20 @@ func server(ctx context.Context, stdout, stderr io.Writer, cfgPath string, hook 
 
 	for {
 		select {
-		// Pick up the latest logger whenever a config reload replaces it.
-		case newLogger := <-l.LoggerUpdates():
-			logger = newLogger
 		// Exit if the config loader fails to start the runners.
 		// Continuing with failed runners would cause EG to function incorrectly.
 		case err := <-l.Errors():
-			logger.Error(err, "failed to start runners")
+			// Read the logger through the loader so the read is guarded by the
+			// same mutex the reload path holds while replacing it. Reading
+			// cfg.Logger directly here races with that swap.
+			l.Logger().Error(err, "failed to start runners")
 			// Wait for runners to finish before shutting down.
 			// This is to make sure no orphaned runner process is left running in standalone mode.
 			l.Wait()
 			return err
 		// Wait for the context to be done, which usually happens the process receives a SIGTERM or SIGINT.
 		case <-ctx.Done():
-			logger.Info("shutting down")
+			l.Logger().Info("shutting down")
 			// Wait for runners to finish before shutting down.
 			// This is to make sure no orphaned runner process is left running in standalone mode.
 			l.Wait()

--- a/internal/envoygateway/config/loader/configloader.go
+++ b/internal/envoygateway/config/loader/configloader.go
@@ -29,21 +29,17 @@ type Loader struct {
 	hook      HookFunc
 	hookErr   chan error
 
-	// loggerUpdates publishes the logger on each config reload; see LoggerUpdates.
-	loggerUpdates chan logging.Logger
-
 	w filewatcher.FileWatcher
 }
 
 func New(cfgPath string, cfg *config.Server, f HookFunc) *Loader {
 	return &Loader{
-		cfgPath:       cfgPath,
-		cfg:           cfg,
-		logger:        cfg.Logger.WithName("config-loader"),
-		hook:          f,
-		hookErr:       make(chan error, 1),
-		loggerUpdates: make(chan logging.Logger, 1),
-		w:             filewatcher.NewWatcher(),
+		cfgPath: cfgPath,
+		cfg:     cfg,
+		logger:  cfg.Logger.WithName("config-loader"),
+		hook:    f,
+		hookErr: make(chan error, 1),
+		w:       filewatcher.NewWatcher(),
 	}
 }
 
@@ -89,13 +85,11 @@ func (r *Loader) Start(ctx context.Context, logOut io.Writer) error {
 					continue
 				}
 
-				newLogger := logging.NewLogger(logOut, eg.Logging)
 				r.cfgMu.Lock()
 				r.cfg.EnvoyGateway = eg
 				// update cfg logger
-				r.cfg.Logger = newLogger
+				r.cfg.Logger = logging.NewLogger(logOut, eg.Logging)
 				r.cfgMu.Unlock()
-				r.publishLogger(newLogger)
 
 				// cancel last
 				if r.cancel != nil {
@@ -148,20 +142,12 @@ func (r *Loader) Errors() <-chan error {
 	return r.hookErr
 }
 
-// LoggerUpdates returns a channel that receives the latest logger on each config reload.
-func (r *Loader) LoggerUpdates() <-chan logging.Logger {
-	return r.loggerUpdates
-}
-
-func (r *Loader) publishLogger(l logging.Logger) {
-	select {
-	case <-r.loggerUpdates: // drain a stale, unconsumed value, if any
-	default:
-	}
-	select {
-	case r.loggerUpdates <- l:
-	default:
-	}
+// Logger returns the current logger, safe to call concurrently with a config
+// reload replacing it.
+func (r *Loader) Logger() logging.Logger {
+	r.cfgMu.RLock()
+	defer r.cfgMu.RUnlock()
+	return r.cfg.Logger
 }
 
 // Wait returns when success to acquire mutex, which means no hook is running.

--- a/internal/envoygateway/config/loader/configloader.go
+++ b/internal/envoygateway/config/loader/configloader.go
@@ -29,17 +29,21 @@ type Loader struct {
 	hook      HookFunc
 	hookErr   chan error
 
+	// loggerUpdates publishes the logger on each config reload; see LoggerUpdates.
+	loggerUpdates chan logging.Logger
+
 	w filewatcher.FileWatcher
 }
 
 func New(cfgPath string, cfg *config.Server, f HookFunc) *Loader {
 	return &Loader{
-		cfgPath: cfgPath,
-		cfg:     cfg,
-		logger:  cfg.Logger.WithName("config-loader"),
-		hook:    f,
-		hookErr: make(chan error, 1),
-		w:       filewatcher.NewWatcher(),
+		cfgPath:       cfgPath,
+		cfg:           cfg,
+		logger:        cfg.Logger.WithName("config-loader"),
+		hook:          f,
+		hookErr:       make(chan error, 1),
+		loggerUpdates: make(chan logging.Logger, 1),
+		w:             filewatcher.NewWatcher(),
 	}
 }
 
@@ -85,11 +89,13 @@ func (r *Loader) Start(ctx context.Context, logOut io.Writer) error {
 					continue
 				}
 
+				newLogger := logging.NewLogger(logOut, eg.Logging)
 				r.cfgMu.Lock()
 				r.cfg.EnvoyGateway = eg
 				// update cfg logger
-				r.cfg.Logger = logging.NewLogger(logOut, eg.Logging)
+				r.cfg.Logger = newLogger
 				r.cfgMu.Unlock()
+				r.publishLogger(newLogger)
 
 				// cancel last
 				if r.cancel != nil {
@@ -140,6 +146,22 @@ func (r *Loader) runHook(ctx context.Context) error {
 // Errors returns a channel where hook errors are reported.
 func (r *Loader) Errors() <-chan error {
 	return r.hookErr
+}
+
+// LoggerUpdates returns a channel that receives the latest logger on each config reload.
+func (r *Loader) LoggerUpdates() <-chan logging.Logger {
+	return r.loggerUpdates
+}
+
+func (r *Loader) publishLogger(l logging.Logger) {
+	select {
+	case <-r.loggerUpdates: // drain a stale, unconsumed value, if any
+	default:
+	}
+	select {
+	case r.loggerUpdates <- l:
+	default:
+	}
 }
 
 // Wait returns when success to acquire mutex, which means no hook is running.

--- a/release-notes/current/bug_fixes/9581-config-reload-server-logger-data-race.md
+++ b/release-notes/current/bug_fixes/9581-config-reload-server-logger-data-race.md
@@ -1,1 +1,1 @@
-Fixed a data race between config-reload and the standalone server's shutdown/error logging by having the config loader publish logger updates over a channel instead of a shared, unguarded field.
+Fixed a data race between config-reload and the standalone server's shutdown/error logging by reading the logger through a new mutex-guarded `Loader.Logger()` accessor instead of the shared `cfg.Logger` field directly.

--- a/release-notes/current/bug_fixes/9581-config-reload-server-logger-data-race.md
+++ b/release-notes/current/bug_fixes/9581-config-reload-server-logger-data-race.md
@@ -1,0 +1,1 @@
+Fixed a data race between config-reload and the standalone server's shutdown/error logging by having the config loader publish logger updates over a channel instead of a shared, unguarded field.


### PR DESCRIPTION
## Summary
`loader.New()` (`internal/envoygateway/config/loader/configloader.go`) stores the `*config.Server` pointer passed to it without copying it, so it's aliased with the `cfg` variable held by `server()` (`internal/cmd/server.go`). On a config-file reload, the loader's watcher goroutine reassigns `cfg.Logger` (and `cfg.EnvoyGateway`) under `cfgMu`. Meanwhile, `server()`'s own top-level `select` loop reads `cfg.Logger` directly (`cfg.Logger.Error(...)` / `cfg.Logger.Info(...)`) with no synchronization at all — it has no knowledge of `cfgMu`. That's an unsynchronized concurrent read/write on the same struct field: a genuine data race.

This was caught by `go test -race` in `TestCustomProviderCancelWhenConfigReload`:
```
WARNING: DATA RACE
Write at 0x00c000d0fba8 by goroutine 629:
  .../configloader.go:91 ...   (watcher goroutine's cfg.Logger reassignment)
Previous read at ...
  .../server.go:112 ...        (server()'s cfg.Logger.Info("shutting down"))
```
Reproduced locally under `-race` (needed Linux, since fsnotify's event-duplication behavior differs enough from macOS/kqueue that it didn't reproduce as reliably there).

## Fix
The loader now publishes each new logger over a small "latest value" channel (`LoggerUpdates()`) as reloads happen. `server()` keeps its own local `logger` variable and swaps it only upon receiving from that channel in its select loop, so the update is synchronized via channel send/receive rather than a shared, unguarded struct field.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cmd/... ./internal/envoygateway/config/loader/...`
- [x] `go test -race -run TestCustomProviderCancelWhenConfigReload -count=100+ ./internal/cmd/...` — reproduced the exact race pre-fix (Linux/Docker); 100/100 clean post-fix (both macOS and Linux)