### PR TITLE
chore: regen xds translator testdata for initialFetchTimeout

### DIFF
--- a/internal/xds/translator/testdata/out/xds-ir/csrf.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/csrf.listeners.yaml
@@ -29,6 +29,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: first-listener
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore-per-resource-secret.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore-per-resource-secret.clusters.yaml
@@ -44,6 +44,7 @@
               name: policy-btls-1/policies-ca
               sdsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
         sni: backend-1.example.com
   type: EDS
@@ -101,6 +102,7 @@
               name: policy-btls-2/policies-ca
               sdsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
         sni: backend-2.example.com
   type: EDS
@@ -158,6 +160,7 @@
               name: policy-btls-3/policies-ca
               sdsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
         sni: backend-3.example.com
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore-per-resource-secret.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore-per-resource-secret.listeners.yaml
@@ -24,6 +24,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-btls/http
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore.clusters.yaml
@@ -44,6 +44,7 @@
               name: system_ca_certificates
               sdsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
         sni: backend-1.example.com
   type: EDS
@@ -101,6 +102,7 @@
               name: system_ca_certificates
               sdsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
         sni: backend-2.example.com
   type: EDS
@@ -158,6 +160,7 @@
               name: system_ca_certificates
               sdsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
         sni: backend-3.example.com
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore.listeners.yaml
@@ -24,6 +24,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-btls/http
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore-per-resource-secret.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore-per-resource-secret.clusters.yaml
@@ -44,6 +44,7 @@
               name: policy-btls/policies-ca
               sdsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
         sni: example.com
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore-per-resource-secret.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore-per-resource-secret.listeners.yaml
@@ -24,6 +24,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-btls/http
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-system-truststore-enforcement.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-system-truststore-enforcement.clusters.yaml
@@ -44,6 +44,7 @@
               name: system_ca_certificates
               sdsConfig:
                 ads: {}
+                initialFetchTimeout: 0s
                 resourceApiVersion: V3
         sni: example.com
   type: EDS

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-system-truststore-enforcement.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-system-truststore-enforcement.listeners.yaml
@@ -24,6 +24,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-btls/http
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-duplicate-backend-weighted.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-duplicate-backend-weighted.listeners.yaml
@@ -24,6 +24,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-1/http
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-gateway-traffic.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-gateway-traffic.listeners.yaml
@@ -24,6 +24,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-1/http
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-healthcheck-hostname.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-healthcheck-hostname.listeners.yaml
@@ -22,6 +22,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: first-listener
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-mixed-merge-multi-filtered.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-mixed-merge-multi-filtered.listeners.yaml
@@ -24,6 +24,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-1/http
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-mixed-merge-weighted.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-mixed-merge-weighted.listeners.yaml
@@ -24,6 +24,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-1/http
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster-grpc.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster-grpc.listeners.yaml
@@ -32,6 +32,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-1/http
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster.listeners.yaml
@@ -24,6 +24,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-1/http
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-statname.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-statname.listeners.yaml
@@ -22,6 +22,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: first-listener
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-weight-per-route.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-weight-per-route.listeners.yaml
@@ -24,6 +24,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: envoy-gateway/gateway-1/http
         serverHeaderTransformation: PASS_THROUGH

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-weighted-mixed.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-weighted-mixed.listeners.yaml
@@ -24,6 +24,7 @@
         rds:
           configSource:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           routeConfigName: first-listener
         serverHeaderTransformation: PASS_THROUGH


### PR DESCRIPTION
Regenerate the xds translator golden files that are missing `initialFetchTimeout: 0s`.

## Why

`main` is currently red — `make gen-check` fails on `TestTranslateXds` with 15 failing subtests. This is a semantic merge conflict, not a bug in any single PR:

- #9532 added `InitialFetchTimeout` to RDS/SDS config sources and regenerated all testdata **that existed on its branch**.
- #9477 (MergeBackends) and #8836 (CSRF origin validation) were generated **before** #9532 and added new golden files that never got the field.

Git merged all three without a textual conflict, so the stale expectations only surfaced in CI after the fact.

Failing run: https://github.com/envoyproxy/gateway/actions/runs/30779176213/job/91580333657

