### PR TITLE
fix: honor access log text format when format.type is unset

### DIFF
--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -864,6 +864,20 @@ func (t *Translator) processAccessLog(gwCtx *GatewayContext, envoyproxy *egv1a1.
 			}
 		}
 
+		// ProxyAccessLogFormat.Type is optional: when it is unset the API only requires that
+		// one of text or json is set. The File and ALS sinks can render just one of the two,
+		// so resolve the effective type once here instead of defaulting to JSON at each sink
+		// and silently dropping a text format that was accepted by the API server.
+		// OpenTelemetry is deliberately excluded below: it can carry text and attributes at
+		// the same time and handles the unset type itself.
+		formatType := egv1a1.ProxyAccessLogFormatTypeJSON
+		switch {
+		case format.Type != nil:
+			formatType = *format.Type
+		case format.Text != nil:
+			formatType = egv1a1.ProxyAccessLogFormatTypeText
+		}
+
 		var (
 			validExprs []string
 			errs       []error
@@ -880,13 +894,23 @@ func (t *Translator) processAccessLog(gwCtx *GatewayContext, envoyproxy *egv1a1.
 		}
 
 		if len(accessLog.Sinks) == 0 {
-			al := &ir.JSONAccessLog{
-				JSON:       ir.MapToSlice(format.JSON),
-				CELMatches: validExprs,
-				LogType:    accessLogType,
-				Path:       "/dev/stdout",
+			if formatType == egv1a1.ProxyAccessLogFormatTypeText {
+				al := &ir.TextAccessLog{
+					Format:     format.Text,
+					CELMatches: validExprs,
+					LogType:    accessLogType,
+					Path:       "/dev/stdout",
+				}
+				irAccessLog.Text = append(irAccessLog.Text, al)
+			} else {
+				al := &ir.JSONAccessLog{
+					JSON:       ir.MapToSlice(format.JSON),
+					CELMatches: validExprs,
+					LogType:    accessLogType,
+					Path:       "/dev/stdout",
+				}
+				irAccessLog.JSON = append(irAccessLog.JSON, al)
 			}
-			irAccessLog.JSON = append(irAccessLog.JSON, al)
 		}
 
 		for j, sink := range accessLog.Sinks {
@@ -896,7 +920,7 @@ func (t *Translator) processAccessLog(gwCtx *GatewayContext, envoyproxy *egv1a1.
 					continue
 				}
 
-				if format.Type != nil && *format.Type == egv1a1.ProxyAccessLogFormatTypeText {
+				if formatType == egv1a1.ProxyAccessLogFormatTypeText {
 					al := &ir.TextAccessLog{
 						Format:     format.Text,
 						Path:       sink.File.Path,
@@ -960,10 +984,9 @@ func (t *Translator) processAccessLog(gwCtx *GatewayContext, envoyproxy *egv1a1.
 					}
 					al.HTTP = http
 				}
-				if format.Type != nil && *format.Type == egv1a1.ProxyAccessLogFormatTypeText {
+				if formatType == egv1a1.ProxyAccessLogFormatTypeText {
 					al.Text = format.Text
 				} else {
-					// Default to JSON format if type is nil or JSON
 					al.Attributes = ir.MapToSlice(format.JSON)
 				}
 

--- a/internal/gatewayapi/listener.go
+++ b/internal/gatewayapi/listener.go
@@ -868,13 +868,15 @@ func (t *Translator) processAccessLog(gwCtx *GatewayContext, envoyproxy *egv1a1.
 		// one of text or json is set. The File and ALS sinks can render just one of the two,
 		// so resolve the effective type once here instead of defaulting to JSON at each sink
 		// and silently dropping a text format that was accepted by the API server.
+		// An unset type with both text and json set stays JSON, which is what those sinks
+		// have always picked for that input; only the text-only case changes.
 		// OpenTelemetry is deliberately excluded below: it can carry text and attributes at
 		// the same time and handles the unset type itself.
 		formatType := egv1a1.ProxyAccessLogFormatTypeJSON
 		switch {
 		case format.Type != nil:
 			formatType = *format.Type
-		case format.Text != nil:
+		case format.Text != nil && format.JSON == nil:
 			formatType = egv1a1.ProxyAccessLogFormatTypeText
 		}
 

--- a/internal/gatewayapi/listener_test.go
+++ b/internal/gatewayapi/listener_test.go
@@ -1208,6 +1208,39 @@ func TestProcessAccessLog(t *testing.T) {
 			},
 		},
 		{
+			name: "nil format type with text and json keeps json for file sink",
+			envoyProxy: &egv1a1.EnvoyProxy{
+				Spec: egv1a1.EnvoyProxySpec{
+					Telemetry: &egv1a1.ProxyTelemetry{
+						AccessLog: &egv1a1.ProxyAccessLog{
+							Settings: []egv1a1.ProxyAccessLogSetting{
+								{
+									Format: &egv1a1.ProxyAccessLogFormat{
+										Text: new("[%START_TIME%]"),
+										JSON: map[string]string{"start_time": "%START_TIME%"},
+									},
+									Sinks: []egv1a1.ProxyAccessLogSink{
+										{
+											Type: egv1a1.ProxyAccessLogSinkTypeFile,
+											File: &egv1a1.FileEnvoyProxyAccessLog{Path: "/dev/stdout"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &ir.AccessLog{
+				JSON: []*ir.JSONAccessLog{
+					{
+						JSON: []ir.MapEntry{{Key: "start_time", Value: "%START_TIME%"}},
+						Path: "/dev/stdout",
+					},
+				},
+			},
+		},
+		{
 			name: "nil format type with json only uses json for file sink",
 			envoyProxy: &egv1a1.EnvoyProxy{
 				Spec: egv1a1.EnvoyProxySpec{

--- a/internal/gatewayapi/listener_test.go
+++ b/internal/gatewayapi/listener_test.go
@@ -1199,9 +1199,10 @@ func TestProcessAccessLog(t *testing.T) {
 				},
 			},
 			expected: &ir.AccessLog{
-				JSON: []*ir.JSONAccessLog{
+				Text: []*ir.TextAccessLog{
 					{
-						Path: "/dev/stdout",
+						Format: new("[%START_TIME%]"),
+						Path:   "/dev/stdout",
 					},
 				},
 			},

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-file-als-text-notype.in.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-file-als-text-notype.in.yaml
@@ -1,0 +1,71 @@
+envoyProxyForGatewayClass:
+  apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: EnvoyProxy
+  metadata:
+    namespace: envoy-gateway-system
+    name: test
+  spec:
+    telemetry:
+      accessLog:
+        settings:
+        # Type is omitted, so the text format is the only format set and both the File
+        # and the ALS sink must render it instead of falling back to the default JSON fields.
+        - format:
+            text: |
+              custom %START_TIME% %REQ(:METHOD)% %RESPONSE_CODE%
+          sinks:
+          - type: File
+            file:
+              path: /dev/stdout
+          - type: ALS
+            als:
+              backendRefs:
+              - name: access-logger
+                namespace: default
+                port: 50051
+              type: HTTP
+    provider:
+      type: Kubernetes
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    namespace: envoy-gateway
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+services:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: access-logger
+    namespace: default
+  spec:
+    clusterIP: 10.11.12.13
+    ports:
+    - port: 50051
+      name: grpc
+      protocol: TCP
+      targetPort: 50051
+endpointSlices:
+- apiVersion: discovery.k8s.io/v1
+  kind: EndpointSlice
+  metadata:
+    name: endpointslice-access-logger
+    namespace: default
+    labels:
+      kubernetes.io/service-name: access-logger
+  ports:
+  - name: grpc
+    protocol: TCP
+    port: 50051
+  endpoints:
+  - addresses:
+    - 7.7.7.7

--- a/internal/gatewayapi/testdata/envoyproxy-accesslog-file-als-text-notype.out.yaml
+++ b/internal/gatewayapi/testdata/envoyproxy-accesslog-file-als-text-notype.out.yaml
@@ -1,0 +1,158 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      config:
+        apiVersion: gateway.envoyproxy.io/v1alpha1
+        kind: EnvoyProxy
+        metadata:
+          name: test
+          namespace: envoy-gateway-system
+        spec:
+          logging: {}
+          provider:
+            type: Kubernetes
+          telemetry:
+            accessLog:
+              settings:
+              - format:
+                  text: |
+                    custom %START_TIME% %REQ(:METHOD)% %RESPONSE_CODE%
+                sinks:
+                - file:
+                    path: /dev/stdout
+                  type: File
+                - als:
+                    backendRefs:
+                    - name: access-logger
+                      namespace: default
+                      port: 50051
+                    type: HTTP
+                  type: ALS
+        status: {}
+      listeners:
+      - name: envoy-gateway/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-1
+      namespace: envoy-gateway-system
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      als:
+      - destination:
+          metadata:
+            kind: EnvoyProxy
+            name: test
+            namespace: envoy-gateway-system
+          name: accesslog_als_0_1
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 50051
+            metadata:
+              kind: Service
+              name: access-logger
+              namespace: default
+              sectionName: "50051"
+            name: accesslog_als_0_1/backend/-1
+            protocol: GRPC
+        name: envoy-gateway-system/test
+        text: |
+          custom %START_TIME% %REQ(:METHOD)% %RESPONSE_CODE%
+        type: HTTP
+      text:
+      - format: |
+          custom %START_TIME% %REQ(:METHOD)% %RESPONSE_CODE%
+        path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-envoy-gateway-gateway-1-196ae069
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: envoy-gateway/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-envoy-gateway-gateway-1-196ae069
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: envoy-gateway/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: http
+      name: envoy-gateway/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/release-notes/current/bug_fixes/9719-accesslog-text-format-without-type.md
+++ b/release-notes/current/bug_fixes/9719-accesslog-text-format-without-type.md
@@ -1,0 +1,1 @@
+Fixed the File and ALS access log sinks silently falling back to the default JSON fields when `telemetry.accessLog.settings[].format` sets `text` without `type`, which the API accepts.


### PR DESCRIPTION
**Fixes #9719**

## What

`ProxyAccessLogFormat.Type` is optional. The CEL rule on the type only requires that *something* is set when the type is omitted:

```go
// +kubebuilder:validation:XValidation:rule="!has(self.type) ? (has(self.text) || has(self.json)) : true",...
```

So `format: {text: "..."}` with no `type` is accepted by the API server for any sink. The OpenTelemetry sink honors it. File and ALS did not:

```go
if format.Type != nil && *format.Type == egv1a1.ProxyAccessLogFormatTypeText {
```

With `format.Type == nil` both fell to the else branch, which builds an `ir.JSONAccessLog` from `format.JSON`. That is nil here, `ir.MapToSlice(nil)` returns nil, and `internal/xds/translator/accesslog.go` then substitutes `EnvoyJSONLogFields`. The configured text format was dropped with no error, no status condition and no log line.

## How

Resolve the effective format type once, before the sink loop — an explicit type wins, otherwise a text-only format resolves to `Text` and everything else to `JSON` — and branch the File and ALS sinks on that. Resolving it in one place rather than patching two conditionals keeps the sinks from disagreeing about what an unset type means.

Two notes on scope:

- **The no-sink default path is fixed too.** `settings[].sinks` empty builds a JSON access log on `/dev/stdout` regardless of format, so a text-only format was silently dropped there as well. Same root cause, same one-line branch — it seemed worse to leave one of the three sites broken. Happy to split it out if you'd rather keep this to the two sinks named in the issue.
- **OpenTelemetry is deliberately untouched.** It can carry text and attributes at the same time and already handles the unset type itself; routing it through the resolved type would change behavior when both `text` and `json` are set.

## Existing test

The unit case `nil format type with text only uses text for file sink`, added in #7720, asserted the JSON fallback that its own name argues against:

```go
name: "nil format type with text only uses text for file sink",
...
expected: &ir.AccessLog{
    JSON: []*ir.JSONAccessLog{{Path: "/dev/stdout"}},
},
```

Its expectation is updated to the text access log. No other golden file changed.

## Tests

- Updated `TestProcessAccessLog/nil_format_type_with_text_only_uses_text_for_file_sink`.
- New translator golden `envoyproxy-accesslog-file-als-text-notype`, covering File and ALS in one EnvoyProxy with `format.text` and no type. Before this change both rendered default JSON fields; now both carry the format string.

## Release Notes

Added under `release-notes/current/bug_fixes/`.