### PR TITLE
docs: add Release Notes link to top navigation menu

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -229,6 +229,10 @@ enable = true
     weight = -102
     url = "/docs"
   [[menu.main]]
+    name = "Release Notes"
+    weight = -103
+    url = "/news/releases/notes"
+  [[menu.main]]
     name = "Tools"
     weight = -99
     url = "/tools"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a "Release Notes" entry to the site top navigation in `site/hugo.toml`, linking to `/news/releases/notes` so release notes are easier to discover without going through the News section.

**Which issue(s) this PR fixes**:
Fixes #6226

---

**PR Checklist**

- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: N/A: no API changes.
- [x] **Required checks pass**: N/A: docs-only Hugo menu change; no code generation or unit tests needed.
- [x] **Tests added/updated**: N/A: docs-only change.
- [x] **Docs**: This PR updates the docs site navigation.
- [x] **Release notes**: N/A: docs site navigation only; no product change.
- [x] **Generated files committed**: N/A: no generated files.
- [x] **Scope & compatibility**: Scoped to the top-nav menu entry; no breaking changes.
- [x] **Codex review**: Requested a Codex review and addressed all of its comments.
- [x] **Copilot review**: Requested a Copilot review and addressed all of its comments.