### PR TITLE
chore: increase loki max_structured_metadata_size

### DIFF
--- a/charts/gateway-addons-helm/README.md
+++ b/charts/gateway-addons-helm/README.md
@@ -116,6 +116,7 @@ helm uninstall eg-addons -n monitoring
 | loki.loki.commonConfig.replication_factor | int | `1` |  |
 | loki.loki.commonConfig.ring.kvstore.store | string | `"memberlist"` |  |
 | loki.loki.compactorAddress | string | `"loki"` |  |
+| loki.loki.limits_config.max_structured_metadata_size | int | `131072` |  |
 | loki.loki.limits_config.otlp_config.resource_attributes.attributes_config[0].action | string | `"index_label"` |  |
 | loki.loki.limits_config.otlp_config.resource_attributes.attributes_config[0].attributes[0] | string | `"exporter"` |  |
 | loki.loki.memberlist | string | `"loki-memberlist"` |  |

--- a/charts/gateway-addons-helm/values.yaml
+++ b/charts/gateway-addons-helm/values.yaml
@@ -766,6 +766,7 @@ loki:
       storage:
         type: "local"
     limits_config:
+      max_structured_metadata_size: 131072
       otlp_config:
         resource_attributes:
           attributes_config:

--- a/site/content/en/latest/install/gateway-addons-helm-api.md
+++ b/site/content/en/latest/install/gateway-addons-helm-api.md
@@ -95,6 +95,7 @@ An Add-ons Helm chart for Envoy Gateway
 | loki.loki.commonConfig.replication_factor | int | `1` |  |
 | loki.loki.commonConfig.ring.kvstore.store | string | `"memberlist"` |  |
 | loki.loki.compactorAddress | string | `"loki"` |  |
+| loki.loki.limits_config.max_structured_metadata_size | int | `131072` |  |
 | loki.loki.limits_config.otlp_config.resource_attributes.attributes_config[0].action | string | `"index_label"` |  |
 | loki.loki.limits_config.otlp_config.resource_attributes.attributes_config[0].attributes[0] | string | `"exporter"` |  |
 | loki.loki.memberlist | string | `"loki-memberlist"` |  |

--- a/test/helm/gateway-addons-helm/default.out.yaml
+++ b/test/helm/gateway-addons-helm/default.out.yaml
@@ -234,6 +234,7 @@ data:
       mode: simple
     limits_config:
       max_cache_freshness_per_query: 10m
+      max_structured_metadata_size: 131072
       otlp_config:
         resource_attributes:
           attributes_config:
@@ -10867,7 +10868,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6b4509c66d127c358eaec628ad628a06a82b9eea1a0d0b619b774e1938e660da
+        checksum/config: 11cf4e31138a898d46620bf2c85ab2b39eba10d307d42f7faaa395ba84dfb732
         storage/size: "10Gi"
         kubectl.kubernetes.io/default-container: "loki"
       labels:

--- a/test/helm/gateway-addons-helm/e2e.out.yaml
+++ b/test/helm/gateway-addons-helm/e2e.out.yaml
@@ -229,6 +229,7 @@ data:
       mode: simple
     limits_config:
       max_cache_freshness_per_query: 10m
+      max_structured_metadata_size: 131072
       otlp_config:
         resource_attributes:
           attributes_config:
@@ -11158,7 +11159,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6b4509c66d127c358eaec628ad628a06a82b9eea1a0d0b619b774e1938e660da
+        checksum/config: 11cf4e31138a898d46620bf2c85ab2b39eba10d307d42f7faaa395ba84dfb732
         storage/size: "10Gi"
         kubectl.kubernetes.io/default-container: "loki"
       labels:


### PR DESCRIPTION
saw following error:
```
2026-08-14T01:08:01.287Z	error	internal/queue_sender.go:50	Exporting failed. Dropping data.	{"resource": {"host.name": "envoy-gateway-worker", "k8s.namespace.name": "monitoring", "k8s.node.ip": "172.18.0.2", "k8s.node.name": "envoy-gateway-worker", "k8s.pod.ip": "10.244.1.25", "k8s.pod.name": "otel-collector-5df79b6ccc-rf5hr", "service.instance.id": "3251f0bf-e4b1-41e2-892b-4d5ea7026e26", "service.name": "otelcol-contrib", "service.version": "0.155.0"}, "otelcol.component.id": "otlphttp/loki", "otelcol.component.kind": "exporter", "otelcol.signal": "logs", "error": "not retryable error: Permanent error: rpc error: code = InvalidArgument desc = error exporting items, request to http://loki.monitoring.svc:3100/otlp/v1/logs responded with HTTP Status Code 400, Message=stream '{exporter=\"OTLP\", service_name=\"unknown_service\"}' has structured metadata too large: '77829' bytes, limit: '65536' bytes. Please see `limits_config.max_structured_metadata_size` or contact your Loki administrator to increase it, Details=[]", "dropped_items": 1}
go.opentelemetry.io/collector/exporter/exporterhelper/internal.NewQueueSender.func1
	go.opentelemetry.io/collector/exporter/exporterhelper@v0.155.0/internal/queue_sender.go:50
go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch.(*disabledBatcher[...]).Consume
	go.opentelemetry.io/collector/exporter/exporterhelper@v0.155.0/internal/queuebatch/disabled_batcher.go:23
go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue.(*asyncQueue[...]).Start.func1
	go.opentelemetry.io/collector/exporter/exporterhelper@v0.155.0/internal/queue/async_queue.go:47
sync.(*WaitGroup).Go.func1
	sync/waitgroup.go:258
```