### PR TITLE
fix: list extension manager resources once per reconcile

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -1851,6 +1851,16 @@ func (r *gatewayAPIReconciler) processGateways(ctx context.Context, managedGC *g
 		r.processServiceClusterForGatewayClass(ctx, resourceTree.EnvoyProxyForGatewayClass, managedGC, resourceMap)
 	}
 
+	if len(gatewayList.Items) == 0 {
+		return nil
+	}
+
+	// The extension ref filters and backend resources are cluster-wide,
+	// so they are collected once per GatewayClass instead of once per Gateway.
+	if err := r.populateExtensionResources(ctx, resourceMap); err != nil {
+		return err
+	}
+
 	for i := range gatewayList.Items {
 		gtw := &gatewayList.Items[i]
 

--- a/internal/provider/kubernetes/controller_test.go
+++ b/internal/provider/kubernetes/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -506,6 +508,60 @@ func TestProcessRateLimitService(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessGatewaysListsExtensionResourcesOnce(t *testing.T) {
+	const ns = "default"
+	extFilterGVK := schema.GroupVersionKind{Group: "gateway.example.io", Version: "v1alpha1", Kind: "CustomFilter"}
+	extBackendGVK := schema.GroupVersionKind{Group: "storage.example.io", Version: "v1alpha1", Kind: "S3Backend"}
+
+	gc := test.GetGatewayClass("test", egv1a1.GatewayControllerName, nil)
+	gw1 := test.GetGateway(types.NamespacedName{Namespace: ns, Name: "gw-1"}, gc.Name, 80)
+	gw2 := test.GetGateway(types.NamespacedName{Namespace: ns, Name: "gw-2"}, gc.Name, 80)
+
+	newExtResource := func(gvk schema.GroupVersionKind, name string) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(gvk)
+		u.SetName(name)
+		u.SetNamespace(ns)
+		return u
+	}
+
+	сalls := map[string]int{}
+	countingLists := interceptor.Funcs{
+		List: func(ctx context.Context, cli client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if uList, ok := list.(*unstructured.UnstructuredList); ok {
+				сalls[strings.TrimSuffix(uList.GroupVersionKind().Kind, "List")]++
+			}
+			return cli.List(ctx, list, opts...)
+		},
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(newTestScheme(extFilterGVK, extBackendGVK)).
+		WithObjects(gc, gw1, gw2,
+			newExtResource(extFilterGVK, "custom-filter"),
+			newExtResource(extBackendGVK, "s3-backend")).
+		WithIndex(&gwapiv1.Gateway{}, classGatewayIndex, gatewayIndexFunc).
+		WithIndex(&gwapiv1.HTTPRoute{}, gatewayHTTPRouteIndex, gatewayHTTPRouteIndexFunc).
+		WithInterceptorFuncs(countingLists).
+		Build()
+
+	r := &gatewayAPIReconciler{
+		log:            logging.DefaultLogger(os.Stdout, egv1a1.LogLevelInfo),
+		client:         fakeClient,
+		extGVKs:        []schema.GroupVersionKind{extFilterGVK},
+		extBackendGVKs: []schema.GroupVersionKind{extBackendGVK},
+	}
+
+	resourceTree := resource.NewResources()
+	resourceMap := newResourceMapping()
+	require.NoError(t, r.processGateways(t.Context(), gc, resourceTree, resourceMap))
+
+	require.Len(t, resourceTree.Gateways, 2)
+	require.Equal(t, 1, сalls[extFilterGVK.Kind])  // called only once
+	require.Equal(t, 1, сalls[extBackendGVK.Kind]) // called only once
+	require.Len(t, resourceMap.extensionRefFilters, 2)
 }
 
 func TestRemoveGatewayClassFinalizer(t *testing.T) {

--- a/internal/provider/kubernetes/routes.go
+++ b/internal/provider/kubernetes/routes.go
@@ -103,6 +103,32 @@ func (r *gatewayAPIReconciler) processTLSRoutes(ctx context.Context, gatewayName
 	return nil
 }
 
+// populateExtensionResources collects extension ref filters and custom backend resources
+// managed by extensions into resourceMap. These resources are cluster-wide and not scoped to a specific Gateway,
+// so this must be called once per reconcile rather than once per Gateway.
+func (r *gatewayAPIReconciler) populateExtensionResources(ctx context.Context, resourceMap *resourceMappings) error {
+	extensionRefFilters, err := r.getExtensionRefFilters(ctx)
+	if err != nil {
+		return err
+	}
+	for i := range extensionRefFilters {
+		filter := extensionRefFilters[i]
+		resourceMap.extensionRefFilters[utils.GetNamespacedNameWithGroupKind(&filter)] = filter
+	}
+
+	// Collect custom backend resources managed by extensions
+	extensionBackendResources, err := r.getExtensionBackendResources(ctx)
+	if err != nil {
+		return err
+	}
+	for i := range extensionBackendResources {
+		backend := extensionBackendResources[i]
+		resourceMap.extensionRefFilters[utils.GetNamespacedNameWithGroupKind(&backend)] = backend
+	}
+
+	return nil
+}
+
 // processGRPCRoutes finds GRPCRoutes corresponding to a gatewayNamespaceName, further checks for
 // the backend references and pushes the GRPCRoutes to the resourceTree.
 func (r *gatewayAPIReconciler) processGRPCRoutes(ctx context.Context, gatewayNamespaceName string,
@@ -248,25 +274,6 @@ func (r *gatewayAPIReconciler) processHTTPRoutes(ctx context.Context, gatewayNam
 	resourceMap *resourceMappings, resourceTree *resource.Resources,
 ) error {
 	httpRouteList := &gwapiv1.HTTPRouteList{}
-
-	extensionRefFilters, err := r.getExtensionRefFilters(ctx)
-	if err != nil {
-		return err
-	}
-	for i := range extensionRefFilters {
-		filter := extensionRefFilters[i]
-		resourceMap.extensionRefFilters[utils.GetNamespacedNameWithGroupKind(&filter)] = filter
-	}
-
-	// Collect custom backend resources managed by extensions
-	extensionBackendResources, err := r.getExtensionBackendResources(ctx)
-	if err != nil {
-		return err
-	}
-	for i := range extensionBackendResources {
-		backend := extensionBackendResources[i]
-		resourceMap.extensionRefFilters[utils.GetNamespacedNameWithGroupKind(&backend)] = backend
-	}
 
 	// Process HTTPRoutes attached to the gateway
 	if err := r.client.List(ctx, httpRouteList, &client.ListOptions{

--- a/internal/provider/kubernetes/routes_test.go
+++ b/internal/provider/kubernetes/routes_test.go
@@ -658,6 +658,7 @@ func TestProcessHTTPRoutes(t *testing.T) {
 			// Process the test case httproutes.
 			resourceTree := resource.NewResources()
 			resourceMap := newResourceMapping()
+			require.NoError(t, r.populateExtensionResources(ctx, resourceMap))
 			err := r.processHTTPRoutes(ctx, gwNsName, resourceMap, resourceTree)
 			if tc.expected {
 				require.NoError(t, err)
@@ -1476,6 +1477,7 @@ func TestProcessHTTPRoutesWithCustomBackends(t *testing.T) {
 			resourceTree.GatewayClass = gatewayClass
 
 			// Call the function under test
+			require.NoError(t, r.populateExtensionResources(t.Context(), resourceMap))
 			err := r.processHTTPRoutes(t.Context(), "default/test-gateway", resourceMap, resourceTree)
 
 			// Verify results

--- a/release-notes/current/performance_improvements/9764-extension-resources-once-per-gatewayclass.md
+++ b/release-notes/current/performance_improvements/9764-extension-resources-once-per-gatewayclass.md
@@ -1,0 +1,1 @@
+Improved reconcile performance by listing the extension manager's `resources` and `backendResources` once per GatewayClass instead of once per Gateway.


### PR DESCRIPTION
**What this PR does / why we need it**:

Collect ext-GVK in populateExtensionResources and call it once per reconcile from processGateways.

**Which issue(s) this PR fixes**:

Fixes #9407

---

**PR Checklist**
<!--
Please tick the boxes below before requesting a review. PRs that leave required items unchecked may
be delayed or closed. Replace `[ ]` with `[x]` to check a box. If an item does not apply, check it
and add "N/A: <reason>".
-->

- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: N/A: PR does not contain API changes.
- [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (Flaky e2e failures are not considered breakages, but `gen-check`, `lint`, and coverage **MUST** pass.)
- [x] **Tests added/updated**: New/changed code is covered by appropriate tests. N/A if this PR does not contain code changes.
- [x] **Docs**: N/A: PR does not contain user-facing changes.
- [x] **Release notes**: N/A: PR does not contain non-trivial changes.
- [x] **Generated files committed**: Ran `make gen-check` and committed the result if API/helm charts/modules changed.
- [x] **Scope & compatibility**: The PR is reasonably scoped (no unrelated changes) and preserves backward compatibility, or any breaking change is called out above and documented in `release-notes/current/breaking_changes/`.
- [x] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.
