### PR TITLE
fix: envoy warn about cpuset-threads

### DIFF
--- a/examples/remote-infra/synthesizer/deployment.go
+++ b/examples/remote-infra/synthesizer/deployment.go
@@ -79,7 +79,6 @@ func (is *InfraSynthesizer) GetDeploymentContainers(ctx context.Context, ir *Inf
 		"--service-node", ir.Proxy.Name,
 		"--config-yaml", buf.String(),
 		"--log-level", "info",
-		"--cpuset-threads",
 		"--drain-strategy", "immediate",
 	}
 

--- a/internal/infrastructure/common/proxy_args.go
+++ b/internal/infrastructure/common/proxy_args.go
@@ -70,7 +70,6 @@ func BuildProxyArgs(
 		"--service-node", serviceNode,
 		"--config-yaml", bootstrapConfigurations,
 		"--log-level", string(logging.DefaultEnvoyProxyLoggingLevel()),
-		"--cpuset-threads",
 		"--drain-strategy", "immediate",
 	}
 

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/component-level.yaml
@@ -46,7 +46,6 @@ spec:
         - test bootstrap config
         - --log-level
         - error
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom-sa.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom-sa.yaml
@@ -227,7 +227,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/custom.yaml
@@ -228,7 +228,6 @@ spec:
                   value: 0.98
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default-env.yaml
@@ -227,7 +227,6 @@ spec:
                   value: 0.98
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/default.yaml
@@ -212,7 +212,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/disable-prometheus.yaml
@@ -161,7 +161,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/extension-env.yaml
@@ -227,7 +227,6 @@ spec:
                   value: 0.98
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/gateway-namespace-mode.yaml
@@ -227,7 +227,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-labels-and-annotations.yaml
@@ -221,7 +221,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/override-prometheus-annotations.yaml
@@ -212,7 +212,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/patch-daemonset.yaml
@@ -212,7 +212,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/shutdown-manager.yaml
@@ -212,7 +212,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/volumes.yaml
@@ -227,7 +227,6 @@ spec:
                   value: 0.98
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-annotations.yaml
@@ -217,7 +217,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-concurrency.yaml
@@ -46,7 +46,6 @@ spec:
         - test bootstrap config
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --concurrency

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-extra-args.yaml
@@ -212,7 +212,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-image-pull-secrets.yaml
@@ -212,7 +212,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-name.yaml
@@ -212,7 +212,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-node-selector.yaml
@@ -212,7 +212,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-priority-class-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-priority-class-name.yaml
@@ -212,7 +212,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/daemonsets/with-topology-spread-constraints.yaml
@@ -212,7 +212,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/bootstrap.yaml
@@ -50,7 +50,6 @@ spec:
         - test bootstrap config
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level-off.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level-off.yaml
@@ -50,7 +50,6 @@ spec:
         - test bootstrap config
         - --log-level
         - "off"
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/component-level.yaml
@@ -50,7 +50,6 @@ spec:
         - test bootstrap config
         - --log-level
         - trace
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom-sa.yaml
@@ -231,7 +231,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom.yaml
@@ -233,7 +233,6 @@ spec:
                   value: 0.98
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/custom_with_initcontainers.yaml
@@ -233,7 +233,6 @@ spec:
                   value: 0.98
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default-env.yaml
@@ -232,7 +232,6 @@ spec:
                   value: 0.98
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/default.yaml
@@ -216,7 +216,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/disable-prometheus.yaml
@@ -165,7 +165,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/dual-stack.yaml
@@ -217,7 +217,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/extension-env.yaml
@@ -232,7 +232,6 @@ spec:
                   value: 0.98
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/gateway-namespace-mode.yaml
@@ -231,7 +231,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/ipv6.yaml
@@ -217,7 +217,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-labels-and-annotations.yaml
@@ -225,7 +225,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/override-prometheus-annotations.yaml
@@ -218,7 +218,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/patch-deployment.yaml
@@ -216,7 +216,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/shutdown-manager.yaml
@@ -216,7 +216,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/volumes.yaml
@@ -232,7 +232,6 @@ spec:
                   value: 0.98
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-annotations.yaml
@@ -221,7 +221,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-concurrency.yaml
@@ -50,7 +50,6 @@ spec:
         - test bootstrap config
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --concurrency

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-empty-memory-limits.yaml
@@ -216,7 +216,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-extra-args.yaml
@@ -216,7 +216,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-hpa.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-hpa.yaml
@@ -216,7 +216,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-image-pull-secrets.yaml
@@ -216,7 +216,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-name.yaml
@@ -216,7 +216,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-node-selector.yaml
@@ -216,7 +216,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-priority-class-name.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-priority-class-name.yaml
@@ -216,7 +216,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/deployments/with-topology-spread-constraints.yaml
@@ -216,7 +216,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
+++ b/internal/infrastructure/kubernetes/proxy/testdata/gateway-namespace-mode/deployment.yaml
@@ -231,7 +231,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level
@@ -667,7 +666,6 @@ spec:
                 max_active_downstream_connections: 50000
         - --log-level
         - warn
-        - --cpuset-threads
         - --drain-strategy
         - immediate
         - --component-log-level

--- a/release-notes/current/bug_fixes/9862-remove-envoy-cpuset-threads-flag.md
+++ b/release-notes/current/bug_fixes/9862-remove-envoy-cpuset-threads-flag.md
@@ -1,0 +1,1 @@
+Removed the `--cpuset-threads` flag from the Envoy proxy startup arguments, which was causing Envoy to log a warning when the container's CPU limits did not align with a CPU set.


### PR DESCRIPTION
```console
Defaulted container "envoy" out of: envoy, shutdown-manager
[2026-08-26 12:55:14.119][1][warning][config] [source/server/options_impl.cc:275] --cpuset-threads is now the default behavior and no longer required.
```