### PR TITLE
feat(metrics): add optional TLS for control-plane metrics

### DIFF
--- a/charts/gateway-helm/README.md
+++ b/charts/gateway-helm/README.md
@@ -175,6 +175,8 @@ helm uninstall eg -n envoy-gateway-system
 | hpa.metrics | list | `[]` |  |
 | hpa.minReplicas | int | `1` |  |
 | kubernetesClusterDomain | string | `"cluster.local"` |  |
+| metrics.tls.enable | bool | `false` |  |
+| metrics.tls.secretRef.name | string | `""` |  |
 | namespaceOverride | string | `""` | Override the namespace for resources deployed by the chart. Defaults to the release namespace. |
 | podDisruptionBudget.minAvailable | int | `0` |  |
 | service.annotations | object | `{}` |  |

--- a/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
@@ -24,7 +24,11 @@ spec:
     {{- include "eg.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.deployment.pod.annotations }}
+      {{- $podAnnotations := deepCopy .Values.deployment.pod.annotations }}
+      {{- if .Values.metrics.tls.enable }}
+      {{- $_ := set $podAnnotations "prometheus.io/scheme" "https" }}
+      {{- end }}
+      {{- with $podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
@@ -60,6 +60,11 @@ spec:
       - args:
         - server
         - --config-path=/config/envoy-gateway.yaml
+        {{- if .Values.metrics.tls.enable }}
+        - --metrics-tls-enable
+        - --metrics-tls-cert-file=/etc/envoy-gateway/metrics-tls/tls.crt
+        - --metrics-tls-key-file=/etc/envoy-gateway/metrics-tls/tls.key
+        {{- end }}
         env:
         - name: ENVOY_GATEWAY_NAMESPACE
           valueFrom:
@@ -100,6 +105,11 @@ spec:
         - mountPath: /certs
           name: certs
           readOnly: true
+        {{- if .Values.metrics.tls.enable }}
+        - mountPath: /etc/envoy-gateway/metrics-tls
+          name: metrics-tls
+          readOnly: true
+        {{- end }}
         - mountPath: /var/lib/eg/wasm
           name: wasm-cache
         {{- with .Values.deployment.pod.extraVolumeMounts }}
@@ -119,6 +129,11 @@ spec:
       - name: certs
         secret:
           secretName: envoy-gateway
+      {{- if .Values.metrics.tls.enable }}
+      - name: metrics-tls
+        secret:
+          secretName: {{ required "metrics.tls.secretRef.name is required when metrics.tls.enable is true" .Values.metrics.tls.secretRef.name | quote }}
+      {{- end }}
       # Writable cache for Wasm modules; required because the controller's
       # root filesystem is read-only by default (readOnlyRootFilesystem).
       - name: wasm-cache

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -50,6 +50,13 @@ podDisruptionBudget:
   # maxUnavailable: 1
   # unhealthyPodEvictionPolicy: IfHealthyBudget
 
+# Control-plane Prometheus metrics configuration. This does not configure EnvoyProxy data-plane metrics.
+metrics:
+  tls:
+    enable: false
+    secretRef:
+      name: ""
+
 deployment:
   annotations: {}
   envoyGateway:

--- a/internal/admin/console/metrics.go
+++ b/internal/admin/console/metrics.go
@@ -13,21 +13,12 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-// createCombinedMetricsHandler creates a handler that uses the controller-runtime registry
+// createCombinedMetricsHandler creates a handler that combines the controller-runtime and
+// default Prometheus registries.
 func createCombinedMetricsHandler() http.Handler {
-	// Check if the controller-runtime registry has any metrics
-	// In test environments, it might be empty
-	if hasMetrics(metricsserver.Registry) {
-		// Use the controller-runtime registry which includes all Envoy Gateway metrics
-		return promhttp.HandlerFor(metricsserver.Registry, promhttp.HandlerOpts{})
+	gatherer := prometheus.Gatherers{
+		metricsserver.Registry,
+		prometheus.DefaultGatherer,
 	}
-
-	// Fallback to default gatherer for test environments
-	return promhttp.Handler()
-}
-
-// hasMetrics checks if a gatherer has any metrics
-func hasMetrics(gatherer prometheus.Gatherer) bool {
-	families, err := gatherer.Gather()
-	return err == nil && len(families) > 0
+	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
 }

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -40,6 +40,12 @@ type Runner interface {
 // cfgPath is the path to the EnvoyGateway configuration file.
 var cfgPath string
 
+var (
+	metricsTLSEnabled  bool
+	metricsTLSCertFile string
+	metricsTLSKeyFile  string
+)
+
 // GetServerCommand returns the server cobra command to be executed.
 // This command receives an async error handler to let the main process decide how to
 // handle critical errors that may happen in the runners that may prevent Envoy Gateway from
@@ -66,6 +72,11 @@ func GetServerCommand(asyncErrHandler func(string, error)) *cobra.Command {
 			)
 
 			hook := func(c context.Context, cfg *config.Server) error {
+				cfg.MetricsTLS = config.MetricsTLSConfig{
+					Enabled:  metricsTLSEnabled,
+					CertFile: metricsTLSCertFile,
+					KeyFile:  metricsTLSKeyFile,
+				}
 				cfg.Logger.Info("Start runners")
 				if err := startRunners(c, cfg, runnerErrors); err != nil {
 					return err
@@ -78,6 +89,12 @@ func GetServerCommand(asyncErrHandler func(string, error)) *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVarP(&cfgPath, "config-path", "c", "",
 		"The path to the configuration file.")
+	cmd.PersistentFlags().BoolVar(&metricsTLSEnabled, "metrics-tls-enable", false,
+		"Enable TLS for the control-plane Prometheus metrics endpoint.")
+	cmd.PersistentFlags().StringVar(&metricsTLSCertFile, "metrics-tls-cert-file", "",
+		"The path to the TLS certificate for the control-plane Prometheus metrics endpoint.")
+	cmd.PersistentFlags().StringVar(&metricsTLSKeyFile, "metrics-tls-key-file", "",
+		"The path to the TLS private key for the control-plane Prometheus metrics endpoint.")
 	return cmd
 }
 

--- a/internal/envoygateway/config/config.go
+++ b/internal/envoygateway/config/config.go
@@ -47,9 +47,19 @@ type Server struct {
 	Stdout io.Writer
 	// Stderr is the writer for error output.
 	Stderr io.Writer
+	// MetricsTLS configures TLS for the control-plane Prometheus metrics endpoint.
+	MetricsTLS MetricsTLSConfig
 	// KubernetesClient holds the controller-runtime client created by the Kubernetes provider.
 	// This is used by the infrastructure runner to create the envoy proxy and rate limit infra resources.
 	KubernetesClient *KubernetesClientHolder
+}
+
+// MetricsTLSConfig configures server-side TLS for the control-plane metrics endpoint.
+// The certificate and key are read from files mounted into the Envoy Gateway Pod.
+type MetricsTLSConfig struct {
+	Enabled  bool
+	CertFile string
+	KeyFile  string
 }
 
 type KubernetesClientHolder struct {

--- a/internal/metrics/register.go
+++ b/internal/metrics/register.go
@@ -7,6 +7,7 @@ package metrics
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -19,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/sdk/metric"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -32,8 +34,9 @@ const (
 )
 
 type Runner struct {
-	cfg    *config.Server
-	server *http.Server
+	cfg      *config.Server
+	server   *http.Server
+	listener net.Listener
 }
 
 func New(cfg *config.Server) *Runner {
@@ -42,7 +45,7 @@ func New(cfg *config.Server) *Runner {
 	}
 }
 
-func (r *Runner) Start(_ context.Context) error {
+func (r *Runner) Start(ctx context.Context) error {
 	metricsLogger := r.cfg.Logger.WithName("metrics")
 	otel.SetLogger(metricsLogger.Logger)
 
@@ -57,7 +60,7 @@ func (r *Runner) Start(_ context.Context) error {
 	}
 
 	if !options.pullOptions.disable {
-		return r.start(options.address, handler)
+		return r.start(ctx, options.address, handler, options.tls)
 	}
 
 	return nil
@@ -76,14 +79,37 @@ func (r *Runner) Close() error {
 	return nil
 }
 
-func (r *Runner) start(address string, handler http.Handler) error {
+func (r *Runner) start(ctx context.Context, address string, handler http.Handler, tlsOptions metricsTLSOptions) error {
 	handlers := http.NewServeMux()
 
 	metricsLogger := r.cfg.Logger.WithName("metrics")
-	metricsLogger.Info("starting metrics server", "address", address)
+	metricsLogger.Info("starting metrics server", "address", address, "secure", tlsOptions.enabled)
 	if handler != nil {
 		handlers.Handle(defaultEndpoint, handler)
 	}
+
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return fmt.Errorf("failed to listen on metrics address %s: %w", address, err)
+	}
+
+	if tlsOptions.enabled {
+		certWatcher, err := certwatcher.New(tlsOptions.certFile, tlsOptions.keyFile)
+		if err != nil {
+			_ = listener.Close()
+			return fmt.Errorf("failed to load metrics TLS certificate: %w", err)
+		}
+
+		listener = tls.NewListener(listener, &tls.Config{
+			GetCertificate: certWatcher.GetCertificate,
+		})
+		go func() {
+			if err := certWatcher.Start(ctx); err != nil && ctx.Err() == nil {
+				metricsLogger.Error(err, "metrics TLS certificate watcher stopped")
+			}
+		}()
+	}
+	r.listener = listener
 
 	r.server = &http.Server{
 		Handler:           handlers,
@@ -94,9 +120,8 @@ func (r *Runner) start(address string, handler http.Handler) error {
 		IdleTimeout:       15 * time.Second,
 	}
 
-	// Listen And Serve Metrics Server.
 	go func() {
-		if err := r.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := r.server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			metricsLogger.Error(err, "start metrics server failed")
 		}
 	}()
@@ -107,6 +132,14 @@ func (r *Runner) start(address string, handler http.Handler) error {
 func (r *Runner) newOptions() (registerOptions, error) {
 	newOpts := registerOptions{}
 	newOpts.address = net.JoinHostPort(egv1a1.GatewayMetricsHost, fmt.Sprint(egv1a1.GatewayMetricsPort))
+	newOpts.tls = metricsTLSOptions{
+		enabled:  r.cfg.MetricsTLS.Enabled,
+		certFile: r.cfg.MetricsTLS.CertFile,
+		keyFile:  r.cfg.MetricsTLS.KeyFile,
+	}
+	if newOpts.tls.enabled && (newOpts.tls.certFile == "" || newOpts.tls.keyFile == "") {
+		return newOpts, fmt.Errorf("metrics TLS requires both certificate and key files")
+	}
 
 	if r.cfg.EnvoyGateway.DisablePrometheus() {
 		newOpts.pullOptions.disable = true
@@ -275,6 +308,7 @@ func (r *Runner) registerOTELgRPCexporter(otelOpts *[]metric.Option, opts *regis
 
 type registerOptions struct {
 	address     string
+	tls         metricsTLSOptions
 	pullOptions struct {
 		registry prometheus.Registerer
 		gatherer prometheus.Gatherer
@@ -283,6 +317,12 @@ type registerOptions struct {
 	pushOptions struct {
 		sinks []metricsSink
 	}
+}
+
+type metricsTLSOptions struct {
+	enabled  bool
+	certFile string
+	keyFile  string
 }
 
 type metricsSink struct {

--- a/internal/metrics/register_test.go
+++ b/internal/metrics/register_test.go
@@ -7,12 +7,18 @@ package metrics
 
 import (
 	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	egcrypto "github.com/envoyproxy/gateway/internal/crypto"
 	"github.com/envoyproxy/gateway/internal/envoygateway/config"
 	"github.com/envoyproxy/gateway/internal/logging"
 )
@@ -32,4 +38,75 @@ func TestMetricServer(t *testing.T) {
 	// Clean up
 	err = runner.Close()
 	require.NoError(t, err)
+}
+
+func TestMetricServerTLS(t *testing.T) {
+	cfg, err := config.New(io.Discard, io.Discard)
+	require.NoError(t, err)
+	cfg.EnvoyGateway.Provider = &egv1a1.EnvoyGatewayProvider{Type: egv1a1.ProviderTypeCustom}
+
+	certs, err := egcrypto.GenerateCerts(cfg)
+	require.NoError(t, err)
+
+	certDir := t.TempDir()
+	certFile := filepath.Join(certDir, "tls.crt")
+	keyFile := filepath.Join(certDir, "tls.key")
+	require.NoError(t, os.WriteFile(certFile, certs.EnvoyGatewayCertificate, 0o600))
+	require.NoError(t, os.WriteFile(keyFile, certs.EnvoyGatewayPrivateKey, 0o600))
+
+	runner := New(cfg)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("metrics"))
+	})
+	err = runner.start(ctx, "127.0.0.1:0", handler, metricsTLSOptions{
+		enabled:  true,
+		certFile: certFile,
+		keyFile:  keyFile,
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, runner.Close()) }()
+
+	require.Eventually(t, func() bool {
+		return runner.listener != nil
+	}, time.Second, time.Millisecond)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			// The test verifies TLS serving; certificate trust is covered by cert-manager integration tests.
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test-only self-signed certificate
+		},
+	}
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = client.Get("https://" + runner.listener.Addr().String() + defaultEndpoint)
+		if err != nil {
+			return false
+		}
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			resp = nil
+			return false
+		}
+		return true
+	}, time.Second, time.Millisecond)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "metrics", string(body))
+}
+
+func TestMetricServerTLSRequiresCertificateFiles(t *testing.T) {
+	cfg, err := config.New(io.Discard, io.Discard)
+	require.NoError(t, err)
+	cfg.MetricsTLS.Enabled = true
+
+	runner := New(cfg)
+	err = runner.Start(t.Context())
+	require.EqualError(t, err, "metrics TLS requires both certificate and key files")
 }

--- a/internal/metrics/register_test.go
+++ b/internal/metrics/register_test.go
@@ -79,26 +79,34 @@ func TestMetricServerTLS(t *testing.T) {
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test-only self-signed certificate
 		},
 	}
-	var resp *http.Response
+	var (
+		statusCode int
+		body       string
+	)
 	require.Eventually(t, func() bool {
 		var err error
-		resp, err = client.Get("https://" + runner.listener.Addr().String() + defaultEndpoint)
+		statusCode, body, err = getMetrics(client, "https://"+runner.listener.Addr().String()+defaultEndpoint)
 		if err != nil {
 			return false
 		}
-		if resp.StatusCode != http.StatusOK {
-			_ = resp.Body.Close()
-			resp = nil
-			return false
-		}
-		return true
+		return statusCode == http.StatusOK
 	}, time.Second, time.Millisecond)
-	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, "metrics", body)
+}
+
+func getMetrics(client *http.Client, url string) (int, string, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return 0, "", err
+	}
 	defer resp.Body.Close()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+
 	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, "metrics", string(body))
+	if err != nil {
+		return 0, "", err
+	}
+	return resp.StatusCode, string(body), nil
 }
 
 func TestMetricServerTLSRequiresCertificateFiles(t *testing.T) {

--- a/release-notes/current/new_features/9854-control-plane-metrics-tls.md
+++ b/release-notes/current/new_features/9854-control-plane-metrics-tls.md
@@ -1,0 +1,1 @@
+Added opt-in server-side TLS for the Envoy Gateway control-plane Prometheus metrics endpoint, using a deployment-provided certificate Secret with certificate rotation support.

--- a/site/content/en/latest/install/gateway-helm-api.md
+++ b/site/content/en/latest/install/gateway-helm-api.md
@@ -114,6 +114,8 @@ The Helm chart for Envoy Gateway
 | hpa.metrics | list | `[]` |  |
 | hpa.minReplicas | int | `1` |  |
 | kubernetesClusterDomain | string | `"cluster.local"` |  |
+| metrics.tls.enable | bool | `false` |  |
+| metrics.tls.secretRef.name | string | `""` |  |
 | namespaceOverride | string | `""` | Override the namespace for resources deployed by the chart. Defaults to the release namespace. |
 | podDisruptionBudget.minAvailable | int | `0` |  |
 | service.annotations | object | `{}` |  |

--- a/test/helm/gateway-helm/control-plane-metrics-tls.in.yaml
+++ b/test/helm/gateway-helm/control-plane-metrics-tls.in.yaml
@@ -1,0 +1,5 @@
+metrics:
+  tls:
+    enable: true
+    secretRef:
+      name: envoy-gateway-metrics-cert

--- a/test/helm/gateway-helm/control-plane-metrics-tls.in.yaml
+++ b/test/helm/gateway-helm/control-plane-metrics-tls.in.yaml
@@ -1,3 +1,8 @@
+global:
+  images:
+    envoyGateway:
+      image: "docker.io/envoyproxy/gateway-dev:latest"
+      pullPolicy: Always
 metrics:
   tls:
     enable: true

--- a/test/helm/gateway-helm/control-plane-metrics-tls.out.yaml
+++ b/test/helm/gateway-helm/control-plane-metrics-tls.out.yaml
@@ -1,0 +1,832 @@
+---
+# Source: gateway-helm/templates/envoy-gateway-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+# Disable token automounting on the ServiceAccount by default to satisfy
+# Kubescape control C-0034. Pods that need Kubernetes API access explicitly
+# enable automountServiceAccountToken in their pod spec.
+automountServiceAccountToken: false
+metadata:
+  name: envoy-gateway
+  namespace: envoy-gateway-system
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: gateway-helm/templates/envoy-gateway-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-gateway-config
+  namespace: envoy-gateway-system
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+data:
+  envoy-gateway.yaml: |
+    apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: EnvoyGateway
+    extensionApis: {}
+    gateway:
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    logging:
+      level:
+        default: info
+    provider:
+      kubernetes:
+        rateLimitDeployment:
+          container:
+            image: docker.io/envoyproxy/ratelimit:master
+          patch:
+            type: StrategicMerge
+            value:
+              spec:
+                template:
+                  spec:
+                    containers:
+                    - imagePullPolicy: IfNotPresent
+                      name: envoy-ratelimit
+        shutdownManager:
+          image: docker.io/envoyproxy/gateway-dev:latest
+      type: Kubernetes
+---
+# Source: gateway-helm/templates/envoy-gateway-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: gateway-helm-envoy-gateway-role
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.envoyproxy.io
+  resources:
+  - envoyproxies
+  - envoypatchpolicies
+  - clienttrafficpolicies
+  - backendtrafficpolicies
+  - securitypolicies
+  - envoyextensionpolicies
+  - backends
+  - httproutefilters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.envoyproxy.io
+  resources:
+  - envoyproxies/status
+  - envoypatchpolicies/status
+  - clienttrafficpolicies/status
+  - backendtrafficpolicies/status
+  - securitypolicies/status
+  - envoyextensionpolicies/status
+  - backends/status
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  - listenersets
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  - tcproutes
+  - tlsroutes
+  - udproutes
+  - backendtlspolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways/status
+  - listenersets/status
+  - grpcroutes/status
+  - httproutes/status
+  - tcproutes/status
+  - tlsroutes/status
+  - udproutes/status
+  - backendtlspolicies/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/binding
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: gateway-helm/templates/envoy-gateway-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gateway-helm-envoy-gateway-rolebinding
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gateway-helm-envoy-gateway-role
+subjects:
+- kind: ServiceAccount
+  name: 'envoy-gateway'
+  namespace: envoy-gateway-system
+---
+# Source: gateway-helm/templates/infra-manager-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-infra-manager
+  namespace: envoy-gateway-system
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - deletecollection
+  - patch
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - deletecollection
+  - patch
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - deletecollection
+  - patch
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - deletecollection
+  - patch
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - clustertrustbundles
+  verbs:
+  - list
+  - get
+  - watch
+---
+# Source: gateway-helm/templates/leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-leader-election-role
+  namespace: envoy-gateway-system
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: gateway-helm/templates/infra-manager-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-infra-manager
+  namespace: envoy-gateway-system
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-infra-manager'
+subjects:
+- kind: ServiceAccount
+  name: 'envoy-gateway'
+  namespace: envoy-gateway-system
+---
+# Source: gateway-helm/templates/leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-leader-election-rolebinding
+  namespace: envoy-gateway-system
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: 'envoy-gateway'
+  namespace: envoy-gateway-system
+---
+# Source: gateway-helm/templates/envoy-gateway-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-gateway
+  namespace: envoy-gateway-system
+  labels:
+    control-plane: envoy-gateway
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    control-plane: envoy-gateway
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+  ports:
+  - name: grpc
+    port: 18000
+    targetPort: 18000
+  - name: ratelimit
+    port: 18001
+    targetPort: 18001
+  - name: wasm
+    port: 18002
+    targetPort: 18002
+  - name: metrics
+    port: 19001
+    targetPort: 19001
+  - name: webhook
+    port: 9443
+    targetPort: 9443
+---
+# Source: gateway-helm/templates/envoy-gateway-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy-gateway
+  namespace: envoy-gateway-system
+  labels:
+    control-plane: envoy-gateway
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: envoy-gateway
+      app.kubernetes.io/name: gateway-helm
+      app.kubernetes.io/instance: gateway-helm
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "19001"
+        prometheus.io/scrape: "true"
+      labels:
+        control-plane: envoy-gateway
+        app.kubernetes.io/name: gateway-helm
+        app.kubernetes.io/instance: gateway-helm
+    spec:
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - args:
+        - server
+        - --config-path=/config/envoy-gateway.yaml
+        - --metrics-tls-enable
+        - --metrics-tls-cert-file=/etc/envoy-gateway/metrics-tls/tls.crt
+        - --metrics-tls-key-file=/etc/envoy-gateway/metrics-tls/tls.key
+        env:
+        - name: ENVOY_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        image: docker.io/envoyproxy/gateway-dev:latest
+        imagePullPolicy: IfNotPresent
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz
+            port: 8081
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: envoy-gateway
+        ports:
+        - containerPort: 18000
+          name: grpc
+        - containerPort: 18001
+          name: ratelimit
+        - containerPort: 18002
+          name: wasm
+        - containerPort: 19001
+          name: metrics
+        - name: webhook
+          containerPort: 9443
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /config
+          name: envoy-gateway-config
+          readOnly: true
+        - mountPath: /certs
+          name: certs
+          readOnly: true
+        - mountPath: /etc/envoy-gateway/metrics-tls
+          name: metrics-tls
+          readOnly: true
+        - mountPath: /var/lib/eg/wasm
+          name: wasm-cache
+      imagePullSecrets: []
+      serviceAccountName: envoy-gateway
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: envoy-gateway-config
+        name: envoy-gateway-config
+      - name: certs
+        secret:
+          secretName: envoy-gateway
+      - name: metrics-tls
+        secret:
+          secretName: "envoy-gateway-metrics-cert"
+      # Writable cache for Wasm modules; required because the controller's
+      # root filesystem is read-only by default (readOnlyRootFilesystem).
+      - name: wasm-cache
+        emptyDir: {}
+---
+# Source: gateway-helm/charts/crds/templates/gatewayapi-safe-upgrade-policy.yaml
+#
+# config/crd/experimental/gateway.networking.k8s.io_vap_safeupgrades.yaml
+#
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v1.6.1
+    gateway.networking.k8s.io/channel: standard
+  name: "safe-upgrades.gateway.networking.k8s.io"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["apiextensions.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["*"]
+  validations:
+    - expression: "object.spec.group != 'gateway.networking.k8s.io' || oldObject == null || (
+        has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && 
+        object.metadata.annotations['gateway.networking.k8s.io/channel'] == 'standard' ) || (
+        oldObject != null && has(oldObject.metadata.annotations) && oldObject.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && 
+        oldObject.metadata.annotations['gateway.networking.k8s.io/channel'] == 'experimental' )"
+      message: "Installing experimental CRDs on top of standard channel CRDs is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install experimental CRDs on top of standard channel CRDs."
+      reason: Invalid
+    - expression: |
+        object.spec.group != 'gateway.networking.k8s.io' ||
+        (has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/bundle-version') &&
+        (object.metadata.annotations['gateway.networking.k8s.io/bundle-version'] == 'v0.0.0-dev' ||
+        (object.metadata.annotations['gateway.networking.k8s.io/bundle-version'].startsWith('v1.') &&
+         !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], '^v1\\.[0-4](\\.|$)'))))
+      message: "Installing CRDs with version other than v0.0.0-dev or v1.5+ is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install other versions."
+      reason: Invalid
+---
+# Source: gateway-helm/charts/crds/templates/gatewayapi-safe-upgrade-policy.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v1.6.1
+    gateway.networking.k8s.io/channel: standard
+  name: safe-upgrades.gateway.networking.k8s.io
+spec:
+  policyName: safe-upgrades.gateway.networking.k8s.io
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+    - apiGroups:   ["apiextensions.k8s.io"]
+      apiVersions: ["v1"]
+      resources:   ["customresourcedefinitions"]
+      operations:  ["CREATE", "UPDATE"]
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+# Disable token automounting on the ServiceAccount by default to satisfy
+# Kubescape control C-0034. Pods that need Kubernetes API access explicitly
+# enable automountServiceAccountToken in their pod spec.
+automountServiceAccountToken: false
+metadata:
+  name: gateway-helm-certgen
+  namespace: envoy-gateway-system
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD or Flux.
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: 'gateway-helm-certgen:envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD or Flux.
+rules:
+  - apiGroups:
+    - admissionregistration.k8s.io
+    resources:
+    - mutatingwebhookconfigurations
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    resourceNames:
+      - 'envoy-gateway-topology-injector.envoy-gateway-system'
+    verbs:
+      - update
+      - patch
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: 'gateway-helm-certgen:envoy-gateway-system'
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD or Flux.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'gateway-helm-certgen:envoy-gateway-system'
+subjects:
+  - kind: ServiceAccount
+    name: 'gateway-helm-certgen'
+    namespace: envoy-gateway-system
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-helm-certgen
+  namespace: envoy-gateway-system
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD or Flux.
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
+# Source: gateway-helm/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-helm-certgen
+  namespace: envoy-gateway-system
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD or Flux.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'gateway-helm-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'gateway-helm-certgen'
+  namespace: envoy-gateway-system
+---
+# Source: gateway-helm/templates/certgen.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gateway-helm-certgen
+  namespace: envoy-gateway-system
+  labels:
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: certgen
+    spec:
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - command:
+        - envoy-gateway
+        - certgen
+        env:
+        - name: ENVOY_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        image: docker.io/envoyproxy/gateway-dev:latest
+        imagePullPolicy: IfNotPresent
+        name: envoy-gateway-certgen
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+      imagePullSecrets: []
+      restartPolicy: Never
+      serviceAccountName: gateway-helm-certgen
+  ttlSecondsAfterFinished: 30
+---
+# Source: gateway-helm/templates/envoy-proxy-topology-injector-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: 'envoy-gateway-topology-injector.envoy-gateway-system'
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"
+  labels:
+    app.kubernetes.io/component: topology-injector
+    helm.sh/chart: gateway-helm-v0.0.0-latest
+    app.kubernetes.io/name: gateway-helm
+    app.kubernetes.io/instance: gateway-helm
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: topology.webhook.gateway.envoyproxy.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    clientConfig:
+      service:
+        name: envoy-gateway
+        namespace: envoy-gateway-system
+        path: "/inject-pod-topology"
+        port: 9443
+    failurePolicy: Ignore
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods/binding"]
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - envoy-gateway-system

--- a/test/helm/gateway-helm/control-plane-metrics-tls.out.yaml
+++ b/test/helm/gateway-helm/control-plane-metrics-tls.out.yaml
@@ -437,6 +437,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/port: "19001"
+        prometheus.io/scheme: https
         prometheus.io/scrape: "true"
       labels:
         control-plane: envoy-gateway
@@ -467,7 +468,7 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
         image: docker.io/envoyproxy/gateway-dev:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         startupProbe:
           failureThreshold: 30
           httpGet:
@@ -774,7 +775,7 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
         image: docker.io/envoyproxy/gateway-dev:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: envoy-gateway-certgen
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
**What this PR does / why we need it**:

This is an intent/prototype PR to discuss securing Envoy Gateway's control-plane Prometheus endpoint (`/metrics`) with optional server-side TLS. It does not change EnvoyProxy data-plane metrics (`/stats/prometheus`).

The deployment owner controls the feature through gateway-helm values:

```yaml
metrics:
  tls:
    enable: false
    secretRef:
      name: ""
```

When enabled, the chart mounts the user-provided Secret into the control-plane Pod and passes certificate paths to the metrics server. The server uses controller-runtime certwatcher so rotated Secret files are used for new TLS connections. Existing Prometheus registry composition, OTEL exporters, port 19001, and default HTTP behavior are preserved.

This PR is intentionally not a final API proposal. If the direction is accepted, the implementation details, naming, validation, observability integration, and compatibility behavior can be refined in follow-up work.

**Open design question: cert-manager Certificate ownership**

This prototype only consumes a Secret supplied by the deployment owner. Should gateway-helm optionally create a cert-manager `Certificate` resource, or should certificate issuance remain entirely outside the chart? Keeping issuance external avoids a hard cert-manager dependency and leaves issuer/namespace/ownership policy to the deployment. An opt-in template could improve convenience, but would need explicit issuer configuration and behavior when cert-manager is absent.

**Which issue(s) this PR fixes**:

Design discussion only; no issue is closed by this PR.

**Verification**

- `go test ./internal/metrics ./internal/cmd ./internal/envoygateway/config`
- `helm lint charts/gateway-helm -f test/helm/gateway-helm/control-plane-metrics-tls.in.yaml`
- `make helm-template.gateway-helm`
- Generated Helm output matches the committed enabled fixture.
- `make gen-check` reached Helm dependency generation but could not resolve the repository versions for `alloy`, `loki`, and `opentelemetry-collector` in this environment.

**PR Checklist**

- [x] Authorship & ownership: reviewed the complete change and understand the implementation.
- [x] DCO: commit is signed off.
- [x] API agreed first: N/A; no changes under `/api`.
- [ ] Required checks pass: full `make gen-check` is blocked by external Helm repository version resolution; targeted checks pass.
- [x] Tests added/updated.
- [x] Docs: generated Helm values API tables updated; this intent PR intentionally does not add a product guide.
- [x] Release notes: N/A for an intent/prototype PR; no release behavior is being proposed for merge.
- [x] Generated files committed.
- [x] Scope & compatibility: TLS is opt-in and default behavior remains HTTP.
- [ ] Codex review.
- [ ] Copilot review.
