### PR TITLE
fix: bound compressor minContentLength before narrowing to uint32

### DIFF
--- a/internal/gatewayapi/backendtrafficpolicy.go
+++ b/internal/gatewayapi/backendtrafficpolicy.go
@@ -15,6 +15,7 @@ import (
 
 	perr "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -1562,7 +1563,10 @@ func (t *Translator) buildTrafficFeatures(policy *egv1a1.BackendTrafficPolicy, o
 		errs = errors.Join(errs, err)
 	}
 
-	cp = buildCompression(policy.Spec.Compression, policy.Spec.Compressor)
+	if cp, err = buildCompression(policy.Spec.Compression, policy.Spec.Compressor); err != nil {
+		err = perr.WithMessage(err, "Compression")
+		errs = errors.Join(errs, err)
+	}
 	httpUpgrade = buildHTTPProtocolUpgradeConfig(policy.Spec.HTTPUpgrade)
 	if rb != nil && len(httpUpgrade) > 0 {
 		err = errors.New("requestBuffer cannot be used together with httpUpgrade")
@@ -2537,7 +2541,7 @@ func defaultResponseOverrideRuleName(policy *egv1a1.BackendTrafficPolicy, index 
 		strconv.Itoa(index))
 }
 
-func buildCompression(compression, compressor []*egv1a1.Compression) []*ir.Compression {
+func buildCompression(compression, compressor []*egv1a1.Compression) ([]*ir.Compression, error) {
 	// Handle the Compressor field first (higher priority)
 	if len(compressor) > 0 {
 		result := make([]*ir.Compression, 0, len(compressor))
@@ -2550,21 +2554,20 @@ func buildCompression(compression, compressor []*egv1a1.Compression) []*ir.Compr
 					Type:        c.Type,
 					ChooseFirst: i == 0, // only the first compressor is marked as ChooseFirst
 				}
-				if c.MinContentLength != nil {
-					minContentLength, ok := c.MinContentLength.AsInt64()
-					if ok {
-						irCompression.MinContentLength = new(uint32(minContentLength))
-					}
+				minContentLength, err := minContentLengthToUint32(c.MinContentLength)
+				if err != nil {
+					return nil, err
 				}
+				irCompression.MinContentLength = minContentLength
 				result = append(result, &irCompression)
 			}
 		}
-		return result
+		return result, nil
 	}
 
 	// Fallback to the deprecated Compression field
 	if compression == nil {
-		return nil
+		return nil, nil
 	}
 	result := make([]*ir.Compression, 0, len(compression))
 	for i, c := range compression {
@@ -2572,16 +2575,34 @@ func buildCompression(compression, compressor []*egv1a1.Compression) []*ir.Compr
 			Type:        c.Type,
 			ChooseFirst: i == 0, // only the first compressor is marked as ChooseFirst
 		}
-		if c.MinContentLength != nil {
-			minContentLength, ok := c.MinContentLength.AsInt64()
-			if ok {
-				irCompression.MinContentLength = new(uint32(minContentLength))
-			}
+		minContentLength, err := minContentLengthToUint32(c.MinContentLength)
+		if err != nil {
+			return nil, err
 		}
+		irCompression.MinContentLength = minContentLength
 		result = append(result, &irCompression)
 	}
 
-	return result
+	return result, nil
+}
+
+// minContentLengthToUint32 converts the CRD quantity to the uint32 Envoy expects. The
+// CRD pattern allows suffixes up to Ei, so a value above MaxUint32 is accepted by the
+// API server; casting it straight to uint32 wraps (e.g. 4Gi becomes 0), turning a
+// large threshold into "compress everything". Reject out-of-range values instead.
+func minContentLengthToUint32(q *apiresource.Quantity) (*uint32, error) {
+	if q == nil {
+		return nil, nil
+	}
+	v, ok := q.AsInt64()
+	if !ok {
+		return nil, fmt.Errorf("invalid minContentLength value %s", q.String())
+	}
+	ui32, ok := int64ToUint32(v)
+	if !ok {
+		return nil, fmt.Errorf("invalid minContentLength value %d", v)
+	}
+	return &ui32, nil
 }
 
 func buildHTTPProtocolUpgradeConfig(cfgs []*egv1a1.ProtocolUpgradeConfig) []ir.HTTPUpgradeConfig {

--- a/internal/gatewayapi/backendtrafficpolicy_test.go
+++ b/internal/gatewayapi/backendtrafficpolicy_test.go
@@ -341,6 +341,7 @@ func TestBuildCompression(t *testing.T) {
 		compression []*egv1a1.Compression
 		compressor  []*egv1a1.Compression
 		expected    []*ir.Compression
+		expectErr   bool
 	}{
 		{
 			name:        "nil compression",
@@ -449,11 +450,44 @@ func TestBuildCompression(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "minContentLength at the uint32 boundary is kept",
+			compressor: []*egv1a1.Compression{
+				{
+					Type:             egv1a1.GzipCompressorType,
+					Gzip:             &egv1a1.GzipCompressor{},
+					MinContentLength: new(resource.MustParse("4294967295")),
+				},
+			},
+			expected: []*ir.Compression{
+				{
+					Type:             egv1a1.GzipCompressorType,
+					ChooseFirst:      true,
+					MinContentLength: new(uint32(math.MaxUint32)),
+				},
+			},
+		},
+		{
+			name: "minContentLength above uint32 is rejected instead of truncated",
+			compressor: []*egv1a1.Compression{
+				{
+					Type:             egv1a1.GzipCompressorType,
+					Gzip:             &egv1a1.GzipCompressor{},
+					MinContentLength: new(resource.MustParse("4Gi")),
+				},
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildCompression(tc.compression, tc.compressor)
+			got, err := buildCompression(tc.compression, tc.compressor)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 			require.Equal(t, tc.expected, got)
 		})
 	}

--- a/release-notes/current/bug_fixes/9852-compression-mincontentlength-overflow.md
+++ b/release-notes/current/bug_fixes/9852-compression-mincontentlength-overflow.md
@@ -1,0 +1,1 @@
+Fixed `backendTrafficPolicy.spec.compressor[].minContentLength` (and the deprecated `spec.compression[]`) silently wrapping when set above 4 GiB: the quantity was cast straight to a uint32, so a value such as `4Gi` truncated to `0` and Envoy compressed every response instead of only large ones. Such out-of-range values are now rejected with a policy error rather than truncated.


### PR DESCRIPTION
**What this PR does / why we need it**:

`minContentLength` on a compressor is a `resource.Quantity`, and its CRD pattern allows suffixes up to `Ei`, so the API server accepts values well above 4 GiB. `buildCompression` cast the parsed int64 straight to a uint32, which quietly wraps: `4Gi` became `0`, so Envoy compressed every response rather than only large ones, the opposite of what was configured (`4Gi`+30 lands on 30, and so on). This routes the value through the existing `int64ToUint32` bounds check, the same helper the other numeric fields in this file already use, and surfaces a policy error for out-of-range values instead of silently truncating. The deprecated `spec.compression[]` path had the same cast and gets the same fix.

**Which issue(s) this PR fixes**:
Fixes #

---

**PR Checklist**

- [ ] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: N/A: no API changes.
- [x] **Required checks pass**: `make lint` and the unit tests for the touched package pass locally.
- [x] **Tests added/updated**: added boundary and overflow cases to `TestBuildCompression`.
- [x] **Docs**: N/A: no user-facing docs change.
- [x] **Release notes**: added `release-notes/current/bug_fixes/9852-compression-mincontentlength-overflow.md`.
- [x] **Generated files committed**: N/A: no API/helm/module changes.
- [x] **Scope & compatibility**: scoped to the compression translation, behaviour for valid inputs is unchanged.
- [ ] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.
