### PR TITLE
fix: reconcile Gateways/Routes on Namespace label changes

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -2650,6 +2651,28 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 				return r.enqueueClass(ctx, cm)
 			}),
 			configMapPredicates...)); err != nil {
+		return err
+	}
+
+	// Watch Namespace label changes and process affected Gateways/Routes, since
+	// allowedRoutes.namespaces.selector match results depend on namespace labels.
+	// Create/Delete/Generic events are ignored: anything referencing a namespace
+	// is already reconciled through its own watch (e.g. Gateway, HTTPRoute), so
+	// only a label change on an existing Namespace needs to retrigger reconciliation.
+	nsPredicates := []predicate.TypedPredicate[*corev1.Namespace]{
+		predicate.TypedLabelChangedPredicate[*corev1.Namespace]{},
+		predicate.TypedFuncs[*corev1.Namespace]{
+			CreateFunc:  func(event.TypedCreateEvent[*corev1.Namespace]) bool { return false },
+			DeleteFunc:  func(event.TypedDeleteEvent[*corev1.Namespace]) bool { return false },
+			GenericFunc: func(event.TypedGenericEvent[*corev1.Namespace]) bool { return false },
+		},
+	}
+	if err := c.Watch(
+		source.Kind(mgr.GetCache(), &corev1.Namespace{},
+			handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, ns *corev1.Namespace) []reconcile.Request {
+				return r.enqueueClass(ctx, ns)
+			}),
+			nsPredicates...)); err != nil {
 		return err
 	}
 

--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -91,11 +91,12 @@ func TestProvider(t *testing.T) {
 	})
 
 	testcases := map[string]func(context.Context, *testing.T, *Provider, *message.ProviderResources){
-		"gatewayclass controller name":         testGatewayClassController,
-		"gatewayclass accepted status":         testGatewayClassAcceptedStatus,
-		"gatewayclass with parameters ref":     testGatewayClassWithParamRef,
-		"gateway scheduled status":             testGatewayScheduledStatus,
-		"httproute":                            testHTTPRoute,
+		"gatewayclass controller name":              testGatewayClassController,
+		"gatewayclass accepted status":              testGatewayClassAcceptedStatus,
+		"gatewayclass with parameters ref":          testGatewayClassWithParamRef,
+		"gateway scheduled status":                  testGatewayScheduledStatus,
+		"httproute":                                 testHTTPRoute,
+		"httproute namespace selector label update": testHTTPRouteNamespaceSelectorLabelUpdate,
 		"tlsroute":                             testTLSRoute,
 		"stale service cleanup route deletion": testServiceCleanupForMultipleRoutes,
 	}
@@ -923,6 +924,128 @@ func testHTTPRoute(ctx context.Context, t *testing.T, provider *Provider, resour
 			}, defaultWait, defaultTick)
 		})
 	}
+}
+
+// testHTTPRouteNamespaceSelectorLabelUpdate is a regression test for the case where a Gateway
+// listener restricts route attachment with allowedRoutes.namespaces.from: Selector. Labeling a
+// namespace to match the selector after an HTTPRoute in it has already been reconciled must be
+// picked up without any other change, since nothing else triggers a reconcile in that scenario.
+func testHTTPRouteNamespaceSelectorLabelUpdate(ctx context.Context, t *testing.T, provider *Provider, resources *message.ProviderResources) {
+	cli := provider.manager.GetClient()
+
+	gc := test.GetGatewayClass("httproute-ns-selector-test", egv1a1.GatewayControllerName, nil)
+	require.NoError(t, cli.Create(ctx, gc))
+
+	requireGatewayClassAccepted(t, cli, gc)
+
+	defer func() {
+		require.NoError(t, cli.Delete(ctx, gc))
+	}()
+
+	gwNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "httproute-ns-selector-test-gw"}}
+	require.NoError(t, cli.Create(ctx, gwNs))
+
+	routeNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "httproute-ns-selector-test-route"}}
+	require.NoError(t, cli.Create(ctx, routeNs))
+
+	gw := &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "httproute-ns-selector-test",
+			Namespace: gwNs.Name,
+		},
+		Spec: gwapiv1.GatewaySpec{
+			GatewayClassName: gwapiv1.ObjectName(gc.Name),
+			Listeners: []gwapiv1.Listener{
+				{
+					Name:     "test",
+					Port:     int32(8080),
+					Protocol: gwapiv1.HTTPProtocolType,
+					AllowedRoutes: &gwapiv1.AllowedRoutes{
+						Namespaces: &gwapiv1.RouteNamespaces{
+							From: new(gwapiv1.NamespacesFromSelector),
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"access": "granted"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, cli.Create(ctx, gw))
+
+	defer func() {
+		require.NoError(t, cli.Delete(ctx, gw))
+	}()
+
+	route := &gwapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "httproute-ns-selector-test",
+			Namespace: routeNs.Name,
+		},
+		Spec: gwapiv1.HTTPRouteSpec{
+			CommonRouteSpec: gwapiv1.CommonRouteSpec{
+				ParentRefs: []gwapiv1.ParentReference{
+					{
+						Name:      gwapiv1.ObjectName(gw.Name),
+						Namespace: new(gwapiv1.Namespace(gwNs.Name)),
+					},
+				},
+			},
+			Rules: []gwapiv1.HTTPRouteRule{
+				{
+					BackendRefs: []gwapiv1.HTTPBackendRef{
+						{
+							BackendRef: gwapiv1.BackendRef{
+								BackendObjectReference: gwapiv1.BackendObjectReference{
+									Name: "test",
+									Port: new(gwapiv1.PortNumber(80)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, cli.Create(ctx, route))
+
+	defer func() {
+		require.NoError(t, cli.Delete(ctx, route))
+	}()
+
+	// Wait for the initial reconcile to observe the route namespace before it is labeled.
+	require.Eventually(t, func() bool {
+		res, ok := getGatewayClassFromResources(resources, gc.Name)
+		if !ok {
+			return false
+		}
+		for _, n := range res.Namespaces {
+			if n.Name == routeNs.Name {
+				return true
+			}
+		}
+		return false
+	}, defaultWait, defaultTick)
+
+	// Label the namespace to match the listener's selector. Nothing else changes, so this must
+	// be picked up solely via a watch on Namespace label changes.
+	require.NoError(t, cli.Get(ctx, utils.NamespacedName(routeNs), routeNs))
+	routeNs.Labels = map[string]string{"access": "granted"}
+	require.NoError(t, cli.Update(ctx, routeNs))
+
+	require.Eventually(t, func() bool {
+		res, ok := getGatewayClassFromResources(resources, gc.Name)
+		if !ok {
+			return false
+		}
+		for _, n := range res.Namespaces {
+			if n.Name == routeNs.Name {
+				return n.Labels["access"] == "granted"
+			}
+		}
+		return false
+	}, defaultWait, defaultTick, "namespace label change was not reconciled without another triggering event")
 }
 
 func testTLSRoute(ctx context.Context, t *testing.T, provider *Provider, resources *message.ProviderResources) {

--- a/release-notes/current/bug_fixes/9625-namespace-selector-watch.md
+++ b/release-notes/current/bug_fixes/9625-namespace-selector-watch.md
@@ -1,0 +1,5 @@
+Fixed HTTPRoutes (and other routes) staying `NotAllowedByListeners` after a
+namespace was labeled to match a Gateway listener's
+`allowedRoutes.namespaces.selector`. The controller had no watch on `Namespace`
+objects, so label-only changes never triggered a reconcile; the fix now watches
+`Namespace` label changes and re-evaluates affected Gateways and routes.


### PR DESCRIPTION
**What this PR does / why we need it**:

When a Gateway listener restricts route attachment with
`allowedRoutes.namespaces.from: Selector`, labeling a namespace to match the
selector after an HTTPRoute in it has already been reconciled did not
trigger re-evaluation: the route stayed `NotAllowedByListeners` indefinitely
even though the namespace now matched the selector. Restarting the
controller (or touching any other watched resource, e.g. annotating the
HTTPRoute) was the only way to make it re-converge, because the controller
had no watch on `Namespace` objects, so a label-only change never enqueued a
reconcile.

This PR adds a watch on `corev1.Namespace` in `watchResources`, following
the same "enqueue the managed GatewayClass" pattern already used for
ConfigMap, Secret, Deployment, DaemonSet, Node, and ReferenceGrant watches
in the same file. The predicate only allows `Update` events where labels
actually changed (`predicate.TypedLabelChangedPredicate`), and explicitly
ignores `Create`/`Delete`/`Generic` events, since anything referencing a
namespace is already reconciled through its own watch (Gateway, HTTPRoute,
etc.) — only a label change on an already-known namespace needs to
retrigger reconciliation here.

No RBAC change is needed: the controller's ClusterRole already grants
`get`/`list`/`watch` on core `namespaces`, and a cached Namespace informer
was already running (existing code already reads `Namespace` via the
manager's cached client) — this only attaches a new handler/predicate to
it.

**Validation**: Added `testHTTPRouteNamespaceSelectorLabelUpdate`, an
envtest-based regression test verified to fail (63.75s timeout) with only
the `watchResources` change reverted, and pass with it restored. Full
details and exact commands run are in the commit message.

**Which issue(s) this PR fixes**:
Fixes #9625

---

**PR Checklist**

- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: N/A this PR does not contain API changes.
- [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (Flaky e2e failures are not considered breakages, but `gen-check`, `lint`, and coverage **MUST** pass.)
- [x] **Tests added/updated**: New/changed code is covered by appropriate tests.
- [x] **Docs**: N/A this PR does not contain user-facing behavior changes (the fix restores the behavior the Gateway API spec already expects).
- [x] **Release notes**: Added `release-notes/current/bug_fixes/9625-namespace-selector-watch.md`.
- [x] **Generated files committed**: N/A no API/helm chart/module changes.
- [x] **Scope & compatibility**: The PR is reasonably scoped (no unrelated changes) and preserves backward compatibility.
- [ ] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.

---
AI assistance: this change was drafted with Claude Code.