### PR TITLE
fix: add default memory limit to shutdown-manager container

### DIFF
--- a/api/v1alpha1/envoyproxy_helpers.go
+++ b/api/v1alpha1/envoyproxy_helpers.go
@@ -179,6 +179,9 @@ func DefaultShutdownManagerContainerResourceRequirements() *corev1.ResourceRequi
 			corev1.ResourceCPU:    resource.MustParse(DefaultShutdownManagerCPUResourceRequests),
 			corev1.ResourceMemory: resource.MustParse(DefaultShutdownManagerMemoryResourceRequests),
 		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse(DefaultShutdownManagerMemoryResourceLimits),
+		},
 	}
 }
 

--- a/api/v1alpha1/envoyproxy_helpers_test.go
+++ b/api/v1alpha1/envoyproxy_helpers_test.go
@@ -1,0 +1,32 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestDefaultShutdownManagerContainerResourceRequirements(t *testing.T) {
+	got := DefaultShutdownManagerContainerResourceRequirements()
+
+	assert.Equal(t, corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(DefaultShutdownManagerCPUResourceRequests),
+			corev1.ResourceMemory: resource.MustParse(DefaultShutdownManagerMemoryResourceRequests),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse(DefaultShutdownManagerMemoryResourceLimits),
+		},
+	}, *got)
+
+	// A CPU limit is intentionally not set to avoid CPU throttling.
+	_, hasCPULimit := got.Limits[corev1.ResourceCPU]
+	assert.False(t, hasCPULimit)
+}

--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -31,6 +31,9 @@ const (
 	DefaultShutdownManagerCPUResourceRequests = "10m"
 	// DefaultShutdownManagerMemoryResourceRequests for shutdown manager memory resource
 	DefaultShutdownManagerMemoryResourceRequests = "32Mi"
+	// DefaultShutdownManagerMemoryResourceLimits for shutdown manager memory resource limit.
+	// A CPU limit is intentionally not set to avoid CPU throttling.
+	DefaultShutdownManagerMemoryResourceLimits = "64Mi"
 	// DefaultShutdownManagerImage is the default image used for the shutdown manager.
 	DefaultShutdownManagerImage = "docker.io/envoyproxy/gateway-dev:latest"
 	// DefaultRateLimitImage is the default image used by ratelimit.

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
@@ -187,6 +187,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom-sa.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom-sa.yaml
@@ -369,6 +369,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
@@ -361,6 +361,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
@@ -360,6 +360,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
@@ -351,6 +351,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
@@ -297,6 +297,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
@@ -364,6 +364,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
@@ -369,6 +369,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
@@ -360,6 +360,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
@@ -351,6 +351,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
@@ -351,6 +351,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
@@ -364,6 +364,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
@@ -356,6 +356,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
@@ -189,6 +189,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
@@ -355,6 +355,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
@@ -351,6 +351,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
@@ -351,6 +351,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
@@ -351,6 +351,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-priority-class-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-priority-class-name.yaml
@@ -351,6 +351,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
@@ -351,6 +351,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -191,6 +191,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level-off.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level-off.yaml
@@ -191,6 +191,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -191,6 +191,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
@@ -373,6 +373,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -366,6 +366,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -368,6 +368,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -365,6 +365,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -355,6 +355,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -301,6 +301,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
@@ -356,6 +356,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -369,6 +369,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
@@ -373,6 +373,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
@@ -356,6 +356,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -364,6 +364,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
@@ -357,6 +357,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -355,6 +355,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -369,6 +369,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -360,6 +360,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -193,6 +193,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -354,6 +354,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -359,6 +359,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-hpa.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-hpa.yaml
@@ -355,6 +355,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -355,6 +355,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
@@ -355,6 +355,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -355,6 +355,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-priority-class-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-priority-class-name.yaml
@@ -355,6 +355,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -355,6 +355,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
@@ -373,6 +373,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi
@@ -807,6 +809,8 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources:
+          limits:
+            memory: 64Mi
           requests:
             cpu: 10m
             memory: 32Mi

--- a/release-notes/current/other_changes/9716-shutdown-manager-default-memory-limit.md
+++ b/release-notes/current/other_changes/9716-shutdown-manager-default-memory-limit.md
@@ -1,0 +1,1 @@
+Added a default memory limit (64Mi) to the `shutdown-manager` container of the Envoy proxy Pod so that it has both resource requests and limits set by default, addressing complaints from security scanners that require all containers to declare limits. A CPU limit was intentionally not added to avoid CPU throttling.


### PR DESCRIPTION
<!--
Your PR title should be descriptive, and generally start with a type that contains a subsystem name with `()` if necessary
and a summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), the API must be discussed and
agreed before the implementation. We strongly recommend separating API changes into their own PR so
we can review the API first, but the API may also live in the same PR as long as it was agreed
beforehand. This will save you a lot of implementation time if the API gets accepted.
-->

**What this PR does / why we need it**:

The `shutdown-manager` sidecar container in the Envoy proxy Pod only has resource *requests*
(10m CPU, 32Mi memory) and no resource *limits*. This is flagged by security scanners / admission
policy engines (e.g. OPA-enforced policies) that require every container to declare limits, and it
also prevents the Pod from qualifying for the Kubernetes "Guaranteed" QoS class, since that requires
all containers to have both requests and limits set for CPU and memory.

In the issue discussion, maintainer @arkodg confirmed a memory limit makes sense here, but that a CPU
limit should **not** be added, to avoid CPU throttling of the shutdown-manager during graceful pod
shutdown.

This PR adds a default memory limit of `64Mi` (2x the existing `32Mi` memory request) to
`DefaultShutdownManagerContainerResourceRequirements()` in `api/v1alpha1/envoyproxy_helpers.go`. No
CPU limit is added. This only changes the default resource values the code already applies — it does
not add a new API field, so it does not require prior API design agreement.

Users who need to further customize shutdown-manager resources can continue to do so via an
`EnvoyProxy` deployment patch (`spec.provider.kubernetes.envoyDeployment.patch`), as already
documented in `site/content/en/latest/tasks/operations/customize-envoyproxy.md`; that mechanism is
unaffected by this change.

Note: there was a previous, now-closed/abandoned PR (#8042) attempting to fix this issue. It
additionally added a CPU limit (against the maintainer's explicit guidance in the issue thread) and a
new `Resources` API field on `ShutdownManager` (unrelated scope creep that drew maintainer pushback
for containing "a lot of unrelated changes"). This PR is deliberately narrower and only changes the
default memory limit.

**Which issue(s) this PR fixes**:
Fixes #7550

---

**PR Checklist**

- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: N/A this PR does not contain API changes (no new fields under `/api`; only a default resource value used internally changed).
- [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (Flaky e2e failures are not considered breakages, but `gen-check`, `lint`, and coverage **MUST** pass.)
- [x] **Tests added/updated**: Added `TestDefaultShutdownManagerContainerResourceRequirements` in `api/v1alpha1/envoyproxy_helpers_test.go`, and regenerated the affected golden test fixtures under `internal/infrastructure/kubernetes/proxy/testdata/`.
- [x] **Docs**: N/A this PR does not change any documented/user-facing API surface; the existing resource-override docs already cover customizing this container via patch and remain accurate.
- [x] **Release notes**: Added `release-notes/current/other_changes/9716-shutdown-manager-default-memory-limit.md`.
- [x] **Generated files committed**: N/A no API/helm chart/module changes requiring `make gen-check` regeneration.
- [x] **Scope & compatibility**: The PR is reasonably scoped (two Go files, one new Go test file, one release note, and mechanically-generated golden test fixture updates) and preserves backward compatibility — this only adds a previously-absent limit; requests are unchanged and existing user overrides via EnvoyProxy patches still work.
- [ ] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.

---
AI assistance: this change was drafted with Claude Code.