### PR TITLE
fix: target branch in go bench

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -97,9 +97,13 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
-        fetch-depth: 0  # Need main branch access for benchmark comparison
+        fetch-depth: 0  # Need base branch access for benchmark comparison
     - uses: ./tools/github-actions/setup-deps
     - name: Run Benchmark Comparison
+      env:
+        # Compare against the PR's base branch, not always main: release branch
+        # PRs pin an older Go toolchain and main would fail to build with it.
+        BASE_REF: origin/${{ github.base_ref || 'main' }}
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           ./tools/hack/go-benchmark-compare.sh

--- a/tools/hack/go-benchmark-compare.sh
+++ b/tools/hack/go-benchmark-compare.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
-# go-benchmark-compare.sh - Compare benchmark results between PR and main branch
+# go-benchmark-compare.sh - Compare benchmark results between PR and its base branch
 # Usage: go-benchmark-compare.sh [--help]
 
 set -euo pipefail
 
 # Environment variables with defaults
 REGRESSION_THRESHOLD=${REGRESSION_THRESHOLD:-5}
+# Baseline to compare against. CI passes the PR's base branch so that release
+# branch PRs are not compared against main, which tracks a different Go
+# toolchain and feature set.
+BASE_REF=${BASE_REF:-origin/main}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 BENCHSTAT=${BENCHSTAT:-go tool -modfile="$REPO_ROOT/tools/go.mod" benchstat}
@@ -16,13 +20,14 @@ usage() {
     cat << EOF
 Usage: $0 [OPTIONS]
 
-Compare benchmark performance between PR branch and main branch.
+Compare benchmark performance between the PR branch and its base branch.
 
 OPTIONS:
     --help          Show this help message
 
 ENVIRONMENT VARIABLES:
     REGRESSION_THRESHOLD    Regression threshold percentage (default: 5)
+    BASE_REF                Baseline git ref to compare against (default: origin/main)
 
 EXIT CODES:
     0    Success (no significant regressions)
@@ -34,7 +39,7 @@ EOF
 # Function to cleanup temporary files
 cleanup() {
     local exit_code=$?
-    rm -f "$REPO_ROOT/pr-bench.txt" "$REPO_ROOT/main-bench.txt" "$REPO_ROOT/comparison.txt"
+    rm -f "$REPO_ROOT/pr-bench.txt" "$REPO_ROOT/base-bench.txt" "$REPO_ROOT/comparison.txt"
     exit $exit_code
 }
 
@@ -131,14 +136,19 @@ if ! run_benchmark "pr-bench.txt" "$current_branch"; then
     exit 1
 fi
 
-# Switch to main branch and run benchmarks
-log "Switching to main branch..."
-if ! git checkout origin/main --quiet; then
-    log "ERROR: Failed to checkout main branch"
+# Switch to the base branch and run benchmarks
+if ! git rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null; then
+    log "ERROR: Base ref $BASE_REF not found; ensure the checkout has full history"
     exit 1
 fi
 
-if ! run_benchmark "main-bench.txt" "origin/main"; then
+log "Switching to base ref $BASE_REF..."
+if ! git checkout "$BASE_REF" --quiet; then
+    log "ERROR: Failed to checkout base ref $BASE_REF"
+    exit 1
+fi
+
+if ! run_benchmark "base-bench.txt" "$BASE_REF"; then
     # Return to original state before failing
     git checkout "$current_commit" --quiet || true
     exit 1
@@ -152,7 +162,7 @@ fi
 
 # Compare benchmarks using benchstat
 log "Comparing benchmark results..."
-if ! $BENCHSTAT main-bench.txt pr-bench.txt > comparison.txt 2>&1; then
+if ! $BENCHSTAT base-bench.txt pr-bench.txt > comparison.txt 2>&1; then
     log "WARNING: Benchstat comparison had issues, but continuing..."
 fi
 


### PR DESCRIPTION
<!--
Your PR title should be descriptive, and generally start with a type that contains a subsystem name with `()` if necessary
and a summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), the API must be discussed and
agreed before the implementation. We strongly recommend separating API changes into their own PR so
we can review the API first, but the API may also live in the same PR as long as it was agreed
beforehand. This will save you a lot of implementation time if the API gets accepted.
-->

**What this PR does / why we need it**:
<!--
Briefly describe what this PR changes and the motivation behind it. Include enough context for a
reviewer to understand the problem being solved and the approach taken, e.g. what behavior changes,
any alternatives considered, and anything reviewers should pay special attention to.
-->
`go-benchmark-test` fails in release branch because of go version diff.
Ref: https://github.com/envoyproxy/gateway/actions/runs/33142425720/job/98772674274?pr=9878

The comparison script hardcodes `origin/main` as the baseline:

```bash
log "Switching to main branch..."
if ! git checkout origin/main --quiet; then
```

Meanwhile setup-deps installs Go from the PR branch's `go.mod` via actions/setup-go (go-version-file: go.mod), which also sets `GOTOOLCHAIN=local`. So on a release/v1.9 PR the runner gets Go 1.26.7, then checks out main, which is now on Go 1.27.0.

Even with a matching toolchain, comparing a release branch against main is not a meaningful baseline — main carries features the release branch does not.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

---

**PR Checklist**
<!--
Please tick the boxes below before requesting a review. PRs that leave required items unchecked may
be delayed or closed. Replace `[ ]` with `[x]` to check a box. If an item does not apply, check it
and add "N/A: <reason>".
-->

- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: If this PR contains API changes (changes under `/api`), the API was discussed and agreed **before** the implementation. The API change can be in a separate PR, or in the same PR, but the API must be agreed before implementation. N/A if this PR does not contain API changes.
- [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (Flaky e2e failures are not considered breakages, but `gen-check`, `lint`, and coverage **MUST** pass.)
- [x] **Tests added/updated**: New/changed code is covered by appropriate tests. N/A if this PR does not contain code changes.
- [x] **Docs**: User-facing changes update the [docs](https://github.com/envoyproxy/gateway/tree/main/site), either in this PR or a follow-up PR. N/A if this PR does not contain user-facing changes.
- [x] **Release notes**: For any non-trivial change, added a release-note fragment under `release-notes/current/<section>/<pr-number>-<slug>.md` (see `release-notes/current/README.md` for sections and naming). N/A if this PR does not contain non-trivial changes.
- [x] **Generated files committed**: Ran `make gen-check` and committed the result if API/helm charts/modules changed.
- [x] **Scope & compatibility**: The PR is reasonably scoped (no unrelated changes) and preserves backward compatibility, or any breaking change is called out above and documented in `release-notes/current/breaking_changes/`.
- [ ] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.
