### PR TITLE
fix: initial fetch timed out for type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment

### DIFF
--- a/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/default-resources.all.yaml
@@ -855,6 +855,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: httproute/default/backend/rule/0
           ignoreHealthOnHostRemoval: true
@@ -888,6 +889,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: grpcroute/default/backend/rule/0
           ignoreHealthOnHostRemoval: true
@@ -927,6 +929,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: tcproute/default/backend/rule/-1
           ignoreHealthOnHostRemoval: true
@@ -959,6 +962,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: tlsroute/default/backend/rule/-1
           ignoreHealthOnHostRemoval: true
@@ -991,6 +995,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: udproute/default/backend/rule/-1
           ignoreHealthOnHostRemoval: true

--- a/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/echo-gateway-api.cluster.yaml
@@ -109,6 +109,7 @@ xds:
         edsClusterConfig:
           edsConfig:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           serviceName: httproute/envoy-gateway-system/backend/rule/0
         ignoreHealthOnHostRemoval: true

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.json
@@ -522,6 +522,7 @@
                 "edsClusterConfig": {
                   "edsConfig": {
                     "ads": {},
+                    "initialFetchTimeout": "0s",
                     "resourceApiVersion": "V3"
                   },
                   "serviceName": "httproute/default/backend/rule/0"
@@ -576,6 +577,7 @@
                 "edsClusterConfig": {
                   "edsConfig": {
                     "ads": {},
+                    "initialFetchTimeout": "0s",
                     "resourceApiVersion": "V3"
                   },
                   "serviceName": "grpcroute/default/backend/rule/0"
@@ -641,6 +643,7 @@
                 "edsClusterConfig": {
                   "edsConfig": {
                     "ads": {},
+                    "initialFetchTimeout": "0s",
                     "resourceApiVersion": "V3"
                   },
                   "serviceName": "tcproute/default/backend/rule/-1"
@@ -695,6 +698,7 @@
                 "edsClusterConfig": {
                   "edsConfig": {
                     "ads": {},
+                    "initialFetchTimeout": "0s",
                     "resourceApiVersion": "V3"
                   },
                   "serviceName": "tlsroute/default/backend/rule/-1"
@@ -749,6 +753,7 @@
                 "edsClusterConfig": {
                   "edsConfig": {
                     "ads": {},
+                    "initialFetchTimeout": "0s",
                     "resourceApiVersion": "V3"
                   },
                   "serviceName": "udproute/default/backend/rule/-1"

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.all.yaml
@@ -290,6 +290,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: httproute/default/backend/rule/0
           ignoreHealthOnHostRemoval: true
@@ -322,6 +323,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: grpcroute/default/backend/rule/0
           ignoreHealthOnHostRemoval: true
@@ -361,6 +363,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: tcproute/default/backend/rule/-1
           ignoreHealthOnHostRemoval: true
@@ -393,6 +396,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: tlsroute/default/backend/rule/-1
           ignoreHealthOnHostRemoval: true
@@ -425,6 +429,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: udproute/default/backend/rule/-1
           ignoreHealthOnHostRemoval: true

--- a/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/from-gateway-api-to-xds.cluster.yaml
@@ -13,6 +13,7 @@ xds:
         edsClusterConfig:
           edsConfig:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           serviceName: httproute/default/backend/rule/0
         ignoreHealthOnHostRemoval: true
@@ -45,6 +46,7 @@ xds:
         edsClusterConfig:
           edsConfig:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           serviceName: grpcroute/default/backend/rule/0
         ignoreHealthOnHostRemoval: true
@@ -84,6 +86,7 @@ xds:
         edsClusterConfig:
           edsConfig:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           serviceName: tcproute/default/backend/rule/-1
         ignoreHealthOnHostRemoval: true
@@ -116,6 +119,7 @@ xds:
         edsClusterConfig:
           edsConfig:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           serviceName: tlsroute/default/backend/rule/-1
         ignoreHealthOnHostRemoval: true
@@ -148,6 +152,7 @@ xds:
         edsClusterConfig:
           edsConfig:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           serviceName: udproute/default/backend/rule/-1
         ignoreHealthOnHostRemoval: true

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.json
@@ -358,6 +358,7 @@
                 "edsClusterConfig": {
                   "edsConfig": {
                     "ads": {},
+                    "initialFetchTimeout": "0s",
                     "resourceApiVersion": "V3"
                   },
                   "serviceName": "httproute/envoy-gateway-system/backend/rule/0"

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.all.yaml
@@ -202,6 +202,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: httproute/envoy-gateway-system/backend/rule/0
           ignoreHealthOnHostRemoval: true

--- a/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/jwt-single-route-single-match-to-xds.cluster.yaml
@@ -13,6 +13,7 @@ xds:
         edsClusterConfig:
           edsConfig:
             ads: {}
+            initialFetchTimeout: 0s
             resourceApiVersion: V3
           serviceName: httproute/envoy-gateway-system/backend/rule/0
         ignoreHealthOnHostRemoval: true

--- a/internal/cmd/egctl/testdata/translate/out/no-service-cluster-ip.all.yaml
+++ b/internal/cmd/egctl/testdata/translate/out/no-service-cluster-ip.all.yaml
@@ -202,6 +202,7 @@ xds:
           edsClusterConfig:
             edsConfig:
               ads: {}
+              initialFetchTimeout: 0s
               resourceApiVersion: V3
             serviceName: httproute/envoy-gateway-system/routes/rule/0
           ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/cluster.go
+++ b/internal/xds/translator/cluster.go
@@ -544,6 +544,7 @@ func buildXdsCluster(args *xdsClusterArgs) (*buildClusterResult, error) {
 				ConfigSourceSpecifier: &corev3.ConfigSource_Ads{
 					Ads: &corev3.AggregatedConfigSource{},
 				},
+				InitialFetchTimeout: durationpb.New(0),
 			},
 		}
 	default:

--- a/internal/xds/translator/testdata/out/extension-xds-ir/extensionpolicy-tcp-udp-http.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/extensionpolicy-tcp-udp-http.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: http-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: udp-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-error.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-error.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: custom-backend-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-multiple-backend-error.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backend-multiple-backend-error.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: custom-backend-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backends-multiple-mixed.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-custom-backends-multiple-mixed.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: custom-backend-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-filter.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-listener-error.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-listener-error.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-route-error.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-route-error.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: extension-post-xdsroute-hook-error-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-translate-error.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-translate-error.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fail-close-error
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-virtualhost-error.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route-extension-virtualhost-error.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/http-route.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/extension-xds-ir/multiple-listeners-same-port-error.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/multiple-listeners-same-port-error.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/extension-xds-ir/post-translate-listeners-routes.clusters.yaml
+++ b/internal/xds/translator/testdata/out/extension-xds-ir/post-translate-listeners-routes.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: test-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-als-tcp.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-als-tcp.clusters.yaml
@@ -8,6 +8,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: accesslog/monitoring/envoy-als/port/9000
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-cel.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-cel.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-endpoint-stats.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-formatters.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-multi-cel.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-multi-cel.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-otel-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-otel-headers.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-types.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-types.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: accesslog_als_0_1
   ignoreHealthOnHostRemoval: true
@@ -60,6 +62,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: accesslog_als_0_2
   ignoreHealthOnHostRemoval: true
@@ -90,6 +93,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: accesslog_als_1_1
   ignoreHealthOnHostRemoval: true
@@ -120,6 +124,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: accesslog_als_1_2
   ignoreHealthOnHostRemoval: true
@@ -150,6 +155,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: accesslog_als_2_1
   ignoreHealthOnHostRemoval: true
@@ -180,6 +186,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: accesslog_als_2_2
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog-with-format.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog-with-format.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: accesslog/monitoring/envoy-als/port/9000
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/accesslog.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true
@@ -37,6 +38,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: accesslog/monitoring/envoy-als/port/9000
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/admission-control.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/admission-control.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -66,6 +67,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -118,6 +120,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/api-key-auth.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/api-key-auth.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-cel.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-cel.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-client-cidr.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-client-cidr.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-3/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-http-header.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-http-header.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-claim.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-jwt-scope.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-multiple-principals.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-multiple-principals.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/authorization-path.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/authorization-path.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-buffer-limit.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: udp-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/backend-preconnect.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-preconnect.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -33,6 +34,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -59,6 +61,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/backend-priority.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-priority.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/default/policy-for-http-route/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/backend-tls-settings.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-tls-settings.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -91,6 +92,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -170,6 +172,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-3/rule/0
   ignoreHealthOnHostRemoval: true
@@ -254,6 +257,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-4/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/backend-tls-skip-verify.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-tls-skip-verify.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/backend-with-auto-san-sni.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/backend-with-auto-san-sni.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: auto-sni-route-dest
   ignoreHealthOnHostRemoval: true
@@ -66,6 +67,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: auto-sni-san-route-dest
   ignoreHealthOnHostRemoval: true
@@ -122,6 +124,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: mixed-sni-route
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/bandwidth-limit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/bandwidth-limit.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth-username-header.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth-username-header.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/basic-auth.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/basic-auth.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/btp-telemetry.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/btp-telemetry.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/circuit-breaker.clusters.yaml
@@ -16,6 +16,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-buffer-limit.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-ip-detection.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/client-listener-scoped-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-listener-scoped-timeout.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/client-stream-idle-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-stream-idle-timeout.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/client-timeout.clusters.yaml
@@ -55,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/compression.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/compression.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/compressor.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/compressor.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/cors-from-httpcorsfilter.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/cors-from-httpcorsfilter.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/cors.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/cors.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/credential-injection-backend-filter.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/credential-injection-backend-filter.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1/backend/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1/backend/1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/credential-injection.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/credential-injection.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/2
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/csrf.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/csrf.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/custom-response-source.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-response-source.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-local/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-backend/rule/0
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-all/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/custom-response.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/custom-response.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/dynamicmodule.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/dynamicmodule.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-3/rule/0
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-4/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-backend.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-body.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-body.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-http-retry.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-http-retry.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-http-route-1/default/http-backend
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-path-override.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-path-override.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-recomputation.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-retry.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-retry.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
   ignoreHealthOnHostRemoval: true
@@ -107,6 +111,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth-with-weighted-backend-ref.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth-with-weighted-backend-ref.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
   ignoreHealthOnHostRemoval: true
@@ -83,6 +86,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ext-auth.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-auth.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-http-route-1/default/grpc-backend
   ignoreHealthOnHostRemoval: true
@@ -106,6 +110,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-gateway-1/envoy-gateway/http-backend
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-health-check-log.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-health-check-log.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/default/policy-for-http-route/extproc/0
   healthChecks:

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-retries.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-retries.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -54,6 +56,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/default/policy-for-http-route/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc-with-traffic-settings.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -54,6 +56,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/default/policy-for-http-route/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ext-proc.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ext-proc.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-3/rule/0
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/default/policy-for-route-2/0/grpc-backend-4
   ignoreHealthOnHostRemoval: true
@@ -106,6 +110,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/default/policy-for-route-1/0/grpc-backend-2
   ignoreHealthOnHostRemoval: true
@@ -136,6 +141,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/envoy-gateway/policy-for-gateway-2/0/grpc-backend-3
   ignoreHealthOnHostRemoval: true
@@ -166,6 +172,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/envoy-gateway/policy-for-gateway-1/0/grpc-backend
   ignoreHealthOnHostRemoval: true
@@ -196,6 +203,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: envoyextensionpolicy/envoy-gateway/policy-for-route-3/0/grpc-backend-3
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/fault-injection.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/fault-injection.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fifth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/geoip-authorization-direct-source-ip.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/geoip-authorization-direct-source-ip.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-geo/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/geoip-authorization.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/geoip-authorization.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-plain/rule/0
   ignoreHealthOnHostRemoval: true
@@ -37,6 +38,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-geo/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-query-parameters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-query-parameters.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-disable-request-id.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-disable-request-id.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-generate-request-id.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-generate-request-id.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-or-generate-request-id.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-or-generate-request-id.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-request-id.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-preserve-request-id.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/headers-with-underscores-action.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/headers-with-underscores-action.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/health-check-backend-log-variants.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check-backend-log-variants.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-1-dest
   healthChecks:
@@ -48,6 +49,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-2-dest
   healthChecks:
@@ -88,6 +90,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-3-dest
   healthChecks:

--- a/internal/xds/translator/testdata/out/xds-ir/health-check-log-precedence.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check-log-precedence.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-override-dest
   healthChecks:
@@ -42,6 +43,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-gateway-dest
   healthChecks:
@@ -78,6 +80,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-no-hc-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/health-check-with-overrides.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check-with-overrides.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: overrides-first-route-dest
   healthChecks:
@@ -41,6 +42,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: no-overrides-first-route-dest
   healthChecks:

--- a/internal/xds/translator/testdata/out/xds-ir/health-check.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/health-check.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   healthChecks:
@@ -56,6 +57,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   healthChecks:
@@ -108,6 +110,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   healthChecks:
@@ -149,6 +152,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   healthChecks:
@@ -191,6 +195,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fifth-route-dest
   healthChecks:

--- a/internal/xds/translator/testdata/out/xds-ir/host-normalization.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/host-normalization.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-connect-proxy.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-connect-proxy.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-connect-terminate.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-connect-terminate.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-early-header-mutation.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-early-header-mutation.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -40,6 +41,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-endpoint-stats.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-health-check.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-health-check.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-late-header-add-if-absent.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-late-header-add-if-absent.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-late-header-mutation.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-late-header-mutation.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -40,6 +41,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-match-upstream-scheme.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-match-upstream-scheme.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-preserve-client-protocol.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-preserve-client-protocol.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-req-resp-sizes-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-req-resp-sizes-stats.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-https-mtls-accept-untrusted.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-https-mtls-accept-untrusted.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-https-mtls-allow-expired-cert.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-https-mtls-allow-expired-cert.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-metrics-stat.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-metrics-stat.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirror.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: mirror-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-mirrors-percentage.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-mirrors-percentage.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: mirror-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-matches.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fifth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -122,6 +127,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: sixth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -145,6 +151,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: seventh-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors-percentage.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors-percentage.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: mirror-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: mirror-route-dest1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-mirrors.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: mirror-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: mirror-route-dest1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore-per-resource-secret.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore-per-resource-secret.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -65,6 +66,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -123,6 +125,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls-3/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-multiple-system-truststore.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -65,6 +66,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -123,6 +125,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls-3/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-partial-invalid.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: valid-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-redirect.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: redirect-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-regex.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: regex-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-request-headers.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: request-header-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-headers.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: response-header-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-add-remove-headers.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: response-header-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-response-remove-headers.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: response-header-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-root-path-url-prefix.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: rewrite-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-sufixx-with-slash-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-sufixx-with-slash-url-prefix.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: rewrite-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-fullpath.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: rewrite-route
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host-no-append-x-forwarded-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host-no-append-x-forwarded-host.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: rewrite-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-host.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: rewrite-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix-with-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix-with-weighted-backend.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest/backend/1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-prefix.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: rewrite-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-regex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-rewrite-url-regex.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: rewrite-route
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: regex-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-stat-name.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-stat-name.clusters.yaml
@@ -8,6 +8,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-timeout.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fifth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -122,6 +127,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: sixth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -145,6 +151,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: seventh-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-uds-ip.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-uds-ip.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-filters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-filters.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest/backend/1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-url-rewrite.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend-with-url-rewrite.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: url-rewrite-route-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: url-rewrite-route-dest/backend/1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-backend.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-invalid-backend.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest/backend/1
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest/backend/1
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -122,6 +127,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest/backend/1
   ignoreHealthOnHostRemoval: true
@@ -145,6 +151,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest/backend/2
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-zones.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-weighted-zones.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-with-weighted-zones-roundrobin-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-with-weighted-zones-maglev-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -52,6 +54,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-with-weighted-zones-backend-utilization-dest/backend/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-clientcert.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-clientcert.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-metadata.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-metadata.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -40,6 +41,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore-per-resource-secret.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore-per-resource-secret.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tls-system-truststore.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle-multiple-certs.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle-multiple-certs.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls/rule/0
   ignoreHealthOnHostRemoval: true
@@ -86,6 +87,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-tlsbundle.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-with-trafficpolicy-metadta.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-with-trafficpolicy-metadta.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: grpcroute/default/grpcroute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-zonal-lb-routing.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-zonal-lb-routing.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-with-settings-preferlocal-dest
   ignoreHealthOnHostRemoval: true
@@ -35,6 +36,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-with-lb-preferlocal-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -59,6 +61,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: route-with-lb-and-settings-preferlocal-dest/backend/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-zonal-routing-weighted-clusters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-zonal-routing-weighted-clusters.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -33,6 +34,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest/backend/1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-zonal-routing.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-zonal-routing.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-upgrade-spdy.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-upgrade-spdy.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http-upgrade-websocket-spdy.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-upgrade-websocket-spdy.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http1-ignore-http11-upgrade.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-ignore-http11-upgrade.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-preserve-case.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -40,6 +41,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http1-trailers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http1-trailers.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http10.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http10.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http2-keepalive.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-keepalive.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http2-mixed.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-mixed.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest/backend/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2-route.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -45,6 +46,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -75,6 +77,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -108,6 +111,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http2.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http2.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/http3.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http3.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/httproute-with-tls-and-http.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/httproute-with-tls-and-http.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/httproute-with-tls-and-tls-handshake-timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/httproute-with-tls-and-tls-handshake-timeout.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-empty-jsonpath.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-add-op-without-value.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-invalid-patch.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-missing-resource.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-move-op-with-value.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-system-truststore-enforcement.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-system-truststore-enforcement.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-btls/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath-invalid.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch-with-jsonpath.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jsonpatch.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jsonpatch.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-allow-missing-or-failed.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-allow-missing-or-failed.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-custom-extractor.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-from-multiple-listeners.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/ns1/domain1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -85,6 +86,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/ns2/domain2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-multi-provider.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-www.test.com-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-www.test.com-dest
   ignoreHealthOnHostRemoval: true
@@ -90,6 +92,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: "192_168_1_250_8080"
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-multi-route-single-provider.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-optional.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-optional.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-ratelimit.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: "192_168_1_250_443"
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-single-route-single-match.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/jwt-with-backend-tls-retry.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/listener-connection-limit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-connection-limit.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: sixth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-route-dest
   ignoreHealthOnHostRemoval: true
@@ -122,6 +127,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-dest
   ignoreHealthOnHostRemoval: true
@@ -145,6 +151,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-dest-2
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/listener-enable-fingerprint.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-enable-fingerprint.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/listener-overlapping-tls-config.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-overlapping-tls-config.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/envoy-gateway/httproute-3/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol-multi.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol-multi.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-proxy-protocol.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/listener-tcp-keepalive.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/load-balancer-backend-utilization-out-of-band.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/load-balancer-backend-utilization-out-of-band.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: backend-utilization-oob-dest
   ignoreHealthOnHostRemoval: true
@@ -34,6 +35,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: backend-utilization-oob-defaults-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/load-balancer-endpointoverride-backend-utilization-weighted-zones.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/load-balancer-endpointoverride-backend-utilization-weighted-zones.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: backend-utilization-weighted-zones-endpoint-override-dest/backend/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/load-balancer.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -97,6 +101,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fifth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -122,6 +127,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: sixth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -147,6 +153,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: seventh-route-dest
   ignoreHealthOnHostRemoval: true
@@ -168,6 +175,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: eighth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -190,6 +198,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: ninth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -211,6 +220,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tenth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -232,6 +242,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: eleventh-route-dest
   ignoreHealthOnHostRemoval: true
@@ -261,6 +272,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: twelfth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -290,6 +302,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: thirteen-route-dest
   ignoreHealthOnHostRemoval: true
@@ -319,6 +332,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourteenth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -340,6 +354,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fifteenth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -361,6 +376,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: sixteenth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -390,6 +406,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: seventeenth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-distinct.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-distinct.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-duplicate-cidr.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-duplicate-cidr.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-method-match.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-method-match.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: post-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: get-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: put-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: delete-dest
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: multi-method-dest
   ignoreHealthOnHostRemoval: true
@@ -122,6 +127,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: premium-post-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-path-match.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-path-match.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: api-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: admin-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: versioned-api-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: premium-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-query-parameters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-query-parameters.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-shadow-mode.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit-shadow-mode.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/local-ratelimit.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/lua.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/lua.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/max-conn-per-socket-event.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/max-conn-per-socket-event.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: max-accept-disabled
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: max-accept-default
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-duplicate-backend-weighted.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-duplicate-backend-weighted.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-1/8080/http
   ignoreHealthOnHostRemoval: true
@@ -38,6 +39,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-2/8080/http
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-gateway-traffic.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-gateway-traffic.clusters.yaml
@@ -8,6 +8,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-1/8080/http
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-health-check-log.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-health-check-log.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-1/8080/http
   healthChecks:

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-healthcheck-hostname.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-healthcheck-hostname.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: shared-cluster
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-mixed-merge-multi-filtered.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-mixed-merge-multi-filtered.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/http-route-mixed/rule/0/backend/1
   ignoreHealthOnHostRemoval: true
@@ -37,6 +38,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/http-route-mixed/rule/0/backend/2
   ignoreHealthOnHostRemoval: true
@@ -67,6 +69,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-1/8080/http
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-mixed-merge-weighted.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-mixed-merge-weighted.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/http-route-mixed/rule/0/backend/1
   ignoreHealthOnHostRemoval: true
@@ -37,6 +38,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-1/8080/http
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-selector-mixed-match.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-selector-mixed-match.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/http-route-1/rule/1
   ignoreHealthOnHostRemoval: true
@@ -37,6 +38,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-selected/8080/http
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster-grpc.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster-grpc.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-1/8080/grpc
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster-tcp.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster-tcp.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-3/8163/tcp
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster-tls.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-3/8163/tcp
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster-udp.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster-udp.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-2/8162/udp
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-shared-cluster.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-1/8080/http
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-statname.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-statname.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: shared-cluster
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-weight-per-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-weight-per-route.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/http-route-a/rule/0/backend/1
   ignoreHealthOnHostRemoval: true
@@ -37,6 +38,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/http-route-b/rule/0/backend/1
   ignoreHealthOnHostRemoval: true
@@ -67,6 +69,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/shared-service/8080/http
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/merge-backends-weighted-mixed.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/merge-backends-weighted-mixed.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/http-route-1/rule/0/backend/1
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: service/default/service-1/8080/http
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/metrics-virtual-host.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-tls-jwt-authn.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/mixed-websocket-and-h2c-backends.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mixed-websocket-and-h2c-backends.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: weighted-protocol-route-dest/backend/0
   ignoreHealthOnHostRemoval: true
@@ -35,6 +36,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: weighted-protocol-route-dest/backend/1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port-with-different-filters.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: securitypolicy/default/policy-for-http-route-2/envoy-gateway/http-backend
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-3/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-listeners-same-port.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-dest
   ignoreHealthOnHostRemoval: true
@@ -122,6 +127,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/multiple-simple-tcp-route-same-port.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-simple-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-simple-1-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-simple-2-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-simple-3-dest
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-simple-4-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate-with-custom-data.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fifth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-forward-client-certificate.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fifth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-required-client-certificate-disabled.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-terminate-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls-san.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls-san.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-terminate-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/mutual-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/mutual-tls.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-terminate-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-and-jwt-with-passthrough.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-backend-cluster-provider.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/oidc-provider-traffic-features.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc-provider-traffic-features.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/oidc.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/panic-threshold.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/panic-threshold.clusters.yaml
@@ -9,6 +9,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -34,6 +35,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -59,6 +61,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -82,6 +85,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -107,6 +111,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fifth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/passive-failure-percentage.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/passive-failure-percentage.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: dest-1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/path-settings.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/path-settings.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream-with-backend-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream-with-backend-tls.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/proxy-protocol-upstream.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-both-type.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-both-type.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-custom-domain.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-disable-headers.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-endpoint-stats.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -32,6 +33,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -57,6 +59,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-global-shared.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-global-shared.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -32,6 +33,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -57,6 +59,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -82,6 +85,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -107,6 +111,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fifth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-headers-and-cidr.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-merge-hostnames.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-merge-hostnames.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-multi-global-shared.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-multi-global-shared.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -32,6 +33,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -57,6 +59,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-per-rule-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-per-rule-headers.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -37,6 +38,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip-invert.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip-invert.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit-sourceip.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/ratelimit.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -76,6 +79,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true
@@ -99,6 +103,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fifth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/request-buffer.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/request-buffer.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/request-id-extension.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/request-id-extension.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -40,6 +41,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -63,6 +65,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: third-route-dest
   ignoreHealthOnHostRemoval: true
@@ -86,6 +89,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: fourth-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry-partial-invalid.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/retry.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/retry.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/sds-listener.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/sds-listener.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: test1-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: test2-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: test3-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/sds.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/sds.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/securitypolicy-with-oidc-jwt-authz.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/service-cluster.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/service-cluster.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -33,6 +34,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: envoy-gateway-gateway-1-196ae069
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/simple-tls.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/suppress-envoy-headers.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-endpoint-stats.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-simple-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-listener-ipfamily.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-listener-ipfamily.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-dual-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-req-resp-sizes-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-req-resp-sizes-stats.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-simple-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-authorization.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-authorization.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-authorization-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-complex.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-complex-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-metrics-stat.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-metrics-stat.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-simple-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-simple.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-simple-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-tls-terminate.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-terminate-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-terminate-hostname-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcp-route-weighted-backend.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcp-route-weighted-backend-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tcproute-mtls.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tcproute-mtls.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcproute/default/tcproute-1/rule/-1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/timeout.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/timeout.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-passthrough.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-passthrough-foo-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tls-route-termination.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-route-termination.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-termination-foo-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tls-with-ciphers-versions-alpn.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tls-terminate-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-datadog-uds.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-datadog-uds.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tracing-0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-datadog.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-datadog.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-endpoint-stats.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-health-check-log.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-health-check-log.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -31,6 +32,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tracing
   healthChecks:

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-otel-headers.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-otel-headers.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-otel-sampler-always-on.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-otel-sampler-always-on.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-otel-sampler.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-otel-sampler.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-span-name.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-span-name.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -37,6 +38,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tracing-zipkin.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing-zipkin.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/tracing.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: direct-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/udp-endpoint-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-endpoint-stats.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: udp-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/udp-req-resp-sizes-stats.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-req-resp-sizes-stats.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: udp-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/udp-route-no-endpoints.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-route-no-endpoints.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: udproute/default/udproute-1/rule/-1
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/udp-route.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: udp-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/upstream-tcpkeepalive.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/wasm.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/wasm.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-2/rule/0
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/websocket-backend-force-http1-upstream.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/websocket-backend-force-http1-upstream.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: websocket-wss-route-dest
   ignoreHealthOnHostRemoval: true
@@ -62,6 +63,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: ordinary-tls-http-route-dest
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v1.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v1.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -83,6 +86,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tlsroute/default/tlsroute-1/rule/-1
   ignoreHealthOnHostRemoval: true
@@ -113,6 +117,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tlsroute/default/tlsroute-2/rule/-1
   ignoreHealthOnHostRemoval: true
@@ -136,6 +141,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcproute/default/tcproute
   ignoreHealthOnHostRemoval: true
@@ -166,6 +172,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: udproute/default/udproute
   ignoreHealthOnHostRemoval: true

--- a/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/xds-name-scheme-v2.clusters.yaml
@@ -7,6 +7,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: first-route-dest
   ignoreHealthOnHostRemoval: true
@@ -30,6 +31,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: second-route-dest
   ignoreHealthOnHostRemoval: true
@@ -53,6 +55,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: httproute/default/httproute-1/rule/0
   ignoreHealthOnHostRemoval: true
@@ -83,6 +86,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tlsroute/default/tlsroute-1/rule/-1
   ignoreHealthOnHostRemoval: true
@@ -113,6 +117,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tlsroute/default/tlsroute-2/rule/-1
   ignoreHealthOnHostRemoval: true
@@ -136,6 +141,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: tcproute/default/tcproute
   ignoreHealthOnHostRemoval: true
@@ -166,6 +172,7 @@
   edsClusterConfig:
     edsConfig:
       ads: {}
+      initialFetchTimeout: 0s
       resourceApiVersion: V3
     serviceName: udproute/default/udproute
   ignoreHealthOnHostRemoval: true

--- a/release-notes/current/bug_fixes/9713-eds-initial-fetch-timed-out.md
+++ b/release-notes/current/bug_fixes/9713-eds-initial-fetch-timed-out.md
@@ -1,0 +1,1 @@
+Fixed initial fetch timed out for type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment.

--- a/test/e2e/tests/backend_health_check.go
+++ b/test/e2e/tests/backend_health_check.go
@@ -71,10 +71,6 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 			passPromQL := fmt.Sprintf(`envoy_cluster_health_check_success{envoy_cluster_name="%s",gateway_envoyproxy_io_owning_gateway_name="%s"}`, passClusterName, gtwName)
 			failPromQL := fmt.Sprintf(`envoy_cluster_health_check_failure{envoy_cluster_name="%s",gateway_envoyproxy_io_owning_gateway_name="%s"}`, failClusterName, gtwName)
 
-			// Capture baseline before the loop to measure new failures relative to any
-			// stale counter left over from a previous test run.
-			baselineFailures, _ := promClient.QuerySum(ctx, failPromQL)
-
 			http.AwaitConvergence(
 				t,
 				suite.TimeoutConfig.RequiredConsecutiveSuccesses,
@@ -101,21 +97,22 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 			http.AwaitConvergence(
 				t,
 				suite.TimeoutConfig.RequiredConsecutiveSuccesses,
-				suite.TimeoutConfig.MaxTimeToConsistency*2,
+				suite.TimeoutConfig.MaxTimeToConsistency,
 				func(_ time.Duration) bool {
+					// check membership_healthy stats from Prometheus
 					v, err := promClient.QuerySum(ctx, failPromQL)
 					if err != nil {
 						// wait until Prometheus sync stats
 						return false
 					}
-					newFailures := v - baselineFailures
-					tlog.Logf(t, "cluster fail health check: new failure count: %v (total: %v)", newFailures, v)
+					tlog.Logf(t, "cluster fail health check: failure stats query count: %v", v)
 
-					// wait all endpoints unhealthy
-					if newFailures < 3 {
-						return false
+					if v == 0 {
+						t.Error("failure is not same as expected")
+					} else {
+						t.Log("failure is same as expected")
 					}
-					t.Log("failure is same as expected")
+
 					return true
 				},
 			)
@@ -145,9 +142,7 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 					Namespace: ns,
 				}
 
-				hcTimeoutConfig := suite.TimeoutConfig
-				hcTimeoutConfig.MaxTimeToConsistency = suite.TimeoutConfig.MaxTimeToConsistency * 2
-				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, hcTimeoutConfig, gwAddr, expectedResponse)
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 			})
 		})
 	},

--- a/test/e2e/tests/backend_health_check.go
+++ b/test/e2e/tests/backend_health_check.go
@@ -71,6 +71,10 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 			passPromQL := fmt.Sprintf(`envoy_cluster_health_check_success{envoy_cluster_name="%s",gateway_envoyproxy_io_owning_gateway_name="%s"}`, passClusterName, gtwName)
 			failPromQL := fmt.Sprintf(`envoy_cluster_health_check_failure{envoy_cluster_name="%s",gateway_envoyproxy_io_owning_gateway_name="%s"}`, failClusterName, gtwName)
 
+			// Capture baseline before the loop to measure new failures relative to any
+			// stale counter left over from a previous test run.
+			baselineFailures, _ := promClient.QuerySum(ctx, failPromQL)
+
 			http.AwaitConvergence(
 				t,
 				suite.TimeoutConfig.RequiredConsecutiveSuccesses,
@@ -97,21 +101,21 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 			http.AwaitConvergence(
 				t,
 				suite.TimeoutConfig.RequiredConsecutiveSuccesses,
-				suite.TimeoutConfig.MaxTimeToConsistency,
+				suite.TimeoutConfig.MaxTimeToConsistency*2,
 				func(_ time.Duration) bool {
 					v, err := promClient.QuerySum(ctx, failPromQL)
 					if err != nil {
 						// wait until Prometheus sync stats
 						return false
 					}
-					tlog.Logf(t, "cluster fail health check: failure stats query count: %v", v)
+					newFailures := v - baselineFailures
+					tlog.Logf(t, "cluster fail health check: new failure count: %v (total: %v)", newFailures, v)
 
-					if v == 0 {
-						t.Error("failure is not same as expected")
-					} else {
-						t.Log("failure is same as expected")
+					// wait all endpoints unhealthy
+					if newFailures < 3 {
+						return false
 					}
-
+					t.Log("failure is same as expected")
 					return true
 				},
 			)

--- a/test/e2e/tests/backend_health_check.go
+++ b/test/e2e/tests/backend_health_check.go
@@ -70,7 +70,6 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 			// we can use membership_healthy stats to check whether health check works as expected.
 			passPromQL := fmt.Sprintf(`envoy_cluster_health_check_success{envoy_cluster_name="%s",gateway_envoyproxy_io_owning_gateway_name="%s"}`, passClusterName, gtwName)
 			failPromQL := fmt.Sprintf(`envoy_cluster_health_check_failure{envoy_cluster_name="%s",gateway_envoyproxy_io_owning_gateway_name="%s"}`, failClusterName, gtwName)
-			failMembershipPromQL := fmt.Sprintf(`envoy_cluster_membership_healthy{envoy_cluster_name="%s",gateway_envoyproxy_io_owning_gateway_name="%s"}`, failClusterName, gtwName)
 
 			http.AwaitConvergence(
 				t,
@@ -98,9 +97,8 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 			http.AwaitConvergence(
 				t,
 				suite.TimeoutConfig.RequiredConsecutiveSuccesses,
-				suite.TimeoutConfig.MaxTimeToConsistency*2,
+				suite.TimeoutConfig.MaxTimeToConsistency,
 				func(_ time.Duration) bool {
-					// check membership_healthy stats from Prometheus
 					v, err := promClient.QuerySum(ctx, failPromQL)
 					if err != nil {
 						// wait until Prometheus sync stats
@@ -110,17 +108,11 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 
 					if v == 0 {
 						t.Error("failure is not same as expected")
-						return false
+					} else {
+						t.Log("failure is same as expected")
 					}
-					t.Log("failure is same as expected")
 
-					// Wait until all endpoints are marked unhealthy before asserting 503.
-					healthy, err := promClient.QuerySum(ctx, failMembershipPromQL)
-					if err != nil {
-						return false
-					}
-					tlog.Logf(t, "cluster fail membership_healthy: %v", healthy)
-					return healthy == 0
+					return true
 				},
 			)
 
@@ -149,7 +141,9 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 					Namespace: ns,
 				}
 
-				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
+				hcTimeoutConfig := suite.TimeoutConfig
+				hcTimeoutConfig.MaxTimeToConsistency = suite.TimeoutConfig.MaxTimeToConsistency * 2
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, hcTimeoutConfig, gwAddr, expectedResponse)
 			})
 		})
 	},

--- a/test/e2e/tests/backend_health_check.go
+++ b/test/e2e/tests/backend_health_check.go
@@ -98,7 +98,7 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 			http.AwaitConvergence(
 				t,
 				suite.TimeoutConfig.RequiredConsecutiveSuccesses,
-				suite.TimeoutConfig.MaxTimeToConsistency,
+				suite.TimeoutConfig.MaxTimeToConsistency*2,
 				func(_ time.Duration) bool {
 					// check membership_healthy stats from Prometheus
 					v, err := promClient.QuerySum(ctx, failPromQL)

--- a/test/e2e/tests/backend_health_check.go
+++ b/test/e2e/tests/backend_health_check.go
@@ -70,6 +70,7 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 			// we can use membership_healthy stats to check whether health check works as expected.
 			passPromQL := fmt.Sprintf(`envoy_cluster_health_check_success{envoy_cluster_name="%s",gateway_envoyproxy_io_owning_gateway_name="%s"}`, passClusterName, gtwName)
 			failPromQL := fmt.Sprintf(`envoy_cluster_health_check_failure{envoy_cluster_name="%s",gateway_envoyproxy_io_owning_gateway_name="%s"}`, failClusterName, gtwName)
+			failMembershipPromQL := fmt.Sprintf(`envoy_cluster_membership_healthy{envoy_cluster_name="%s",gateway_envoyproxy_io_owning_gateway_name="%s"}`, failClusterName, gtwName)
 
 			http.AwaitConvergence(
 				t,
@@ -109,11 +110,17 @@ var BackendHealthCheckActiveHTTPTest = suite.ConformanceTest{
 
 					if v == 0 {
 						t.Error("failure is not same as expected")
-					} else {
-						t.Log("failure is same as expected")
+						return false
 					}
+					t.Log("failure is same as expected")
 
-					return true
+					// Wait until all endpoints are marked unhealthy before asserting 503.
+					healthy, err := promClient.QuerySum(ctx, failMembershipPromQL)
+					if err != nil {
+						return false
+					}
+					tlog.Logf(t, "cluster fail membership_healthy: %v", healthy)
+					return healthy == 0
 				},
 			)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
the initial_fetch_timeout: 0s will disable timeout in envoy. however, that setting only applies to [LDS and CDS](https://github.com/envoyproxy/gateway/blob/6c72ce4ee828442db4061a2f41108a7f64e06df5/internal/xds/bootstrap/bootstrap.yaml.tpl#L67C5-L71C30), not to EDS. It caused initial fetch timed out for type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment.

the sds_config can't be added in to [dynamic_resources](https://github.com/envoyproxy/gateway/blob/6c72ce4ee828442db4061a2f41108a7f64e06df5/internal/xds/bootstrap/bootstrap.yaml.tpl#L57). the config.bootstrap.v3.Bootstrap.DynamicResources only has [three fields](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/bootstrap/v3/bootstrap.proto#config-bootstrap-v3-bootstrap-dynamicresources) listed below. the EDS go through xDS discovery.
{
"lds_config": {...},
"cds_config": {...},
"ads_config": {...}
}
This PR set EDS default InitialFetchTimeout as 0 to mitigate the issue.

**Which issue(s) this PR fixes**:
Fixes #9712

---

**PR Checklist**
- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: N/A. this PR does not contain API changes.
- [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (Flaky e2e failures are not considered breakages, but `gen-check`, `lint`, and coverage **MUST** pass.)
- [x] **Tests added/updated**: New/changed code is covered by appropriate tests. N/A if this PR does not contain code changes.
- [x] **Docs**: N/A. this PR does not contain user-facing changes.
- [x] **Release notes**: For any non-trivial change, added a release-note fragment under `release-notes/current/<section>/<pr-number>-<slug>.md` (see `release-notes/current/README.md` for sections and naming). N/A if this PR does not contain non-trivial changes.
- [x] **Generated files committed**: Ran `make gen-check` and committed the result if API/helm charts/modules changed.
- [x] **Scope & compatibility**: The PR is reasonably scoped (no unrelated changes) and preserves backward compatibility, or any breaking change is called out above and documented in `release-notes/current/breaking_changes/`.
- [x] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.
