### PR TITLE
docs: fix local rate limit unit in combined example

### DIFF
--- a/site/content/en/latest/concepts/rate-limiting.md
+++ b/site/content/en/latest/concepts/rate-limiting.md
@@ -134,7 +134,7 @@ spec:
       rules:
       - limit:
           requests: 50
-          unit: Minute
+          unit: Second
     global:
       rules:
       - limit:

--- a/site/content/en/v1.8/concepts/rate-limiting.md
+++ b/site/content/en/v1.8/concepts/rate-limiting.md
@@ -134,7 +134,7 @@ spec:
       rules:
       - limit:
           requests: 50
-          unit: Minute
+          unit: Second
     global:
       rules:
       - limit:

--- a/site/content/en/v1.9/concepts/rate-limiting.md
+++ b/site/content/en/v1.9/concepts/rate-limiting.md
@@ -134,7 +134,7 @@ spec:
       rules:
       - limit:
           requests: 50
-          unit: Minute
+          unit: Second
     global:
       rules:
       - limit:


### PR DESCRIPTION
Fixes #9869

The combined global/local rate limiting example used unit: Minute for the local limit while the surrounding text describes a per-second limit. Updated the local limit unit to Second.

## Test plan
- [x] Docs-only change; reviewed rendered markdown section for internal consistency