### PR TITLE
chore: replace sets.NewString with sets.New[string]

### DIFF
--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -2323,13 +2323,13 @@ func makeIrStatusSet(in []egv1a1.HTTPStatus) []ir.HTTPStatus {
 }
 
 func makeIrTriggerSet(in []egv1a1.TriggerEnum) []ir.TriggerEnum {
-	triggerSet := sets.NewString()
+	triggerSet := sets.New[string]()
 	for _, r := range in {
 		triggerSet.Insert(string(r))
 	}
 	irTriggers := make([]ir.TriggerEnum, 0, triggerSet.Len())
 
-	for _, r := range triggerSet.List() {
+	for _, r := range sets.List(triggerSet) {
 		irTriggers = append(irTriggers, ir.TriggerEnum(r))
 	}
 	return irTriggers

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -309,7 +309,7 @@ func computeHosts(routeHostnames []string, listenerContext *ListenerContext) []s
 		return []string{"*"}
 	}
 
-	hostnamesSet := sets.NewString()
+	hostnamesSet := sets.New[string]()
 
 	// Find intersecting hostnames
 	for i := range routeHostnames {
@@ -377,7 +377,7 @@ func computeHosts(routeHostnames []string, listenerContext *ListenerContext) []s
 		hostnamesSet.Delete(string(*listener.Hostname))
 	}
 
-	return hostnamesSet.List()
+	return sets.List(hostnamesSet)
 }
 
 // wildcardHostnameMatchesHostname returns true if wildcardHostname matches hostname.

--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -1232,7 +1232,7 @@ func (t *Translator) processMetrics(gwCtx *GatewayContext, envoyproxy *egv1a1.En
 	}
 
 	var resolvedSinks []ir.ResolvedMetricSink
-	seen := sets.NewString()
+	seen := sets.New[string]()
 
 	for i, sink := range envoyproxy.Spec.Telemetry.Metrics.Sinks {
 		if sink.OpenTelemetry == nil {

--- a/internal/gatewayapi/resource/load.go
+++ b/internal/gatewayapi/resource/load.go
@@ -542,7 +542,7 @@ func loadKubernetesYAMLToResources(input []byte, addMissingResources bool, envoy
 			if provided, found := providedServiceMap[key]; !found {
 				resources.Services = append(resources.Services, service)
 			} else {
-				providedPorts := sets.NewString()
+				providedPorts := sets.New[string]()
 				for _, port := range provided.Spec.Ports {
 					portKey := fmt.Sprintf("%s-%d", port.Protocol, port.Port)
 					providedPorts.Insert(portKey)

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -2026,7 +2026,7 @@ func (h *HTTPRoute) Validate() error {
 		}
 	}
 	if len(h.AddRequestHeaders) > 0 {
-		occurred := sets.NewString()
+		occurred := sets.New[string]()
 		for _, header := range h.AddRequestHeaders {
 			if err := header.Validate(); err != nil {
 				errs = errors.Join(errs, err)
@@ -2039,7 +2039,7 @@ func (h *HTTPRoute) Validate() error {
 		}
 	}
 	if len(h.RemoveRequestHeaders) > 0 {
-		occurred := sets.NewString()
+		occurred := sets.New[string]()
 		for _, header := range h.RemoveRequestHeaders {
 			if occurred.Has(header) {
 				errs = errors.Join(errs, ErrRemoveHeaderDuplicate)
@@ -2049,7 +2049,7 @@ func (h *HTTPRoute) Validate() error {
 		}
 	}
 	if len(h.AddResponseHeaders) > 0 {
-		occurred := sets.NewString()
+		occurred := sets.New[string]()
 		for _, header := range h.AddResponseHeaders {
 			if err := header.Validate(); err != nil {
 				errs = errors.Join(errs, err)
@@ -2062,7 +2062,7 @@ func (h *HTTPRoute) Validate() error {
 		}
 	}
 	if len(h.RemoveResponseHeaders) > 0 {
-		occurred := sets.NewString()
+		occurred := sets.New[string]()
 		for _, header := range h.RemoveResponseHeaders {
 			if occurred.Has(header) {
 				errs = errors.Join(errs, ErrRemoveHeaderDuplicate)

--- a/internal/utils/path/path.go
+++ b/internal/utils/path/path.go
@@ -29,7 +29,7 @@ func ValidateOutputPath(outputPath string) (string, error) {
 func ListDirsAndFiles(paths []string) (sets.Set[string], sets.Set[string]) {
 	dirs, files := sets.New[string](), sets.New[string]()
 	// Separate paths by whether is a directory or not.
-	paths = sets.NewString(paths...).UnsortedList()
+	paths = sets.New[string](paths...).UnsortedList()
 	for _, path := range paths {
 		var p os.FileInfo
 		p, err := os.Lstat(path)

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -238,7 +238,7 @@ func GetRenderedBootstrapConfig(opts *RenderBootstrapConfigOptions) (string, err
 			metricSinks = opts.ResolvedMetricSinks
 		} else {
 			// Fall back to resolving from ProxyMetrics (legacy path for Service-type backends)
-			addresses := sets.NewString()
+			addresses := sets.New[string]()
 			for _, sink := range proxyMetrics.Sinks {
 				if sink.OpenTelemetry == nil {
 					continue

--- a/test/e2e/tests/load_balancing.go
+++ b/test/e2e/tests/load_balancing.go
@@ -917,12 +917,12 @@ var EndpointOverrideLoadBalancing = suite.ConformanceTest{
 func runEndpointOverrideTest(t *testing.T, suite *suite.ConformanceTestSuite, gwAddr string, podIPToName map[string]string, expectedResponse *http.ExpectedResponse) {
 	req := http.MakeRequest(t, expectedResponse, gwAddr, "HTTP", "http")
 
-	allPodNames := sets.NewString()
+	allPodNames := sets.New[string]()
 	for _, podName := range podIPToName {
 		allPodNames.Insert(podName)
 	}
 
-	tlog.Logf(t, "all pods: %v", allPodNames.List())
+	tlog.Logf(t, "all pods: %v", sets.List(allPodNames))
 
 	// Make multiple requests and verify fallback behavior (just check 200 response)
 	for range sendRequests {


### PR DESCRIPTION
## Summary
- Replace deprecated `sets.NewString()` with generic `sets.New[string]()` across 8 files
- Replace `sets.String.List()` with `sets.List()` package-level function