### PR TITLE
fix(docs): replace dead Envoy Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ Envoy Gateway contributor meetings are held on Thursdays and alternate weekly be
 [meeting]: https://docs.google.com/document/d/1i5wa1VsxIbQw7jbWvGmvy8C4Zpp7SGV1aVViSLgqU4M/edit?usp=sharing
 [community-calendar]: https://zoom-lfx.platform.linuxfoundation.org/meetings/envoy?view=week
 [blog]: https://blog.envoyproxy.io/introducing-envoy-gateway-ad385cc59532
-[Envoy Slack workspace]: https://communityinviter.com/apps/envoyproxy/envoy
+[Envoy Slack workspace]: https://www.envoyproxy.io/slack
 [Envoy Gateway channel]: https://envoyproxy.slack.com/archives/C03E6NHLESV

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,7 @@ We announce advisories and patched releases through:
 
 - [GitHub Security Advisories](https://github.com/envoyproxy/gateway/security/advisories)
 - The [GitHub Releases page](https://github.com/envoyproxy/gateway/releases)
-- The `#gateway-users` channel in the [Envoy Slack workspace](https://communityinviter.com/apps/envoyproxy/envoy)
+- The `#gateway-users` channel in the [Envoy Slack workspace](https://www.envoyproxy.io/slack)
 - The [envoy-gateway-announce mailing list](https://groups.google.com/g/envoy-gateway-announce)
 
 Security fixes are merged into active, non-EOL release branches as patch releases when the affected versions are still supported. See the [release matrix](https://gateway.envoyproxy.io/news/releases/matrix/) for support windows and the [patch release process](https://gateway.envoyproxy.io/community/releasing/#patch-release) for release mechanics.

--- a/site/content/en/tools/_index.md
+++ b/site/content/en/tools/_index.md
@@ -25,7 +25,7 @@ description = "Explore tools available on Envoy Gateway site"
         <p class="text-center mb-5 lead">
                 Our tools ecosystem is new and evolving and we welcome your contributions!<br/>
                 Get involved with the Envoy Gateway community and expand our tooling library.<br/>
-                Join us on <a href="https://communityinviter.com/apps/envoyproxy/envoy"><i class="fab fa-slack me-2"></i>Slack</a> and <a href="https://github.com/envoyproxy/gateway"> <i class="fab fa-github me-2"></i>GitHub</a>.
+                Join us on <a href="https://www.envoyproxy.io/slack"><i class="fab fa-slack me-2"></i>Slack</a> and <a href="https://github.com/envoyproxy/gateway"> <i class="fab fa-github me-2"></i>GitHub</a>.
         </p>
 
 </div>

--- a/site/content/en/tools/benchmark-report-explorer/index.md
+++ b/site/content/en/tools/benchmark-report-explorer/index.md
@@ -38,7 +38,7 @@ includeBenchmark: true
   <p class="bt-description">
     Explore benchmark results from Envoy Gateway Releleases. The test code is open source and available for you to run and contribute to.
   </p>
-  <p class="bt-description">Curious to learn more? Join the conversation in <code>#gateway-users</code> channel in <a href="https://communityinviter.com/apps/envoyproxy/envoy">Envoy Slack</a></p>
+  <p class="bt-description">Curious to learn more? Join the conversation in <code>#gateway-users</code> channel in <a href="https://www.envoyproxy.io/slack">Envoy Slack</a></p>
 
   {{< benchmark-dashboard
     version="latest"

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -12,7 +12,7 @@
       <div class="footer-column">
         <h3>Community</h3>
         <ul class="footer-links">
-          <li><a href="https://communityinviter.com/apps/envoyproxy/envoy">Join us on Slack <i class="fas fa-external-link-alt"></i></a></li>
+          <li><a href="https://www.envoyproxy.io/slack">Join us on Slack <i class="fas fa-external-link-alt"></i></a></li>
           <li><a href="https://docs.google.com/document/d/1i5wa1VsxIbQw7jbWvGmvy8C4Zpp7SGV1aVViSLgqU4M/edit?tab=t.0#heading=h.5229onpee4dg">Weekly Meetings <i class="fas fa-external-link-alt"></i></a></li>
           <li><a href="https://www.linkedin.com/company/envoy-cloud-native">LinkedIn <i class="fas fa-external-link-alt"></i></a></li>
         </ul>

--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -4,8 +4,11 @@ RELEASE_VERSIONS ?= $(foreach v,$(wildcard ${ROOT_DIR}/docs/*),$(notdir ${v}))
 #       find a way to remove github.com from ignore list
 # TODO: example.com is not a valid domain, we should remove it from ignore list
 # TODO: https://www.gnu.org/software/make became unstable, we should remove it from ignore list later
+# NOTE: envoyproxy.io/slack redirects to a Slack shared invite, and Slack answers 403 to
+#       automated clients, so the redirect target can't be verified by the link checker.
 LINKINATOR_IGNORE := "opentelemetry.io \
 	blog.envoyproxy.io \
+	envoyproxy.io/slack \
 	ntia.gov \
 	github.com \
 	jwt.io \


### PR DESCRIPTION
**Description**

`https://communityinviter.com/apps/envoyproxy/envoy` now returns `404` — the third-party community-inviter app for the Envoy Slack workspace has been removed. 

```
ERROR: Detected 863 broken links. Scanned 3062 links in 584.345 seconds.
```

This replaces it with `https://www.envoyproxy.io/slack`, a 302 redirect the Envoy project maintains in [`envoyproxy/envoy-website`'s `netlify.toml`](https://github.com/envoyproxy/envoy-website/blob/main/netlify.toml#L33-L37). 

Slack answers `403` to non-browser clients at the end of the redirect chain, so `envoyproxy.io/slack` is also added to `LINKINATOR_IGNORE`. Verified with linkinator on a stub page: `[403]` and exit 1 without the skip, `[SKP]` and pass with it.
