### PR TITLE
lint: enable staticcheck SA1019 and fix deprecated API usage

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -25,7 +25,7 @@ var (
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// localSchemeBuilder is used for controller-runtime compatibility
-	localSchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	localSchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion} //nolint:staticcheck
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/api/v1alpha1/validation/envoygateway_validate.go
+++ b/api/v1alpha1/validation/envoygateway_validate.go
@@ -68,7 +68,7 @@ func ValidateEnvoyGateway(eg *egv1a1.EnvoyGateway) error {
 		return err
 	}
 
-	if eg.ExtensionAPIs != nil && eg.ExtensionAPIs.DisableLua != nil && *eg.ExtensionAPIs.DisableLua == eg.ExtensionAPIs.EnableLua {
+	if eg.ExtensionAPIs != nil && eg.ExtensionAPIs.DisableLua != nil && *eg.ExtensionAPIs.DisableLua == eg.ExtensionAPIs.EnableLua { //nolint:staticcheck
 		return fmt.Errorf("disableLua and enableLua must not have the same value")
 	}
 
@@ -81,7 +81,7 @@ func WarnEnvoyGateway(eg *egv1a1.EnvoyGateway) []string {
 		return nil
 	}
 	var warnings []string
-	if eg.ExtensionAPIs.DisableLua != nil {
+	if eg.ExtensionAPIs.DisableLua != nil { //nolint:staticcheck
 		warnings = append(warnings, "disableLua is deprecated, use enableLua instead")
 	}
 	return warnings
@@ -415,12 +415,12 @@ func validateExtensionService(extensionService *egv1a1.ExtensionService) error {
 	}
 
 	switch {
-	case extensionService.Host == "" && extensionService.FQDN == nil && extensionService.Unix == nil && extensionService.IP == nil:
+	case extensionService.Host == "" && extensionService.FQDN == nil && extensionService.Unix == nil && extensionService.IP == nil: //nolint:staticcheck
 		return fmt.Errorf("extension service must contain a configured target")
 
-	case extensionService.FQDN != nil && (extensionService.IP != nil || extensionService.Unix != nil || extensionService.Host != ""),
-		extensionService.IP != nil && (extensionService.FQDN != nil || extensionService.Unix != nil || extensionService.Host != ""),
-		extensionService.Unix != nil && (extensionService.IP != nil || extensionService.FQDN != nil || extensionService.Host != ""):
+	case extensionService.FQDN != nil && (extensionService.IP != nil || extensionService.Unix != nil || extensionService.Host != ""), //nolint:staticcheck
+		extensionService.IP != nil && (extensionService.FQDN != nil || extensionService.Unix != nil || extensionService.Host != ""), //nolint:staticcheck
+		extensionService.Unix != nil && (extensionService.IP != nil || extensionService.FQDN != nil || extensionService.Host != ""): //nolint:staticcheck
 		return fmt.Errorf("only one backend target can be configured for the extension manager")
 	}
 

--- a/api/v1alpha1/validation/envoygateway_validate_test.go
+++ b/api/v1alpha1/validation/envoygateway_validate_test.go
@@ -366,8 +366,8 @@ func TestValidateEnvoyGateway(t *testing.T) {
 							},
 						},
 						Service: &egv1a1.ExtensionService{
-							Host: "foo.extension",
-							Port: 80,
+							Host: "foo.extension", //nolint:staticcheck
+							Port: 80,              //nolint:staticcheck
 						},
 					},
 				},
@@ -400,8 +400,8 @@ func TestValidateEnvoyGateway(t *testing.T) {
 							},
 						},
 						Service: &egv1a1.ExtensionService{
-							Host: "foo.extension",
-							Port: 443,
+							Host: "foo.extension", //nolint:staticcheck
+							Port: 443,             //nolint:staticcheck
 							TLS: &egv1a1.ExtensionTLS{
 								CertificateRef: gwapiv1.SecretObjectReference{
 									Kind: &TLSSecretKind,
@@ -437,8 +437,8 @@ func TestValidateEnvoyGateway(t *testing.T) {
 							},
 						},
 						Service: &egv1a1.ExtensionService{
-							Host: "foo.extension",
-							Port: 443,
+							Host: "foo.extension", //nolint:staticcheck
+							Port: 443,             //nolint:staticcheck
 							TLS: &egv1a1.ExtensionTLS{
 								CertificateRef: gwapiv1.SecretObjectReference{
 									Kind: &TLSSecretKind,
@@ -481,8 +481,8 @@ func TestValidateEnvoyGateway(t *testing.T) {
 							},
 						},
 						Service: &egv1a1.ExtensionService{
-							Host: "foo.extension",
-							Port: 8080,
+							Host: "foo.extension", //nolint:staticcheck
+							Port: 8080,            //nolint:staticcheck
 							TLS: &egv1a1.ExtensionTLS{
 								CertificateRef: gwapiv1.SecretObjectReference{
 									Kind: &TLSUnrecognizedKind,
@@ -544,8 +544,8 @@ func TestValidateEnvoyGateway(t *testing.T) {
 							},
 						},
 						Service: &egv1a1.ExtensionService{
-							Host: "foo.extension",
-							Port: 8080,
+							Host: "foo.extension", //nolint:staticcheck
+							Port: 8080,            //nolint:staticcheck
 						},
 					},
 				},
@@ -823,7 +823,7 @@ func TestValidateEnvoyGateway(t *testing.T) {
 							},
 						},
 						Service: &egv1a1.ExtensionService{
-							Port: 8080,
+							Port: 8080, //nolint:staticcheck
 						},
 					},
 				},
@@ -906,8 +906,8 @@ func TestValidateEnvoyGateway(t *testing.T) {
 							},
 						},
 						Service: &egv1a1.ExtensionService{
-							Host: "foo.example.com",
-							Port: 8080,
+							Host: "foo.example.com", //nolint:staticcheck
+							Port: 8080,              //nolint:staticcheck
 							BackendEndpoint: egv1a1.BackendEndpoint{
 								FQDN: &egv1a1.FQDNEndpoint{
 									Hostname: "foo.example.com",
@@ -932,7 +932,7 @@ func TestValidateEnvoyGateway(t *testing.T) {
 								Post: []egv1a1.XDSTranslatorHook{egv1a1.XDSRoute},
 							},
 						},
-						Service: &egv1a1.ExtensionService{Host: "foo.extension", Port: 80},
+						Service: &egv1a1.ExtensionService{Host: "foo.extension", Port: 80}, //nolint:staticcheck
 					},
 					ExtensionManagers: []egv1a1.ExtensionManager{
 						{
@@ -942,7 +942,7 @@ func TestValidateEnvoyGateway(t *testing.T) {
 									Post: []egv1a1.XDSTranslatorHook{egv1a1.XDSRoute},
 								},
 							},
-							Service: &egv1a1.ExtensionService{Host: "bar.extension", Port: 80},
+							Service: &egv1a1.ExtensionService{Host: "bar.extension", Port: 80}, //nolint:staticcheck
 						},
 					},
 				},
@@ -974,7 +974,7 @@ func TestValidateEnvoyGateway(t *testing.T) {
 									Post: []egv1a1.XDSTranslatorHook{egv1a1.XDSRoute},
 								},
 							},
-							Service: &egv1a1.ExtensionService{Host: "foo.extension", Port: 80},
+							Service: &egv1a1.ExtensionService{Host: "foo.extension", Port: 80}, //nolint:staticcheck
 						},
 						{
 							Name: "ext1",
@@ -983,7 +983,7 @@ func TestValidateEnvoyGateway(t *testing.T) {
 									Post: []egv1a1.XDSTranslatorHook{egv1a1.XDSRoute},
 								},
 							},
-							Service: &egv1a1.ExtensionService{Host: "bar.extension", Port: 80},
+							Service: &egv1a1.ExtensionService{Host: "bar.extension", Port: 80}, //nolint:staticcheck
 						},
 					},
 				},
@@ -1003,7 +1003,7 @@ func TestValidateEnvoyGateway(t *testing.T) {
 									Post: []egv1a1.XDSTranslatorHook{egv1a1.XDSRoute},
 								},
 							},
-							Service: &egv1a1.ExtensionService{Host: "foo.extension", Port: 80},
+							Service: &egv1a1.ExtensionService{Host: "foo.extension", Port: 80}, //nolint:staticcheck
 						},
 					},
 				},
@@ -1024,12 +1024,12 @@ func TestValidateEnvoyGateway(t *testing.T) {
 									Post: []egv1a1.XDSTranslatorHook{egv1a1.XDSRoute},
 								},
 							},
-							Service: &egv1a1.ExtensionService{Host: "good.extension", Port: 80},
+							Service: &egv1a1.ExtensionService{Host: "good.extension", Port: 80}, //nolint:staticcheck
 						},
 						{
 							Name: "bad-ext",
 							// Missing hooks → should fail individual validation
-							Service: &egv1a1.ExtensionService{Host: "bad.extension", Port: 80},
+							Service: &egv1a1.ExtensionService{Host: "bad.extension", Port: 80}, //nolint:staticcheck
 						},
 					},
 				},
@@ -1050,7 +1050,7 @@ func TestValidateEnvoyGateway(t *testing.T) {
 									Post: []egv1a1.XDSTranslatorHook{egv1a1.XDSRoute, egv1a1.XDSTranslation},
 								},
 							},
-							Service: &egv1a1.ExtensionService{Host: "ai-gw.extension", Port: 80},
+							Service: &egv1a1.ExtensionService{Host: "ai-gw.extension", Port: 80}, //nolint:staticcheck
 						},
 						{
 							Name: "observability",
@@ -1059,7 +1059,7 @@ func TestValidateEnvoyGateway(t *testing.T) {
 									Post: []egv1a1.XDSTranslatorHook{egv1a1.XDSHTTPListener},
 								},
 							},
-							Service: &egv1a1.ExtensionService{Host: "obs.extension", Port: 80},
+							Service: &egv1a1.ExtensionService{Host: "obs.extension", Port: 80}, //nolint:staticcheck
 						},
 					},
 				},
@@ -1417,7 +1417,7 @@ func TestWarnEnvoyGateway(t *testing.T) {
 					Gateway:  egv1a1.DefaultGateway(),
 					Provider: egv1a1.DefaultEnvoyGatewayProvider(),
 					ExtensionAPIs: &egv1a1.ExtensionAPISettings{
-						DisableLua: new(true),
+						DisableLua: new(true), //nolint:staticcheck
 					},
 				},
 			},
@@ -1469,17 +1469,17 @@ func TestLuaDisabled(t *testing.T) {
 		},
 		{
 			name:     "disableLua true",
-			ext:      &egv1a1.ExtensionAPISettings{DisableLua: new(true)},
+			ext:      &egv1a1.ExtensionAPISettings{DisableLua: new(true)}, //nolint:staticcheck
 			expected: true,
 		},
 		{
 			name:     "disableLua false (explicit enable via deprecated field)",
-			ext:      &egv1a1.ExtensionAPISettings{DisableLua: new(false)},
+			ext:      &egv1a1.ExtensionAPISettings{DisableLua: new(false)}, //nolint:staticcheck
 			expected: false,
 		},
 		{
 			name:     "enableLua takes precedence over disableLua",
-			ext:      &egv1a1.ExtensionAPISettings{EnableLua: true, DisableLua: new(true)},
+			ext:      &egv1a1.ExtensionAPISettings{EnableLua: true, DisableLua: new(true)}, //nolint:staticcheck
 			expected: false,
 		},
 	}

--- a/api/v1alpha1/validation/envoyproxy_validate_test.go
+++ b/api/v1alpha1/validation/envoyproxy_validate_test.go
@@ -443,8 +443,8 @@ func TestValidateEnvoyProxy(t *testing.T) {
 								{
 									Type: egv1a1.MetricSinkTypeOpenTelemetry,
 									OpenTelemetry: &egv1a1.ProxyOpenTelemetrySink{
-										Host: new("0.0.0.0"),
-										Port: 3217,
+										Host: new("0.0.0.0"), //nolint:staticcheck
+										Port: 3217,           //nolint:staticcheck
 									},
 								},
 							},

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/ohler55/ojg v1.28.5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/otlptranslator v1.0.0
 	github.com/replicatedhq/troubleshoot v0.133.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/spf13/cobra v1.10.2
@@ -72,6 +73,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad
 	k8s.io/kubectl v0.36.4
+	k8s.io/streaming v0.36.4
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/gateway-api v1.6.1
@@ -231,7 +233,6 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
-	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rubenv/sql-migrate v1.8.1 // indirect
@@ -283,7 +284,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/component-base v0.36.4 // indirect
 	k8s.io/metrics v0.36.4 // indirect
-	k8s.io/streaming v0.36.4 // indirect
 	oras.land/oras-go/v2 v2.6.2 // indirect
 	periph.io/x/host/v3 v3.8.5 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect

--- a/internal/crypto/cert_load.go
+++ b/internal/crypto/cert_load.go
@@ -6,7 +6,6 @@
 package crypto
 
 import (
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -49,7 +48,6 @@ func LoadTLSConfig(tlsCrt, tlsKey, caCrt string) (*tls.Config, error) {
 	return &tls.Config{
 		MinVersion: tls.VersionTLS13,
 		ClientAuth: tls.RequireAndVerifyClientCert,
-		Rand:       rand.Reader,
 		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
 			return loadConfig()
 		},
@@ -80,7 +78,6 @@ func LoadServerTLSConfig(tlsCrt, tlsKey string) (*tls.Config, error) {
 
 	return &tls.Config{
 		MinVersion: tls.VersionTLS13,
-		Rand:       rand.Reader,
 		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
 			return loadConfig()
 		},

--- a/internal/envoygateway/scheme.go
+++ b/internal/envoygateway/scheme.go
@@ -31,7 +31,7 @@ func init() {
 	// Add Gateway API types.
 	utilruntime.Must(gwapischeme.AddToScheme(scheme))
 	// Add mcs api types.
-	utilruntime.Must(mcsapiv1a1.AddToScheme(scheme))
+	utilruntime.Must(mcsapiv1a1.Install(scheme))
 	// Add CRD kind to known types, experimental conformance test requires this.
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 }

--- a/internal/extension/grpc.go
+++ b/internal/extension/grpc.go
@@ -57,9 +57,9 @@ func GetExtensionServerAddress(service *egv1a1.ExtensionService) string {
 	case service.Unix != nil:
 		serverAddr = fmt.Sprintf("unix://%s", service.Unix.Path)
 	case service.Hostname != nil:
-		serverAddr = net.JoinHostPort(*service.Hostname, strconv.Itoa(int(service.Port)))
-	case service.Host != "":
-		serverAddr = net.JoinHostPort(service.Host, strconv.Itoa(int(service.Port)))
+		serverAddr = net.JoinHostPort(*service.Hostname, strconv.Itoa(int(service.Port))) //nolint:staticcheck
+	case service.Host != "": //nolint:staticcheck
+		serverAddr = net.JoinHostPort(service.Host, strconv.Itoa(int(service.Port))) //nolint:staticcheck
 	}
 	return serverAddr
 }

--- a/internal/extension/grpc_test.go
+++ b/internal/extension/grpc_test.go
@@ -310,8 +310,8 @@ func TestGetExtensionServerAddress(t *testing.T) {
 		{
 			Name: "has a Unix path",
 			Service: &egv1a1.ExtensionService{
-				Host: "foo.bar",
-				Port: 5050,
+				Host: "foo.bar", //nolint:staticcheck
+				Port: 5050,      //nolint:staticcheck
 			},
 			Expected: "foo.bar:5050",
 		},

--- a/internal/extension/registry/extension_manager.go
+++ b/internal/extension/registry/extension_manager.go
@@ -148,7 +148,7 @@ func NewInMemoryManager(cfg *egv1a1.ExtensionManager, server extension.EnvoyGate
 		inMemoryManagerOpts = append(inMemoryManagerOpts, opts...)
 	}
 
-	conn, err := grpc.DialContext(context.Background(), "", inMemoryManagerOpts...)
+	conn, err := grpc.NewClient("passthrough:///", inMemoryManagerOpts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -231,7 +231,7 @@ func (m *Manager) GetPreXDSHookClient(xdsHookType egv1a1.XDSTranslatorHook) (ext
 			return nil, err
 		}
 
-		conn, err := grpc.Dial(serverAddr, opts...)
+		conn, err := grpc.NewClient(serverAddr, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -280,7 +280,7 @@ func (m *Manager) GetPostXDSHookClient(xdsHookType egv1a1.XDSTranslatorHook) (ex
 			return nil, err
 		}
 
-		conn, err := grpc.Dial(serverAddr, opts...)
+		conn, err := grpc.NewClient(serverAddr, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/extension/registry/extension_manager_test.go
+++ b/internal/extension/registry/extension_manager_test.go
@@ -68,7 +68,7 @@ func TestNewManager(t *testing.T) {
 						Resources: []egv1a1.GroupVersionKind{
 							{Group: "foo.io", Version: "v1", Kind: "Foo"},
 						},
-						Service: &egv1a1.ExtensionService{Host: "foo.svc", Port: 8080},
+						Service: &egv1a1.ExtensionService{Host: "foo.svc", Port: 8080}, //nolint:staticcheck
 					},
 				},
 			},
@@ -101,7 +101,7 @@ func TestNewManager(t *testing.T) {
 							BackendResources: []egv1a1.GroupVersionKind{
 								{Group: "foo.io", Version: "v1", Kind: "FooBackend"},
 							},
-							Service: &egv1a1.ExtensionService{Host: "foo.svc", Port: 8080},
+							Service: &egv1a1.ExtensionService{Host: "foo.svc", Port: 8080}, //nolint:staticcheck
 						},
 						{
 							Name: "ext2",
@@ -114,7 +114,7 @@ func TestNewManager(t *testing.T) {
 							BackendResources: []egv1a1.GroupVersionKind{
 								{Group: "bar.io", Version: "v1", Kind: "BarBackend"},
 							},
-							Service: &egv1a1.ExtensionService{Host: "bar.svc", Port: 8080},
+							Service: &egv1a1.ExtensionService{Host: "bar.svc", Port: 8080}, //nolint:staticcheck
 						},
 					},
 				},
@@ -249,7 +249,7 @@ func Test_TLS(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, opts)
 
-	conn, err := grpc.DialContext(context.Background(), fmt.Sprintf("localhost:%d", port),
+	conn, err := grpc.NewClient(fmt.Sprintf("localhost:%d", port),
 		opts...,
 	)
 	require.NoError(t, err)
@@ -361,7 +361,7 @@ func Test_mTLS(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, opts)
 
-	conn, err := grpc.DialContext(context.Background(), fmt.Sprintf("localhost:%d", port),
+	conn, err := grpc.NewClient(fmt.Sprintf("localhost:%d", port),
 		opts...,
 	)
 	require.NoError(t, err)

--- a/internal/extension/registry/inmemory_composite.go
+++ b/internal/extension/registry/inmemory_composite.go
@@ -45,7 +45,7 @@ func NewInMemoryCompositeManager(
 		_ = baseServer.Serve(lis)
 	}()
 
-	conn, err := grpc.DialContext(context.Background(), "",
+	conn, err := grpc.NewClient("passthrough:///",
 		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 			return lis.Dial()
 		}),

--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -268,10 +268,10 @@ func BuildBTPIndexes(
 // deprecatedFieldsUsedInBackendTrafficPolicy returns a map of deprecated field paths to their alternatives.
 func deprecatedFieldsUsedInBackendTrafficPolicy(policy *egv1a1.BackendTrafficPolicy) map[string]string {
 	deprecatedFields := make(map[string]string)
-	if policy.Spec.TargetRef != nil {
+	if policy.Spec.TargetRef != nil { //nolint:staticcheck
 		deprecatedFields["spec.targetRef"] = "spec.targetRefs"
 	}
-	if len(policy.Spec.Compression) > 0 {
+	if len(policy.Spec.Compression) > 0 { //nolint:staticcheck
 		deprecatedFields["spec.compression"] = "spec.compressor"
 	}
 	return deprecatedFields
@@ -1562,7 +1562,7 @@ func (t *Translator) buildTrafficFeatures(policy *egv1a1.BackendTrafficPolicy, o
 		errs = errors.Join(errs, err)
 	}
 
-	cp = buildCompression(policy.Spec.Compression, policy.Spec.Compressor)
+	cp = buildCompression(policy.Spec.Compression, policy.Spec.Compressor) //nolint:staticcheck
 	httpUpgrade = buildHTTPProtocolUpgradeConfig(policy.Spec.HTTPUpgrade)
 	if rb != nil && len(httpUpgrade) > 0 {
 		err = errors.New("requestBuffer cannot be used together with httpUpgrade")
@@ -1615,7 +1615,7 @@ func buildBackendTracing(tracing *egv1a1.Tracing) *ir.BackendTracing {
 		SamplingFraction:        tracing.SamplingFraction,
 		ClientSamplingFraction:  tracing.ClientSamplingFraction,
 		OverallSamplingFraction: tracing.OverallSamplingFraction,
-		CustomTags:              ir.CustomTagMapToSlice(tracing.CustomTags),
+		CustomTags:              ir.CustomTagMapToSlice(tracing.CustomTags), //nolint:staticcheck
 		Tags:                    ir.MapToSlice(tracing.Tags),
 		SpanName:                tracing.SpanName,
 	}
@@ -1800,14 +1800,14 @@ func appendTrafficPolicyMetadata(md *ir.ResourceMetadata, policy *egv1a1.Backend
 
 func (t *Translator) buildRateLimit(policy *egv1a1.BackendTrafficPolicy) (*ir.RateLimit, error) {
 	// For backward compatibility, process the deprecated Type field if specified.
-	if policy.Spec.RateLimit.Type != nil {
-		switch *policy.Spec.RateLimit.Type {
+	if policy.Spec.RateLimit.Type != nil { //nolint:staticcheck
+		switch *policy.Spec.RateLimit.Type { //nolint:staticcheck
 		case egv1a1.GlobalRateLimitType:
 			return t.buildGlobalRateLimit(policy)
 		case egv1a1.LocalRateLimitType:
 			return t.buildLocalRateLimit(policy)
 		}
-		return nil, fmt.Errorf("invalid rateLimit type: %s", *policy.Spec.RateLimit.Type)
+		return nil, fmt.Errorf("invalid rateLimit type: %s", *policy.Spec.RateLimit.Type) //nolint:staticcheck
 	}
 
 	return t.buildBothRateLimit(policy)

--- a/internal/gatewayapi/backendtrafficpolicy_test.go
+++ b/internal/gatewayapi/backendtrafficpolicy_test.go
@@ -1021,7 +1021,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1039,7 +1039,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1068,7 +1068,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1097,7 +1097,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1115,7 +1115,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1146,7 +1146,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1164,7 +1164,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1195,7 +1195,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1213,7 +1213,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("ListenerSet"),
@@ -1231,7 +1231,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("ListenerSet"),
@@ -1264,7 +1264,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1282,7 +1282,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("ListenerSet"),
@@ -1314,7 +1314,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1333,7 +1333,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1365,7 +1365,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("ListenerSet"),
@@ -1384,7 +1384,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1418,7 +1418,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1436,7 +1436,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1465,7 +1465,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1484,7 +1484,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1510,7 +1510,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-gateway"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1525,7 +1525,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-rule-oldest-accepted"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1540,7 +1540,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-rule-younger-conflicting"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1568,7 +1568,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-gateway"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1583,7 +1583,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-route-oldest-accepted"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1597,7 +1597,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-route-younger-conflicting"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1623,7 +1623,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-gateway"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1638,7 +1638,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-listener-oldest-accepted"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1654,7 +1654,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-listener-younger-conflicting"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1681,7 +1681,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-gateway-oldest-accepted"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1695,7 +1695,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-gateway-younger-conflicting"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1723,7 +1723,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1790,7 +1790,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1808,7 +1808,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -1827,7 +1827,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1857,7 +1857,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1875,7 +1875,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1906,7 +1906,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1925,7 +1925,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -1955,7 +1955,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2116,7 +2116,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2156,7 +2156,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -2174,7 +2174,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -2193,7 +2193,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2211,7 +2211,7 @@ func TestBTPRoutingTypeIndex(t *testing.T) {
 					},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2689,7 +2689,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-no-mergetype"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2714,7 +2714,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-with-mergetype"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2740,7 +2740,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-route-no-mergetype"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2763,7 +2763,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-route-with-mergetype"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2787,7 +2787,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-gateway"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -2811,7 +2811,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-route"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2826,7 +2826,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-rule-a"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2852,7 +2852,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-route"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2867,7 +2867,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-rule-a"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2893,7 +2893,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-rule-oldest-accepted"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2909,7 +2909,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-rule-younger-conflicting"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2935,7 +2935,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-route-oldest-accepted"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2950,7 +2950,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-route-younger-conflicting"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -2974,7 +2974,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-oldest-accepted"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -2989,7 +2989,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-younger-conflicting"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),
@@ -3016,7 +3016,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-listenerset"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("ListenerSet"),
@@ -3043,7 +3043,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-listenerset-listener"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("ListenerSet"),
@@ -3071,7 +3071,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-other-listenerset"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("ListenerSet"),
@@ -3098,7 +3098,7 @@ func TestBTPClusterSettingsIndex(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "btp-gateway-for-ls-fallthrough"},
 					Spec: egv1a1.BackendTrafficPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Group: gwapiv1.Group("gateway.networking.k8s.io"),
 									Kind:  gwapiv1.Kind("Gateway"),

--- a/internal/gatewayapi/clienttrafficpolicy.go
+++ b/internal/gatewayapi/clienttrafficpolicy.go
@@ -137,19 +137,19 @@ func hasSectionName(target *policyTargetReferenceWithSectionName) bool {
 // deprecatedFieldsUsedInClientTrafficPolicy returns a map of deprecated field paths to their alternatives.
 func deprecatedFieldsUsedInClientTrafficPolicy(policy *egv1a1.ClientTrafficPolicy) map[string]string {
 	deprecatedFields := make(map[string]string)
-	if policy.Spec.EnableProxyProtocol != nil {
+	if policy.Spec.EnableProxyProtocol != nil { //nolint:staticcheck
 		deprecatedFields["spec.enableProxyProtocol"] = "spec.proxyProtocol"
 	}
-	if policy.Spec.Headers != nil && policy.Spec.Headers.PreserveXRequestID != nil {
+	if policy.Spec.Headers != nil && policy.Spec.Headers.PreserveXRequestID != nil { //nolint:staticcheck
 		deprecatedFields["spec.headers.preserveXRequestID"] = "spec.headers.requestID"
 	}
-	if policy.Spec.TargetRef != nil {
+	if policy.Spec.TargetRef != nil { //nolint:staticcheck
 		deprecatedFields["spec.targetRef"] = "spec.targetRefs"
 	}
 	// Optional is a non-pointer bool, so deprecated usage is only observable when it changes behavior.
 	if policy.Spec.TLS != nil &&
 		policy.Spec.TLS.ClientValidation != nil &&
-		policy.Spec.TLS.ClientValidation.Optional {
+		policy.Spec.TLS.ClientValidation.Optional { //nolint:staticcheck
 		deprecatedFields["spec.tls.clientValidation.optional"] = "spec.tls.clientValidation.mode"
 	}
 	return deprecatedFields
@@ -757,7 +757,7 @@ func (t *Translator) translateClientTrafficPolicyForListener(
 		proxyProtocol = &ir.ProxyProtocolSettings{
 			Optional: ptr.Deref(policy.Spec.ProxyProtocol.Optional, false),
 		}
-	} else if ptr.Deref(policy.Spec.EnableProxyProtocol, false) {
+	} else if ptr.Deref(policy.Spec.EnableProxyProtocol, false) { //nolint:staticcheck
 		// Fallback to legacy EnableProxyProtocol field
 		proxyProtocol = &ir.ProxyProtocolSettings{
 			Optional: false, // Default behavior for legacy field
@@ -1024,7 +1024,7 @@ func translateListenerHeaderSettings(headerSettings *egv1a1.HeaderSettings, http
 	}
 	if headerSettings.RequestID != nil {
 		httpIR.Headers.RequestID = (*ir.RequestIDAction)(headerSettings.RequestID)
-	} else if headerSettings.PreserveXRequestID != nil && *headerSettings.PreserveXRequestID {
+	} else if headerSettings.PreserveXRequestID != nil && *headerSettings.PreserveXRequestID { //nolint:staticcheck
 		httpIR.Headers.RequestID = new(ir.RequestIDActionPreserveOrGenerate)
 	}
 
@@ -1253,7 +1253,7 @@ func (t *Translator) buildListenerTLSParameters(
 		mode := egv1a1.ClientValidationRequireAndVerify
 		if tlsParams.ClientValidation.Mode != nil {
 			mode = *tlsParams.ClientValidation.Mode
-		} else if tlsParams.ClientValidation.Optional {
+		} else if tlsParams.ClientValidation.Optional { //nolint:staticcheck
 			// Legacy mapping: Optional=true means VerifyIfGiven.
 			mode = egv1a1.ClientValidationVerifyIfGiven
 		}
@@ -1288,7 +1288,7 @@ func (t *Translator) buildListenerTLSParameters(
 
 		// CA certificates are required for verification modes.
 		if (mode == egv1a1.ClientValidationVerifyIfGiven || mode == egv1a1.ClientValidationRequireAndVerify) && len(irCACert.Certificate) == 0 {
-			if tlsParams.ClientValidation.Mode == nil && tlsParams.ClientValidation.Optional {
+			if tlsParams.ClientValidation.Mode == nil && tlsParams.ClientValidation.Optional { //nolint:staticcheck
 				return irTLSConfig, fmt.Errorf(`tls.clientValidation.optional=true requires caCertificateRefs (maps to mode %q)`, mode)
 			}
 			return irTLSConfig, fmt.Errorf(`tls.clientValidation.mode %q requires caCertificateRefs`, mode)

--- a/internal/gatewayapi/clustersettings.go
+++ b/internal/gatewayapi/clustersettings.go
@@ -468,10 +468,10 @@ func buildConsistentHashLoadBalancer(policy egv1a1.LoadBalancer) (*ir.Consistent
 	switch policy.ConsistentHash.Type {
 	case egv1a1.SourceIPConsistentHashType:
 		consistentHash.SourceIP = new(true)
-	case egv1a1.HeaderConsistentHashType:
+	case egv1a1.HeaderConsistentHashType: //nolint:staticcheck
 		consistentHash.Headers = []*egv1a1.Header{
 			{
-				Name: policy.ConsistentHash.Header.Name,
+				Name: policy.ConsistentHash.Header.Name, //nolint:staticcheck
 			},
 		}
 	case egv1a1.HeadersConsistentHashType:

--- a/internal/gatewayapi/envoyextensionpolicy.go
+++ b/internal/gatewayapi/envoyextensionpolicy.go
@@ -42,7 +42,7 @@ const (
 // deprecatedFieldsUsedInEnvoyExtensionPolicy returns a map of deprecated field paths to their alternatives.
 func deprecatedFieldsUsedInEnvoyExtensionPolicy(policy *egv1a1.EnvoyExtensionPolicy) map[string]string {
 	deprecatedFields := make(map[string]string)
-	if policy.Spec.TargetRef != nil {
+	if policy.Spec.TargetRef != nil { //nolint:staticcheck
 		deprecatedFields["spec.targetRef"] = "spec.targetRefs"
 	}
 	return deprecatedFields

--- a/internal/gatewayapi/extensionserverpolicy.go
+++ b/internal/gatewayapi/extensionserverpolicy.go
@@ -188,10 +188,10 @@ func extractTargetRefs(policy *unstructured.Unstructured) (egv1a1.PolicyTargetRe
 	if err := json.Unmarshal(specAsJSON, &targetRefs); err != nil {
 		return targetRefs, fmt.Errorf("no targets found for the policy")
 	}
-	if (targetRefs.TargetRef == nil ||
-		targetRefs.TargetRef.Group == "" ||
-		targetRefs.TargetRef.Kind == "" ||
-		targetRefs.TargetRef.Name == "") &&
+	if (targetRefs.TargetRef == nil || //nolint:staticcheck
+		targetRefs.TargetRef.Group == "" || //nolint:staticcheck
+		targetRefs.TargetRef.Kind == "" || //nolint:staticcheck
+		targetRefs.TargetRef.Name == "") && //nolint:staticcheck
 		len(targetRefs.TargetRefs) < 1 &&
 		len(targetRefs.TargetSelectors) < 1 {
 		return targetRefs, fmt.Errorf("no targets found for the policy")

--- a/internal/gatewayapi/extensionserverpolicy_test.go
+++ b/internal/gatewayapi/extensionserverpolicy_test.go
@@ -64,7 +64,7 @@ func TestExtractTargetRefs(t *testing.T) {
 				},
 			},
 			output: egv1a1.PolicyTargetReferences{
-				TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+				TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 					LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 						Group: "some.group",
 						Kind:  "SomeKind",

--- a/internal/gatewayapi/helpers_test.go
+++ b/internal/gatewayapi/helpers_test.go
@@ -928,7 +928,7 @@ func TestResolvePolicyTargetsFromReferences(t *testing.T) {
 		{
 			name: "target ref",
 			targetRefs: egv1a1.PolicyTargetReferences{
-				TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+				TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 					LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 						Group: "gateway.networking.k8s.io",
 						Kind:  "Gateway",

--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -1028,8 +1028,8 @@ func (t *Translator) processAccessLog(gwCtx *GatewayContext, envoyproxy *egv1a1.
 					// fallback to host and port
 					var host string
 					var port uint32
-					if sink.OpenTelemetry.Host != nil {
-						host, port = *sink.OpenTelemetry.Host, uint32(sink.OpenTelemetry.Port)
+					if sink.OpenTelemetry.Host != nil { //nolint:staticcheck
+						host, port = *sink.OpenTelemetry.Host, uint32(sink.OpenTelemetry.Port) //nolint:staticcheck
 					}
 					al.Destination.Settings = destinationSettingFromHostAndPort(settingName, host, port)
 					al.Authority = host
@@ -1082,8 +1082,8 @@ func (t *Translator) processTracing(gwCtx *GatewayContext, envoyproxy *egv1a1.En
 	if len(ds) == 0 {
 		var host string
 		var port uint32
-		if tracing.Provider.Host != nil {
-			host, port = *tracing.Provider.Host, uint32(tracing.Provider.Port)
+		if tracing.Provider.Host != nil { //nolint:staticcheck
+			host, port = *tracing.Provider.Host, uint32(tracing.Provider.Port) //nolint:staticcheck
 		}
 		ds = destinationSettingFromHostAndPort(settingName, host, port)
 		authority = host
@@ -1106,7 +1106,7 @@ func (t *Translator) processTracing(gwCtx *GatewayContext, envoyproxy *egv1a1.En
 		SamplingRate:        proxySamplingRate(tracing.SamplingRate, tracing.SamplingFraction),
 		ClientSamplingRate:  proxySamplingFractionPtr(tracing.ClientSamplingFraction),
 		OverallSamplingRate: proxySamplingFractionPtr(tracing.OverallSamplingFraction),
-		CustomTags:          ir.CustomTagMapToSlice(tracing.CustomTags),
+		CustomTags:          ir.CustomTagMapToSlice(tracing.CustomTags), //nolint:staticcheck
 		Tags:                ir.MapToSlice(tracing.Tags),
 		ResourceAttributes:  ir.MapToSlice(getOpenTelemetryTracingResourceAttributes(&tracing.Provider)),
 		Destination: ir.RouteDestination{
@@ -1278,9 +1278,9 @@ func (t *Translator) processMetrics(gwCtx *GatewayContext, envoyproxy *egv1a1.En
 		authority := getAuthorityFromDestination(ds)
 
 		// Fallback to deprecated host/port
-		if len(ds) == 0 && sink.OpenTelemetry.Host != nil {
-			ds = destinationSettingFromHostAndPort(settingName, *sink.OpenTelemetry.Host, uint32(sink.OpenTelemetry.Port))
-			authority = *sink.OpenTelemetry.Host
+		if len(ds) == 0 && sink.OpenTelemetry.Host != nil { //nolint:staticcheck
+			ds = destinationSettingFromHostAndPort(settingName, *sink.OpenTelemetry.Host, uint32(sink.OpenTelemetry.Port)) //nolint:staticcheck
+			authority = *sink.OpenTelemetry.Host                                                                           //nolint:staticcheck
 		}
 
 		if len(ds) > 0 && len(ds[0].Endpoints) > 0 {

--- a/internal/gatewayapi/luavalidator/lua_validator.go
+++ b/internal/gatewayapi/luavalidator/lua_validator.go
@@ -87,8 +87,8 @@ func (l *LuaValidator) getLuaValidation() egv1a1.LuaValidation {
 		if cfg := l.envoyProxy.Spec.Lua; cfg != nil && cfg.ValidationType != nil {
 			return *cfg.ValidationType
 		}
-		if l.envoyProxy.Spec.LuaValidation != nil {
-			return *l.envoyProxy.Spec.LuaValidation
+		if l.envoyProxy.Spec.LuaValidation != nil { //nolint:staticcheck
+			return *l.envoyProxy.Spec.LuaValidation //nolint:staticcheck
 		}
 	}
 	return egv1a1.LuaValidationStrict

--- a/internal/gatewayapi/luavalidator/lua_validator_test.go
+++ b/internal/gatewayapi/luavalidator/lua_validator_test.go
@@ -144,7 +144,7 @@ func Test_BasicValidation(t *testing.T) {
                   end`,
 			proxy: &egv1a1.EnvoyProxy{
 				Spec: egv1a1.EnvoyProxySpec{
-					LuaValidation: new(egv1a1.LuaValidationInsecureSyntax),
+					LuaValidation: new(egv1a1.LuaValidationInsecureSyntax), //nolint:staticcheck
 				},
 			},
 			expectedErrSubstring: "",
@@ -161,7 +161,7 @@ func Test_BasicValidation(t *testing.T) {
                   end`,
 			proxy: &egv1a1.EnvoyProxy{
 				Spec: egv1a1.EnvoyProxySpec{
-					LuaValidation: new(egv1a1.LuaValidationInsecureSyntax),
+					LuaValidation: new(egv1a1.LuaValidationInsecureSyntax), //nolint:staticcheck
 				},
 			},
 			expectedErrSubstring: "<string> at EOF:   syntax error",
@@ -178,7 +178,7 @@ func Test_BasicValidation(t *testing.T) {
                    end`,
 			proxy: &egv1a1.EnvoyProxy{
 				Spec: egv1a1.EnvoyProxySpec{
-					LuaValidation: new(egv1a1.LuaValidationDisabled),
+					LuaValidation: new(egv1a1.LuaValidationDisabled), //nolint:staticcheck
 				},
 			},
 			expectedErrSubstring: "",

--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -66,14 +66,14 @@ var newOIDCDiscoveryHTTPClient = newGuardedOIDCDiscoveryHTTPClient
 // deprecatedFieldsUsedInSecurityPolicy returns a map of deprecated field paths to their alternatives.
 func deprecatedFieldsUsedInSecurityPolicy(policy *egv1a1.SecurityPolicy) map[string]string {
 	deprecatedFields := make(map[string]string)
-	if policy.Spec.TargetRef != nil {
+	if policy.Spec.TargetRef != nil { //nolint:staticcheck
 		deprecatedFields["spec.targetRef"] = "spec.targetRefs"
 	}
 	if policy.Spec.ExtAuth != nil {
-		if policy.Spec.ExtAuth.GRPC != nil && policy.Spec.ExtAuth.GRPC.BackendRef != nil {
+		if policy.Spec.ExtAuth.GRPC != nil && policy.Spec.ExtAuth.GRPC.BackendRef != nil { //nolint:staticcheck
 			deprecatedFields["spec.extAuth.grpc.backendRef"] = "spec.extAuth.grpc.backendRefs"
 		}
-		if policy.Spec.ExtAuth.HTTP != nil && policy.Spec.ExtAuth.HTTP.BackendRef != nil {
+		if policy.Spec.ExtAuth.HTTP != nil && policy.Spec.ExtAuth.HTTP.BackendRef != nil { //nolint:staticcheck
 			deprecatedFields["spec.extAuth.http.backendRef"] = "spec.extAuth.http.backendRefs"
 		}
 	}
@@ -2813,10 +2813,10 @@ func (t *Translator) buildExtAuth(
 		switch {
 		case len(http.BackendRefs) > 0:
 			backendRefs = http.BackendRefs
-		case http.BackendRef != nil:
+		case http.BackendRef != nil: //nolint:staticcheck
 			backendRefs = []egv1a1.BackendRef{
 				{
-					BackendObjectReference: *http.BackendRef,
+					BackendObjectReference: *http.BackendRef, //nolint:staticcheck
 				},
 			}
 		default:
@@ -2829,10 +2829,10 @@ func (t *Translator) buildExtAuth(
 		switch {
 		case len(grpc.BackendRefs) > 0:
 			backendRefs = grpc.BackendRefs
-		case grpc.BackendRef != nil:
+		case grpc.BackendRef != nil: //nolint:staticcheck
 			backendRefs = []egv1a1.BackendRef{
 				{
-					BackendObjectReference: *grpc.BackendRef,
+					BackendObjectReference: *grpc.BackendRef, //nolint:staticcheck
 				},
 			}
 		default:
@@ -3250,10 +3250,10 @@ func buildSecurityPolicyOwners(route, parent *egv1a1.SecurityPolicy) *securityPo
 			if ea == nil {
 				return false
 			}
-			if ea.HTTP != nil && (len(ea.HTTP.BackendRefs) > 0 || ea.HTTP.BackendRef != nil) {
+			if ea.HTTP != nil && (len(ea.HTTP.BackendRefs) > 0 || ea.HTTP.BackendRef != nil) { //nolint:staticcheck
 				return true
 			}
-			if ea.GRPC != nil && (len(ea.GRPC.BackendRefs) > 0 || ea.GRPC.BackendRef != nil) {
+			if ea.GRPC != nil && (len(ea.GRPC.BackendRefs) > 0 || ea.GRPC.BackendRef != nil) { //nolint:staticcheck
 				return true
 			}
 			return false

--- a/internal/gatewayapi/translator.go
+++ b/internal/gatewayapi/translator.go
@@ -696,7 +696,7 @@ func validateEnvoyProxy(ep *egv1a1.EnvoyProxy) error {
 
 func deprecatedFieldsUsedInEnvoyProxy(ep *egv1a1.EnvoyProxy) map[string]string {
 	deprecatedFields := make(map[string]string)
-	if ep.Spec.LuaValidation != nil {
+	if ep.Spec.LuaValidation != nil { //nolint:staticcheck
 		deprecatedFields["spec.luaValidation"] = "spec.lua.validationType"
 	}
 

--- a/internal/infrastructure/host/proxy_infra_test.go
+++ b/internal/infrastructure/host/proxy_infra_test.go
@@ -620,8 +620,8 @@ func TestUserConfiguredMetricSinksPreserved(t *testing.T) {
 						{
 							Type: egv1a1.MetricSinkTypeOpenTelemetry,
 							OpenTelemetry: &egv1a1.ProxyOpenTelemetrySink{
-								Host: new("otel-collector.example.com"),
-								Port: 4317,
+								Host: new("otel-collector.example.com"), //nolint:staticcheck
+								Port: 4317,                              //nolint:staticcheck
 							},
 						},
 					},

--- a/internal/infrastructure/kubernetes/infra_client.go
+++ b/internal/infrastructure/kubernetes/infra_client.go
@@ -27,7 +27,7 @@ func New(cli client.Client) *InfraClient {
 
 func (cli *InfraClient) ServerSideApply(ctx context.Context, obj client.Object) error {
 	opts := []client.PatchOption{client.ForceOwnership, client.FieldOwner("envoy-gateway")}
-	if err := cli.Patch(ctx, obj, client.Apply, opts...); err != nil {
+	if err := cli.Patch(ctx, obj, client.Apply, opts...); err != nil { //nolint:staticcheck
 		return fmt.Errorf("failed to create/update resource with server-side apply for obj %v: %w", obj, err)
 	}
 

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -16,12 +16,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/kubernetes"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/streaming/pkg/httpstream"
 
 	"github.com/envoyproxy/gateway/internal/envoygateway"
 )

--- a/internal/kubernetes/port_forwarder.go
+++ b/internal/kubernetes/port_forwarder.go
@@ -14,10 +14,10 @@ import (
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+	"k8s.io/streaming/pkg/httpstream"
 
 	netutil "github.com/envoyproxy/gateway/internal/utils/net"
 )

--- a/internal/metrics/register.go
+++ b/internal/metrics/register.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/otlptranslator"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -188,9 +189,8 @@ func (r *Runner) registerOTELPromExporter(otelOpts *[]metric.Option, opts *regis
 		promOpts := []otelprom.Option{
 			otelprom.WithoutScopeInfo(),
 			otelprom.WithoutTargetInfo(),
-			otelprom.WithoutUnits(),
+			otelprom.WithTranslationStrategy(otlptranslator.UnderscoreEscapingWithoutSuffixes),
 			otelprom.WithRegisterer(opts.pullOptions.registry),
-			otelprom.WithoutCounterSuffixes(),
 		}
 		promreader, err := otelprom.New(promOpts...)
 		if err != nil {

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -1163,8 +1163,8 @@ func (r *gatewayAPIReconciler) processSecurityPolicyObjectRefs(
 
 func getBackendRefs(backendCluster egv1a1.BackendCluster) []gwapiv1.BackendObjectReference {
 	backendRefs := make([]gwapiv1.BackendObjectReference, 0, 1+len(backendCluster.BackendRefs))
-	if backendCluster.BackendRef != nil {
-		backendRefs = append(backendRefs, *backendCluster.BackendRef)
+	if backendCluster.BackendRef != nil { //nolint:staticcheck
+		backendRefs = append(backendRefs, *backendCluster.BackendRef) //nolint:staticcheck
 	}
 	// There is a CEL validation rule to ensure that backendRefs and backendRef
 	// cannot both be set at the same time.

--- a/internal/provider/kubernetes/controller_test.go
+++ b/internal/provider/kubernetes/controller_test.go
@@ -1454,7 +1454,7 @@ func TestProcessSecurityPolicyObjectRefs(t *testing.T) {
 					ExtAuth: &egv1a1.ExtAuth{
 						GRPC: &egv1a1.GRPCExtAuthService{
 							BackendCluster: egv1a1.BackendCluster{
-								BackendRef: &gwapiv1.BackendObjectReference{
+								BackendRef: &gwapiv1.BackendObjectReference{ //nolint:staticcheck
 									Namespace: gatewayapi.NamespacePtr("ns-2"),
 									Name:      "test-backend",
 									Kind:      gatewayapi.KindPtr(resource.KindBackend),
@@ -1618,7 +1618,7 @@ func TestProcessSecurityPolicyObjectRefs(t *testing.T) {
 					ExtAuth: &egv1a1.ExtAuth{
 						HTTP: &egv1a1.HTTPExtAuthService{
 							BackendCluster: egv1a1.BackendCluster{
-								BackendRef: &gwapiv1.BackendObjectReference{
+								BackendRef: &gwapiv1.BackendObjectReference{ //nolint:staticcheck
 									Namespace: gatewayapi.NamespacePtr("ns-2"),
 									Name:      "test-backend",
 									Kind:      gatewayapi.KindPtr(resource.KindBackend),

--- a/internal/provider/kubernetes/indexers.go
+++ b/internal/provider/kubernetes/indexers.go
@@ -868,16 +868,16 @@ func backendSecurityPolicyIndexFunc(rawObj client.Object) []string {
 	if securityPolicy.Spec.ExtAuth != nil {
 		if securityPolicy.Spec.ExtAuth.HTTP != nil {
 			http := securityPolicy.Spec.ExtAuth.HTTP
-			if http.BackendRef != nil {
-				backendRefs = append(backendRefs, *http.BackendRef)
+			if http.BackendRef != nil { //nolint:staticcheck
+				backendRefs = append(backendRefs, *http.BackendRef) //nolint:staticcheck
 			}
 			if len(http.BackendRefs) > 0 {
 				backendRefs = append(backendRefs, http.BackendRefs[0].BackendObjectReference)
 			}
 		} else if securityPolicy.Spec.ExtAuth.GRPC != nil {
 			grpc := securityPolicy.Spec.ExtAuth.GRPC
-			if grpc.BackendRef != nil {
-				backendRefs = append(backendRefs, *grpc.BackendRef)
+			if grpc.BackendRef != nil { //nolint:staticcheck
+				backendRefs = append(backendRefs, *grpc.BackendRef) //nolint:staticcheck
 			}
 			if len(grpc.BackendRefs) > 0 {
 				backendRefs = append(backendRefs, grpc.BackendRefs[0].BackendObjectReference)

--- a/internal/provider/kubernetes/predicates_test.go
+++ b/internal/provider/kubernetes/predicates_test.go
@@ -702,7 +702,7 @@ func TestValidateSecretForReconcile(t *testing.T) {
 					},
 					Spec: egv1a1.SecurityPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Kind: "Gateway",
 									Name: "scheduled-status-test",
@@ -737,7 +737,7 @@ func TestValidateSecretForReconcile(t *testing.T) {
 					},
 					Spec: egv1a1.SecurityPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Kind: "Gateway",
 									Name: "scheduled-status-test",
@@ -768,7 +768,7 @@ func TestValidateSecretForReconcile(t *testing.T) {
 					},
 					Spec: egv1a1.SecurityPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Kind: "Gateway",
 									Name: "scheduled-status-test",
@@ -1588,7 +1588,7 @@ func TestValidateServiceForReconcile(t *testing.T) {
 					},
 					Spec: egv1a1.SecurityPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Kind: "Gateway",
 									Name: "scheduled-status-test",
@@ -1623,7 +1623,7 @@ func TestValidateServiceForReconcile(t *testing.T) {
 					},
 					Spec: egv1a1.SecurityPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Kind: "Gateway",
 									Name: "scheduled-status-test",
@@ -1658,7 +1658,7 @@ func TestValidateServiceForReconcile(t *testing.T) {
 					},
 					Spec: egv1a1.EnvoyExtensionPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Kind: "Gateway",
 									Name: "scheduled-status-test",
@@ -1693,7 +1693,7 @@ func TestValidateServiceForReconcile(t *testing.T) {
 					},
 					Spec: egv1a1.EnvoyExtensionPolicySpec{
 						PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+							TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 								LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 									Kind: "Gateway",
 									Name: "scheduled-status-test",

--- a/internal/provider/kubernetes/routes_test.go
+++ b/internal/provider/kubernetes/routes_test.go
@@ -42,7 +42,7 @@ func newTestScheme(unstructuredGVKs ...schema.GroupVersionKind) *runtime.Scheme 
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(egv1a1.AddToScheme(scheme))
 	utilruntime.Must(gwapischeme.AddToScheme(scheme))
-	utilruntime.Must(mcsapiv1a1.AddToScheme(scheme))
+	utilruntime.Must(mcsapiv1a1.Install(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	for _, gvk := range unstructuredGVKs {
 		scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})

--- a/internal/utils/proto/proto.go
+++ b/internal/utils/proto/proto.go
@@ -9,11 +9,9 @@
 package proto
 
 import (
-	"bytes"
 	"errors"
 
-	"github.com/golang/protobuf/jsonpb"
-	protov1 "github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"sigs.k8s.io/yaml"
@@ -22,11 +20,14 @@ import (
 )
 
 var (
-	// Setting the OrigName flag to true will preserve the expected snake case field names in the JSON output.
+	// Setting UseProtoNames to true preserves the expected snake case field names in the JSON output.
 	// Otherwise, camel case is produced, and it causes issues with the func-e library used to unmarshal the
 	// bootstrap configuration.
-	marshaler   = &jsonpb.Marshaler{OrigName: true}
-	unmarshaler = &jsonpb.Unmarshaler{AllowUnknownFields: true}
+	marshaler = protojson.MarshalOptions{
+		UseProtoNames: true,
+	}
+	// Leave DiscardUnknown unset so invalid enum values still error, matching previous jsonpb behavior.
+	unmarshaler = protojson.UnmarshalOptions{}
 )
 
 func FromYAML(content []byte, pb proto.Message) error {
@@ -38,15 +39,15 @@ func FromYAML(content []byte, pb proto.Message) error {
 }
 
 func ToYAML(pb proto.Message) ([]byte, error) {
-	json, err := marshaler.MarshalToString(protov1.MessageV1(pb))
+	j, err := marshaler.Marshal(pb)
 	if err != nil {
 		return nil, err
 	}
-	return yaml.JSONToYAML([]byte(json))
+	return yaml.JSONToYAML(j)
 }
 
 func FromJSON(content []byte, out proto.Message) error {
-	return unmarshaler.Unmarshal(bytes.NewReader(content), protov1.MessageV1(out))
+	return unmarshaler.Unmarshal(content, out)
 }
 
 func ToAnyWithValidation(msg proto.Message) (*anypb.Any, error) {

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -246,8 +246,8 @@ func GetRenderedBootstrapConfig(opts *RenderBootstrapConfigOptions) (string, err
 
 				var host string
 				var port uint32
-				if sink.OpenTelemetry.Host != nil {
-					host, port = *sink.OpenTelemetry.Host, uint32(sink.OpenTelemetry.Port)
+				if sink.OpenTelemetry.Host != nil { //nolint:staticcheck
+					host, port = *sink.OpenTelemetry.Host, uint32(sink.OpenTelemetry.Port) //nolint:staticcheck
 				}
 				if len(sink.OpenTelemetry.BackendRefs) > 0 {
 					ref := sink.OpenTelemetry.BackendRefs[0].BackendObjectReference

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -99,8 +99,8 @@ func TestGetRenderedBootstrapConfig(t *testing.T) {
 						{
 							Type: egv1a1.MetricSinkTypeOpenTelemetry,
 							OpenTelemetry: &egv1a1.ProxyOpenTelemetrySink{
-								Host: new("otel-collector.monitoring.svc"),
-								Port: 4317,
+								Host: new("otel-collector.monitoring.svc"), //nolint:staticcheck
+								Port: 4317,                                 //nolint:staticcheck
 							},
 						},
 					},
@@ -119,8 +119,8 @@ func TestGetRenderedBootstrapConfig(t *testing.T) {
 						{
 							Type: egv1a1.MetricSinkTypeOpenTelemetry,
 							OpenTelemetry: &egv1a1.ProxyOpenTelemetrySink{
-								Host: new("otel-collector.monitoring.svc"),
-								Port: 4317,
+								Host: new("otel-collector.monitoring.svc"), //nolint:staticcheck
+								Port: 4317,                                 //nolint:staticcheck
 								BackendCluster: egv1a1.BackendCluster{
 									BackendRefs: []egv1a1.BackendRef{
 										{
@@ -150,8 +150,8 @@ func TestGetRenderedBootstrapConfig(t *testing.T) {
 						{
 							Type: egv1a1.MetricSinkTypeOpenTelemetry,
 							OpenTelemetry: &egv1a1.ProxyOpenTelemetrySink{
-								Host:                     new("otel-collector.monitoring.svc"),
-								Port:                     4317,
+								Host:                     new("otel-collector.monitoring.svc"), //nolint:staticcheck
+								Port:                     4317,                                 //nolint:staticcheck
 								ReportCountersAsDeltas:   new(true),
 								ReportHistogramsAsDeltas: new(true),
 							},
@@ -172,8 +172,8 @@ func TestGetRenderedBootstrapConfig(t *testing.T) {
 						{
 							Type: egv1a1.MetricSinkTypeOpenTelemetry,
 							OpenTelemetry: &egv1a1.ProxyOpenTelemetrySink{
-								Host: new("otel-collector.monitoring.svc"),
-								Port: 4317,
+								Host: new("otel-collector.monitoring.svc"), //nolint:staticcheck
+								Port: 4317,                                 //nolint:staticcheck
 								Headers: []gwapiv1.HTTPHeader{
 									{
 										Name:  "Authorization",

--- a/internal/xds/translator/accesslog.go
+++ b/internal/xds/translator/accesslog.go
@@ -288,7 +288,7 @@ func buildXdsAccessLog(al *ir.AccessLog, accessLogType ir.ProxyAccessLogType) ([
 		defaultLogTypeForListener := accessLogType == ir.ProxyAccessLogTypeListener && otel.LogType == nil
 
 		al := &otelaccesslog.OpenTelemetryAccessLogConfig{
-			CommonConfig: &grpcaccesslog.CommonGrpcAccessLogConfig{
+			CommonConfig: &grpcaccesslog.CommonGrpcAccessLogConfig{ //nolint:staticcheck
 				LogName: otelLogName,
 				GrpcService: &cfgcore.GrpcService{
 					TargetSpecifier: &cfgcore.GrpcService_EnvoyGrpc_{

--- a/internal/xds/translator/custom_response.go
+++ b/internal/xds/translator/custom_response.go
@@ -564,7 +564,7 @@ func (c *customResponse) buildResponseAction(r *ir.ResponseOverrideRule) (*anypb
 	if len(r.Response.Body) > 0 {
 		response.BodyFormat = &corev3.SubstitutionFormatString{
 			Format: &corev3.SubstitutionFormatString_TextFormat{
-				TextFormat: string(r.Response.Body),
+				TextFormat: string(r.Response.Body), //nolint:staticcheck
 			},
 		}
 	}

--- a/internal/xds/translator/listener.go
+++ b/internal/xds/translator/listener.go
@@ -851,7 +851,7 @@ func buildConnectionLimitFilter(statPrefix string, connection *ir.ClientConnecti
 func addXdsTLSInspectorFilter(xdsListener *listenerv3.Listener, fingerprints []ir.TLSFingerprintType) error {
 	// Return early if it exists
 	for _, filter := range xdsListener.ListenerFilters {
-		if filter.Name == wellknown.TlsInspector {
+		if filter.Name == wellknown.TLSInspector {
 			return nil
 		}
 	}
@@ -873,7 +873,7 @@ func addXdsTLSInspectorFilter(xdsListener *listenerv3.Listener, fingerprints []i
 	}
 
 	filter := &listenerv3.ListenerFilter{
-		Name: wellknown.TlsInspector,
+		Name: wellknown.TLSInspector,
 		ConfigType: &listenerv3.ListenerFilter_TypedConfig{
 			TypedConfig: tlsInspectorAny,
 		},

--- a/internal/xds/translator/sds.go
+++ b/internal/xds/translator/sds.go
@@ -99,7 +99,7 @@ func buildSDSCluster(sdsURL string) *cluster.Cluster {
 			},
 		},
 		ConnectTimeout:       durationpb.New(defaultConnectionTimeout),
-		Http2ProtocolOptions: &corev3.Http2ProtocolOptions{},
+		Http2ProtocolOptions: &corev3.Http2ProtocolOptions{}, //nolint:staticcheck
 	}
 }
 

--- a/internal/xds/translator/server_names_match_test.go
+++ b/internal/xds/translator/server_names_match_test.go
@@ -140,7 +140,7 @@ func TestAddServerNamesMatch(t *testing.T) {
 			if tt.xdsListener != nil && tt.expectTLSInspector {
 				hasTLSInspector := false
 				for _, filter := range tt.xdsListener.ListenerFilters {
-					if filter.Name == wellknown.TlsInspector {
+					if filter.Name == wellknown.TLSInspector {
 						hasTLSInspector = true
 						break
 					}
@@ -150,7 +150,7 @@ func TestAddServerNamesMatch(t *testing.T) {
 				// For non-nil listeners that shouldn't have TLS inspector
 				hasTLSInspector := false
 				for _, filter := range tt.xdsListener.ListenerFilters {
-					if filter.Name == wellknown.TlsInspector {
+					if filter.Name == wellknown.TLSInspector {
 						hasTLSInspector = true
 						break
 					}

--- a/internal/xds/translator/translator.go
+++ b/internal/xds/translator/translator.go
@@ -930,7 +930,7 @@ func findHCMinFilterChain(filterChain *listenerv3.FilterChain) (*hcmv3.HttpConne
 
 func buildHTTP3AltSvcHeader(port int) *corev3.HeaderValueOption {
 	return &corev3.HeaderValueOption{
-		Append: &wrapperspb.BoolValue{Value: true},
+		Append: &wrapperspb.BoolValue{Value: true}, //nolint:staticcheck
 		Header: &corev3.HeaderValue{
 			Key:   "alt-svc",
 			Value: strings.Join([]string{fmt.Sprintf(`%s=":%d"; ma=86400`, "h3", port)}, ", "),

--- a/internal/xds/translator/wasm.go
+++ b/internal/xds/translator/wasm.go
@@ -163,7 +163,7 @@ func wasmConfig(wasm *ir.Wasm) (*wasmfilterv3.Wasm, error) {
 				VmConfig: vmConfig,
 			},
 			Configuration: configAny,
-			FailOpen:      wasm.FailOpen,
+			FailOpen:      wasm.FailOpen, //nolint:staticcheck
 		},
 	}
 

--- a/test/cel-validation/backendtrafficpolicy_test.go
+++ b/test/cel-validation/backendtrafficpolicy_test.go
@@ -46,7 +46,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -63,7 +63,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("ListenerSet"),
@@ -99,7 +99,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -116,7 +116,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -151,7 +151,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("ListenerSet"),
@@ -206,7 +206,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -227,7 +227,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -247,7 +247,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -267,7 +267,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("TCPRoute"),
@@ -328,7 +328,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -348,7 +348,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("ListenerSet"),
@@ -368,7 +368,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("GRPCRoute"),
@@ -398,7 +398,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("foo"),
@@ -440,7 +440,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("foo"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -460,7 +460,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("foo"),
 								Kind:  gwapiv1.Kind("bar"),
@@ -481,7 +481,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -499,7 +499,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -524,7 +524,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -549,7 +549,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -562,7 +562,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 							Type: egv1a1.ConsistentHashLoadBalancerType,
 							ConsistentHash: &egv1a1.ConsistentHash{
 								Type: "Header",
-								Header: &egv1a1.Header{
+								Header: &egv1a1.Header{ //nolint:staticcheck
 									Name: "name",
 								},
 							},
@@ -577,7 +577,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -605,7 +605,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -633,7 +633,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -661,7 +661,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -687,7 +687,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -718,7 +718,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -749,7 +749,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -771,7 +771,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -794,7 +794,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -826,7 +826,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -856,7 +856,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -881,7 +881,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -906,7 +906,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -934,7 +934,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -962,7 +962,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -991,7 +991,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1020,7 +1020,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1048,7 +1048,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1076,7 +1076,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1104,7 +1104,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1132,7 +1132,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1160,7 +1160,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1185,7 +1185,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1209,7 +1209,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1236,7 +1236,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1265,7 +1265,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1288,7 +1288,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1315,7 +1315,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1341,7 +1341,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1366,7 +1366,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1395,7 +1395,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1425,7 +1425,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1455,7 +1455,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1491,7 +1491,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1517,7 +1517,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1540,7 +1540,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1563,7 +1563,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1586,7 +1586,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1612,7 +1612,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1637,7 +1637,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1658,7 +1658,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1682,7 +1682,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 				valMin := new(int64(0))
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1709,7 +1709,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 				valUnderMin := new(int64(-1))
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1741,7 +1741,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1770,7 +1770,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1800,7 +1800,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1830,7 +1830,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1860,7 +1860,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1889,7 +1889,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1919,7 +1919,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1947,7 +1947,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -1977,7 +1977,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2013,7 +2013,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2049,7 +2049,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2088,7 +2088,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2128,7 +2128,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 				d := gwapiv1.Duration("3s")
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2167,7 +2167,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2200,7 +2200,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2226,7 +2226,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2255,7 +2255,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2284,7 +2284,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2313,7 +2313,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2342,7 +2342,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2371,7 +2371,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2400,7 +2400,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2421,7 +2421,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2443,7 +2443,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2467,7 +2467,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2494,7 +2494,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2518,7 +2518,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2546,7 +2546,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2577,7 +2577,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2606,7 +2606,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2654,7 +2654,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2689,7 +2689,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2730,7 +2730,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2772,7 +2772,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2817,7 +2817,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2861,7 +2861,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2904,7 +2904,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2945,7 +2945,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -2988,7 +2988,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3026,7 +3026,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3063,7 +3063,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3105,7 +3105,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3134,7 +3134,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3170,7 +3170,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3250,7 +3250,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3272,7 +3272,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3308,7 +3308,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3338,7 +3338,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3369,7 +3369,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3400,7 +3400,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3422,7 +3422,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3618,7 +3618,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3647,7 +3647,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3686,7 +3686,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3726,7 +3726,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -3755,7 +3755,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -3763,7 +3763,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 							},
 						},
 					},
-					Compression: []*egv1a1.Compression{
+					Compression: []*egv1a1.Compression{ //nolint:staticcheck
 						{
 							Type: egv1a1.GzipCompressorType,
 						},
@@ -3777,7 +3777,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -3800,7 +3800,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -3808,7 +3808,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 							},
 						},
 					},
-					Compression: []*egv1a1.Compression{
+					Compression: []*egv1a1.Compression{ //nolint:staticcheck
 						{
 							Type: egv1a1.GzipCompressorType,
 						},
@@ -3828,7 +3828,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -3853,7 +3853,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -3878,7 +3878,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -3909,7 +3909,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -3937,7 +3937,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -3968,7 +3968,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -3999,7 +3999,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -4030,7 +4030,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -4048,7 +4048,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -4080,7 +4080,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -4111,7 +4111,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -4143,7 +4143,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -4175,7 +4175,7 @@ func TestBackendTrafficPolicyTarget(t *testing.T) {
 			mutate: func(btp *egv1a1.BackendTrafficPolicy) {
 				btp.Spec = egv1a1.BackendTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",

--- a/test/cel-validation/clienttrafficpolicy_test.go
+++ b/test/cel-validation/clienttrafficpolicy_test.go
@@ -42,7 +42,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -69,7 +69,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("foo"),
@@ -89,7 +89,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("ListenerSet"),
@@ -106,7 +106,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("foo"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -149,7 +149,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("foo"),
 								Kind:  gwapiv1.Kind("bar"),
@@ -170,7 +170,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -196,7 +196,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -221,7 +221,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -249,7 +249,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -270,7 +270,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -290,7 +290,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -316,7 +316,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -346,7 +346,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -374,7 +374,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -400,7 +400,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -423,7 +423,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -450,7 +450,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 				d := gwapiv1.Duration("300s")
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -472,7 +472,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -494,7 +494,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -514,7 +514,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -538,7 +538,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -561,7 +561,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -585,7 +585,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -607,7 +607,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -629,7 +629,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -652,7 +652,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 			mutate: func(ctp *egv1a1.ClientTrafficPolicy) {
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -681,7 +681,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 				d := gwapiv1.Duration("300s")
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -775,7 +775,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 				ctp.Name = "ctp-headers"
 				ctp.Spec = egv1a1.ClientTrafficPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -784,7 +784,7 @@ func TestClientTrafficPolicyTarget(t *testing.T) {
 						},
 					},
 					Headers: &egv1a1.HeaderSettings{
-						PreserveXRequestID: new(true),
+						PreserveXRequestID: new(true), //nolint:staticcheck
 						RequestID:          new(egv1a1.RequestIDActionGenerate),
 					},
 				}

--- a/test/cel-validation/envoyextensionpolicy_test.go
+++ b/test/cel-validation/envoyextensionpolicy_test.go
@@ -44,7 +44,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 			mutate: func(eep *egv1a1.EnvoyExtensionPolicy) {
 				eep.Spec = egv1a1.EnvoyExtensionPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -61,7 +61,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 			mutate: func(eep *egv1a1.EnvoyExtensionPolicy) {
 				eep.Spec = egv1a1.EnvoyExtensionPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -78,7 +78,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 			mutate: func(eep *egv1a1.EnvoyExtensionPolicy) {
 				eep.Spec = egv1a1.EnvoyExtensionPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("ListenerSet"),
@@ -114,7 +114,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 			mutate: func(eep *egv1a1.EnvoyExtensionPolicy) {
 				eep.Spec = egv1a1.EnvoyExtensionPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -149,7 +149,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 			mutate: func(eep *egv1a1.EnvoyExtensionPolicy) {
 				eep.Spec = egv1a1.EnvoyExtensionPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("ListenerSet"),
@@ -204,7 +204,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 			mutate: func(eep *egv1a1.EnvoyExtensionPolicy) {
 				eep.Spec = egv1a1.EnvoyExtensionPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("foo"),
@@ -243,7 +243,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 			mutate: func(eep *egv1a1.EnvoyExtensionPolicy) {
 				eep.Spec = egv1a1.EnvoyExtensionPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("foo"),
@@ -285,7 +285,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 			mutate: func(eep *egv1a1.EnvoyExtensionPolicy) {
 				eep.Spec = egv1a1.EnvoyExtensionPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("foo"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -327,7 +327,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 			mutate: func(eep *egv1a1.EnvoyExtensionPolicy) {
 				eep.Spec = egv1a1.EnvoyExtensionPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("foo"),
 								Kind:  gwapiv1.Kind("bar"),
@@ -371,7 +371,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 			mutate: func(eep *egv1a1.EnvoyExtensionPolicy) {
 				eep.Spec = egv1a1.EnvoyExtensionPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -425,7 +425,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -458,7 +458,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -490,7 +490,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -525,7 +525,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -567,7 +567,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -607,7 +607,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -644,7 +644,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -676,7 +676,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -716,7 +716,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -756,7 +756,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -795,7 +795,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -835,7 +835,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -878,7 +878,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -904,7 +904,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -931,7 +931,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -958,7 +958,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -984,7 +984,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1014,7 +1014,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1044,7 +1044,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1075,7 +1075,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1103,7 +1103,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1125,7 +1125,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1147,7 +1147,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1177,7 +1177,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1200,7 +1200,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1314,7 +1314,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1362,7 +1362,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1407,7 +1407,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1446,7 +1446,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1486,7 +1486,7 @@ func TestEnvoyExtensionPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",

--- a/test/cel-validation/envoyproxy_test.go
+++ b/test/cel-validation/envoyproxy_test.go
@@ -783,7 +783,7 @@ func TestEnvoyProxyProvider(t *testing.T) {
 														},
 													},
 												},
-												Resources: map[string]string{
+												Resources: map[string]string{ //nolint:staticcheck
 													"service.name": "eg",
 												},
 											},
@@ -861,7 +861,7 @@ func TestEnvoyProxyProvider(t *testing.T) {
 														},
 													},
 												},
-												Resources: map[string]string{
+												Resources: map[string]string{ //nolint:staticcheck
 													"service.name": "eg",
 												},
 												ResourceAttributes: map[string]string{
@@ -2603,7 +2603,7 @@ func TestEnvoyProxyProvider(t *testing.T) {
 			desc: "luaValidation-and-lua-mutually-exclusive",
 			mutate: func(envoy *egv1a1.EnvoyProxy) {
 				envoy.Spec = egv1a1.EnvoyProxySpec{
-					LuaValidation: new(egv1a1.LuaValidationStrict),
+					LuaValidation: new(egv1a1.LuaValidationStrict), //nolint:staticcheck
 					Lua:           &egv1a1.LuaValidationConfig{StrictValidation: &egv1a1.StrictValidation{AllowedPaths: []string{"/tmp"}}},
 				}
 			},

--- a/test/cel-validation/securitypolicy_test.go
+++ b/test/cel-validation/securitypolicy_test.go
@@ -45,7 +45,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 			mutate: func(sp *egv1a1.SecurityPolicy) {
 				sp.Spec = egv1a1.SecurityPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -62,7 +62,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 			mutate: func(sp *egv1a1.SecurityPolicy) {
 				sp.Spec = egv1a1.SecurityPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("ListenerSet"),
@@ -98,7 +98,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 			mutate: func(sp *egv1a1.SecurityPolicy) {
 				sp.Spec = egv1a1.SecurityPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -133,7 +133,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 			mutate: func(sp *egv1a1.SecurityPolicy) {
 				sp.Spec = egv1a1.SecurityPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("ListenerSet"),
@@ -198,7 +198,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 			mutate: func(sp *egv1a1.SecurityPolicy) {
 				sp.Spec = egv1a1.SecurityPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("foo"),
@@ -218,7 +218,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 			mutate: func(sp *egv1a1.SecurityPolicy) {
 				sp.Spec = egv1a1.SecurityPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("foo"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -238,7 +238,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 			mutate: func(sp *egv1a1.SecurityPolicy) {
 				sp.Spec = egv1a1.SecurityPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("foo"),
 								Kind:  gwapiv1.Kind("bar"),
@@ -283,7 +283,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 			mutate: func(sp *egv1a1.SecurityPolicy) {
 				sp.Spec = egv1a1.SecurityPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -321,7 +321,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 			mutate: func(sp *egv1a1.SecurityPolicy) {
 				sp.Spec = egv1a1.SecurityPolicySpec{
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("HTTPRoute"),
@@ -366,7 +366,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -388,7 +388,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -410,7 +410,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -432,7 +432,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -454,7 +454,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -476,7 +476,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -498,7 +498,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -520,7 +520,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -544,7 +544,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -568,7 +568,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -590,7 +590,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -612,7 +612,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -641,7 +641,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -663,7 +663,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						AdditionalOrigins: []egv1a1.Origin{"www.example.com"},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -686,7 +686,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						AdditionalOrigins: []egv1a1.Origin{"https://www.example.com/app"},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: gwapiv1.Group("gateway.networking.k8s.io"),
 								Kind:  gwapiv1.Kind("Gateway"),
@@ -721,7 +721,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -753,7 +753,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -786,7 +786,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -806,7 +806,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						GRPC: &egv1a1.GRPCExtAuthService{},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -837,7 +837,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -870,7 +870,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -904,7 +904,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -937,7 +937,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -957,7 +957,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						HTTP: &egv1a1.HTTPExtAuthService{},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -975,7 +975,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 				sp.Spec = egv1a1.SecurityPolicySpec{
 					ExtAuth: &egv1a1.ExtAuth{},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -997,7 +997,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 					ExtAuth: &egv1a1.ExtAuth{
 						GRPC: &egv1a1.GRPCExtAuthService{
 							BackendCluster: egv1a1.BackendCluster{
-								BackendRef: &gwapiv1.BackendObjectReference{
+								BackendRef: &gwapiv1.BackendObjectReference{ //nolint:staticcheck
 									Name: "grpc-auth-service",
 									Port: new(gwapiv1.PortNumber(80)),
 								},
@@ -1005,7 +1005,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 						HTTP: &egv1a1.HTTPExtAuthService{
 							BackendCluster: egv1a1.BackendCluster{
-								BackendRef: &gwapiv1.BackendObjectReference{
+								BackendRef: &gwapiv1.BackendObjectReference{ //nolint:staticcheck
 									Name: "http-auth-service",
 									Port: new(gwapiv1.PortNumber(15001)),
 								},
@@ -1013,7 +1013,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1048,7 +1048,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1082,7 +1082,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1114,7 +1114,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1148,7 +1148,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1183,7 +1183,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						Timeout: new(gwapiv1.Duration("50s")),
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1216,7 +1216,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						Timeout: new(gwapiv1.Duration("2s")),
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1245,7 +1245,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1278,7 +1278,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1306,7 +1306,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1343,7 +1343,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1384,7 +1384,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1410,7 +1410,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1441,7 +1441,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -1482,7 +1482,7 @@ func TestSecurityPolicyTarget(t *testing.T) {
 						},
 					},
 					PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+						TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 							LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "Gateway",
@@ -2284,7 +2284,7 @@ func TestSecurityPolicyAPIKeyAuthExtractFrom(t *testing.T) {
 		},
 		Spec: egv1a1.SecurityPolicySpec{
 			PolicyTargetReferences: egv1a1.PolicyTargetReferences{
-				TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+				TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{ //nolint:staticcheck
 					LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
 						Group: gwapiv1.Group("gateway.networking.k8s.io"),
 						Kind:  gwapiv1.Kind("Gateway"),

--- a/test/e2e/tests/api_key_auth.go
+++ b/test/e2e/tests/api_key_auth.go
@@ -263,7 +263,7 @@ var APIKeyAuthTest = suite.ConformanceTest{
 					AbsentHeaders: []string{"X-API-KEY"},
 				},
 				Response: http.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200},
 				},
 				Namespace: ns,
 			}
@@ -278,7 +278,7 @@ var APIKeyAuthTest = suite.ConformanceTest{
 					},
 				},
 				Response: http.Response{
-					StatusCode: 401,
+					StatusCodes: []int{401},
 				},
 				Namespace: ns,
 			}

--- a/test/e2e/tests/backend_tls.go
+++ b/test/e2e/tests/backend_tls.go
@@ -132,7 +132,7 @@ var BackendTLSTest = suite.ConformanceTest{
 					Path: "/backend-auto-sni",
 				},
 				Response: http.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200},
 				},
 				Namespace: ConformanceInfraNamespace,
 			}
@@ -162,7 +162,7 @@ var BackendTLSTest = suite.ConformanceTest{
 					},
 				},
 				Response: http.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200},
 				},
 			}
 

--- a/test/e2e/tests/backend_tls_settings.go
+++ b/test/e2e/tests/backend_tls_settings.go
@@ -257,7 +257,7 @@ var BackendTLSSettingsTest = suite.ConformanceTest{
 					Path: "/backend-client-tls",
 				},
 				Response: http.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200},
 				},
 				Namespace: ConformanceInfraNamespace,
 			}

--- a/test/e2e/tests/backendtrafficpolicy_listenerset.go
+++ b/test/e2e/tests/backendtrafficpolicy_listenerset.go
@@ -164,7 +164,7 @@ func expectBackendTrafficPolicyStatus(t *testing.T, suite *suite.ConformanceTest
 			Path: path,
 		},
 		Response: httputils.Response{
-			StatusCode: statusCode,
+			StatusCodes: []int{statusCode},
 		},
 	}
 	httputils.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, addr, expectedResponse)

--- a/test/e2e/tests/backendtrafficpolicy_section_merged.go
+++ b/test/e2e/tests/backendtrafficpolicy_section_merged.go
@@ -104,7 +104,7 @@ var BackendTrafficPolicyMergedTest = suite.ConformanceTest{
 			expectedResponse := http.ExpectedResponse{
 				Namespace: ns,
 				Request:   http.Request{Host: "listener1.merged.example.com", Path: "/bar"},
-				Response:  http.Response{StatusCode: 419},
+				Response:  http.Response{StatusCodes: []int{419}},
 			}
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 
@@ -114,7 +114,7 @@ var BackendTrafficPolicyMergedTest = suite.ConformanceTest{
 			expectedResponse = http.ExpectedResponse{
 				Namespace: ns,
 				Request:   http.Request{Host: "listener1.merged.example.com", Path: "/foo"},
-				Response:  http.Response{StatusCode: 500},
+				Response:  http.Response{StatusCodes: []int{500}},
 			}
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 
@@ -124,7 +124,7 @@ var BackendTrafficPolicyMergedTest = suite.ConformanceTest{
 			expectedResponse = http.ExpectedResponse{
 				Namespace: ns,
 				Request:   http.Request{Host: "listener2.merged.example.com", Path: "/foo"},
-				Response:  http.Response{StatusCode: 420},
+				Response:  http.Response{StatusCodes: []int{420}},
 			}
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
 		})

--- a/test/e2e/tests/listener_health_check.go
+++ b/test/e2e/tests/listener_health_check.go
@@ -8,11 +8,11 @@
 package tests
 
 import (
+	"slices"
 	"testing"
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/kubectl/pkg/util/slice"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
@@ -67,7 +67,7 @@ var ListenerHealthCheckTest = suite.ConformanceTest{
 				// directly check the status code of the response, since health check request will be
 				// terminated by envoy instead of echo server in backend, no request will be captured
 				// from the response.
-				return slice.Contains(expectedResponse.Response.StatusCodes, cResp.StatusCode, nil)
+				return slices.Contains(expectedResponse.Response.StatusCodes, cResp.StatusCode)
 			})
 		})
 	},

--- a/test/e2e/tests/ratelimit.go
+++ b/test/e2e/tests/ratelimit.go
@@ -376,8 +376,8 @@ var RateLimitPathMatchTest = suite.ConformanceTest{
 					Path: "/get/specific-path",
 				},
 				Response: http.Response{
-					StatusCode: 200,
-					Headers:    ratelimitHeader,
+					StatusCodes: []int{200},
+					Headers:     ratelimitHeader,
 				},
 				Namespace: ns,
 			}
@@ -389,7 +389,7 @@ var RateLimitPathMatchTest = suite.ConformanceTest{
 					Path: "/get/specific-path",
 				},
 				Response: http.Response{
-					StatusCode: 429,
+					StatusCodes: []int{429},
 				},
 				Namespace: ns,
 			}
@@ -414,7 +414,7 @@ var RateLimitPathMatchTest = suite.ConformanceTest{
 					Path: "/get/specific-path/subpath",
 				},
 				Response: http.Response{
-					StatusCode: 429,
+					StatusCodes: []int{429},
 				},
 				Namespace: ns,
 			}
@@ -429,7 +429,7 @@ var RateLimitPathMatchTest = suite.ConformanceTest{
 					Path: "/get/specific-path2",
 				},
 				Response: http.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200},
 				},
 				Namespace: ns,
 			}
@@ -446,7 +446,7 @@ var RateLimitPathMatchTest = suite.ConformanceTest{
 					Path: "/get/no-specific-path",
 				},
 				Response: http.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200},
 				},
 				Namespace: ns,
 			}
@@ -1568,8 +1568,8 @@ var RateLimitGlobalShadowModeTest = suite.ConformanceTest{
 					Method: "GET",
 				},
 				Response: http.Response{
-					StatusCode: 200,
-					Headers:    ratelimitHeader,
+					StatusCodes: []int{200},
+					Headers:     ratelimitHeader,
 				},
 				Namespace: ns,
 			}

--- a/test/e2e/tests/securitypolicy_merged.go
+++ b/test/e2e/tests/securitypolicy_merged.go
@@ -78,7 +78,7 @@ var SecurityPolicyMergedTest = suite.ConformanceTest{
 					},
 				},
 				Response: httputils.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200},
 					Headers: map[string]string{
 						"Access-Control-Allow-Origin": "https://www.example.com",
 					},

--- a/test/e2e/tests/session_persistence.go
+++ b/test/e2e/tests/session_persistence.go
@@ -164,7 +164,7 @@ var SessionPersistenceTest = suite.ConformanceTest{
 					Path: "/cookie-session-persistence-multiple-backends",
 				},
 				Response: http.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200},
 				},
 				Namespace: ns,
 			}

--- a/tools/linter/golangci-lint/.golangci.yml
+++ b/tools/linter/golangci-lint/.golangci.yml
@@ -60,9 +60,6 @@ linters:
       - std-error-handling
     rules:
       - linters:
-          - staticcheck
-        text: 'SA1019:'
-      - linters:
           - bodyclose
         path: test/e2e
       - linters:


### PR DESCRIPTION
<!--
Your PR title should be descriptive, and generally start with a type that contains a subsystem name with `()` if necessary
and a summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), the API must be discussed and
agreed before the implementation. We strongly recommend separating API changes into their own PR so
we can review the API first, but the API may also live in the same PR as long as it was agreed
beforehand. This will save you a lot of implementation time if the API gets accepted.
-->

**What this PR does / why we need it**:
<!--
Briefly describe what this PR changes and the motivation behind it. Include enough context for a
reviewer to understand the problem being solved and the approach taken, e.g. what behavior changes,
any alternatives considered, and anything reviewers should pay special attention to.
-->

staticcheck's `SA1019` check (use of deprecated functions, variables, constants, or fields) is currently silenced by an exclusion rule in the golangci-lint config.

This exclusion hides real usages of deprecated APIs, so deprecated calls can be introduced without any signal from CI. This PR removes the exclusion to turn SA1019 on, and fixes the deprecation warnings it surfaces by migrating each call site to its recommended replacement.

Note:
APIs that Envoy Gateway itself has deprecated are intentionally left as-is. We still need to reference these fields/functions internally (e.g. for backward compatibility and conversion of the deprecated fields), so migrating away from them is not possible yet. These call sites are suppressed locally with `//nolint:staticcheck` rather than being changed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

relate to comments: https://github.com/envoyproxy/gateway/pull/9703#issuecomment-5223718167

---

**PR Checklist**
<!--
Please tick the boxes below before requesting a review. PRs that leave required items unchecked may
be delayed or closed. Replace `[ ]` with `[x]` to check a box. If an item does not apply, check it
and add "N/A: <reason>".
-->

- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: If this PR contains API changes (changes under `/api`), the API was discussed and agreed **before** the implementation. The API change can be in a separate PR, or in the same PR, but the API must be agreed before implementation. N/A if this PR does not contain API changes.
- [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (Flaky e2e failures are not considered breakages, but `gen-check`, `lint`, and coverage **MUST** pass.)
- [x] **Tests added/updated**: New/changed code is covered by appropriate tests. N/A if this PR does not contain code changes.
- [x] **Docs**: User-facing changes update the [docs](https://github.com/envoyproxy/gateway/tree/main/site), either in this PR or a follow-up PR. N/A if this PR does not contain user-facing changes.
- [x] **Release notes**: For any non-trivial change, added a release-note fragment under `release-notes/current/<section>/<pr-number>-<slug>.md` (see `release-notes/current/README.md` for sections and naming). N/A if this PR does not contain non-trivial changes.
- [x] **Generated files committed**: Ran `make gen-check` and committed the result if API/helm charts/modules changed.
- [x] **Scope & compatibility**: The PR is reasonably scoped (no unrelated changes) and preserves backward compatibility, or any breaking change is called out above and documented in `release-notes/current/breaking_changes/`.
- [ ] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.
