### PR TITLE
fix(e2e): ipv6 envoy host match

### DIFF
--- a/test/e2e/tests/udproute_load_balancing.go
+++ b/test/e2e/tests/udproute_load_balancing.go
@@ -10,6 +10,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -167,6 +168,14 @@ func WaitForEnvoyClusterHosts(t *testing.T, suite *suite.ConformanceTestSuite, g
 	}
 }
 
+// clusterHostRegexp matches the address prefixing the stats of a single host of
+// a cluster in the /clusters output, either "10.244.0.168:53" or, on an IPv6
+// cluster, "[fd00:10:244:1::46]:53". Envoy brackets an IPv6 address to keep it
+// apart from the port, and the address itself holds "::", so splitting the
+// stats on "::" truncates it to its node prefix and collapses every host of a
+// node into one.
+var clusterHostRegexp = regexp.MustCompile(`^(\[[0-9a-fA-F:]+\]:\d+|\d{1,3}(?:\.\d{1,3}){3}:\d+)::`)
+
 // envoyClusterHosts returns the distinct hosts that the Envoy proxy of the
 // given gateway holds for the cluster whose name contains clusterName.
 func envoyClusterHosts(t *testing.T, suite *suite.ConformanceTestSuite, gwNN types.NamespacedName, clusterName string) ([]string, error) {
@@ -184,19 +193,22 @@ func envoyClusterHosts(t *testing.T, suite *suite.ConformanceTestSuite, gwNN typ
 	// /clusters returns one stat per line as "<cluster_name>::<stat_path>::<value>".
 	// The stats of a single host are prefixed by its address, e.g.:
 	//   udproute/ns/udp-lb-coredns/rule/-1::10.244.0.168:53::health_flags::healthy
+	//   udproute/ns/udp-lb-coredns/rule/-1::[fd00:10:244:1::46]:53::health_flags::healthy
 	//   udproute/ns/udp-lb-coredns/rule/-1::added_via_api::true
-	// Only the former carries a port, which is what tells the two apart.
+	// Only the host stats are prefixed by an address, which is what tells them
+	// apart. A cluster name never holds "::", so cutting the line on it is safe,
+	// but an IPv6 address does, so the address is matched rather than cut off.
 	hosts := sets.New[string]()
 	for _, line := range strings.Split(body, "\n") {
 		name, stat, ok := strings.Cut(line, "::")
 		if !ok || !strings.Contains(name, clusterName) {
 			continue
 		}
-		host, _, ok := strings.Cut(stat, "::")
-		if !ok || !strings.Contains(host, ":") {
+		host := clusterHostRegexp.FindStringSubmatch(stat)
+		if host == nil {
 			continue
 		}
-		hosts.Insert(host)
+		hosts.Insert(host[1])
 	}
 
 	return sets.List(hosts), nil


### PR DESCRIPTION
<!--
Your PR title should be descriptive, and generally start with a type that contains a subsystem name with `()` if necessary
and a summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

<!--
NOTE: If your PR contains any API changes (changes under `/api`), the API must be discussed and
agreed before the implementation. We strongly recommend separating API changes into their own PR so
we can review the API first, but the API may also live in the same PR as long as it was agreed
beforehand. This will save you a lot of implementation time if the API gets accepted.
-->

**What this PR does / why we need it**:
<!--
Briefly describe what this PR changes and the motivation behind it. Include enough context for a
reviewer to understand the problem being solved and the approach taken, e.g. what behavior changes,
any alternatives considered, and anything reviewers should pay special attention to.
-->
In previous code, Host match doesn't consider in IPv6 case, so this match ended up becoming flaky.
Use regex match.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #9901 

---

**PR Checklist**
<!--
Please tick the boxes below before requesting a review. PRs that leave required items unchecked may
be delayed or closed. Replace `[ ]` with `[x]` to check a box. If an item does not apply, check it
and add "N/A: <reason>".
-->

- [x] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: If this PR contains API changes (changes under `/api`), the API was discussed and agreed **before** the implementation. The API change can be in a separate PR, or in the same PR, but the API must be agreed before implementation. N/A if this PR does not contain API changes.
- [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (Flaky e2e failures are not considered breakages, but `gen-check`, `lint`, and coverage **MUST** pass.)
- [x] **Tests added/updated**: New/changed code is covered by appropriate tests. N/A if this PR does not contain code changes.
- [x] **Docs**: User-facing changes update the [docs](https://github.com/envoyproxy/gateway/tree/main/site), either in this PR or a follow-up PR. N/A if this PR does not contain user-facing changes.
- [x] **Release notes**: For any non-trivial change, added a release-note fragment under `release-notes/current/<section>/<pr-number>-<slug>.md` (see `release-notes/current/README.md` for sections and naming). N/A if this PR does not contain non-trivial changes.
- [x] **Generated files committed**: Ran `make gen-check` and committed the result if API/helm charts/modules changed.
- [x] **Scope & compatibility**: The PR is reasonably scoped (no unrelated changes) and preserves backward compatibility, or any breaking change is called out above and documented in `release-notes/current/breaking_changes/`.
- [ ] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.
