### PR TITLE
fix(e2e): MultiReferenceGrantsSameNamespace flaky

### DIFF
--- a/test/e2e/testdata/multi-referencegrants-same-namespace-services.yaml
+++ b/test/e2e/testdata/multi-referencegrants-same-namespace-services.yaml
@@ -47,6 +47,12 @@ spec:
               fieldPath: metadata.namespace
         - name: SERVICE_NAME
           value: app-backend-v1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 1
+          periodSeconds: 1
         resources:
           requests:
             cpu: 10m
@@ -95,6 +101,12 @@ spec:
               fieldPath: metadata.namespace
         - name: SERVICE_NAME
           value: app-backend-v2
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 1
+          periodSeconds: 1
         resources:
           requests:
             cpu: 10m
@@ -143,6 +155,12 @@ spec:
               fieldPath: metadata.namespace
         - name: SERVICE_NAME
           value: app-backend-v3
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 1
+          periodSeconds: 1
         resources:
           requests:
             cpu: 10m

--- a/test/e2e/tests/referencegrants.go
+++ b/test/e2e/tests/referencegrants.go
@@ -18,10 +18,10 @@ import (
 )
 
 func init() {
-	ConformanceTests = append(ConformanceTests, MultiReferenceGrantsSameNamespaceTest)
+	ConformanceTests = append(ConformanceTests, MultiReferenceGrantsSameNamespace)
 }
 
-var MultiReferenceGrantsSameNamespaceTest = suite.ConformanceTest{
+var MultiReferenceGrantsSameNamespace = suite.ConformanceTest{
 	ShortName:   "MultiReferenceGrantsSameNamespace",
 	Description: "Test for multiple reference grants in the same namespace",
 	Manifests:   []string{"testdata/multi-referencegrants-same-namespace-services.yaml", "testdata/multi-referencegrants-same-namespace.yaml"},
@@ -30,6 +30,11 @@ var MultiReferenceGrantsSameNamespaceTest = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "multi-referencegrant-same-namespace", Namespace: resourceNS}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: resourceNS}
 		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+
+		appBackendNamespace := "multireferencegrants-ns"
+		WaitForPodsReady(t, suite.Client, appBackendNamespace, map[string]string{"app": "app-backend-v1"})
+		WaitForPodsReady(t, suite.Client, appBackendNamespace, map[string]string{"app": "app-backend-v2"})
+		WaitForPodsReady(t, suite.Client, appBackendNamespace, map[string]string{"app": "app-backend-v3"})
 
 		targetHost := "multireferencegrant.local"
 		targetNS := "multireferencegrants-ns"

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -84,6 +84,10 @@ func TimeoutConfig() config.TimeoutConfig {
 	return timeout
 }
 
+func WaitForPodsReady(t *testing.T, cl client.Client, namespace string, selectors map[string]string) {
+	WaitForPods(t, cl, namespace, selectors, corev1.PodRunning, &PodReady)
+}
+
 // WaitForPods waits for the pods in the given namespace and with the given selector
 // to be in the given phase and condition.
 func WaitForPods(t *testing.T, cl client.Client, namespace string, selectors map[string]string, phase corev1.PodPhase, condition *corev1.PodCondition) {


### PR DESCRIPTION
fixes: https://github.com/envoyproxy/gateway/issues/9909

- add readinessProbe
- wait for pod ready before starting the traffic test