### PR TITLE
add communityinviter.com to LINKINATOR_IGNORE to pass docs lint ci

### DIFF
--- a/site/content/en/latest/tasks/security/oidc.md
+++ b/site/content/en/latest/tasks/security/oidc.md
@@ -15,7 +15,7 @@ This instantiated resource can be linked to a [Gateway][Gateway] and [HTTPRoute]
 
 {{< boilerplate prerequisites >}}
 
-EG OIDC authentication requires the redirect URL to be HTTPS. Follow the [Secure Gateways](../secure-gateways) guide
+EG OIDC authentication requires the redirect URL to be HTTPS. Follow the [Secure Gateways](../secure-gateways/) guide
 to generate the TLS certificates and update the Gateway configuration to add an HTTPS listener.
 
 Verify the Gateway status:

--- a/site/content/en/latest/tasks/traffic/http-redirect.md
+++ b/site/content/en/latest/tasks/traffic/http-redirect.md
@@ -92,7 +92,7 @@ $ curl -L -vvv --header "Host: redirect.example" "http://${GATEWAY_HOST}/get"
 ...
 ```
 
-If you followed the steps in the [Secure Gateways](../security/secure-gateways) task, you should be able to curl the redirect
+If you followed the steps in the [Secure Gateways](../security/secure-gateways/) task, you should be able to curl the redirect
 location.
 
 ## HTTP --> HTTPS

--- a/site/content/en/v1.5/tasks/security/oidc.md
+++ b/site/content/en/v1.5/tasks/security/oidc.md
@@ -15,7 +15,7 @@ This instantiated resource can be linked to a [Gateway][Gateway] and [HTTPRoute]
 
 {{< boilerplate prerequisites >}}
 
-EG OIDC authentication requires the redirect URL to be HTTPS. Follow the [Secure Gateways](../secure-gateways) guide
+EG OIDC authentication requires the redirect URL to be HTTPS. Follow the [Secure Gateways](../secure-gateways/) guide
 to generate the TLS certificates and update the Gateway configuration to add an HTTPS listener.
 
 Verify the Gateway status:

--- a/site/content/en/v1.5/tasks/traffic/http-redirect.md
+++ b/site/content/en/v1.5/tasks/traffic/http-redirect.md
@@ -94,7 +94,7 @@ $ curl -L -vvv --header "Host: redirect.example" "http://${GATEWAY_HOST}/get"
 ...
 ```
 
-If you followed the steps in the [Secure Gateways](../security/secure-gateways) task, you should be able to curl the redirect
+If you followed the steps in the [Secure Gateways](../security/secure-gateways/) task, you should be able to curl the redirect
 location.
 
 ## HTTP --> HTTPS

--- a/site/content/en/v1.6/tasks/security/oidc.md
+++ b/site/content/en/v1.6/tasks/security/oidc.md
@@ -15,7 +15,7 @@ This instantiated resource can be linked to a [Gateway][Gateway] and [HTTPRoute]
 
 {{< boilerplate prerequisites >}}
 
-EG OIDC authentication requires the redirect URL to be HTTPS. Follow the [Secure Gateways](../secure-gateways) guide
+EG OIDC authentication requires the redirect URL to be HTTPS. Follow the [Secure Gateways](../secure-gateways/) guide
 to generate the TLS certificates and update the Gateway configuration to add an HTTPS listener.
 
 Verify the Gateway status:

--- a/site/content/en/v1.6/tasks/traffic/http-redirect.md
+++ b/site/content/en/v1.6/tasks/traffic/http-redirect.md
@@ -94,7 +94,7 @@ $ curl -L -vvv --header "Host: redirect.example" "http://${GATEWAY_HOST}/get"
 ...
 ```
 
-If you followed the steps in the [Secure Gateways](../security/secure-gateways) task, you should be able to curl the redirect
+If you followed the steps in the [Secure Gateways](../security/secure-gateways/) task, you should be able to curl the redirect
 location.
 
 ## HTTP --> HTTPS

--- a/site/content/en/v1.7/tasks/security/oidc.md
+++ b/site/content/en/v1.7/tasks/security/oidc.md
@@ -15,7 +15,7 @@ This instantiated resource can be linked to a [Gateway][Gateway] and [HTTPRoute]
 
 {{< boilerplate prerequisites >}}
 
-EG OIDC authentication requires the redirect URL to be HTTPS. Follow the [Secure Gateways](../secure-gateways) guide
+EG OIDC authentication requires the redirect URL to be HTTPS. Follow the [Secure Gateways](../secure-gateways/) guide
 to generate the TLS certificates and update the Gateway configuration to add an HTTPS listener.
 
 Verify the Gateway status:

--- a/site/content/en/v1.7/tasks/traffic/http-redirect.md
+++ b/site/content/en/v1.7/tasks/traffic/http-redirect.md
@@ -94,7 +94,7 @@ $ curl -L -vvv --header "Host: redirect.example" "http://${GATEWAY_HOST}/get"
 ...
 ```
 
-If you followed the steps in the [Secure Gateways](../security/secure-gateways) task, you should be able to curl the redirect
+If you followed the steps in the [Secure Gateways](../security/secure-gateways/) task, you should be able to curl the redirect
 location.
 
 ## HTTP --> HTTPS

--- a/site/content/en/v1.8/tasks/security/oidc.md
+++ b/site/content/en/v1.8/tasks/security/oidc.md
@@ -15,7 +15,7 @@ This instantiated resource can be linked to a [Gateway][Gateway] and [HTTPRoute]
 
 {{< boilerplate prerequisites >}}
 
-EG OIDC authentication requires the redirect URL to be HTTPS. Follow the [Secure Gateways](../secure-gateways) guide
+EG OIDC authentication requires the redirect URL to be HTTPS. Follow the [Secure Gateways](../secure-gateways/) guide
 to generate the TLS certificates and update the Gateway configuration to add an HTTPS listener.
 
 Verify the Gateway status:

--- a/site/content/en/v1.8/tasks/traffic/http-redirect.md
+++ b/site/content/en/v1.8/tasks/traffic/http-redirect.md
@@ -92,7 +92,7 @@ $ curl -L -vvv --header "Host: redirect.example" "http://${GATEWAY_HOST}/get"
 ...
 ```
 
-If you followed the steps in the [Secure Gateways](../security/secure-gateways) task, you should be able to curl the redirect
+If you followed the steps in the [Secure Gateways](../security/secure-gateways/) task, you should be able to curl the redirect
 location.
 
 ## HTTP --> HTTPS

--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -19,6 +19,7 @@ LINKINATOR_IGNORE := "opentelemetry.io \
 	gnu.org \
 	_print \
 	canva.com \
+	communityinviter.com \
 	sched.co \
 	sap.com \
 	httpbin.org \


### PR DESCRIPTION
<!--
Your PR title should be descriptive, and generally start with a type that contains a subsystem name with `()` if necessary
and a summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), the API must be discussed and
agreed before the implementation. We strongly recommend separating API changes into their own PR so
we can review the API first, but the API may also live in the same PR as long as it was agreed
beforehand. This will save you a lot of implementation time if the API gets accepted.
-->

**What this PR does / why we need it**:
<!--
Briefly describe what this PR changes and the motivation behind it. Include enough context for a
reviewer to understand the problem being solved and the approach taken, e.g. what behavior changes,
any alternatives considered, and anything reviewers should pay special attention to.
-->

Adds `communityinviter.com` to `LINKINATOR_IGNORE` for docs link checks.
Before this change, `make docs-check-links` fails because `https://communityinviter.com/apps/envoyproxy/envoy` returns 404 and is present in the generated footer across many docs pages.

before

```
)$ make docs-check-links
===========> Running docs-check-links ...
tools/node_modules/.bin/linkinator site/public/ -r --concurrency 25 --retry-errors --retry --retry-errors-jitter --retry-errors-count 5 --skip "opentelemetry.io blog.envoyproxy.io envoyproxy.io/slack ntia.gov github.com jwt.io githubusercontent.com example.com foo.bar.com github.io gnu.org _print canva.com sched.co sap.com httpbin.org nemlig.com verve.com goteleport.com developer.hashicorp.com www.signal-ai.com v0.1 v0.2 v0.3 v0.4 v0.5 v0.6 v1.0 v1.1 v1.2 v1.3 v1.4" --verbosity error
â crawling site/public/
[408] site/public/v1.6/tasks/security/index.xml
site/public/v1.6/tasks/security/
  [408] site/public/v1.6/tasks/security/index.xml
ERROR: Detected 1 broken links. Scanned 2206 links in 455.24 seconds.
make[1]: *** [docs-check-links] Error 1
make: *** [_run] Error 2

```

after

```
$ make docs-check-links
===========> Running docs-check-links ...
tools/node_modules/.bin/linkinator site/public/ -r --concurrency 25 --retry-errors --retry --retry-errors-jitter --retry-errors-count 5 --skip "opentelemetry.io blog.envoyproxy.io envoyproxy.io/slack ntia.gov github.com jwt.io githubusercontent.com example.com foo.bar.com github.io gnu.org _print canva.com communityinviter.com sched.co sap.com httpbin.org nemlig.com verve.com goteleport.com developer.hashicorp.com www.signal-ai.com v0.1 v0.2 v0.3 v0.4 v0.5 v0.6 v1.0 v1.1 v1.2 v1.3 v1.4" --verbosity error
â crawling site/public/
â Successfully scanned 2206 links in 459.069 seconds.
```

https://github.com/envoyproxy/gateway/actions/runs/31080123213/job/92546808504?pr=9675

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

---

**PR Checklist**
<!--
Please tick the boxes below before requesting a review. PRs that leave required items unchecked may
be delayed or closed. Replace `[ ]` with `[x]` to check a box. If an item does not apply, check it
and add "N/A: <reason>".
-->

- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: If this PR contains API changes (changes under `/api`), the API was discussed and agreed **before** the implementation. The API change can be in a separate PR, or in the same PR, but the API must be agreed before implementation. N/A if this PR does not contain API changes.
- [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (Flaky e2e failures are not considered breakages, but `gen-check`, `lint`, and coverage **MUST** pass.)
- [x] **Tests added/updated**: New/changed code is covered by appropriate tests. N/A if this PR does not contain code changes.
- [x] **Docs**: User-facing changes update the [docs](https://github.com/envoyproxy/gateway/tree/main/site), either in this PR or a follow-up PR. N/A if this PR does not contain user-facing changes.
- [x] **Release notes**: For any non-trivial change, added a release-note fragment under `release-notes/current/<section>/<pr-number>-<slug>.md` (see `release-notes/current/README.md` for sections and naming). N/A if this PR does not contain non-trivial changes.
- [x] **Generated files committed**: Ran `make gen-check` and committed the result if API/helm charts/modules changed.
- [x] **Scope & compatibility**: The PR is reasonably scoped (no unrelated changes) and preserves backward compatibility, or any breaking change is called out above and documented in `release-notes/current/breaking_changes/`.
- [ ] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.
