### PR TITLE
chore: ignore nvd.nist.gov

### DIFF
--- a/tools/make/docs.mk
+++ b/tools/make/docs.mk
@@ -10,6 +10,7 @@ LINKINATOR_IGNORE := "opentelemetry.io \
 	blog.envoyproxy.io \
 	envoyproxy.io/slack \
 	ntia.gov \
+	nvd.nist.gov \
 	github.com \
 	jwt.io \
 	githubusercontent.com \


### PR DESCRIPTION
nvd.nist.gov return 502 in doc-lint pipeline, https://github.com/envoyproxy/gateway/actions/runs/31379982976/job/93647377898