### PR TITLE
fix: RateLimitBasedJwtClaims flaky

### DIFF
--- a/test/e2e/tests/ratelimit.go
+++ b/test/e2e/tests/ratelimit.go
@@ -777,23 +777,13 @@ var RateLimitBasedJwtClaimsTest = suite.ConformanceTest{
 				Namespace: ns,
 			}
 
-			expectLimitResp := http.ExpectedResponse{
-				Request: http.Request{
-					Path: "/foo",
-				},
-				Response: http.Response{
-					StatusCodes: []int{429},
-				},
-				Namespace: ns,
-			}
-
 			// Just to construct the request that carries a jwt token that can be limited
 			ratelimitHeader := make(map[string]string)
-			TokenHeader := make(map[string]string)
-			JwtOkResp := http.ExpectedResponse{
+			tokenHeader := make(map[string]string)
+			jwtOkResp := http.ExpectedResponse{
 				Request: http.Request{
 					Path:    "/foo",
-					Headers: TokenHeader,
+					Headers: tokenHeader,
 				},
 				ExpectedRequest: &http.ExpectedRequest{
 					Request: http.Request{
@@ -806,17 +796,28 @@ var RateLimitBasedJwtClaimsTest = suite.ConformanceTest{
 				},
 				Namespace: ns,
 			}
-			JwtOkResp.Request.Headers["Authorization"] = "Bearer " + "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ"
-			JwtOkResp.Response.Headers["X-Ratelimit-Limit"] = "3, 3;w=3600"
+			jwtOkResp.Request.Headers["Authorization"] = "Bearer " + "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ"
+			jwtOkResp.Response.Headers["X-Ratelimit-Limit"] = "3, 3;w=3600"
 
-			JwtReq := http.MakeRequest(t, &JwtOkResp, gwAddr, "HTTP", "http")
+			// The same jwt token, but expecting to be rate limited. It has to carry the token as well,
+			// otherwise the request is rejected by the jwt authn filter before the rate limit filter.
+			jwtLimitResp := http.ExpectedResponse{
+				Request: http.Request{
+					Path:    "/foo",
+					Headers: tokenHeader,
+				},
+				Response: http.Response{
+					StatusCodes: []int{429},
+				},
+				Namespace: ns,
+			}
 
 			// Just to construct the request that carries a jwt token that can not be limited
-			DifTokenHeader := make(map[string]string)
+			difTokenHeader := make(map[string]string)
 			difJwtOkResp := http.ExpectedResponse{
 				Request: http.Request{
 					Path:    "/foo",
-					Headers: DifTokenHeader,
+					Headers: difTokenHeader,
 				},
 				Response: http.Response{
 					StatusCodes: []int{200},
@@ -828,7 +829,7 @@ var RateLimitBasedJwtClaimsTest = suite.ConformanceTest{
 			difJwtReq := http.MakeRequest(t, &difJwtOkResp, gwAddr, "HTTP", "http")
 
 			// make sure the gateway is available
-			OkResp := http.ExpectedResponse{
+			okResp := http.ExpectedResponse{
 				Request: http.Request{
 					Path: "/bar",
 				},
@@ -839,20 +840,13 @@ var RateLimitBasedJwtClaimsTest = suite.ConformanceTest{
 			}
 
 			// keep sending requests till get 200 first to make sure the gateway is available
-			MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &OkResp)
-
-			// should just send exactly 4 requests, and expect 429
+			MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &okResp)
 
 			// keep sending requests till get 200 first, that will cost one 200
-			MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &JwtOkResp)
+			MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &jwtOkResp)
 
-			// fire the rest of requests
-			if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, JwtReq, JwtOkResp); err != nil {
-				t.Errorf("failed to get expected response at third request: %v", err)
-			}
-			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, JwtReq, expectLimitResp); err != nil {
-				t.Errorf("failed to get expected response at the fourth request: %v", err)
-			}
+			// the rate limit counter only moves toward the limit, so requests with the same jwt token will eventually get a 429
+			MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &jwtLimitResp)
 
 			// Carrying different jwt claims will not be limited
 			if err := GotExactExpectedResponseExceptErrors(t, 4, suite.RoundTripper, difJwtReq, expectOkResp); err != nil {


### PR DESCRIPTION
<!--
Your PR title should be descriptive, and generally start with a type that contains a subsystem name with `()` if necessary
and a summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), the API must be discussed and
agreed before the implementation. We strongly recommend separating API changes into their own PR so
we can review the API first, but the API may also live in the same PR as long as it was agreed
beforehand. This will save you a lot of implementation time if the API gets accepted.
-->

**What this PR does / why we need it**:
<!--
Briefly describe what this PR changes and the motivation behind it. Include enough context for a
reviewer to understand the problem being solved and the approach taken, e.g. what behavior changes,
any alternatives considered, and anything reviewers should pay special attention to.
-->

The test asserted that exactly requests 1-3 return 200 and request 4 returns 429.
The rate limit counter can be advanced by requests the test never observes (e.g. the
Go HTTP client silently retries a GET on a dead keep-alive connection), so the 429
can arrive earlier. Keep sending requests until a 429 is observed instead: the counter only moves
toward the limit, so this converges deterministically.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #9689 

---

**PR Checklist**
<!--
Please tick the boxes below before requesting a review. PRs that leave required items unchecked may
be delayed or closed. Replace `[ ]` with `[x]` to check a box. If an item does not apply, check it
and add "N/A: <reason>".
-->

- [ ] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [ ] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [ ] **API agreed first**: If this PR contains API changes (changes under `/api`), the API was discussed and agreed **before** the implementation. The API change can be in a separate PR, or in the same PR, but the API must be agreed before implementation. N/A if this PR does not contain API changes.
- [ ] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (Flaky e2e failures are not considered breakages, but `gen-check`, `lint`, and coverage **MUST** pass.)
- [ ] **Tests added/updated**: New/changed code is covered by appropriate tests. N/A if this PR does not contain code changes.
- [ ] **Docs**: User-facing changes update the [docs](https://github.com/envoyproxy/gateway/tree/main/site), either in this PR or a follow-up PR. N/A if this PR does not contain user-facing changes.
- [ ] **Release notes**: For any non-trivial change, added a release-note fragment under `release-notes/current/<section>/<pr-number>-<slug>.md` (see `release-notes/current/README.md` for sections and naming). N/A if this PR does not contain non-trivial changes.
- [ ] **Generated files committed**: Ran `make gen-check` and committed the result if API/helm charts/modules changed.
- [ ] **Scope & compatibility**: The PR is reasonably scoped (no unrelated changes) and preserves backward compatibility, or any breaking change is called out above and documented in `release-notes/current/breaking_changes/`.
- [ ] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.
