### PR TITLE
fix: rate limiting cannot scale or enforce correctly

### DIFF
--- a/internal/gatewayapi/globalresources.go
+++ b/internal/gatewayapi/globalresources.go
@@ -51,6 +51,9 @@ func (t *Translator) ProcessGlobalResources(resources *resource.Resources, xdsIR
 			if xdsIR.GlobalResources == nil {
 				xdsIR.GlobalResources = &ir.GlobalResources{}
 			}
+			if containsGlobalRateLimit(xdsIR.HTTP) {
+				xdsIR.GlobalResources.RateLimitServiceCluster = t.processRateLimitServiceCluster(resources)
+			}
 			xdsIR.GlobalResources.EnvoyClientCertificate = &ir.TLSCertificate{
 				Name:        irGlobalConfigName(envoyTLSSecret),
 				Certificate: envoyTLSSecret.Data[corev1.TLSCertKey],
@@ -60,6 +63,47 @@ func (t *Translator) ProcessGlobalResources(resources *resource.Resources, xdsIR
 	}
 
 	return nil
+}
+
+func (t *Translator) processRateLimitServiceCluster(resources *resource.Resources) *ir.RouteDestination {
+	const rateLimitServiceName = "envoy-ratelimit"
+
+	var service *corev1.Service
+	for _, candidate := range resources.Services {
+		if candidate.Namespace == t.ControllerNamespace && candidate.Name == rateLimitServiceName {
+			service = candidate
+			break
+		}
+	}
+	if service == nil {
+		return nil
+	}
+
+	var servicePort *corev1.ServicePort
+	for i := range service.Spec.Ports {
+		if service.Spec.Ports[i].Name == "http" {
+			servicePort = &service.Spec.Ports[i]
+			break
+		}
+	}
+	if servicePort == nil {
+		return nil
+	}
+
+	endpointSlices := resources.GetEndpointSlicesForBackend(
+		t.ControllerNamespace, rateLimitServiceName, resource.KindService)
+	endpoints, addressType := getIREndpointsFromEndpointSlices(endpointSlices, servicePort.Name, servicePort.Protocol)
+	setting := &ir.DestinationSetting{
+		Name:        "ratelimit_cluster/backend/-1",
+		Protocol:    ir.GRPC,
+		Endpoints:   endpoints,
+		AddressType: addressType,
+		Metadata:    nil,
+	}
+	return &ir.RouteDestination{
+		Name:     "ratelimit_cluster",
+		Settings: []*ir.DestinationSetting{setting},
+	}
 }
 
 // processServiceClusterForGateway returns the matching IR key for a gateway and builds a RouteDestination to represent the ProxyServiceCluster

--- a/internal/gatewayapi/testdata/global-ratelimit-service-discovery.in.yaml
+++ b/internal/gatewayapi/testdata/global-ratelimit-service-discovery.in.yaml
@@ -1,0 +1,92 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - namespace: envoy-gateway
+      name: gateway-1
+    rules:
+    - matches:
+      - path:
+          value: "/"
+      backendRefs:
+      - name: service-1
+        port: 8080
+backendTrafficPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    namespace: envoy-gateway
+    name: policy-for-gateway
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-1
+    rateLimit:
+      type: Global
+      global:
+        rules:
+        - clientSelectors:
+          - headers:
+            - name: x-user-id
+              value: one
+          limit:
+            requests: 10
+            unit: Hour
+# The envoy-ratelimit Service and its EndpointSlice represent the in-cluster rate limit
+# service deployed by Envoy Gateway. When present, the translator should discover its
+# endpoints directly instead of falling back to the DNS-resolved cluster address.
+services:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: envoy-ratelimit
+    namespace: envoy-gateway-system
+  spec:
+    clusterIP: 10.99.99.99
+    ports:
+    - name: http
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+endpointSlices:
+- apiVersion: discovery.k8s.io/v1
+  kind: EndpointSlice
+  metadata:
+    name: envoy-ratelimit-abcde
+    namespace: envoy-gateway-system
+    labels:
+      kubernetes.io/service-name: envoy-ratelimit
+  addressType: IPv4
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8081
+  endpoints:
+  - addresses:
+    - "10.10.0.1"
+    conditions:
+      ready: true
+  - addresses:
+    - "10.10.0.2"
+    conditions:
+      ready: true

--- a/internal/gatewayapi/testdata/global-ratelimit-service-discovery.out.yaml
+++ b/internal/gatewayapi/testdata/global-ratelimit-service-discovery.out.yaml
@@ -1,0 +1,242 @@
+backendTrafficPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: BackendTrafficPolicy
+  metadata:
+    name: policy-for-gateway
+    namespace: envoy-gateway
+  spec:
+    rateLimit:
+      global:
+        rules:
+        - clientSelectors:
+          - headers:
+            - name: x-user-id
+              value: one
+          limit:
+            requests: 10
+            unit: Hour
+      type: Global
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-1
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+      conditions:
+      - lastTransitionTime: null
+        message: Policy has been accepted.
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: spec.targetRef is deprecated, use spec.targetRefs instead
+        reason: DeprecatedField
+        status: "True"
+        type: Warning
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-1
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          value: /
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-1
+      namespace: envoy-gateway-system
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    globalResources:
+      envoyClientCertificate:
+        certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lVRUZNaFA5ZUo5WEFCV3NRNVptNmJSazJjTE5Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZqRVVNQklHQTFVRUF3d0xabTl2TG1KaGNpNWpiMjB3SGhjTk1qUXdNakk1TURrek1ERXdXaGNOTXpRdwpNakkyTURrek1ERXdXakFXTVJRd0VnWURWUVFEREF0bWIyOHVZbUZ5TG1OdmJUQ0NBU0l3RFFZSktvWklodmNOCkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFKbEk2WXhFOVprQ1BzNnBDUXhickNtZWl4OVA1RGZ4OVJ1NUxENFQKSm1kVzdJS2R0UVYvd2ZMbXRzdTc2QithVGRDaldlMEJUZmVPT1JCYlIzY1BBRzZFbFFMaWNsUVVydW4zcStncwpKcEsrSTdjSStqNXc4STY4WEg1V1E3clZVdGJ3SHBxYncrY1ZuQnFJVU9MaUlhdGpJZjdLWDUxTTF1RjljZkVICkU0RG5jSDZyYnI1OS9SRlpCc2toeHM1T3p3Sklmb2hreXZGd2V1VHd4Sy9WcGpJKzdPYzQ4QUJDWHBOTzlEL3EKRWgrck9hdWpBTWNYZ0hRSVRrQ2lpVVRjVW82TFNIOXZMWlB0YXFmem9acTZuaE1xcFc2NUUxcEF3RjNqeVRUeAphNUk4SmNmU0Zqa2llWjIwTFVRTW43TThVNHhIamFvL2d2SDBDQWZkQjdSTFUyc0NBd0VBQWFOVE1GRXdIUVlEClZSME9CQllFRk9SQ0U4dS8xRERXN2loWnA3Y3g5dFNtUG02T01COEdBMVVkSXdRWU1CYUFGT1JDRTh1LzFERFcKN2loWnA3Y3g5dFNtUG02T01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBRnQ1M3pqc3FUYUg1YThFMmNodm1XQWdDcnhSSzhiVkxNeGl3TkdqYm1FUFJ6K3c2TngrazBBOEtFY0lEc0tjClNYY2k1OHU0b1didFZKQmx6YS9adWpIUjZQMUJuT3BsK2FveTc4NGJiZDRQMzl3VExvWGZNZmJCQ20xdmV2aDkKQUpLbncyWnRxcjRta2JMY3hFcWxxM3NCTEZBUzlzUUxuS05DZTJjR0xkVHAyYm9HK3FjZ3lRZ0NJTTZmOEVNdgpXUGlmQ01NR3V6Sy9HUkY0YlBPL1lGNDhld0R1M1VlaWgwWFhkVUFPRTlDdFVhOE5JaGMxVVBhT3pQcnRZVnFyClpPR2t2L0t1K0I3OGg4U0VzTzlYclFjdXdiT25KeDZLdFIrYWV5a3ZBcFhDUTNmWkMvYllLQUFSK1A4QUpvUVoKYndJVW1YaTRnajVtK2JLUGhlK2lyK0U9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
+        name: envoy-gateway-system/envoy
+        privateKey: '[redacted]'
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-envoy-gateway-gateway-1-196ae069
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: envoy-gateway/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-envoy-gateway-gateway-1-196ae069
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: envoy-gateway/gateway-1
+          protocol: TCP
+      rateLimitServiceCluster:
+        name: ratelimit_cluster
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 10.10.0.1
+            port: 8081
+          - host: 10.10.0.2
+            port: 8081
+          name: ratelimit_cluster/backend/-1
+          protocol: GRPC
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-1
+            namespace: default
+          name: httproute/default/httproute-1/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-1/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-1
+          namespace: default
+          policies:
+          - kind: BackendTrafficPolicy
+            name: policy-for-gateway
+            namespace: envoy-gateway
+        name: httproute/default/httproute-1/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /
+        traffic:
+          rateLimit:
+            global:
+              rules:
+              - headerMatches:
+                - distinct: false
+                  exact: one
+                  name: x-user-id
+                limit:
+                  requests: 10
+                  unit: Hour
+                name: envoy-gateway/policy-for-gateway/rule/0
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/internal/ir/xds.go
+++ b/internal/ir/xds.go
@@ -2878,6 +2878,8 @@ type GlobalResources struct {
 	// EnvoyClientCertificate holds the client certificate secret for envoy to use when establishing a TLS connection to
 	// control plane components. For example, the rate limit service, WASM HTTP server, etc.
 	EnvoyClientCertificate *TLSCertificate `json:"envoyClientCertificate,omitempty" yaml:"envoyClientCertificate,omitempty"`
+	// RateLimitServiceCluster holds the rate limit service endpoints discovered from Kubernetes resources.
+	RateLimitServiceCluster *RouteDestination `json:"rateLimitServiceCluster,omitempty" yaml:"rateLimitServiceCluster,omitempty"`
 	// ProxyServiceCluster holds the local cluster of EnvoyProxy instances
 	ProxyServiceCluster *RouteDestination `json:"proxyServiceCluster,omitempty" yaml:"proxyServiceCluster,omitempty"`
 	// HMACSecret holds the HMAC Secret used by the OIDC.

--- a/internal/ir/zz_generated.deepcopy.go
+++ b/internal/ir/zz_generated.deepcopy.go
@@ -2265,6 +2265,11 @@ func (in *GlobalResources) DeepCopyInto(out *GlobalResources) {
 		*out = new(TLSCertificate)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.RateLimitServiceCluster != nil {
+		in, out := &in.RateLimitServiceCluster, &out.RateLimitServiceCluster
+		*out = new(RouteDestination)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ProxyServiceCluster != nil {
 		in, out := &in.ProxyServiceCluster, &out.ProxyServiceCluster
 		*out = new(RouteDestination)

--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -453,6 +453,15 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 			gcLogger.Error(err, "failed to process EnvoyTLSSecret")
 		}
 
+		// add the rate limit Service and its EndpointSlices to the resourceTree
+		if err = r.processRateLimitService(ctx, gwcResource, gwcResourceMapping); err != nil {
+			if isTransientError(err) {
+				gcLogger.Error(err, "transient error processing rate limit Service")
+				return reconcile.Result{}, err
+			}
+			gcLogger.Error(err, "failed to process rate limit Service")
+		}
+
 		// Add all Gateways, their associated ListenerSets, Routes, and referenced resources to the resourceTree
 		if err = r.processGateways(ctx, managedGC, gwcResource, gwcResourceMapping); err != nil {
 			if isTransientError(err) {
@@ -1277,6 +1286,56 @@ func (r *gatewayAPIReconciler) processEnvoyTLSSecret(ctx context.Context, resour
 		resourceMap.allAssociatedSecrets.Insert(key)
 		resourceTree.Secrets = append(resourceTree.Secrets, &secret)
 		r.log.Info("processing Envoy TLS Secret", "namespace", r.namespace, "name", envoyTLSSecretName)
+	}
+	return nil
+}
+
+// processRateLimitService adds the in-cluster envoy-ratelimit Service and its
+// EndpointSlices to the resourceTree. Unlike other backends, this Service is
+// never referenced by a Gateway API backendRef, so processBackendRefs never
+// picks it up on its own. The gatewayapi translator uses these resources to
+// build an EDS-based ratelimit_cluster instead of falling back to the
+// DNS-resolved rate limit service address.
+func (r *gatewayAPIReconciler) processRateLimitService(ctx context.Context, resourceTree *resource.Resources, resourceMap *resourceMappings) error {
+	if r.envoyGateway == nil || r.envoyGateway.RateLimit == nil {
+		// Global rate limiting isn't configured, so the rate limit Service won't exist.
+		return nil
+	}
+
+	var service corev1.Service
+	if err := r.client.Get(ctx,
+		types.NamespacedName{Namespace: r.namespace, Name: rateLimitServiceName},
+		&service,
+	); err != nil {
+		return err
+	}
+
+	svcKey := utils.NamespacedName(&service).String()
+	if !resourceMap.allAssociatedServices.Has(svcKey) {
+		resourceMap.allAssociatedServices.Insert(svcKey)
+		resourceTree.Services = append(resourceTree.Services, &service)
+		r.log.Info("processing rate limit Service", "namespace", r.namespace, "name", rateLimitServiceName)
+	}
+
+	endpointSliceList := new(discoveryv1.EndpointSliceList)
+	opts := []client.ListOption{client.InNamespace(r.namespace)}
+	if r.endpointSliceIndexEnabled() {
+		opts = append(opts, client.MatchingFields{serviceEndpointSliceIndex: rateLimitServiceName})
+	} else {
+		opts = append(opts, client.MatchingLabels{discoveryv1.LabelServiceName: rateLimitServiceName})
+	}
+	if err := r.client.List(ctx, endpointSliceList, opts...); err != nil {
+		return err
+	}
+	for i := range endpointSliceList.Items {
+		endpointSlice := &endpointSliceList.Items[i]
+		key := utils.NamespacedName(endpointSlice).String()
+		if !resourceMap.allAssociatedEndpointSlices.Has(key) {
+			resourceMap.allAssociatedEndpointSlices.Insert(key)
+			resourceTree.EndpointSlices = append(resourceTree.EndpointSlices, endpointSlice)
+			r.log.Info("processing EndpointSlice for rate limit Service",
+				"namespace", endpointSlice.Namespace, "name", endpointSlice.Name)
+		}
 	}
 	return nil
 }

--- a/internal/provider/kubernetes/controller_test.go
+++ b/internal/provider/kubernetes/controller_test.go
@@ -419,6 +419,95 @@ func TestProcessBackendRefsEndpointSliceIndexDisabled(t *testing.T) {
 	require.Equal(t, matchingEndpointSlice.Name, gwcResource.EndpointSlices[0].Name)
 }
 
+func TestProcessRateLimitService(t *testing.T) {
+	const ns = "envoy-gateway-system"
+	rateLimitService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rateLimitServiceName,
+			Namespace: ns,
+		},
+	}
+	matchingEndpointSlice := test.GetEndpointSlice(
+		types.NamespacedName{Namespace: ns, Name: "envoy-ratelimit-abcde"}, rateLimitServiceName, false)
+	otherEndpointSlice := test.GetEndpointSlice(
+		types.NamespacedName{Namespace: ns, Name: "es-other"}, "other", false)
+
+	testCases := []struct {
+		name           string
+		envoyGateway   *egv1a1.EnvoyGateway
+		objects        []client.Object
+		expectNotFound bool
+		expectSvc      bool
+		expectEPS      bool
+	}{
+		{
+			name:         "global rate limit disabled",
+			envoyGateway: &egv1a1.EnvoyGateway{},
+			objects:      []client.Object{rateLimitService, matchingEndpointSlice, otherEndpointSlice},
+			expectSvc:    false,
+			expectEPS:    false,
+		},
+		{
+			// Mirrors processEnvoyTLSSecret: a Get error (including NotFound) is
+			// returned to the caller, which logs it and continues rather than
+			// failing the reconcile - this Service may not exist yet at startup.
+			name:           "global rate limit enabled but service not found",
+			envoyGateway:   &egv1a1.EnvoyGateway{EnvoyGatewaySpec: egv1a1.EnvoyGatewaySpec{RateLimit: &egv1a1.RateLimit{}}},
+			objects:        nil,
+			expectNotFound: true,
+			expectSvc:      false,
+			expectEPS:      false,
+		},
+		{
+			name:         "global rate limit enabled and service discovered",
+			envoyGateway: &egv1a1.EnvoyGateway{EnvoyGatewaySpec: egv1a1.EnvoyGatewaySpec{RateLimit: &egv1a1.RateLimit{}}},
+			objects:      []client.Object{rateLimitService, matchingEndpointSlice, otherEndpointSlice},
+			expectSvc:    true,
+			expectEPS:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(envoygateway.GetScheme()).
+				WithObjects(tc.objects...).
+				WithIndex(&discoveryv1.EndpointSlice{}, serviceEndpointSliceIndex, serviceEndpointSliceIndexFunc).
+				Build()
+
+			r := &gatewayAPIReconciler{
+				log:          logging.DefaultLogger(os.Stdout, egv1a1.LogLevelInfo),
+				client:       fakeClient,
+				namespace:    ns,
+				envoyGateway: tc.envoyGateway,
+			}
+
+			gwcResource := resource.NewResources()
+			err := r.processRateLimitService(t.Context(), gwcResource, newResourceMapping())
+			if tc.expectNotFound {
+				require.Error(t, err)
+				require.True(t, kerrors.IsNotFound(err))
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.expectSvc {
+				require.Len(t, gwcResource.Services, 1)
+				require.Equal(t, rateLimitServiceName, gwcResource.Services[0].Name)
+			} else {
+				require.Empty(t, gwcResource.Services)
+			}
+
+			if tc.expectEPS {
+				require.Len(t, gwcResource.EndpointSlices, 1)
+				require.Equal(t, matchingEndpointSlice.Name, gwcResource.EndpointSlices[0].Name)
+			} else {
+				require.Empty(t, gwcResource.EndpointSlices)
+			}
+		})
+	}
+}
+
 func TestRemoveGatewayClassFinalizer(t *testing.T) {
 	testCases := []struct {
 		name   string

--- a/internal/provider/kubernetes/predicates.go
+++ b/internal/provider/kubernetes/predicates.go
@@ -33,6 +33,11 @@ import (
 const (
 	oidcHMACSecretName = "envoy-oidc-hmac"
 	envoyTLSSecretName = "envoy"
+	// rateLimitServiceName is the name of the in-cluster Service fronting the
+	// envoy-ratelimit deployment. It is not referenced by any Gateway API
+	// backendRef, so it needs its own reconcile-trigger checks below, mirroring
+	// the OIDC HMAC and Envoy TLS Secrets.
+	rateLimitServiceName = "envoy-ratelimit"
 )
 
 // hasMatchingController returns true if the provided object is a GatewayClass
@@ -473,6 +478,22 @@ func (r *gatewayAPIReconciler) isEnvoyTLSSecret(nsName *types.NamespacedName) bo
 	return *nsName == envoyTLSSecret
 }
 
+// isRateLimitService returns true if nsName is the in-cluster envoy-ratelimit
+// Service, and global rate limiting is configured. The gatewayapi translator
+// discovers this Service's endpoints to build an EDS-based ratelimit_cluster,
+// so changes to it (or its EndpointSlices, see validateEndpointSliceForReconcile)
+// must trigger reconciliation even though nothing references it as a backendRef.
+func (r *gatewayAPIReconciler) isRateLimitService(nsName *types.NamespacedName) bool {
+	if r.envoyGateway == nil || r.envoyGateway.RateLimit == nil {
+		return false
+	}
+	rateLimitService := types.NamespacedName{
+		Namespace: r.namespace,
+		Name:      rateLimitServiceName,
+	}
+	return *nsName == rateLimitService
+}
+
 // validateServiceForReconcile tries finding the owning Gateway of the Service
 // if it exists, finds the Gateway's Deployment, and further updates the Gateway
 // status Ready condition. All Services are pushed for reconciliation.
@@ -503,6 +524,10 @@ func (r *gatewayAPIReconciler) validateServiceForReconcile(obj client.Object) bo
 	}
 
 	nsName := utils.NamespacedName(svc)
+	if r.isRateLimitService(&nsName) {
+		return true
+	}
+
 	if r.isRouteReferencingBackend(&nsName) {
 		return true
 	}
@@ -683,6 +708,10 @@ func (r *gatewayAPIReconciler) validateEndpointSliceForReconcile(obj client.Obje
 
 	if isMCS {
 		nsName.Name = multiClusterSvcName
+	}
+
+	if r.isRateLimitService(&nsName) {
+		return true
 	}
 
 	if r.isRouteReferencingBackend(&nsName) {

--- a/internal/provider/kubernetes/predicates_test.go
+++ b/internal/provider/kubernetes/predicates_test.go
@@ -1181,6 +1181,8 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 		name          string
 		configs       []client.Object
 		endpointSlice client.Object
+		namespace     string
+		envoyGateway  *egv1a1.EnvoyGateway
 		expect        bool
 	}{
 		{
@@ -1268,6 +1270,29 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 			endpointSlice: test.GetEndpointSlice(types.NamespacedName{Name: "endpointslice"}, "mirror-service", false),
 			expect:        true,
 		},
+		{
+			name:         "rate limit service endpointslice with global rate limit enabled",
+			namespace:    "envoy-gateway-system",
+			envoyGateway: &egv1a1.EnvoyGateway{EnvoyGatewaySpec: egv1a1.EnvoyGatewaySpec{RateLimit: &egv1a1.RateLimit{}}},
+			endpointSlice: test.GetEndpointSlice(
+				types.NamespacedName{Namespace: "envoy-gateway-system", Name: "envoy-ratelimit-abcde"}, rateLimitServiceName, false),
+			expect: true,
+		},
+		{
+			name:      "rate limit service endpointslice but global rate limit disabled",
+			namespace: "envoy-gateway-system",
+			endpointSlice: test.GetEndpointSlice(
+				types.NamespacedName{Namespace: "envoy-gateway-system", Name: "envoy-ratelimit-abcde"}, rateLimitServiceName, false),
+			expect: false,
+		},
+		{
+			name:         "endpointslice for an unrelated service named envoy-ratelimit in another namespace",
+			namespace:    "envoy-gateway-system",
+			envoyGateway: &egv1a1.EnvoyGateway{EnvoyGatewaySpec: egv1a1.EnvoyGatewaySpec{RateLimit: &egv1a1.RateLimit{}}},
+			endpointSlice: test.GetEndpointSlice(
+				types.NamespacedName{Namespace: "other-namespace", Name: "envoy-ratelimit-abcde"}, rateLimitServiceName, false),
+			expect: false,
+		},
 	}
 
 	// Create the reconciler.
@@ -1279,6 +1304,8 @@ func TestValidateEndpointSliceForReconcile(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		r.namespace = tc.namespace
+		r.envoyGateway = tc.envoyGateway
 		r.client = fakeclient.NewClientBuilder().
 			WithScheme(envoygateway.GetScheme()).
 			WithObjects(tc.configs...).
@@ -1381,6 +1408,8 @@ func TestValidateServiceForReconcile(t *testing.T) {
 		tlsRouteCRDAbsent  bool
 		configs            []client.Object
 		service            client.Object
+		namespace          string
+		envoyGateway       *egv1a1.EnvoyGateway
 		expect             bool
 	}{
 		{
@@ -1725,6 +1754,26 @@ func TestValidateServiceForReconcile(t *testing.T) {
 			}, nil),
 			expect: false,
 		},
+		{
+			name:         "rate limit service in controller namespace with global rate limit enabled",
+			namespace:    "envoy-gateway-system",
+			envoyGateway: &egv1a1.EnvoyGateway{EnvoyGatewaySpec: egv1a1.EnvoyGatewaySpec{RateLimit: &egv1a1.RateLimit{}}},
+			service:      test.GetService(types.NamespacedName{Namespace: "envoy-gateway-system", Name: rateLimitServiceName}, nil, nil),
+			expect:       true,
+		},
+		{
+			name:      "rate limit service in controller namespace but global rate limit disabled",
+			namespace: "envoy-gateway-system",
+			service:   test.GetService(types.NamespacedName{Namespace: "envoy-gateway-system", Name: rateLimitServiceName}, nil, nil),
+			expect:    false,
+		},
+		{
+			name:         "unrelated service named envoy-ratelimit in a different namespace",
+			namespace:    "envoy-gateway-system",
+			envoyGateway: &egv1a1.EnvoyGateway{EnvoyGatewaySpec: egv1a1.EnvoyGatewaySpec{RateLimit: &egv1a1.RateLimit{}}},
+			service:      test.GetService(types.NamespacedName{Namespace: "other-namespace", Name: rateLimitServiceName}, nil, nil),
+			expect:       false,
+		},
 	}
 
 	// Create the reconciler.
@@ -1745,6 +1794,8 @@ func TestValidateServiceForReconcile(t *testing.T) {
 	for _, tc := range testCases {
 		r.grpcRouteCRDExists = !tc.grpcRouteCRDAbsent
 		r.tlsRouteCRDExists = !tc.tlsRouteCRDAbsent
+		r.namespace = tc.namespace
+		r.envoyGateway = tc.envoyGateway
 		r.client = fakeclient.NewClientBuilder().
 			WithScheme(envoygateway.GetScheme()).
 			WithObjects(tc.configs...).

--- a/internal/xds/translator/globalresources.go
+++ b/internal/xds/translator/globalresources.go
@@ -43,7 +43,7 @@ func (t *Translator) patchGlobalResources(tCtx *types.ResourceVersionTable, irXd
 		}
 
 		if containsGlobalRateLimit(irXds.HTTP) {
-			if err := t.createRateLimitServiceCluster(tCtx, irXds.GlobalResources.EnvoyClientCertificate, irXds.Metrics); err != nil {
+			if err := t.createRateLimitServiceCluster(tCtx, irXds.GlobalResources, irXds.Metrics); err != nil {
 				errs = errors.Join(errs, err)
 			}
 		}
@@ -156,31 +156,41 @@ func createEnvoyClientTLSCertSecret(tCtx *types.ResourceVersionTable, globalReso
 	return nil
 }
 
-func (t *Translator) createRateLimitServiceCluster(tCtx *types.ResourceVersionTable, envoyClientCertificate *ir.TLSCertificate, metrics *ir.Metrics) error {
+func (t *Translator) createRateLimitServiceCluster(tCtx *types.ResourceVersionTable, globalResources *ir.GlobalResources, metrics *ir.Metrics) error {
 	clusterName := getRateLimitServiceClusterName()
-	// Create cluster if it does not exist
-	host, port := t.getRateLimitServiceGrpcHostPort()
-	ds := &ir.DestinationSetting{
-		Weight:    new(uint32(1)),
-		Protocol:  ir.GRPC,
-		Endpoints: []*ir.DestinationEndpoint{ir.NewDestEndpoint(nil, host, port, false, nil)},
-		Name:      destinationSettingName(clusterName),
-		// TODO: tracked with issue #6861
-		Metadata: nil,
+	destination := globalResources.RateLimitServiceCluster
+	// EDS-discovered destinations resolve directly to endpoint IPs, so they use a
+	// STATIC cluster. The DNS fallback below resolves a hostname, so it keeps the
+	// original STRICT_DNS cluster type.
+	endpointType := EndpointTypeStatic
+	if destination == nil {
+		host, port := t.getRateLimitServiceGrpcHostPort()
+		destination = &ir.RouteDestination{
+			Name: clusterName,
+			Settings: []*ir.DestinationSetting{{
+				Weight:    new(uint32(1)),
+				Protocol:  ir.GRPC,
+				Endpoints: []*ir.DestinationEndpoint{ir.NewDestEndpoint(nil, host, port, false, nil)},
+				Name:      destinationSettingName(clusterName),
+				// TODO: tracked with issue #6861
+				Metadata: nil,
+			}},
+		}
+		endpointType = EndpointTypeDNS
 	}
 
-	tSocket, err := buildEnvoyClientTLSSocket(envoyClientCertificate)
+	tSocket, err := buildEnvoyClientTLSSocket(globalResources.EnvoyClientCertificate)
 	if err != nil {
 		return err
 	}
 
 	return addXdsCluster(tCtx, &xdsClusterArgs{
 		name:         clusterName,
-		settings:     []*ir.DestinationSetting{ds},
+		settings:     destination.Settings,
 		tSocket:      tSocket,
-		endpointType: EndpointTypeDNS,
+		endpointType: endpointType,
 		metrics:      metrics,
-		metadata:     ds.Metadata,
+		metadata:     destination.Settings[0].Metadata,
 	})
 }
 

--- a/internal/xds/translator/testdata/in/xds-ir/global-ratelimit-service-cluster-discovered.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/global-ratelimit-service-cluster-discovered.yaml
@@ -1,0 +1,51 @@
+globalResources:
+  envoyClientCertificate:
+    name: envoy-gateway-system/envoy
+    privateKey: [107, 101, 121, 45, 100, 97, 116, 97]
+    certificate: [99, 101, 114, 116, 45, 100, 97, 116, 97]
+  # RateLimitServiceCluster is populated when the gatewayapi translator discovers the
+  # in-cluster envoy-ratelimit Service/EndpointSlices. When set, the xds translator must
+  # build the ratelimit_cluster from these endpoints instead of the DNS-resolved fallback
+  # host/port derived from GlobalRateLimit.ServiceURL.
+  rateLimitServiceCluster:
+    name: ratelimit_cluster
+    settings:
+    - name: ratelimit_cluster/backend/-1
+      protocol: GRPC
+      addressType: IP
+      endpoints:
+      - host: "10.10.0.1"
+        port: 8081
+      - host: "10.10.0.2"
+        port: 8081
+http:
+- name: "first-listener"
+  address: "::"
+  port: 10080
+  hostnames:
+  - "*"
+  path:
+    mergeSlashes: true
+    escapedSlashesAction: UnescapeAndRedirect
+  routes:
+  - name: "first-route"
+    hostname: "*"
+    traffic:
+      rateLimit:
+        global:
+          rules:
+          - headerMatches:
+            - name: "x-user-id"
+              exact: "one"
+            limit:
+              requests: 5
+              unit: second
+    pathMatch:
+      exact: "foo/bar"
+    destination:
+      name: "first-route-dest"
+      settings:
+      - endpoints:
+        - host: "1.2.3.4"
+          port: 50000
+        name: "first-route-dest/backend/0"

--- a/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-service-cluster-discovered.clusters.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-service-cluster-discovered.clusters.yaml
@@ -1,0 +1,69 @@
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: first-route-dest
+  ignoreHealthOnHostRemoval: true
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: first-route-dest
+  perConnectionBufferLimitBytes: 32768
+  type: EDS
+- circuitBreakers:
+    thresholds:
+    - maxRetries: 1024
+  commonLbConfig: {}
+  connectTimeout: 10s
+  dnsLookupFamily: V4_PREFERRED
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+    serviceName: ratelimit_cluster
+  ignoreHealthOnHostRemoval: true
+  loadBalancingPolicy:
+    policies:
+    - typedExtensionConfig:
+        name: envoy.load_balancing_policies.least_request
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.load_balancing_policies.least_request.v3.LeastRequest
+          localityLbConfig:
+            localityWeightedLbConfig: {}
+  name: ratelimit_cluster
+  perConnectionBufferLimitBytes: 32768
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        tlsCertificateSdsSecretConfigs:
+        - name: envoy-gateway-system/envoy
+          sdsConfig:
+            ads: {}
+            initialFetchTimeout: 0s
+            resourceApiVersion: V3
+        tlsParams:
+          tlsMaximumProtocolVersion: TLSv1_3
+        validationContext:
+          trustedCa:
+            filename: /certs/ca.crt
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536

--- a/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-service-cluster-discovered.endpoints.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-service-cluster-discovered.endpoints.yaml
@@ -1,0 +1,30 @@
+- clusterName: first-route-dest
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 1.2.3.4
+            portValue: 50000
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: first-route-dest/backend/0
+- clusterName: ratelimit_cluster
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.10.0.1
+            portValue: 8081
+      loadBalancingWeight: 1
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.10.0.2
+            portValue: 8081
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: ratelimit_cluster/backend/-1

--- a/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-service-cluster-discovered.listeners.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-service-cluster-discovered.listeners.yaml
@@ -1,0 +1,47 @@
+- address:
+    socketAddress:
+      address: '::'
+      portValue: 10080
+  defaultFilterChain:
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        commonHttpProtocolOptions:
+          headersWithUnderscoresAction: REJECT_REQUEST
+        http2ProtocolOptions:
+          initialConnectionWindowSize: 1048576
+          initialStreamWindowSize: 65536
+          maxConcurrentStreams: 100
+        httpFilters:
+        - name: envoy.filters.http.ratelimit
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
+            disableXEnvoyRatelimitedHeader: true
+            domain: first-listener
+            enableXRatelimitHeaders: DRAFT_VERSION_03
+            rateLimitService:
+              grpcService:
+                envoyGrpc:
+                  clusterName: ratelimit_cluster
+              transportApiVersion: V3
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            suppressEnvoyHeaders: true
+        mergeSlashes: true
+        normalizePath: true
+        pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+        rds:
+          configSource:
+            ads: {}
+            initialFetchTimeout: 0s
+            resourceApiVersion: V3
+          routeConfigName: first-listener
+        serverHeaderTransformation: PASS_THROUGH
+        statPrefix: http-10080
+        useRemoteAddress: true
+    name: first-listener
+  maxConnectionsToAcceptPerSocketEvent: 1
+  name: first-listener
+  perConnectionBufferLimitBytes: 32768

--- a/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-service-cluster-discovered.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-service-cluster-discovered.routes.yaml
@@ -1,0 +1,31 @@
+- ignorePortInHostMatching: true
+  name: first-listener
+  virtualHosts:
+  - domains:
+    - '*'
+    name: first-listener/*
+    routes:
+    - match:
+        path: foo/bar
+      name: first-route
+      route:
+        cluster: first-route-dest
+        upgradeConfigs:
+        - upgradeType: websocket
+      typedPerFilterConfig:
+        envoy.filters.http.ratelimit:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+          domain: first-listener
+          rateLimits:
+          - actions:
+            - genericKey:
+                descriptorKey: first-route
+                descriptorValue: first-route
+            - headerValueMatch:
+                descriptorKey: rule-0-match-0
+                descriptorValue: rule-0-match-0
+                expectMatch: true
+                headers:
+                - name: x-user-id
+                  stringMatch:
+                    exact: one

--- a/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-service-cluster-discovered.secrets.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/global-ratelimit-service-cluster-discovered.secrets.yaml
@@ -1,0 +1,6 @@
+- name: envoy-gateway-system/envoy
+  tlsCertificate:
+    certificateChain:
+      inlineBytes: Y2VydC1kYXRh
+    privateKey:
+      inlineBytes: a2V5LWRhdGE=

--- a/release-notes/current/bug_fixes/9814-ratelimit-cluster-eds.md
+++ b/release-notes/current/bug_fixes/9814-ratelimit-cluster-eds.md
@@ -1,0 +1,1 @@
+The global rate limit cluster is now built from the in-cluster `envoy-ratelimit` Service/EndpointSlices using EDS instead of resolving a static DNS hostname, so requests keep hitting rate limit service replicas correctly as they scale up or down. When the Service or its endpoints can't be discovered, Envoy Gateway falls back to the previous STRICT_DNS behavior.

--- a/test/config/envoy-gateaway-config/gateway-namespace-mode.yaml
+++ b/test/config/envoy-gateaway-config/gateway-namespace-mode.yaml
@@ -12,6 +12,10 @@ data:
       kubernetes:
         deploy:
           type: GatewayNamespace
+        # increase the replicas of the rate limit deployment to 2,
+        # this is to test the rate limit service discovery with multiple replicas.
+        rateLimitDeployment:
+          replicas: 2
     gateway:
       controllerName: gateway.envoyproxy.io/gatewayclass-controller
     extensionApis:


### PR DESCRIPTION
Before this patch, the RateLimit cluster was effectively resolved with a DNS-based address, which does not automatically track the live set of pod endpoints behind the Service. In practice:

- when rate-limit replicas scale up/down, Envoy keeps using stale backend targets
- traffic may not land on healthy replicas
- global rate limiting becomes unreliable or partially broken under churn