### PR TITLE
gatewayapi: fix ListenerSet scope in MergeBackends cluster-settings index

### DIFF
--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -111,7 +111,7 @@ func newBTPClusterSettingsIndex() *BTPClusterSettingsIndex {
 	return &BTPClusterSettingsIndex{policyIndex: newPolicyIndex[bool]()}
 }
 
-// HasClusterSettingsBelowGateway reports whether a route-rule, route, or listener-level
+// HasClusterSettingsBelowGateway reports whether a route-rule, route, listener, or ListenerSet-level
 // BackendTrafficPolicy contributes backend-cluster-scoped settings for the given target, or
 // targets it with MergeType unset. A gateway-level setting is never the answer here: it applies
 // uniformly to every route sharing a merged cluster, so it can't cause a divergence -
@@ -122,12 +122,13 @@ func (idx *BTPClusterSettingsIndex) HasClusterSettingsBelowGateway(
 	routeNN types.NamespacedName,
 	gatewayNN types.NamespacedName,
 	listenerName *gwapiv1.SectionName,
+	listenerSetNN *types.NamespacedName,
 	routeRuleName *gwapiv1.SectionName,
 ) bool {
 	if idx == nil {
 		return false
 	}
-	hasClusterSettings, replacesParent := idx.Lookup(routeKind, routeNN, gatewayNN, listenerName, nil, routeRuleName)
+	hasClusterSettings, replacesParent := idx.Lookup(routeKind, routeNN, gatewayNN, listenerName, listenerSetNN, routeRuleName)
 	// replacesParent catches what hasClusterSettings alone would miss: a rule's own BTP with
 	// MergeType nil and no cluster-scoped field (false) still resolves to its own empty settings,
 	// not the gateway's - diverging from a sibling rule that has no BTP and does inherit the

--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -238,10 +238,6 @@ func BuildBTPIndexes(
 				case kind == resource.KindListenerSet && ref.SectionName != nil:
 					clusterSettingsIdx.setListenerSetListenerLevel(nn, *ref.SectionName, hasClusterScoped, true)
 				case kind == resource.KindListenerSet:
-					// Unlike bare-Gateway, a bare-ListenerSet setting is NOT uniform across every
-					// route that could share a merged cluster under the same Gateway - sibling
-					// ListenerSets/listeners under that Gateway don't get it. So, unlike the
-					// Gateway case above, this needs a real entry.
 					clusterSettingsIdx.setListenerSetLevel(nn, hasClusterScoped, true)
 				case ref.SectionName != nil:
 					clusterSettingsIdx.setRouteRuleLevel(nn, kind, *ref.SectionName, hasClusterScoped, btp.Spec.MergeType)
@@ -249,19 +245,13 @@ func BuildBTPIndexes(
 					clusterSettingsIdx.setRouteLevel(nn, kind, hasClusterScoped, btp.Spec.MergeType)
 				}
 
-				// No ListenerSet case needed here, unlike clusterSettingsIdx above: IsConsistentHash
-				// (this index's only consumer) only ever checks bare-Gateway scope, and
-				// mergeIncompatibleForWeightedRule already checks hasClusterSettingsBelowGateway
-				// (backed by clusterSettingsIdx, which does track ListenerSet/listener-level
-				// LoadBalancer settings as a cluster-scoped field) first, short-circuiting before
-				// this index is ever consulted for anything below bare-Gateway scope.
 				switch {
 				case kind == resource.KindGateway && ref.SectionName == nil:
 					// Every accepted Gateway-wide BTP must claim this slot, even one that leaves
 					// LoadBalancer unset, so a younger conflicting BTP can't silently win it.
 					loadBalancerIdx.setGatewayLevel(nn, hasLoadBalancer && btp.Spec.LoadBalancer.Type == egv1a1.ConsistentHashLoadBalancerType)
 				default:
-					// A listener/route-rule/route-level LoadBalancer setting already disqualifies
+					// A listener/listenerSet/route-rule/route-level LoadBalancer setting already disqualifies
 					// its own rule from merging on its own, so it's never looked up here.
 				}
 			}

--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -229,22 +229,32 @@ func BuildBTPIndexes(
 			// ClusterSettings/LoadBalancer only inform merge-eligibility, so they're moot when no
 			// accepted gateway can enable merging; RoutingType (above) applies regardless.
 			if mergeBackendsEnabled {
-				// TODO(#9619): unlike routingTypeIdx above, this switch has no ListenerSet case, so
-				// ListenerSet-level BTP attachment isn't tracked here.
 				switch {
 				case kind == resource.KindGateway && ref.SectionName != nil:
 					clusterSettingsIdx.setGatewayListenerLevel(nn, *ref.SectionName, hasClusterScoped, true)
 				case kind == resource.KindGateway:
 					// Gateway-level settings apply uniformly to every route sharing a merged
 					// cluster, so they don't disqualify merging - no entry needed.
+				case kind == resource.KindListenerSet && ref.SectionName != nil:
+					clusterSettingsIdx.setListenerSetListenerLevel(nn, *ref.SectionName, hasClusterScoped, true)
+				case kind == resource.KindListenerSet:
+					// Unlike bare-Gateway, a bare-ListenerSet setting is NOT uniform across every
+					// route that could share a merged cluster under the same Gateway - sibling
+					// ListenerSets/listeners under that Gateway don't get it. So, unlike the
+					// Gateway case above, this needs a real entry.
+					clusterSettingsIdx.setListenerSetLevel(nn, hasClusterScoped, true)
 				case ref.SectionName != nil:
 					clusterSettingsIdx.setRouteRuleLevel(nn, kind, *ref.SectionName, hasClusterScoped, btp.Spec.MergeType)
 				default:
 					clusterSettingsIdx.setRouteLevel(nn, kind, hasClusterScoped, btp.Spec.MergeType)
 				}
 
-				// TODO(#9619): same gap as clusterSettingsIdx above - this switch has no
-				// ListenerSet case either, so ListenerSet-level BTP attachment isn't tracked here.
+				// No ListenerSet case needed here, unlike clusterSettingsIdx above: IsConsistentHash
+				// (this index's only consumer) only ever checks bare-Gateway scope, and
+				// mergeIncompatibleForWeightedRule already checks hasClusterSettingsBelowGateway
+				// (backed by clusterSettingsIdx, which does track ListenerSet/listener-level
+				// LoadBalancer settings as a cluster-scoped field) first, short-circuiting before
+				// this index is ever consulted for anything below bare-Gateway scope.
 				switch {
 				case kind == resource.KindGateway && ref.SectionName == nil:
 					// Every accepted Gateway-wide BTP must claim this slot, even one that leaves

--- a/internal/gatewayapi/backendtrafficpolicy_test.go
+++ b/internal/gatewayapi/backendtrafficpolicy_test.go
@@ -2644,6 +2644,7 @@ func TestBuildBTPClusterSettingsIndexCrossNamespace(t *testing.T) {
 		types.NamespacedName{},
 		nil,
 		nil,
+		nil,
 	)
 	require.True(t, got)
 }
@@ -2663,10 +2664,12 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 		btps          []*egv1a1.BackendTrafficPolicy
 		routes        []client.Object
 		gateways      []*GatewayContext
+		listenerSets  []*gwapiv1.ListenerSet
 		routeKind     gwapiv1.Kind
 		routeNN       types.NamespacedName
 		gatewayNN     types.NamespacedName
 		listenerName  *gwapiv1.SectionName
+		listenerSetNN *types.NamespacedName
 		routeRuleName *gwapiv1.SectionName
 		expected      bool
 	}{
@@ -3001,8 +3004,8 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			idx := BuildBTPIndexes(tt.btps, tt.routes, tt.gateways, nil, nil, nil, true)
-			got := idx.ClusterSettings.HasClusterSettingsBelowGateway(tt.routeKind, tt.routeNN, tt.gatewayNN, tt.listenerName, tt.routeRuleName)
+			idx := BuildBTPIndexes(tt.btps, tt.routes, tt.gateways, tt.listenerSets, nil, nil, true)
+			got := idx.ClusterSettings.HasClusterSettingsBelowGateway(tt.routeKind, tt.routeNN, tt.gatewayNN, tt.listenerName, tt.listenerSetNN, tt.routeRuleName)
 			require.Equal(t, tt.expected, got)
 		})
 	}

--- a/internal/gatewayapi/backendtrafficpolicy_test.go
+++ b/internal/gatewayapi/backendtrafficpolicy_test.go
@@ -3010,7 +3010,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 			expected:     false,
 		},
 		{
-			name: "bare ListenerSet-targeted BTP with cluster-scoped field disqualifies merging for a route attached via that ListenerSet",
+			name: "bare ListenerSet-targeted BTP with cluster-scoped field disqualifies merging",
 			btps: []*egv1a1.BackendTrafficPolicy{
 				{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-listenerset"},
@@ -3092,7 +3092,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 			expected:      false,
 		},
 		{
-			name: "ListenerSet-attached route with no ListenerSet-level BTP falls through to bare Gateway scope",
+			name: "listenerSetNN set with no ListenerSet-level BTP falls through to bare Gateway scope",
 			btps: []*egv1a1.BackendTrafficPolicy{
 				{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-gateway-for-ls-fallthrough"},

--- a/internal/gatewayapi/backendtrafficpolicy_test.go
+++ b/internal/gatewayapi/backendtrafficpolicy_test.go
@@ -2659,6 +2659,15 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 	ruleAName := gwapiv1.SectionName("rule-a")
 	ruleBName := gwapiv1.SectionName("rule-b")
 
+	defaultListenerSet := &gwapiv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "listenerset-1"},
+	}
+	listenerSetNN := types.NamespacedName{Namespace: "default", Name: "listenerset-1"}
+	otherListenerSet := &gwapiv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "listenerset-2"},
+	}
+	lsListenerName := gwapiv1.SectionName("ls-http")
+
 	tests := []struct {
 		name          string
 		btps          []*egv1a1.BackendTrafficPolicy
@@ -2999,6 +3008,115 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 			gatewayNN:    types.NamespacedName{Namespace: "default", Name: "gateway-1"},
 			listenerName: new(gwapiv1.SectionName("http")),
 			expected:     false,
+		},
+		{
+			name: "bare ListenerSet-targeted BTP with cluster-scoped field disqualifies merging for a route attached via that ListenerSet",
+			btps: []*egv1a1.BackendTrafficPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-listenerset"},
+					Spec: egv1a1.BackendTrafficPolicySpec{
+						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
+									Group: gwapiv1.Group("gateway.networking.k8s.io"),
+									Kind:  gwapiv1.Kind("ListenerSet"),
+									Name:  gwapiv1.ObjectName("listenerset-1"),
+								},
+							},
+						},
+						ClusterSettings: egv1a1.ClusterSettings{CircuitBreaker: &egv1a1.CircuitBreaker{}},
+					},
+				},
+			},
+			listenerSets:  []*gwapiv1.ListenerSet{defaultListenerSet},
+			routeKind:     "HTTPRoute",
+			routeNN:       routeNN,
+			gatewayNN:     types.NamespacedName{Namespace: "default", Name: "gateway-1"},
+			listenerName:  &lsListenerName,
+			listenerSetNN: &listenerSetNN,
+			expected:      true,
+		},
+		{
+			name: "ListenerSet-listener-targeted BTP with cluster-scoped field disqualifies merging for that specific listener",
+			btps: []*egv1a1.BackendTrafficPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-listenerset-listener"},
+					Spec: egv1a1.BackendTrafficPolicySpec{
+						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
+									Group: gwapiv1.Group("gateway.networking.k8s.io"),
+									Kind:  gwapiv1.Kind("ListenerSet"),
+									Name:  gwapiv1.ObjectName("listenerset-1"),
+								},
+								SectionName: &lsListenerName,
+							},
+						},
+						ClusterSettings: egv1a1.ClusterSettings{CircuitBreaker: &egv1a1.CircuitBreaker{}},
+					},
+				},
+			},
+			listenerSets:  []*gwapiv1.ListenerSet{defaultListenerSet},
+			routeKind:     "HTTPRoute",
+			routeNN:       routeNN,
+			gatewayNN:     types.NamespacedName{Namespace: "default", Name: "gateway-1"},
+			listenerName:  &lsListenerName,
+			listenerSetNN: &listenerSetNN,
+			expected:      true,
+		},
+		{
+			name: "bare ListenerSet-targeted BTP on a different ListenerSet does not disqualify merging",
+			btps: []*egv1a1.BackendTrafficPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-other-listenerset"},
+					Spec: egv1a1.BackendTrafficPolicySpec{
+						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
+									Group: gwapiv1.Group("gateway.networking.k8s.io"),
+									Kind:  gwapiv1.Kind("ListenerSet"),
+									Name:  gwapiv1.ObjectName("listenerset-2"),
+								},
+							},
+						},
+						ClusterSettings: egv1a1.ClusterSettings{CircuitBreaker: &egv1a1.CircuitBreaker{}},
+					},
+				},
+			},
+			listenerSets:  []*gwapiv1.ListenerSet{defaultListenerSet, otherListenerSet},
+			routeKind:     "HTTPRoute",
+			routeNN:       routeNN,
+			gatewayNN:     types.NamespacedName{Namespace: "default", Name: "gateway-1"},
+			listenerName:  &lsListenerName,
+			listenerSetNN: &listenerSetNN,
+			expected:      false,
+		},
+		{
+			name: "ListenerSet-attached route with no ListenerSet-level BTP falls through to bare Gateway scope",
+			btps: []*egv1a1.BackendTrafficPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-gateway-for-ls-fallthrough"},
+					Spec: egv1a1.BackendTrafficPolicySpec{
+						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
+									Group: gwapiv1.Group("gateway.networking.k8s.io"),
+									Kind:  gwapiv1.Kind("Gateway"),
+									Name:  gwapiv1.ObjectName("gateway-1"),
+								},
+							},
+						},
+						ClusterSettings: egv1a1.ClusterSettings{CircuitBreaker: &egv1a1.CircuitBreaker{}},
+					},
+				},
+			},
+			listenerSets:  []*gwapiv1.ListenerSet{defaultListenerSet},
+			routeKind:     "HTTPRoute",
+			routeNN:       routeNN,
+			gatewayNN:     types.NamespacedName{Namespace: "default", Name: "gateway-1"},
+			listenerName:  &lsListenerName,
+			listenerSetNN: &listenerSetNN,
+			expected:      false,
 		},
 	}
 

--- a/internal/gatewayapi/route.go
+++ b/internal/gatewayapi/route.go
@@ -596,11 +596,19 @@ func (t *Translator) hasClusterSettingsBelowGateway(
 		return false
 	}
 	gatewayNN := types.NamespacedName{Namespace: gatewayCtx.GetNamespace(), Name: gatewayCtx.GetName()}
+	var listenerSetNN *types.NamespacedName
+	if listener.isFromListenerSet() {
+		listenerSetNN = &types.NamespacedName{
+			Namespace: listener.listenerSet.Namespace,
+			Name:      listener.listenerSet.Name,
+		}
+	}
 	if t.BTPClusterSettingsIndex.HasClusterSettingsBelowGateway(
 		routeCtx.GetRouteType(),
 		types.NamespacedName{Namespace: routeCtx.GetNamespace(), Name: routeCtx.GetName()},
 		gatewayNN,
 		&listener.Name,
+		listenerSetNN,
 		routeRuleName,
 	) {
 		return true

--- a/internal/gatewayapi/testdata/mergebackends-http-demerge-listenerset-btp.in.yaml
+++ b/internal/gatewayapi/testdata/mergebackends-http-demerge-listenerset-btp.in.yaml
@@ -1,0 +1,84 @@
+envoyProxyForGatewayClass:
+  apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: EnvoyProxy
+  metadata:
+    namespace: envoy-gateway-system
+    name: test
+  spec:
+    mergeBackends: {}
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      namespace: default
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      allowedListeners:
+        namespaces:
+          from: Same
+      listeners:
+        - name: http-1
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+listenerSets:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: ListenerSet
+    metadata:
+      namespace: default
+      name: ls-1
+    spec:
+      parentRef:
+        name: gateway-1
+      listeners:
+        - name: ls-http
+          protocol: HTTP
+          port: 8081
+          allowedRoutes:
+            namespaces:
+              from: Same
+backendTrafficPolicies:
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: BackendTrafficPolicy
+    metadata:
+      namespace: default
+      name: btp-listenerset-1
+    spec:
+      targetRefs:
+        - group: gateway.networking.k8s.io
+          kind: ListenerSet
+          name: ls-1
+      circuitBreaker:
+        maxConnections: 1024
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: http-route-1
+    spec:
+      parentRefs:
+        - name: gateway-1
+          sectionName: http-1
+      rules:
+        - backendRefs:
+            - name: service-1
+              port: 8080
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: http-route-2
+    spec:
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: ListenerSet
+          name: ls-1
+          sectionName: ls-http
+      rules:
+        - backendRefs:
+            - name: service-1
+              port: 8080

--- a/internal/gatewayapi/testdata/mergebackends-http-demerge-listenerset-btp.out.yaml
+++ b/internal/gatewayapi/testdata/mergebackends-http-demerge-listenerset-btp.out.yaml
@@ -1,0 +1,358 @@
+backendTrafficPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    name: btp-listenerset-1
+    namespace: default
+  spec:
+    circuitBreaker:
+      maxConnections: 1024
+    targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: ls-1
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: ListenerSet
+        name: ls-1
+        namespace: default
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: default
+  spec:
+    allowedListeners:
+      namespaces:
+        from: Same
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: http-1
+      port: 80
+      protocol: HTTP
+  status:
+    attachedListenerSets: 1
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http-1
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: http-route-1
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      sectionName: http-1
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        sectionName: http-1
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: http-route-2
+    namespace: default
+  spec:
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: ls-1
+      sectionName: ls-http
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: ListenerSet
+        name: ls-1
+        sectionName: ls-http
+infraIR:
+  default/gateway-1:
+    proxy:
+      config:
+        apiVersion: gateway.envoyproxy.io/v1alpha1
+        kind: EnvoyProxy
+        metadata:
+          name: test
+          namespace: envoy-gateway-system
+        spec:
+          logging: {}
+          mergeBackends: {}
+        status: {}
+      listeners:
+      - name: default/gateway-1/http-1
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      - name: default/gateway-1/default/ls-1/ls-http
+        ports:
+        - containerPort: 8081
+          name: http-8081
+          protocol: HTTP
+          servicePort: 8081
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: default
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: default/gateway-1
+      namespace: envoy-gateway-system
+listenerSets:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: ListenerSet
+  metadata:
+    name: ls-1
+    namespace: default
+  spec:
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: ls-http
+      port: 8081
+      protocol: HTTP
+    parentRef:
+      name: gateway-1
+  status:
+    conditions:
+    - lastTransitionTime: null
+      message: All listeners are accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: null
+      message: All listeners are programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      name: ls-http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+xdsIR:
+  default/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    backendClusters:
+    - metadata:
+        kind: Service
+        name: service-1
+        namespace: default
+        sectionName: "8080"
+      name: service/default/service-1/8080/http
+      setting:
+        addressType: IP
+        endpoints:
+        - host: 7.7.7.7
+          port: 8080
+        metadata:
+          kind: Service
+          name: service-1
+          namespace: default
+          sectionName: "8080"
+        name: service/default/service-1/8080/http
+        protocol: HTTP
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-default-gateway-1-bfd08ef4
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: default/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-default-gateway-1-bfd08ef4
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: default/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+        sectionName: http-1
+      name: default/gateway-1/http-1
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          backendClusterRefs:
+          - name: service/default/service-1/8080/http
+            weight: 1
+          metadata:
+            kind: HTTPRoute
+            name: http-route-1
+            namespace: default
+          name: httproute/default/http-route-1/rule/0
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: http-route-1
+          namespace: default
+        name: httproute/default/http-route-1/rule/0/match/-1/*
+    - address: 0.0.0.0
+      externalPort: 8081
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+        sectionName: ls-http
+      name: default/gateway-1/default/ls-1/ls-http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8081
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: http-route-2
+            namespace: default
+          name: httproute/default/http-route-2/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/http-route-2/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: http-route-2
+          namespace: default
+          policies:
+          - kind: BackendTrafficPolicy
+            name: btp-listenerset-1
+            namespace: default
+        name: httproute/default/http-route-2/rule/0/match/-1/*
+        traffic:
+          circuitBreaker:
+            maxConnections: 1024
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/internal/gatewayapi/testdata/mergebackends-http-demerge-listenerset-listener-btp.in.yaml
+++ b/internal/gatewayapi/testdata/mergebackends-http-demerge-listenerset-listener-btp.in.yaml
@@ -1,0 +1,85 @@
+envoyProxyForGatewayClass:
+  apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: EnvoyProxy
+  metadata:
+    namespace: envoy-gateway-system
+    name: test
+  spec:
+    mergeBackends: {}
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      namespace: default
+      name: gateway-1
+    spec:
+      gatewayClassName: envoy-gateway-class
+      allowedListeners:
+        namespaces:
+          from: Same
+      listeners:
+        - name: http-1
+          protocol: HTTP
+          port: 80
+          allowedRoutes:
+            namespaces:
+              from: All
+listenerSets:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: ListenerSet
+    metadata:
+      namespace: default
+      name: ls-1
+    spec:
+      parentRef:
+        name: gateway-1
+      listeners:
+        - name: ls-http
+          protocol: HTTP
+          port: 8081
+          allowedRoutes:
+            namespaces:
+              from: Same
+backendTrafficPolicies:
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: BackendTrafficPolicy
+    metadata:
+      namespace: default
+      name: btp-listenerset-listener-1
+    spec:
+      targetRefs:
+        - group: gateway.networking.k8s.io
+          kind: ListenerSet
+          name: ls-1
+          sectionName: ls-http
+      circuitBreaker:
+        maxConnections: 1024
+httpRoutes:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: http-route-1
+    spec:
+      parentRefs:
+        - name: gateway-1
+          sectionName: http-1
+      rules:
+        - backendRefs:
+            - name: service-1
+              port: 8080
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      namespace: default
+      name: http-route-2
+    spec:
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: ListenerSet
+          name: ls-1
+          sectionName: ls-http
+      rules:
+        - backendRefs:
+            - name: service-1
+              port: 8080

--- a/internal/gatewayapi/testdata/mergebackends-http-demerge-listenerset-listener-btp.out.yaml
+++ b/internal/gatewayapi/testdata/mergebackends-http-demerge-listenerset-listener-btp.out.yaml
@@ -1,0 +1,360 @@
+backendTrafficPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    name: btp-listenerset-listener-1
+    namespace: default
+  spec:
+    circuitBreaker:
+      maxConnections: 1024
+    targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: ls-1
+      sectionName: ls-http
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: ListenerSet
+        name: ls-1
+        namespace: default
+        sectionName: ls-http
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: default
+  spec:
+    allowedListeners:
+      namespaces:
+        from: Same
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: http-1
+      port: 80
+      protocol: HTTP
+  status:
+    attachedListenerSets: 1
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http-1
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: http-route-1
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      sectionName: http-1
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        sectionName: http-1
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: http-route-2
+    namespace: default
+  spec:
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: ls-1
+      sectionName: ls-http
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: ListenerSet
+        name: ls-1
+        sectionName: ls-http
+infraIR:
+  default/gateway-1:
+    proxy:
+      config:
+        apiVersion: gateway.envoyproxy.io/v1alpha1
+        kind: EnvoyProxy
+        metadata:
+          name: test
+          namespace: envoy-gateway-system
+        spec:
+          logging: {}
+          mergeBackends: {}
+        status: {}
+      listeners:
+      - name: default/gateway-1/http-1
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      - name: default/gateway-1/default/ls-1/ls-http
+        ports:
+        - containerPort: 8081
+          name: http-8081
+          protocol: HTTP
+          servicePort: 8081
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: default
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: default/gateway-1
+      namespace: envoy-gateway-system
+listenerSets:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: ListenerSet
+  metadata:
+    name: ls-1
+    namespace: default
+  spec:
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: ls-http
+      port: 8081
+      protocol: HTTP
+    parentRef:
+      name: gateway-1
+  status:
+    conditions:
+    - lastTransitionTime: null
+      message: All listeners are accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: null
+      message: All listeners are programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      name: ls-http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+xdsIR:
+  default/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    backendClusters:
+    - metadata:
+        kind: Service
+        name: service-1
+        namespace: default
+        sectionName: "8080"
+      name: service/default/service-1/8080/http
+      setting:
+        addressType: IP
+        endpoints:
+        - host: 7.7.7.7
+          port: 8080
+        metadata:
+          kind: Service
+          name: service-1
+          namespace: default
+          sectionName: "8080"
+        name: service/default/service-1/8080/http
+        protocol: HTTP
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-default-gateway-1-bfd08ef4
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: default/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-default-gateway-1-bfd08ef4
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: default/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+        sectionName: http-1
+      name: default/gateway-1/http-1
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          backendClusterRefs:
+          - name: service/default/service-1/8080/http
+            weight: 1
+          metadata:
+            kind: HTTPRoute
+            name: http-route-1
+            namespace: default
+          name: httproute/default/http-route-1/rule/0
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: http-route-1
+          namespace: default
+        name: httproute/default/http-route-1/rule/0/match/-1/*
+    - address: 0.0.0.0
+      externalPort: 8081
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+        sectionName: ls-http
+      name: default/gateway-1/default/ls-1/ls-http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 8081
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: http-route-2
+            namespace: default
+          name: httproute/default/http-route-2/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/http-route-2/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: http-route-2
+          namespace: default
+          policies:
+          - kind: BackendTrafficPolicy
+            name: btp-listenerset-listener-1
+            namespace: default
+        name: httproute/default/http-route-2/rule/0/match/-1/*
+        traffic:
+          circuitBreaker:
+            maxConnections: 1024
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003


### PR DESCRIPTION
## Summary

Fixes #9619: a `BackendTrafficPolicy` attached to a `ListenerSet` (bare, or scoped to one of its listeners) wasn't tracked by the `MergeBackends` cluster-deduplication eligibility check, so a route could get incorrectly deduplicated into a shared cluster with sibling routes that don't share its settings.

Adds the missing `ListenerSet`/`ListenerSet-listener` cases to `BuildBTPIndexes`, with TDD'd unit tests and end-to-end golden fixtures proving the fix through the real translator pipeline.

While investigating, found and filed a related but separate issue: #9676 — a route whose `parentRef` omits `sectionName` can silently miss a listener-scoped BTP's settings entirely. Different root cause, not fixed here, just cross-referencing.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/gatewayapi/...` — all packages pass
- [x] New unit tests (bare ListenerSet, ListenerSet-listener, sibling isolation, Gateway fallthrough) — TDD'd, confirmed failing before the fix, passing after
- [x] New golden fixtures confirm the correct demerge outcome
- [x] `make lint.golint` clean