### PR TITLE
fix(listenerset): preserve routes on hostname conflict winner

### DIFF
--- a/internal/gatewayapi/contexts.go
+++ b/internal/gatewayapi/contexts.go
@@ -157,6 +157,10 @@ type ListenerContext struct {
 	// slot from a valid same-hostname listener that uses the winner protocol.
 	protocolConflicted bool
 
+	// hostnameConflictLoser is set when another listener wins hostname conflict
+	// precedence. Losing listeners must not suppress routes on the winner.
+	hostnameConflictLoser bool
+
 	tls ListenerTLSConfig
 
 	httpIR *ir.HTTPListener

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -368,6 +368,9 @@ func computeHosts(routeHostnames []string, listenerContext *ListenerContext) []s
 		if listenerContext == listener {
 			continue
 		}
+		if listener.hostnameConflictLoser {
+			continue
+		}
 		if listenerContext != nil && listenerContext.Port != listener.Port {
 			continue
 		}

--- a/internal/gatewayapi/helpers_test.go
+++ b/internal/gatewayapi/helpers_test.go
@@ -1409,6 +1409,100 @@ func TestWildcardHostnameMatchesHostname(t *testing.T) {
 	}
 }
 
+func TestComputeHostsConflictOwnership(t *testing.T) {
+	const hostname = "winner.example.com"
+
+	newListener := func(gateway *GatewayContext, name, listenerHostname string) *ListenerContext {
+		listener := &ListenerContext{
+			Listener: &gwapiv1.Listener{
+				Name:     gwapiv1.SectionName(name),
+				Port:     80,
+				Protocol: gwapiv1.HTTPProtocolType,
+				Hostname: new(gwapiv1.Hostname(listenerHostname)),
+			},
+			gateway: gateway,
+		}
+		return listener
+	}
+
+	tests := []struct {
+		name            string
+		winnerHostname  string
+		routeHostname   string
+		siblingHostname string
+		configure       func(*ListenerContext)
+		want            []string
+	}{
+		{
+			name:            "normal sibling reserves hostname",
+			siblingHostname: hostname,
+			want:            []string{},
+		},
+		{
+			name:            "hostname conflict loser does not reserve hostname",
+			siblingHostname: hostname,
+			configure: func(listener *ListenerContext) {
+				listener.hostnameConflictLoser = true
+			},
+			want: []string{hostname},
+		},
+		{
+			name:            "invalid non-conflicted sibling reserves hostname",
+			siblingHostname: hostname,
+			configure: func(listener *ListenerContext) {
+				listener.specValid = false
+			},
+			want: []string{},
+		},
+		{
+			name:            "no-winner gateway conflict reserves hostname",
+			siblingHostname: hostname,
+			configure: func(listener *ListenerContext) {
+				listener.SetCondition(gwapiv1.ListenerConditionConflicted, metav1.ConditionTrue, gwapiv1.ListenerReasonHostnameConflict, "no winner")
+			},
+			want: []string{},
+		},
+		{
+			name:            "wildcard hostname conflict loser does not suppress intersection",
+			winnerHostname:  "*.example.com",
+			routeHostname:   "*.example.com",
+			siblingHostname: "*.example.com",
+			configure: func(listener *ListenerContext) {
+				listener.hostnameConflictLoser = true
+			},
+			want: []string{"*.example.com"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gateway := &GatewayContext{Gateway: &gwapiv1.Gateway{}}
+			winnerHostname := tc.winnerHostname
+			if winnerHostname == "" {
+				winnerHostname = hostname
+			}
+			routeHostname := tc.routeHostname
+			if routeHostname == "" {
+				routeHostname = hostname
+			}
+			winner := newListener(gateway, "winner", winnerHostname)
+			sibling := newListener(gateway, "sibling", tc.siblingHostname)
+			gateway.listeners = []*ListenerContext{winner, sibling}
+			gateway.Status.Listeners = []gwapiv1.ListenerStatus{
+				{Name: winner.Name},
+				{Name: sibling.Name},
+			}
+			winner.listenerStatusIdx = 0
+			sibling.listenerStatusIdx = 1
+			if tc.configure != nil {
+				tc.configure(sibling)
+			}
+
+			require.ElementsMatch(t, tc.want, computeHosts([]string{routeHostname}, winner))
+		})
+	}
+}
+
 func TestPolicyScopeGraphGetDirectChildren(t *testing.T) {
 	gatewayNN := types.NamespacedName{Namespace: "default", Name: "gateway"}
 	listenerSetNN := types.NamespacedName{Namespace: "default", Name: "listener-set"}

--- a/internal/gatewayapi/testdata/listenerset-conflict-route-attachment.in.yaml
+++ b/internal/gatewayapi/testdata/listenerset-conflict-route-attachment.in.yaml
@@ -1,0 +1,104 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-with-conflicting-listenersets
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    allowedListeners:
+      namespaces:
+        from: Same
+    listeners:
+    - name: gateway-winner
+      port: 80
+      protocol: HTTP
+      hostname: gateway-winner.example.com
+      allowedRoutes:
+        namespaces:
+          from: All
+listenerSets:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: ListenerSet
+  metadata:
+    creationTimestamp: "2026-05-21T10:27:11Z"
+    name: listenerset-winner
+    namespace: envoy-gateway
+  spec:
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-with-conflicting-listenersets
+      namespace: envoy-gateway
+    listeners:
+    - name: gateway-conflict
+      port: 80
+      protocol: HTTP
+      hostname: gateway-winner.example.com
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: listenerset-winner
+      port: 80
+      protocol: HTTP
+      hostname: listenerset-winner.example.com
+      allowedRoutes:
+        namespaces:
+          from: All
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: ListenerSet
+  metadata:
+    creationTimestamp: "2026-08-17T08:09:23Z"
+    name: listenerset-loser
+    namespace: envoy-gateway
+  spec:
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-with-conflicting-listenersets
+      namespace: envoy-gateway
+    listeners:
+    - name: listenerset-conflict
+      port: 80
+      protocol: HTTP
+      hostname: listenerset-winner.example.com
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: route-attached-to-gateway-winner
+    namespace: default
+  spec:
+    hostnames:
+    - gateway-winner.example.com
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-with-conflicting-listenersets
+      namespace: envoy-gateway
+      sectionName: gateway-winner
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: route-attached-to-listenerset-winner
+    namespace: default
+  spec:
+    hostnames:
+    - listenerset-winner.example.com
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: listenerset-winner
+      namespace: envoy-gateway
+      sectionName: listenerset-winner
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080

--- a/internal/gatewayapi/testdata/listenerset-conflict-route-attachment.out.yaml
+++ b/internal/gatewayapi/testdata/listenerset-conflict-route-attachment.out.yaml
@@ -1,0 +1,422 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-with-conflicting-listenersets
+    namespace: envoy-gateway
+  spec:
+    allowedListeners:
+      namespaces:
+        from: Same
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      hostname: gateway-winner.example.com
+      name: gateway-winner
+      port: 80
+      protocol: HTTP
+  status:
+    attachedListenerSets: 1
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: gateway-winner
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: route-attached-to-gateway-winner
+    namespace: default
+  spec:
+    hostnames:
+    - gateway-winner.example.com
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-with-conflicting-listenersets
+      namespace: envoy-gateway
+      sectionName: gateway-winner
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-with-conflicting-listenersets
+        namespace: envoy-gateway
+        sectionName: gateway-winner
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: route-attached-to-listenerset-winner
+    namespace: default
+  spec:
+    hostnames:
+    - listenerset-winner.example.com
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: listenerset-winner
+      namespace: envoy-gateway
+      sectionName: listenerset-winner
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: ListenerSet
+        name: listenerset-winner
+        namespace: envoy-gateway
+        sectionName: listenerset-winner
+infraIR:
+  envoy-gateway/gateway-with-conflicting-listenersets:
+    proxy:
+      listeners:
+      - name: envoy-gateway/gateway-with-conflicting-listenersets/gateway-winner
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-with-conflicting-listenersets
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-with-conflicting-listenersets
+      namespace: envoy-gateway-system
+listenerSets:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: ListenerSet
+  metadata:
+    creationTimestamp: "2026-05-21T10:27:11Z"
+    name: listenerset-winner
+    namespace: envoy-gateway
+  spec:
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      hostname: gateway-winner.example.com
+      name: gateway-conflict
+      port: 80
+      protocol: HTTP
+    - allowedRoutes:
+        namespaces:
+          from: All
+      hostname: listenerset-winner.example.com
+      name: listenerset-winner
+      port: 80
+      protocol: HTTP
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-with-conflicting-listenersets
+      namespace: envoy-gateway
+  status:
+    conditions:
+    - lastTransitionTime: null
+      message: Some listeners are invalid
+      reason: ListenersNotValid
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: null
+      message: Some listeners are not programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: 'All listeners for a given port must use a unique hostname, conflicting
+          listeners: envoy-gateway/gateway-with-conflicting-listenersets/gateway-winner,
+          envoy-gateway/listenerset-winner/gateway-conflict'
+        reason: HostnameConflict
+        status: "True"
+        type: Conflicted
+      - lastTransitionTime: null
+        message: 'All listeners for a given port must use a unique hostname, conflicting
+          listeners: envoy-gateway/gateway-with-conflicting-listenersets/gateway-winner,
+          envoy-gateway/listenerset-winner/gateway-conflict'
+        reason: HostnameConflict
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: 'All listeners for a given port must use a unique hostname, conflicting
+          listeners: envoy-gateway/gateway-with-conflicting-listenersets/gateway-winner,
+          envoy-gateway/listenerset-winner/gateway-conflict'
+        reason: HostnameConflict
+        status: "False"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: gateway-conflict
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      - lastTransitionTime: null
+        message: No conflicts detected
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      name: listenerset-winner
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: ListenerSet
+  metadata:
+    creationTimestamp: "2026-08-17T08:09:23Z"
+    name: listenerset-loser
+    namespace: envoy-gateway
+  spec:
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      hostname: listenerset-winner.example.com
+      name: listenerset-conflict
+      port: 80
+      protocol: HTTP
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-with-conflicting-listenersets
+      namespace: envoy-gateway
+  status:
+    conditions:
+    - lastTransitionTime: null
+      message: No listeners are accepted
+      reason: ListenersNotValid
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: null
+      message: No listeners are programmed
+      reason: ListenersNotValid
+      status: "False"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: 'All listeners for a given port must use a unique hostname, conflicting
+          listeners: envoy-gateway/listenerset-loser/listenerset-conflict, envoy-gateway/listenerset-winner/listenerset-winner'
+        reason: HostnameConflict
+        status: "True"
+        type: Conflicted
+      - lastTransitionTime: null
+        message: 'All listeners for a given port must use a unique hostname, conflicting
+          listeners: envoy-gateway/listenerset-loser/listenerset-conflict, envoy-gateway/listenerset-winner/listenerset-winner'
+        reason: HostnameConflict
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: 'All listeners for a given port must use a unique hostname, conflicting
+          listeners: envoy-gateway/listenerset-loser/listenerset-conflict, envoy-gateway/listenerset-winner/listenerset-winner'
+        reason: HostnameConflict
+        status: "False"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: listenerset-conflict
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+xdsIR:
+  envoy-gateway/gateway-with-conflicting-listenersets:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-envoy-gateway-gateway-with-conflicting-listeners-bcf0e614
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: envoy-gateway/gateway-with-conflicting-listenersets
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-envoy-gateway-gateway-with-conflicting-listeners-bcf0e614
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: envoy-gateway/gateway-with-conflicting-listenersets
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - gateway-winner.example.com
+      metadata:
+        kind: Gateway
+        name: gateway-with-conflicting-listenersets
+        namespace: envoy-gateway
+        sectionName: gateway-winner
+      name: envoy-gateway/gateway-with-conflicting-listenersets/gateway-winner
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: route-attached-to-gateway-winner
+            namespace: default
+          name: httproute/default/route-attached-to-gateway-winner/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/route-attached-to-gateway-winner/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: gateway-winner.example.com
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: route-attached-to-gateway-winner
+          namespace: default
+        name: httproute/default/route-attached-to-gateway-winner/rule/0/match/-1/gateway-winner_example_com
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - listenerset-winner.example.com
+      metadata:
+        kind: Gateway
+        name: gateway-with-conflicting-listenersets
+        namespace: envoy-gateway
+        sectionName: listenerset-winner
+      name: envoy-gateway/gateway-with-conflicting-listenersets/envoy-gateway/listenerset-winner/listenerset-winner
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: route-attached-to-listenerset-winner
+            namespace: default
+          name: httproute/default/route-attached-to-listenerset-winner/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/route-attached-to-listenerset-winner/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: listenerset-winner.example.com
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: route-attached-to-listenerset-winner
+          namespace: default
+        name: httproute/default/route-attached-to-listenerset-winner/rule/0/match/-1/listenerset-winner_example_com
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/internal/gatewayapi/validate.go
+++ b/internal/gatewayapi/validate.go
@@ -1174,6 +1174,7 @@ func (t *Translator) validateConflictedHostnameListeners(gateways []*GatewayCont
 				if winner, hasWinner := hostnameWinners[hostname]; hasWinner {
 					// A winner exists: only the non-winner listeners are conflicted.
 					if listener != winner {
+						listener.hostnameConflictLoser = true
 						setConflictedConditions(listener, gwapiv1.ListenerReasonHostnameConflict, conflictMsg)
 					}
 				} else if info.hostnames[hostname] > 1 {

--- a/release-notes/current/bug_fixes/9768-listenerset-conflict-route-attachment.md
+++ b/release-notes/current/bug_fixes/9768-listenerset-conflict-route-attachment.md
@@ -1,0 +1,1 @@
+Fixed HTTPRoutes attached to a listener that won a hostname conflict being rejected with `NoMatchingListenerHostname` and omitted from xDS by excluding conflict-losing listeners from route hostname filtering.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes HTTPRoutes becoming `Accepted=False` with `NoMatchingListenerHostname` when their parent listener wins a hostname conflict.

After #9192, ListenerSet precedence is reported correctly, but the losing listener can still remove the winner's hostname during route intersection. This causes the winning listener to report `attachedRoutes: 0` and omits the route from xDS.

This change tracks listeners that explicitly lose hostname conflict precedence and excludes only those listeners from route hostname filtering. Listeners that are unprogrammed for unrelated reasons retain their existing behavior.

This is my initial approach to the fix. I am open to alternatives if you prefer another way to represent hostname ownership after conflict resolution.

Tests cover both Gateway and ListenerSet winners, route status, attached route counts, conflict conditions, and xDS output.

Which issue(s) this PR fixes:
Fixes #9767

---

**PR Checklist**
<!--
Please tick the boxes below before requesting a review. PRs that leave required items unchecked may
be delayed or closed. Replace `[ ]` with `[x]` to check a box. If an item does not apply, check it
and add "N/A: <reason>".
-->

- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`).
- [x] **API agreed first**: N/A: This PR does not contain API changes.
- [x] **Required checks pass**: `make generate gen-check` and `make lint` pass locally. The unit-test/coverage build will be verified by CI.
- [x] **Tests added/updated**: Added focused unit tests and translator golden coverage for Gateway and ListenerSet conflict winners.
- [x] **Docs**: N/A: This fixes controller behavior without changing user-facing configuration.
- [x] **Release notes**: A release-note fragment will be added after the PR number is assigned.
- [x] **Generated files committed**: N/A: This PR does not change APIs, Helm charts, or modules; `gen-check` passes.
- [x] **Scope & compatibility**: The change is limited to explicit hostname-conflict losers and preserves existing behavior for unrelated invalid listeners and no-winner conflicts.
- [ ] **Codex review**: Not requested yet.
- [ ] **Copilot review**: Not requested yet.
