### PR TITLE
fix(e2e): RateLimit flaky

### DIFF
--- a/internal/cmd/egctl/config_test.go
+++ b/internal/cmd/egctl/config_test.go
@@ -6,6 +6,7 @@
 package egctl
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -83,6 +84,10 @@ func (fw *fakePortForwarder) Start() error {
 	return nil
 }
 
+func (fw *fakePortForwarder) StartWithContext(_ context.Context) error {
+	return fw.Start()
+}
+
 func (fw *fakePortForwarder) Stop() {}
 
 func (fw *fakePortForwarder) Address() string {
@@ -97,6 +102,10 @@ type failingStartPortForwarder struct {
 
 func (fw *failingStartPortForwarder) Start() error {
 	return fw.err
+}
+
+func (fw *failingStartPortForwarder) StartWithContext(_ context.Context) error {
+	return fw.Start()
 }
 
 func (fw *failingStartPortForwarder) Stop() {}

--- a/internal/kubernetes/port_forwarder.go
+++ b/internal/kubernetes/port_forwarder.go
@@ -6,12 +6,14 @@
 package kubernetes
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"os"
 	"strconv"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/httpstream"
@@ -23,7 +25,16 @@ import (
 )
 
 type PortForwarder interface {
+	// Start waits indefinitely for the port forward to become ready. Prefer
+	// StartWithContext when the caller needs a bound on how long it can block.
 	Start() error
+
+	// StartWithContext is like Start, but returns ctx.Err() once ctx is done instead of
+	// blocking forever. This can't interrupt a Kubernetes upgrade/dial already in flight -
+	// client-go's dialer offers no cancellation hook for it - but it guarantees the caller
+	// isn't blocked past ctx's deadline, and it stops the forwarder before returning so a
+	// dial that does eventually complete doesn't outlive the caller.
+	StartWithContext(ctx context.Context) error
 
 	Stop()
 
@@ -42,7 +53,8 @@ type localForwarder struct {
 	localPort int
 	podPort   int
 
-	stopCh chan struct{}
+	stopCh   chan struct{}
+	stopOnce sync.Once
 }
 
 func NewLocalPortForwarder(client CLIClient, namespacedName types.NamespacedName, localPort, podPort int) (PortForwarder, error) {
@@ -66,6 +78,10 @@ func NewLocalPortForwarder(client CLIClient, namespacedName types.NamespacedName
 }
 
 func (f *localForwarder) Start() error {
+	return f.StartWithContext(context.Background())
+}
+
+func (f *localForwarder) StartWithContext(ctx context.Context) error {
 	errCh := make(chan error, 1)
 	readyCh := make(chan struct{}, 1)
 	go func() {
@@ -96,6 +112,12 @@ func (f *localForwarder) Start() error {
 		return fmt.Errorf("failed to start port forwarder: %w", err)
 	case <-readyCh:
 		return nil
+	case <-ctx.Done():
+		// Give up rather than block the caller past ctx's deadline. Stop the forwarder
+		// so that, if the wedged dial above does eventually return, it tears down
+		// instead of lingering with a bound local port nobody is using anymore.
+		f.Stop()
+		return ctx.Err()
 	}
 }
 
@@ -138,7 +160,12 @@ func (f *localForwarder) buildKubernetesPortForwarder(readyCh chan struct{}) (*p
 }
 
 func (f *localForwarder) Stop() {
-	close(f.stopCh)
+	// Idempotent: StartWithContext may already have stopped the forwarder on a timeout
+	// before the caller gets a chance to call Stop() itself (e.g. via a deferred call
+	// guarded by a successful Start, or an explicit Stop() in an error path).
+	f.stopOnce.Do(func() {
+		close(f.stopCh)
+	})
 }
 
 func (f *localForwarder) WaitForStop() {

--- a/test/config/envoy-gateaway-config/debounce.yaml
+++ b/test/config/envoy-gateaway-config/debounce.yaml
@@ -26,6 +26,13 @@ data:
         type: Redis
         redis:
           url: redis.redis-system.svc.cluster.local:6379
+      # Bumped from the 20ms default (unset field) - that default is tuned for a colocated,
+      # low-latency ratelimit service, but this gRPC call also has to cover the ratelimit
+      # service's own Redis round trip, which can exceed 20ms under CI load. failClosed
+      # defaults to false, so a timed-out check fails open (request passed through unlimited)
+      # instead of erroring - which shows up as flaky "expected 429, got 200" e2e failures
+      # rather than a hard, easily-diagnosed error.
+      timeout: 1s
     envoyProxy:
       provider:
         kubernetes:

--- a/test/config/envoy-gateaway-config/default.yaml
+++ b/test/config/envoy-gateaway-config/default.yaml
@@ -23,6 +23,13 @@ data:
         type: Redis
         redis:
           url: redis.redis-system.svc.cluster.local:6379
+      # Bumped from the 20ms default (unset field) - that default is tuned for a colocated,
+      # low-latency ratelimit service, but this gRPC call also has to cover the ratelimit
+      # service's own Redis round trip, which can exceed 20ms under CI load. failClosed
+      # defaults to false, so a timed-out check fails open (request passed through unlimited)
+      # instead of erroring - which shows up as flaky "expected 429, got 200" e2e failures
+      # rather than a hard, easily-diagnosed error.
+      timeout: 1s
     envoyProxy:
       provider:
         kubernetes:

--- a/test/config/envoy-gateaway-config/gateway-namespace-mode.yaml
+++ b/test/config/envoy-gateaway-config/gateway-namespace-mode.yaml
@@ -30,6 +30,13 @@ data:
         type: Redis
         redis:
           url: redis.redis-system.svc.cluster.local:6379
+      # Bumped from the 20ms default (unset field) - that default is tuned for a colocated,
+      # low-latency ratelimit service, but this gRPC call also has to cover the ratelimit
+      # service's own Redis round trip, which can exceed 20ms under CI load. failClosed
+      # defaults to false, so a timed-out check fails open (request passed through unlimited)
+      # instead of erroring - which shows up as flaky "expected 429, got 200" e2e failures
+      # rather than a hard, easily-diagnosed error.
+      timeout: 1s
     telemetry:
       traces:
         sink:

--- a/test/config/envoy-gateaway-config/watch-namespaces.yaml
+++ b/test/config/envoy-gateaway-config/watch-namespaces.yaml
@@ -40,6 +40,13 @@ data:
         type: Redis
         redis:
           url: redis.redis-system.svc.cluster.local:6379
+      # Bumped from the 20ms default (unset field) - that default is tuned for a colocated,
+      # low-latency ratelimit service, but this gRPC call also has to cover the ratelimit
+      # service's own Redis round trip, which can exceed 20ms under CI load. failClosed
+      # defaults to false, so a timed-out check fails open (request passed through unlimited)
+      # instead of erroring - which shows up as flaky "expected 429, got 200" e2e failures
+      # rather than a hard, easily-diagnosed error.
+      timeout: 1s
     envoyProxy:
       provider:
         kubernetes:

--- a/test/config/envoy-gateaway-config/xds-name-scheme-v2.yaml
+++ b/test/config/envoy-gateaway-config/xds-name-scheme-v2.yaml
@@ -23,6 +23,13 @@ data:
         type: Redis
         redis:
           url: redis.redis-system.svc.cluster.local:6379
+      # Bumped from the 20ms default (unset field) - that default is tuned for a colocated,
+      # low-latency ratelimit service, but this gRPC call also has to cover the ratelimit
+      # service's own Redis round trip, which can exceed 20ms under CI load. failClosed
+      # defaults to false, so a timed-out check fails open (request passed through unlimited)
+      # instead of erroring - which shows up as flaky "expected 429, got 200" e2e failures
+      # rather than a hard, easily-diagnosed error.
+      timeout: 1s
     runtimeFlags:
       enabled:
       - XDSNameSchemeV2

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -52,7 +52,7 @@ func TestE2E(t *testing.T) {
 			tests.DynamicResolverBackendTest.ShortName,
 			tests.DynamicResolverBackendWithTLSTest.ShortName,
 			tests.RateLimitCIDRMatchTest.ShortName,
-			tests.RateLimitCIDRInvertMatchAlwaysEnforceTest.ShortName,
+			tests.RateLimitCIDRInvertMatchAlwaysEnforce.ShortName,
 			tests.RateLimitCIDRInvertAlwaysExemptTest.ShortName,
 			tests.RateLimitMultipleListenersTest.ShortName,
 			tests.RateLimitGlobalSharedCidrMatchTest.ShortName,
@@ -84,7 +84,7 @@ func TestE2E(t *testing.T) {
 	// All e2e tests should leave Features empty.
 	suiteOpts.SupportedFeatures = enabledFeatures.UnsortedList()
 	suiteOpts.SkipTests = skipTests
-	suiteOpts.FailFast = true
+	// suiteOpts.FailFast = true
 	cSuite, err := suite.NewConformanceTestSuite(suite.ConformanceOptions{
 		Client:              c,
 		RestConfig:          cfg,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -84,7 +84,7 @@ func TestE2E(t *testing.T) {
 	// All e2e tests should leave Features empty.
 	suiteOpts.SupportedFeatures = enabledFeatures.UnsortedList()
 	suiteOpts.SkipTests = skipTests
-	// suiteOpts.FailFast = true
+	suiteOpts.FailFast = true
 	cSuite, err := suite.NewConformanceTestSuite(suite.ConformanceOptions{
 		Client:              c,
 		RestConfig:          cfg,

--- a/test/e2e/testdata/ratelimit-based-jwt-claims.yaml
+++ b/test/e2e/testdata/ratelimit-based-jwt-claims.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-based-jwt-claims
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: http
+    port: 8080
+    protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
@@ -46,7 +58,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-  - name: same-namespace
+  - name: ratelimit-based-jwt-claims
   rules:
   - backendRefs:
     - name: infra-backend-v1
@@ -63,7 +75,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-  - name: same-namespace
+  - name: ratelimit-based-jwt-claims
   rules:
   - backendRefs:
     - name: infra-backend-v1

--- a/test/e2e/testdata/ratelimit-cidr-invert-always-exempt.yaml
+++ b/test/e2e/testdata/ratelimit-cidr-invert-always-exempt.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-cidr-invert-always-exempt
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -28,7 +40,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-cidr-invert-always-exempt
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/ratelimit-cidr-invert-match-always-enforce.yaml
+++ b/test/e2e/testdata/ratelimit-cidr-invert-match-always-enforce.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-cidr-invert-match-always-enforce
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -28,12 +40,12 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-cidr-invert-match-always-enforce
   rules:
     - matches:
         - path:
             type: PathPrefix
-            value: /
+            value: /ratelimit-cidr-invert-match-always-enforce
       backendRefs:
         - name: infra-backend-v1
           port: 8080

--- a/test/e2e/testdata/ratelimit-cidr-match.yaml
+++ b/test/e2e/testdata/ratelimit-cidr-match.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-cidr-match
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -27,13 +39,13 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-cidr-match
     - name: ratelimit-gateway
   rules:
     - matches:
         - path:
             type: PathPrefix
-            value: /
+            value: /cidr-match
       backendRefs:
         - name: infra-backend-v1
           port: 8080

--- a/test/e2e/testdata/ratelimit-global-shadow-mode.yaml
+++ b/test/e2e/testdata/ratelimit-global-shadow-mode.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-global-shadow-mode
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -27,7 +39,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-global-shadow-mode
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/ratelimit-global-shared-and-unshared-header-match.yaml
+++ b/test/e2e/testdata/ratelimit-global-shared-and-unshared-header-match.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: eg-rate-limit
+  name: ratelimit-global-merge
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
@@ -17,7 +17,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: eg-rate-limit
+    - name: ratelimit-global-merge
   rules:
     - matches:
         - path:
@@ -34,7 +34,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: eg-rate-limit
+    - name: ratelimit-global-merge
   rules:
     - matches:
         - path:
@@ -88,7 +88,7 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: eg-rate-limit
+      name: ratelimit-global-merge
   rateLimit:
     type: Global
     global:

--- a/test/e2e/testdata/ratelimit-global-shared-cidr-match.yaml
+++ b/test/e2e/testdata/ratelimit-global-shared-cidr-match.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-global-shared-cidr-match
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -31,7 +43,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-global-shared-cidr-match
   rules:
     - matches:
         - path:
@@ -48,7 +60,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-global-shared-cidr-match
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/ratelimit-global-shared-gateway-header-match.yaml
+++ b/test/e2e/testdata/ratelimit-global-shared-gateway-header-match.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: eg-rate-limit
+  name: ratelimit-global-shared-gateway-header-match
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
@@ -17,7 +17,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: eg-rate-limit
+    - name: ratelimit-global-shared-gateway-header-match
   rules:
     - matches:
         - path:
@@ -34,7 +34,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: eg-rate-limit
+    - name: ratelimit-global-shared-gateway-header-match
   rules:
     - matches:
         - path:
@@ -53,7 +53,7 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: eg-rate-limit
+      name: ratelimit-global-shared-gateway-header-match
   rateLimit:
     type: Global
     global:

--- a/test/e2e/testdata/ratelimit-header-invert-match-global.yaml
+++ b/test/e2e/testdata/ratelimit-header-invert-match-global.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-header-invert-match-global
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -7,7 +19,7 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: header-ratelimit
+      name: header-ratelimit-invert
   rateLimit:
     type: Global
     global:
@@ -27,11 +39,11 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: header-ratelimit
+  name: header-ratelimit-invert
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-header-invert-match-global
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/ratelimit-header-match.yaml
+++ b/test/e2e/testdata/ratelimit-header-match.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-header-match
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -31,7 +43,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-header-match
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/ratelimit-headers-and-cidr-match.yaml
+++ b/test/e2e/testdata/ratelimit-headers-and-cidr-match.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-headers-and-cidr-match
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -34,7 +46,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-headers-and-cidr-match
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/ratelimit-headers-disabled.yaml
+++ b/test/e2e/testdata/ratelimit-headers-disabled.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-headers-disabled
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:
@@ -9,7 +21,7 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: same-namespace
+      name: ratelimit-headers-disabled
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
@@ -44,7 +56,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-headers-disabled
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/ratelimit-method-match.yaml
+++ b/test/e2e/testdata/ratelimit-method-match.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-method-match
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -27,7 +39,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-method-match
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/ratelimit-multiple-listeners.yaml
+++ b/test/e2e/testdata/ratelimit-multiple-listeners.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: eg-rate-limit
+  name: eg-multiple-listeners
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
@@ -16,16 +16,16 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: cidr-ratelimit
+  name: multiple-listeners
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: eg-rate-limit
+    - name: eg-multiple-listeners
   rules:
     - matches:
         - path:
             type: PathPrefix
-            value: /
+            value: /multiple-listeners
       backendRefs:
         - name: infra-backend-v1
           port: 8080
@@ -39,7 +39,7 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: cidr-ratelimit
+      name: multiple-listeners
   rateLimit:
     type: Global
     global:

--- a/test/e2e/testdata/ratelimit-path-match.yaml
+++ b/test/e2e/testdata/ratelimit-path-match.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-path-match
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -27,7 +39,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-path-match
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/ratelimit-query-parameters.yaml
+++ b/test/e2e/testdata/ratelimit-query-parameters.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-query-parameters
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -28,7 +40,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-query-parameters
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/ratelimit-usage-ratelimit.yaml
+++ b/test/e2e/testdata/ratelimit-usage-ratelimit.yaml
@@ -1,3 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ratelimit-usage-ratelimit
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -38,7 +50,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+    - name: ratelimit-usage-ratelimit
   rules:
     - matches:
         - path:

--- a/test/e2e/tests/ratelimit.go
+++ b/test/e2e/tests/ratelimit.go
@@ -43,20 +43,20 @@ func prometheusVectorHasSamples(v model.Value) bool {
 func init() {
 	ConformanceTests = append(ConformanceTests,
 		RateLimitCIDRMatchTest,
-		RateLimitCIDRInvertMatchAlwaysEnforceTest,
+		RateLimitCIDRInvertMatchAlwaysEnforce,
 		RateLimitCIDRInvertAlwaysExemptTest,
 		RateLimitHeaderMatchTest,
 		RateLimitMethodMatchTest,
 		RateLimitPathMatchTest,
 		GlobalRateLimitHeaderInvertMatchTest,
 		RateLimitHeadersDisabled,
-		RateLimitBasedJwtClaimsTest,
+		RateLimitBasedJwtClaims,
 		RateLimitMultipleListenersTest,
 		RateLimitHeadersAndCIDRMatchTest,
 		UsageRateLimitTest,
 		RateLimitGlobalSharedCidrMatchTest,
-		RateLimitGlobalSharedGatewayHeaderMatchTest,
-		RateLimitGlobalMergeTest,
+		RateLimitGlobalSharedGatewayHeaderMatch,
+		RateLimitGlobalMerge,
 		RateLimitGlobalShadowModeTest,
 		RateLimitQueryParametersTest,
 		RateLimitGlobalSharedWithCost,
@@ -71,8 +71,9 @@ var RateLimitCIDRMatchTest = suite.ConformanceTest{
 		t.Run("block all ips", func(t *testing.T) {
 			ns := "gateway-conformance-infra"
 			routeNN := types.NamespacedName{Name: "cidr-ratelimit", Namespace: ns}
-			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-			gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+			gwNN := types.NamespacedName{Name: "ratelimit-cidr-match", Namespace: ns}
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+			WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 			BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 				types.NamespacedName{Name: "ratelimit-all-ips", Namespace: ns},
@@ -82,11 +83,12 @@ var RateLimitCIDRMatchTest = suite.ConformanceTest{
 					Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 					Name:      gwapiv1.ObjectName(gwNN.Name),
 				})
+			WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
 
 			ratelimitHeader := make(map[string]string)
 			expectOkResp := http.ExpectedResponse{
 				Request: http.Request{
-					Path: "/",
+					Path: "/cidr-match",
 				},
 				Response: http.Response{
 					StatusCodes: []int{200},
@@ -102,7 +104,7 @@ var RateLimitCIDRMatchTest = suite.ConformanceTest{
 			// fire the rest of the requests, and expect 429 at the end
 			MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &http.ExpectedResponse{
 				Request: http.Request{
-					Path: "/",
+					Path: "/cidr-match",
 				},
 				Response: http.Response{
 					StatusCodes: []int{429},
@@ -122,7 +124,7 @@ var RateLimitCIDRMatchTest = suite.ConformanceTest{
 				}
 				return false, nil
 			}); err != nil {
-				t.Errorf("failed to get expected response for the last (fourth) request: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the last (fourth) request: %v", err)
 			}
 		})
 
@@ -130,8 +132,8 @@ var RateLimitCIDRMatchTest = suite.ConformanceTest{
 			ns := "gateway-conformance-infra"
 			routeNN := types.NamespacedName{Name: "cidr-ratelimit", Namespace: ns}
 			gwNN := types.NamespacedName{Name: "ratelimit-gateway", Namespace: ns}
-			gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName,
-				kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+			WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 			BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 				types.NamespacedName{Name: "ratelimit-all-ips", Namespace: ns},
@@ -141,13 +143,16 @@ var RateLimitCIDRMatchTest = suite.ConformanceTest{
 					Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 					Name:      gwapiv1.ObjectName(gwNN.Name),
 				})
+			// The route has no sectionName, so it (and the policy targeting it) attaches to both
+			// listeners on this Gateway.
+			WaitForRateLimitDomainsToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http-1"), RateLimitListenerDomain(gwNN, "http-2"))
 
 			// ratelimit-gateway serves for both app1.example.com and app2.example.com, and the CIDR rule should apply to both hostnames,
 			// requests to both hostnames should be rate limited, and we should see the header in responses.
 			for _, host := range []string{"app1.example.com", "app2.example.com"} {
 				MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &http.ExpectedResponse{
 					Request: http.Request{
-						Path: "/",
+						Path: "/cidr-match",
 						Host: host,
 					},
 					Response: http.Response{
@@ -163,7 +168,7 @@ var RateLimitCIDRMatchTest = suite.ConformanceTest{
 	},
 }
 
-var RateLimitCIDRInvertMatchAlwaysEnforceTest = suite.ConformanceTest{
+var RateLimitCIDRInvertMatchAlwaysEnforce = suite.ConformanceTest{
 	ShortName:   "RateLimitCIDRInvertMatchAlwaysEnforce",
 	Description: "Rate limit all IPs except a defined CIDR (invert match)",
 	Manifests:   []string{"testdata/ratelimit-cidr-invert-match-always-enforce.yaml"},
@@ -171,12 +176,15 @@ var RateLimitCIDRInvertMatchAlwaysEnforceTest = suite.ConformanceTest{
 		t.Run("rate limit all IPs except CIDR", func(t *testing.T) {
 			ns := "gateway-conformance-infra"
 			routeNN := types.NamespacedName{Name: "cidr-invert-ratelimit", Namespace: ns}
-			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-			gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+			gwNN := types.NamespacedName{Name: "ratelimit-cidr-invert-match-always-enforce", Namespace: ns}
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+			WaitForGatewayPodsReady(t, suite.Client, gwNN)
+			WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
+
 			ratelimitHeader := make(map[string]string)
 			expectOkResp := http.ExpectedResponse{
 				Request: http.Request{
-					Path: "/",
+					Path: "/ratelimit-cidr-invert-match-always-enforce",
 				},
 				Response: http.Response{
 					StatusCodes: []int{200},
@@ -185,11 +193,19 @@ var RateLimitCIDRInvertMatchAlwaysEnforceTest = suite.ConformanceTest{
 				Namespace: ns,
 			}
 			expectOkResp.Response.Headers["X-Ratelimit-Limit"] = "2, 2;w=3600"
+			// Limit is 2/hour. With invert: true, client IP is not in 192.0.2.0/24 (TEST-NET-1), so the rule applies. Expect 2 OK then 429.
+			// keep sending requests till get 200 first, that will cost one 200
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectOkResp)
+
+			// fire the rest of the requests
 			expectOkReq := http.MakeRequest(t, &expectOkResp, gwAddr, "HTTP", "http")
+			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
+				tlog.Fatalf(t, "failed to get expected response for the first two requests: %v", err)
+			}
 
 			expectLimitResp := http.ExpectedResponse{
 				Request: http.Request{
-					Path: "/",
+					Path: "/ratelimit-cidr-invert-match-always-enforce",
 				},
 				Response: http.Response{
 					StatusCodes: []int{429},
@@ -197,21 +213,13 @@ var RateLimitCIDRInvertMatchAlwaysEnforceTest = suite.ConformanceTest{
 				Namespace: ns,
 			}
 			expectLimitReq := http.MakeRequest(t, &expectLimitResp, gwAddr, "HTTP", "http")
-
-			// Limit is 2/hour. With invert: true, client IP is not in 192.0.2.0/24 (TEST-NET-1), so the rule applies. Expect 2 OK then 429.
-			// keep sending requests till get 200 first, that will cost one 200
-			MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &expectOkResp)
-
-			// fire the rest of the requests
-			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected response for the first two requests: %v", err)
-			}
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectLimitReq, expectLimitResp); err != nil {
-				t.Errorf("failed to get expected response for the last (third) request: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the last (third) request: %v", err)
 			}
 			// key2 comes from the sanitized stat segment: ":" and IPv4 "." become "_", while "/" is preserved.
 			// make sure that metric worked as expected.
-			if err := wait.PollUntilContextTimeout(context.TODO(), 3*time.Second, time.Minute, true, func(_ context.Context) (done bool, err error) {
+			tlog.Logf(t, "checking ratelimit_service stats")
+			if err := wait.PollUntilContextTimeout(t.Context(), 3*time.Second, time.Minute, true, func(_ context.Context) (done bool, err error) {
 				v, err := prometheus.QueryPrometheus(suite.Client, `ratelimit_service_rate_limit_over_limit{key2="masked_remote_address_invert_192_0_2_0/24"}`)
 				if err != nil {
 					tlog.Logf(t, "failed to query prometheus: %v", err)
@@ -223,7 +231,7 @@ var RateLimitCIDRInvertMatchAlwaysEnforceTest = suite.ConformanceTest{
 				}
 				return false, nil
 			}); err != nil {
-				t.Errorf("failed to get expected response for the last (third) request: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the last (third) request: %v", err)
 			}
 		})
 	},
@@ -237,8 +245,11 @@ var RateLimitCIDRInvertAlwaysExemptTest = suite.ConformanceTest{
 		t.Run("never rate limited when exempt range is all IPv4", func(t *testing.T) {
 			ns := "gateway-conformance-infra"
 			routeNN := types.NamespacedName{Name: "cidr-invert-always-exempt", Namespace: ns}
-			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-			gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+			gwNN := types.NamespacedName{Name: "ratelimit-cidr-invert-always-exempt", Namespace: ns}
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+			WaitForGatewayPodsReady(t, suite.Client, gwNN)
+			WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
+
 			expectOkResp := http.ExpectedResponse{
 				Request: http.Request{
 					Path: "/never-limited",
@@ -254,7 +265,7 @@ var RateLimitCIDRInvertAlwaysExemptTest = suite.ConformanceTest{
 			// Every IPv4 client is in 0.0.0.0/0, so the rule never applies — we should never get 429.
 			MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &expectOkResp)
 			if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("expected all requests to succeed (no rate limit): %v", err)
+				tlog.Fatalf(t, "expected all requests to succeed (no rate limit): %v", err)
 			}
 		})
 	},
@@ -267,8 +278,9 @@ var RateLimitMethodMatchTest = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "method-ratelimit", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+		gwNN := types.NamespacedName{Name: "ratelimit-method-match", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 			types.NamespacedName{Name: "ratelimit-method-match", Namespace: ns},
@@ -278,6 +290,7 @@ var RateLimitMethodMatchTest = suite.ConformanceTest{
 				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 				Name:      gwapiv1.ObjectName(gwNN.Name),
 			})
+		WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
 
 		t.Run("matched method can got limited", func(t *testing.T) {
 			ratelimitHeader := make(map[string]string)
@@ -343,7 +356,7 @@ var RateLimitMethodMatchTest = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 3, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected responses for the request: %v", err)
+				tlog.Fatalf(t, "failed to get expected responses for the request: %v", err)
 			}
 		})
 	},
@@ -356,8 +369,9 @@ var RateLimitPathMatchTest = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "path-ratelimit", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+		gwNN := types.NamespacedName{Name: "ratelimit-path-match", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 			types.NamespacedName{Name: "ratelimit-path-match", Namespace: ns},
@@ -367,6 +381,7 @@ var RateLimitPathMatchTest = suite.ConformanceTest{
 				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 				Name:      gwapiv1.ObjectName(gwNN.Name),
 			})
+		WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
 
 		t.Run("matched path can got limited", func(t *testing.T) {
 			ratelimitHeader := make(map[string]string)
@@ -402,10 +417,10 @@ var RateLimitPathMatchTest = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected response for the first three requests: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the first three requests: %v", err)
 			}
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectLimitReq, expectLimitResp); err != nil {
-				t.Errorf("failed to get expected response for the last (fourth) request: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the last (fourth) request: %v", err)
 			}
 
 			// Subpath should be rate limited due to prefix matching.
@@ -420,7 +435,7 @@ var RateLimitPathMatchTest = suite.ConformanceTest{
 			}
 			expectLimitReq = http.MakeRequest(t, &expectLimitResp, gwAddr, "HTTP", "http")
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectLimitReq, expectLimitResp); err != nil {
-				t.Errorf("failed to get expected response for the last (fourth) request: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the last (fourth) request: %v", err)
 			}
 
 			// Different path (contains the path prefix) should not be rate limited.
@@ -435,7 +450,7 @@ var RateLimitPathMatchTest = suite.ConformanceTest{
 			}
 			expectOkReq = http.MakeRequest(t, &expectOkResp, gwAddr, "HTTP", "http")
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected response for the last (fourth) request: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the last (fourth) request: %v", err)
 			}
 		})
 
@@ -459,7 +474,7 @@ var RateLimitPathMatchTest = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 3, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected responses for the request: %v", err)
+				tlog.Fatalf(t, "failed to get expected responses for the request: %v", err)
 			}
 		})
 	},
@@ -472,8 +487,9 @@ var RateLimitHeaderMatchTest = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "header-ratelimit", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+		gwNN := types.NamespacedName{Name: "ratelimit-header-match", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 		// TODO: this seems not right,
 		// BTP targets to HTTPRoute instead of Gateway,
@@ -486,6 +502,7 @@ var RateLimitHeaderMatchTest = suite.ConformanceTest{
 				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 				Name:      gwapiv1.ObjectName(gwNN.Name),
 			})
+		WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
 
 		t.Run("all matched headers can got limited", func(t *testing.T) {
 			requestHeaders := map[string]string{
@@ -545,7 +562,7 @@ var RateLimitHeaderMatchTest = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 3, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected responses for the request: %v", err)
+				tlog.Fatalf(t, "failed to get expected responses for the request: %v", err)
 			}
 		})
 	},
@@ -557,9 +574,10 @@ var GlobalRateLimitHeaderInvertMatchTest = suite.ConformanceTest{
 	Manifests:   []string{"testdata/ratelimit-header-invert-match-global.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
-		routeNN := types.NamespacedName{Name: "header-ratelimit", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+		routeNN := types.NamespacedName{Name: "header-ratelimit-invert", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "ratelimit-header-invert-match-global", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 			types.NamespacedName{Name: "ratelimit-anded-headers-with-invert", Namespace: ns},
@@ -569,6 +587,7 @@ var GlobalRateLimitHeaderInvertMatchTest = suite.ConformanceTest{
 				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 				Name:      gwapiv1.ObjectName(gwNN.Name),
 			})
+		WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
 
 		t.Run("all matched headers got limited", func(t *testing.T) {
 			requestHeaders := map[string]string{
@@ -609,10 +628,10 @@ var GlobalRateLimitHeaderInvertMatchTest = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected response for the first three requests: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the first three requests: %v", err)
 			}
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectLimitReq, expectLimitResp); err != nil {
-				t.Errorf("failed to get expected response for the last (fourth) request: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the last (fourth) request: %v", err)
 			}
 		})
 
@@ -641,7 +660,7 @@ var GlobalRateLimitHeaderInvertMatchTest = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 3, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected responses for the request: %v", err)
+				tlog.Fatalf(t, "failed to get expected responses for the request: %v", err)
 			}
 		})
 	},
@@ -654,8 +673,9 @@ var RateLimitHeadersDisabled = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "ratelimit-headers-disabled", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+		gwNN := types.NamespacedName{Name: "ratelimit-headers-disabled", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 			types.NamespacedName{Name: "ratelimit-headers-disabled-btp", Namespace: ns},
@@ -665,6 +685,7 @@ var RateLimitHeadersDisabled = suite.ConformanceTest{
 				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 				Name:      gwapiv1.ObjectName(gwNN.Name),
 			})
+		WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
 
 		t.Run("all matched headers can get limited", func(t *testing.T) {
 			requestHeaders := map[string]string{
@@ -706,10 +727,10 @@ var RateLimitHeadersDisabled = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected response for the first three requests: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the first three requests: %v", err)
 			}
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectLimitReq, expectLimitResp); err != nil {
-				t.Errorf("failed to get expected response for the last (fourth) request: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the last (fourth) request: %v", err)
 			}
 		})
 
@@ -738,13 +759,13 @@ var RateLimitHeadersDisabled = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 3, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected responses for the request: %v", err)
+				tlog.Fatalf(t, "failed to get expected responses for the request: %v", err)
 			}
 		})
 	},
 }
 
-var RateLimitBasedJwtClaimsTest = suite.ConformanceTest{
+var RateLimitBasedJwtClaims = suite.ConformanceTest{
 	ShortName:   "RateLimitBasedJwtClaims",
 	Description: "Limit based jwt claims",
 	Manifests:   []string{"testdata/ratelimit-based-jwt-claims.yaml"},
@@ -752,8 +773,9 @@ var RateLimitBasedJwtClaimsTest = suite.ConformanceTest{
 		t.Run("ratelimit based on jwt claims", func(t *testing.T) {
 			ns := "gateway-conformance-infra"
 			routeNN := types.NamespacedName{Name: "http-ratelimit-based-jwt-claims", Namespace: ns}
-			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-			gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+			gwNN := types.NamespacedName{Name: "ratelimit-based-jwt-claims", Namespace: ns}
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+			WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 			BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 				types.NamespacedName{Name: "ratelimit-specific-user", Namespace: ns},
@@ -763,6 +785,7 @@ var RateLimitBasedJwtClaimsTest = suite.ConformanceTest{
 					Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 					Name:      gwapiv1.ObjectName(gwNN.Name),
 				})
+			WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
 
 			preCount, err := OverLimitCount(suite)
 			require.NoError(t, err)
@@ -790,7 +813,7 @@ var RateLimitBasedJwtClaimsTest = suite.ConformanceTest{
 			// Just to construct the request that carries a jwt token that can be limited
 			ratelimitHeader := make(map[string]string)
 			TokenHeader := make(map[string]string)
-			JwtOkResp := http.ExpectedResponse{
+			jwtOkResp := http.ExpectedResponse{
 				Request: http.Request{
 					Path:    "/foo",
 					Headers: TokenHeader,
@@ -806,17 +829,15 @@ var RateLimitBasedJwtClaimsTest = suite.ConformanceTest{
 				},
 				Namespace: ns,
 			}
-			JwtOkResp.Request.Headers["Authorization"] = "Bearer " + "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ"
-			JwtOkResp.Response.Headers["X-Ratelimit-Limit"] = "3, 3;w=3600"
-
-			JwtReq := http.MakeRequest(t, &JwtOkResp, gwAddr, "HTTP", "http")
+			jwtOkResp.Request.Headers["Authorization"] = "Bearer " + "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ"
+			jwtOkResp.Response.Headers["X-Ratelimit-Limit"] = "3, 3;w=3600"
 
 			// Just to construct the request that carries a jwt token that can not be limited
-			DifTokenHeader := make(map[string]string)
+			difTokenHeader := make(map[string]string)
 			difJwtOkResp := http.ExpectedResponse{
 				Request: http.Request{
 					Path:    "/foo",
-					Headers: DifTokenHeader,
+					Headers: difTokenHeader,
 				},
 				Response: http.Response{
 					StatusCodes: []int{200},
@@ -844,19 +865,20 @@ var RateLimitBasedJwtClaimsTest = suite.ConformanceTest{
 			// should just send exactly 4 requests, and expect 429
 
 			// keep sending requests till get 200 first, that will cost one 200
-			MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &JwtOkResp)
+			MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &jwtOkResp)
 
 			// fire the rest of requests
-			if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, JwtReq, JwtOkResp); err != nil {
-				t.Errorf("failed to get expected response at third request: %v", err)
+			jwtReq := http.MakeRequest(t, &jwtOkResp, gwAddr, "HTTP", "http")
+			if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, jwtReq, jwtOkResp); err != nil {
+				tlog.Fatalf(t, "failed to get expected response at third request: %v", err)
 			}
-			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, JwtReq, expectLimitResp); err != nil {
-				t.Errorf("failed to get expected response at the fourth request: %v", err)
+			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, jwtReq, expectLimitResp); err != nil {
+				tlog.Fatalf(t, "failed to get expected response at the fourth request: %v", err)
 			}
 
 			// Carrying different jwt claims will not be limited
 			if err := GotExactExpectedResponseExceptErrors(t, 4, suite.RoundTripper, difJwtReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected response for the request with a different jwt: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the request with a different jwt: %v", err)
 			}
 
 			// make sure the request with no token is rejected
@@ -871,13 +893,19 @@ var RateLimitBasedJwtClaimsTest = suite.ConformanceTest{
 			}
 			noTokenReq := http.MakeRequest(t, &noTokenResp, gwAddr, "HTTP", "http")
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, noTokenReq, noTokenResp); err != nil {
-				t.Errorf("failed to get expected response: %v", err)
+				tlog.Fatalf(t, "failed to get expected response: %v", err)
 			}
 
-			err = wait.PollUntilContextTimeout(context.TODO(), time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
+			// There're multiple ratelimit replicas in gateway namespace mode.
+
+			err = wait.PollUntilContextTimeout(t.Context(), time.Second, 1*time.Minute, true, func(_ context.Context) (bool, error) {
 				curCount, err := OverLimitCount(suite)
 				if err != nil {
 					return false, err
+				}
+				if curCount <= preCount {
+					tlog.Logf(t, "current over limit count %d is not greater than previous count %d, retrying...", curCount, preCount)
+					return false, nil
 				}
 				return curCount > preCount, nil
 			})
@@ -891,28 +919,34 @@ var RateLimitMultipleListenersTest = suite.ConformanceTest{
 	Description: "Limit requests on multiple listeners",
 	Manifests:   []string{"testdata/ratelimit-multiple-listeners.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
-		t.Run("block all ips on listener 80 and 8080", func(t *testing.T) {
-			ns := "gateway-conformance-infra"
-			routeNN := types.NamespacedName{Name: "cidr-ratelimit", Namespace: ns}
-			gwNN := types.NamespacedName{Name: "eg-rate-limit", Namespace: ns}
-			gwHost := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "multiple-listeners", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "eg-multiple-listeners", Namespace: ns}
+		gwHost := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+		WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
-			BackendTrafficPolicyMustBeAccepted(t, suite.Client,
-				types.NamespacedName{Name: "ratelimit-all-ips", Namespace: ns},
-				suite.ControllerName, gwapiv1.ParentReference{
-					Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
-					Kind:      gatewayapi.KindPtr(resource.KindGateway),
-					Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
-					Name:      gwapiv1.ObjectName(gwNN.Name),
-				})
+		BackendTrafficPolicyMustBeAccepted(t, suite.Client,
+			types.NamespacedName{Name: "ratelimit-all-ips", Namespace: ns},
+			suite.ControllerName, gwapiv1.ParentReference{
+				Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
+				Kind:      gatewayapi.KindPtr(resource.KindGateway),
+				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
+				Name:      gwapiv1.ObjectName(gwNN.Name),
+			})
+		// The route has no sectionName, so it (and the policy targeting it) attaches to both
+		// listeners on this Gateway.
+		WaitForRateLimitDomainsToBeLoaded(t, suite,
+			RateLimitListenerDomain(gwNN, "http-80"),
+			RateLimitListenerDomain(gwNN, "http-8080"))
 
-			for _, port := range []string{"80", "8080"} {
+		for _, port := range []string{"80", "8080"} {
+			t.Run(port, func(t *testing.T) {
 				gwAddr := net.JoinHostPort(gwHost, port)
 
 				ratelimitHeader := make(map[string]string)
 				expectOkResp := http.ExpectedResponse{
 					Request: http.Request{
-						Path: "/",
+						Path: "/multiple-listeners",
 					},
 					Response: http.Response{
 						StatusCodes: []int{200},
@@ -925,7 +959,7 @@ var RateLimitMultipleListenersTest = suite.ConformanceTest{
 
 				expectLimitResp := http.ExpectedResponse{
 					Request: http.Request{
-						Path: "/",
+						Path: "/multiple-listeners",
 					},
 					Response: http.Response{
 						StatusCodes: []int{429},
@@ -941,13 +975,13 @@ var RateLimitMultipleListenersTest = suite.ConformanceTest{
 
 				// fire the rest of requests
 				if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-					t.Errorf("failed to get expected response for the first three requests: %v", err)
+					tlog.Fatalf(t, "failed to get expected response for the first three requests: %v", err)
 				}
 				if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectLimitReq, expectLimitResp); err != nil {
-					t.Errorf("failed to get expected response for the last (fourth) request: %v", err)
+					tlog.Fatalf(t, "failed to get expected response for the last (fourth) request: %v", err)
 				}
-			}
-		})
+			})
+		}
 	},
 }
 
@@ -958,8 +992,9 @@ var RateLimitHeadersAndCIDRMatchTest = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "header-and-cidr-ratelimit", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+		gwNN := types.NamespacedName{Name: "ratelimit-headers-and-cidr-match", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 			types.NamespacedName{Name: "ratelimit-headers-and-cidr", Namespace: ns},
@@ -969,6 +1004,7 @@ var RateLimitHeadersAndCIDRMatchTest = suite.ConformanceTest{
 				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 				Name:      gwapiv1.ObjectName(gwNN.Name),
 			})
+		WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
 
 		t.Run("all matched both headers and cidr can got limited", func(t *testing.T) {
 			if IPFamily == "ipv6" {
@@ -1014,10 +1050,10 @@ var RateLimitHeadersAndCIDRMatchTest = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected response for the first three requests: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the first three requests: %v", err)
 			}
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectLimitReq, expectLimitResp); err != nil {
-				t.Errorf("failed to get expected response for the last (fourth) request: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the last (fourth) request: %v", err)
 			}
 		})
 
@@ -1046,7 +1082,7 @@ var RateLimitHeadersAndCIDRMatchTest = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 3, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected responses for the request: %v", err)
+				tlog.Fatalf(t, "failed to get expected responses for the request: %v", err)
 			}
 		})
 
@@ -1070,7 +1106,7 @@ var RateLimitHeadersAndCIDRMatchTest = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 3, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected responses for the request: %v", err)
+				tlog.Fatalf(t, "failed to get expected responses for the request: %v", err)
 			}
 		})
 	},
@@ -1083,8 +1119,9 @@ var UsageRateLimitTest = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "usage-rate-limit", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+		gwNN := types.NamespacedName{Name: "ratelimit-usage-ratelimit", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 			types.NamespacedName{Name: "usage-rate-limit", Namespace: ns},
@@ -1094,6 +1131,12 @@ var UsageRateLimitTest = suite.ConformanceTest{
 				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 				Name:      gwapiv1.ObjectName(gwNN.Name),
 			})
+
+		// The policy's Accepted status above only confirms EG finished translating it, not that
+		// the (separately-updated) ratelimit service has received and applied its descriptor
+		// config yet. Wait for that explicitly before sending any test traffic, rather than
+		// discovering it as a flaky first request.
+		WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
 
 		// Waiting for the extproc service to be ready.
 		ancestorRef := gwapiv1.ParentReference{
@@ -1131,19 +1174,21 @@ var UsageRateLimitTest = suite.ConformanceTest{
 			},
 			Namespace: ns,
 		}
-		expectLimitReq := http.MakeRequest(t, &expectLimitResp, gwAddr, "HTTP", "http")
-
 		// Keep sending requests till get 200 first, that will cost 10 usage.
 		MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &expectOkResp)
 
 		// The next two request will be fine as the limit is set to 21.
 		if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-			t.Errorf("failed to get expected response for the first three requests: %v", err)
+			tlog.Fatalf(t, "failed to get expected response for the first three requests: %v", err)
+			t.FailNow()
 		}
-		// At this point, the budget must be zero (21 -> 11 -> 1 -> 0), so the next request will be limited.
-		if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectLimitReq, expectLimitResp); err != nil {
-			t.Errorf("failed to get expected response for the last (fourth) request: %v", err)
-		}
+		// At this point, the budget must be zero (21 -> 11 -> 1 -> 0). The per-response cost
+		// (from ext-proc metadata) is charged asynchronously via ApplyOnStreamDone, i.e. after
+		// the response has already been sent to the client, so the counter update from one of
+		// the previous requests may not have landed yet by the time we fire the next one. Retry
+		// (an extra 200 here would just push the budget further negative) instead of asserting
+		// the 429 on the very first attempt.
+		MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t, suite.RoundTripper, &suite.TimeoutConfig, gwAddr, &expectLimitResp)
 	},
 }
 
@@ -1156,13 +1201,14 @@ var RateLimitGlobalSharedCidrMatchTest = suite.ConformanceTest{
 			ns := "gateway-conformance-infra"
 			route1NN := types.NamespacedName{Name: "cidr-ratelimit-1", Namespace: ns}
 			route2NN := types.NamespacedName{Name: "cidr-ratelimit-2", Namespace: ns}
-			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+			gwNN := types.NamespacedName{Name: "ratelimit-global-shared-cidr-match", Namespace: ns}
 
 			// Get gateway address for the first route
 			gwAddr1 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), route1NN)
 
 			// Get gateway address for the second route
 			gwAddr2 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), route2NN)
+			WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 			BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 				types.NamespacedName{Name: "ratelimit-all-ips", Namespace: ns},
@@ -1172,6 +1218,9 @@ var RateLimitGlobalSharedCidrMatchTest = suite.ConformanceTest{
 					Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 					Name:      gwapiv1.ObjectName(gwNN.Name),
 				})
+			// This policy's rule is shared, so the two target routes collapse onto one domain
+			// keyed by the policy itself, rather than by listener.
+			WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitSharedDomain(types.NamespacedName{Name: "ratelimit-all-ips", Namespace: ns}))
 
 			ratelimitHeader := make(map[string]string)
 			expectOkRespFoo := http.ExpectedResponse{
@@ -1224,7 +1273,7 @@ var RateLimitGlobalSharedCidrMatchTest = suite.ConformanceTest{
 	},
 }
 
-var RateLimitGlobalSharedGatewayHeaderMatchTest = suite.ConformanceTest{
+var RateLimitGlobalSharedGatewayHeaderMatch = suite.ConformanceTest{
 	ShortName:   "RateLimitGlobalSharedGatewayHeaderMatch",
 	Description: "Limit all requests with matching headers across multiple routes with a shared rate limit",
 	Manifests:   []string{"testdata/ratelimit-global-shared-gateway-header-match.yaml"},
@@ -1233,13 +1282,14 @@ var RateLimitGlobalSharedGatewayHeaderMatchTest = suite.ConformanceTest{
 			ns := "gateway-conformance-infra"
 			route1NN := types.NamespacedName{Name: "header-ratelimit-1", Namespace: ns}
 			route2NN := types.NamespacedName{Name: "header-ratelimit-2", Namespace: ns}
-			gwNN := types.NamespacedName{Name: "eg-rate-limit", Namespace: ns}
+			gwNN := types.NamespacedName{Name: "ratelimit-global-shared-gateway-header-match", Namespace: ns}
 
 			// Get gateway address for the first route
 			gwAddr1 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), route1NN)
 
 			// Get gateway address for the second route
 			gwAddr2 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), route2NN)
+			WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 			BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 				types.NamespacedName{Name: "ratelimit-header-match-gateway", Namespace: ns},
@@ -1249,6 +1299,9 @@ var RateLimitGlobalSharedGatewayHeaderMatchTest = suite.ConformanceTest{
 					Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 					Name:      gwapiv1.ObjectName(gwNN.Name),
 				})
+			// This policy's rule is shared, so both target routes collapse onto one domain keyed
+			// by the policy itself, rather than by listener.
+			WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitSharedDomain(types.NamespacedName{Name: "ratelimit-header-match-gateway", Namespace: ns}))
 
 			// Define headers that will trigger the rate limit
 			requestHeaders := map[string]string{
@@ -1305,19 +1358,19 @@ var RateLimitGlobalSharedGatewayHeaderMatchTest = suite.ConformanceTest{
 
 			// Send 1 more request to the first route with /foo path (total: 2 requests)
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectOkReq1, expectOkResp1); err != nil {
-				t.Errorf("failed to get expected response for the request to first route (/foo): %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the request to first route (/foo): %v", err)
 			}
 
 			// Send a request to the second route with /bar path (total: 3 requests)
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectOkReq2, expectOkResp2); err != nil {
-				t.Errorf("failed to get expected response for the request to second route (/bar): %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the request to second route (/bar): %v", err)
 			}
 
 			// At this point, 3 requests have been sent in total (2 to /foo, 1 to /bar)
 			// Since the rate limit is shared and set to 3, the next request should be rate limited
 			// even though it's going to a different path
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectLimitReq2, expectLimitResp); err != nil {
-				t.Errorf("failed to get expected rate limit response for the second request to /bar: %v", err)
+				tlog.Fatalf(t, "failed to get expected rate limit response for the second request to /bar: %v", err)
 			}
 
 			// Make sure that metric worked as expected.
@@ -1333,24 +1386,25 @@ var RateLimitGlobalSharedGatewayHeaderMatchTest = suite.ConformanceTest{
 				}
 				return false, nil
 			}); err != nil {
-				t.Errorf("failed to get expected metric for rate limit: %v", err)
+				tlog.Fatalf(t, "failed to get expected metric for rate limit: %v", err)
 			}
 		})
 	},
 }
 
-var RateLimitGlobalMergeTest = suite.ConformanceTest{
-	ShortName:   "RateLimitGlobalMergeTest",
+var RateLimitGlobalMerge = suite.ConformanceTest{
+	ShortName:   "RateLimitGlobalMerge",
 	Description: "Limit requests with matching headers across multiple routes, verifying both shared and unshared rate limit behaviors",
 	Manifests:   []string{"testdata/ratelimit-global-shared-and-unshared-header-match.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		route1NN := types.NamespacedName{Name: "header-ratelimit-1", Namespace: ns}
 		route2NN := types.NamespacedName{Name: "header-ratelimit-2", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "eg-rate-limit", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "ratelimit-global-merge", Namespace: ns}
 
 		gwAddr1 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), route1NN)
 		gwAddr2 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), route2NN)
+		WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 			types.NamespacedName{Name: "ratelimit-headers-route-policy", Namespace: ns},
@@ -1360,6 +1414,20 @@ var RateLimitGlobalMergeTest = suite.ConformanceTest{
 				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 				Name:      gwapiv1.ObjectName(gwNN.Name),
 			})
+		// Two policies contribute here: ratelimit-headers-route-policy (route-targeted) has one
+		// shared rule (its own domain) and one non-shared rule (the listener domain);
+		// ratelimit-headers-gateway-policy (gateway-targeted) merges in two more shared rules
+		// (its own domain) and one non-shared rule (the same listener domain). Wait for all three
+		// resulting domains before any subtest sends traffic.
+		//
+		// Both policies' non-shared rules land on the same listener domain
+		// (this Gateway's own "http-8080"), so pin that wait to one of this test's own
+		// httproutes to disambiguate which of the two policies' config has loaded.
+		WaitForRateLimitDomainsToBeLoaded(t, suite,
+			RateLimitSharedDomain(types.NamespacedName{Name: "ratelimit-headers-route-policy", Namespace: ns}),
+			RateLimitListenerDomain(gwNN, "http-8080")+"httproute/gateway-conformance-infra/header-ratelimit-1",
+			RateLimitSharedDomain(types.NamespacedName{Name: "ratelimit-headers-gateway-policy", Namespace: ns}),
+		)
 
 		t.Run("shared_route_policy_x-user-id=one", func(t *testing.T) {
 			headers := map[string]string{"x-user-id": "one"}
@@ -1379,11 +1447,11 @@ var RateLimitGlobalMergeTest = suite.ConformanceTest{
 
 			for _, expect := range []http.ExpectedResponse{expectOk1, expectOk2} {
 				if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &expect, gwAddr2, "HTTP", "http"), expect); err != nil {
-					t.Errorf("expected 200 response: %v", err)
+					tlog.Fatalf(t, "expected 200 response: %v", err)
 				}
 			}
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &expectLimit, gwAddr1, "HTTP", "http"), expectLimit); err != nil {
-				t.Errorf("expected 429 response: %v", err)
+				tlog.Fatalf(t, "expected 429 response: %v", err)
 			}
 		})
 
@@ -1399,20 +1467,20 @@ var RateLimitGlobalMergeTest = suite.ConformanceTest{
 
 			for i := range 2 {
 				if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &okFoo, gwAddr1, "HTTP", "http"), okFoo); err != nil {
-					t.Errorf("foo request #%d failed: %v", i+1, err)
+					tlog.Fatalf(t, "foo request #%d failed: %v", i+1, err)
 				}
 			}
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &limitFoo, gwAddr1, "HTTP", "http"), limitFoo); err != nil {
-				t.Errorf("expected 429 on 4th foo: %v", err)
+				tlog.Fatalf(t, "expected 429 on 4th foo: %v", err)
 			}
 
 			for i := 0; i < 3; i++ {
 				if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &okBar, gwAddr2, "HTTP", "http"), okBar); err != nil {
-					t.Errorf("bar request #%d failed: %v", i+1, err)
+					tlog.Fatalf(t, "bar request #%d failed: %v", i+1, err)
 				}
 			}
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &limitBar, gwAddr2, "HTTP", "http"), limitBar); err != nil {
-				t.Errorf("expected 429 on 4th bar: %v", err)
+				tlog.Fatalf(t, "expected 429 on 4th bar: %v", err)
 			}
 		})
 
@@ -1427,11 +1495,11 @@ var RateLimitGlobalMergeTest = suite.ConformanceTest{
 
 			for _, expect := range []http.ExpectedResponse{ok1, ok2} {
 				if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &expect, gwAddr2, "HTTP", "http"), expect); err != nil {
-					t.Errorf("expected 200 response: %v", err)
+					tlog.Fatalf(t, "expected 200 response: %v", err)
 				}
 			}
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &limit, gwAddr1, "HTTP", "http"), limit); err != nil {
-				t.Errorf("expected 429 response: %v", err)
+				tlog.Fatalf(t, "expected 429 response: %v", err)
 			}
 		})
 
@@ -1447,20 +1515,20 @@ var RateLimitGlobalMergeTest = suite.ConformanceTest{
 
 			for i := range 2 {
 				if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &okFoo, gwAddr1, "HTTP", "http"), okFoo); err != nil {
-					t.Errorf("foo request #%d failed: %v", i+1, err)
+					tlog.Fatalf(t, "foo request #%d failed: %v", i+1, err)
 				}
 			}
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &limitFoo, gwAddr1, "HTTP", "http"), limitFoo); err != nil {
-				t.Errorf("expected 429 on 4th foo: %v", err)
+				tlog.Fatalf(t, "expected 429 on 4th foo: %v", err)
 			}
 
 			for i := range 3 {
 				if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &okBar, gwAddr2, "HTTP", "http"), okBar); err != nil {
-					t.Errorf("bar request #%d failed: %v", i+1, err)
+					tlog.Fatalf(t, "bar request #%d failed: %v", i+1, err)
 				}
 			}
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, http.MakeRequest(t, &limitBar, gwAddr2, "HTTP", "http"), limitBar); err != nil {
-				t.Errorf("expected 429 on 4th bar: %v", err)
+				tlog.Fatalf(t, "expected 429 on 4th bar: %v", err)
 			}
 		})
 
@@ -1528,13 +1596,13 @@ var RateLimitGlobalMergeTest = suite.ConformanceTest{
 			// Consume the remaining tokens
 			if remaining > 0 {
 				if err := GotExactExpectedResponseExceptErrors(t, remaining, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-					t.Errorf("failed to exhaust remaining %d requests: %v", remaining, err)
+					tlog.Fatalf(t, "failed to exhaust remaining %d requests: %v", remaining, err)
 				}
 			}
 
 			// The next request should be rate limited
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, expectLimitReq, expectLimitResp); err != nil {
-				t.Errorf("expected 429 after exhaustion: %v", err)
+				tlog.Fatalf(t, "expected 429 after exhaustion: %v", err)
 			}
 		})
 	},
@@ -1547,8 +1615,9 @@ var RateLimitGlobalShadowModeTest = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		shadowRouteNN := types.NamespacedName{Name: "shadow-mode-ratelimit", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, shadowRouteNN)
+		gwNN := types.NamespacedName{Name: "ratelimit-global-shadow-mode", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), shadowRouteNN)
+		WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 			types.NamespacedName{Name: "shadow-mode-ratelimit", Namespace: ns},
@@ -1558,6 +1627,7 @@ var RateLimitGlobalShadowModeTest = suite.ConformanceTest{
 				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 				Name:      gwapiv1.ObjectName(gwNN.Name),
 			})
+		WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
 
 		t.Run("matched with shadow mode can't got limited", func(t *testing.T) {
 			ratelimitHeader := make(map[string]string)
@@ -1583,12 +1653,12 @@ var RateLimitGlobalShadowModeTest = suite.ConformanceTest{
 
 			// fire the next 2 requests (total: 3 requests, reaching the limit)
 			if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected response for the first three requests: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the first three requests: %v", err)
 			}
 
 			// send 2 more requests that exceed the limit, but still expect 200 (not 429) due to shadow mode
 			if err := GotExactExpectedResponseExceptErrors(t, 2, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected response for requests exceeding the limit: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for requests exceeding the limit: %v", err)
 			}
 		})
 	},
@@ -1601,8 +1671,9 @@ var RateLimitQueryParametersTest = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "query-parameters-ratelimit", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+		gwNN := types.NamespacedName{Name: "ratelimit-query-parameters", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 		BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 			types.NamespacedName{Name: "ratelimit-query-parameters", Namespace: ns},
@@ -1612,6 +1683,7 @@ var RateLimitQueryParametersTest = suite.ConformanceTest{
 				Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 				Name:      gwapiv1.ObjectName(gwNN.Name),
 			})
+		WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitListenerDomain(gwNN, "http"))
 
 		t.Run("all matched query parameters can got limited", func(t *testing.T) {
 			ratelimitHeader := make(map[string]string)
@@ -1651,7 +1723,7 @@ var RateLimitQueryParametersTest = suite.ConformanceTest{
 				}
 				return false, nil
 			}); err != nil {
-				t.Errorf("failed to get expected response for the last (fourth) request: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for the last (fourth) request: %v", err)
 			}
 		})
 
@@ -1672,7 +1744,7 @@ var RateLimitQueryParametersTest = suite.ConformanceTest{
 
 			// fire the rest of the requests
 			if err := GotExactExpectedResponseExceptErrors(t, 3, suite.RoundTripper, expectOkReq, expectOkResp); err != nil {
-				t.Errorf("failed to get expected responses for the request: %v", err)
+				tlog.Fatalf(t, "failed to get expected responses for the request: %v", err)
 			}
 		})
 	},
@@ -1691,6 +1763,7 @@ var RateLimitGlobalSharedWithCost = suite.ConformanceTest{
 
 			gwAddr1 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), route1NN)
 			gwAddr2 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), route2NN)
+			WaitForGatewayPodsReady(t, suite.Client, gwNN)
 
 			BackendTrafficPolicyMustBeAccepted(t, suite.Client,
 				types.NamespacedName{Name: "ratelimit-shared-gateway-cost", Namespace: ns},
@@ -1700,6 +1773,9 @@ var RateLimitGlobalSharedWithCost = suite.ConformanceTest{
 					Namespace: gatewayapi.NamespacePtr(gwNN.Namespace),
 					Name:      gwapiv1.ObjectName(gwNN.Name),
 				})
+			// This policy's rule is shared, so both target routes collapse onto one domain keyed
+			// by the policy itself, rather than by listener.
+			WaitForRateLimitDomainToBeLoaded(t, suite, RateLimitSharedDomain(types.NamespacedName{Name: "ratelimit-shared-gateway-cost", Namespace: ns}))
 
 			requestHeaders := map[string]string{"x-user-id": "cost-test"}
 
@@ -1748,12 +1824,12 @@ var RateLimitGlobalSharedWithCost = suite.ConformanceTest{
 
 			// Second request to /bar (costs 2 more, total 4 consumed — bucket exhausted)
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, req2, expectOkResp2); err != nil {
-				t.Errorf("failed to get expected response for second request to /bar: %v", err)
+				tlog.Fatalf(t, "failed to get expected response for second request to /bar: %v", err)
 			}
 
 			// Third request must be rate limited: shared bucket is exhausted across both routes
 			if err := GotExactExpectedResponseExceptErrors(t, 1, suite.RoundTripper, limitReq, expectLimitResp); err != nil {
-				t.Errorf("expected 429 after cost exhausted shared bucket across routes: %v", err)
+				tlog.Fatalf(t, "expected 429 after cost exhausted shared bucket across routes: %v", err)
 			}
 
 			// Requests without the matching header are not affected
@@ -1778,7 +1854,7 @@ var RateLimitGlobalSharedWithCost = suite.ConformanceTest{
 //
 // We use a 1s poll interval (not RequestTimeout) so we get many attempts within
 // MaxTimeToConsistency, matching gateway-api's AwaitConvergence which only delays 1s on failure.
-func MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t *testing.T, r roundtripper.RoundTripper, timeoutConfig *config.TimeoutConfig, gwAddr string, expectedResponse *http.ExpectedResponse) {
+func MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t *testing.T, r roundtripper.RoundTripper, timeout *config.TimeoutConfig, gwAddr string, expectedResponse *http.ExpectedResponse) {
 	req := http.MakeRequest(t, expectedResponse, gwAddr, "HTTP", "http")
 	require.Eventually(t, func() bool {
 		cReq, cRes, err := r.CaptureRoundTrip(req)
@@ -1787,7 +1863,7 @@ func MakeRequestAndExpectEventuallyConsistentResponseExceptErrors(t *testing.T, 
 			return false // retry on network/transport error
 		}
 		return http.CompareRoundTrip(t, &req, cReq, cRes, *expectedResponse) == nil
-	}, timeoutConfig.MaxTimeToConsistency, time.Second)
+	}, timeout.MaxTimeToConsistency, time.Second)
 }
 
 // GotExactExpectedResponseExceptErrors requires exactly n round trips that match the expected response.

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -88,6 +88,22 @@ func WaitForPodsReady(t *testing.T, cl client.Client, namespace string, selector
 	WaitForPods(t, cl, namespace, selectors, corev1.PodRunning, &PodReady)
 }
 
+// WaitForGatewayPodsReady waits for the Envoy Proxy pod(s) backing the given Gateway to reach
+// Ready. GatewayAndRoutesMustBeAccepted/GatewayAndHTTPRoutesMustBeAccepted only confirm the
+// Gateway's k8s status conditions and that its Service was assigned an address - which happens
+// almost instantly (e.g. via MetalLB) regardless of whether the data-plane pod behind it is
+// actually up yet. Since this suite's EnvoyProxy config doesn't set mergeGateways, every distinct
+// Gateway gets its own freshly-provisioned Envoy Proxy Deployment/Pod, which can take tens of
+// seconds to become Ready - without this wait, the first request(s) sent to a newly-created
+// Gateway race pod startup instead of deterministically waiting for it.
+func WaitForGatewayPodsReady(t *testing.T, cl client.Client, gwNN types.NamespacedName) {
+	t.Helper()
+	WaitForPodsReady(t, cl, GetGatewayResourceNamespace(), map[string]string{
+		"gateway.envoyproxy.io/owning-gateway-name":      gwNN.Name,
+		"gateway.envoyproxy.io/owning-gateway-namespace": gwNN.Namespace,
+	})
+}
+
 // WaitForPods waits for the pods in the given namespace and with the given selector
 // to be in the given phase and condition.
 func WaitForPods(t *testing.T, cl client.Client, namespace string, selectors map[string]string, phase corev1.PodPhase, condition *corev1.PodCondition) {
@@ -758,9 +774,23 @@ func OverLimitCount(suite *suite.ConformanceTestSuite) (int, error) {
 		return -1, fmt.Errorf("no envoy-ratelimit pod found")
 	}
 
+	total := 0
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		count, err := getOverLimitCount(cli, pod)
+		if err != nil {
+			return -1, err
+		}
+		total += count
+	}
+
+	return total, nil
+}
+
+func getOverLimitCount(cli kubernetes.CLIClient, pod *corev1.Pod) (int, error) {
 	fwd, err := kubernetes.NewLocalPortForwarder(cli, types.NamespacedName{
 		Namespace: "envoy-gateway-system",
-		Name:      pods.Items[0].Name,
+		Name:      pod.Name,
 	}, 0, 19001)
 	if err != nil {
 		return -1, err
@@ -786,8 +816,126 @@ func OverLimitCount(suite *suite.ConformanceTestSuite) (int, error) {
 			total += int(*m.Counter.Value)
 		}
 	}
-
 	return total, nil
+}
+
+// rateLimitDebugPort is the debug HTTP port the envoy-ratelimit service listens on
+// (DEBUG_HOST/DEBUG_PORT in the envoyproxy/ratelimit project), which exposes the
+// /rlconfig endpoint used to dump the currently loaded rate limit config.
+const rateLimitDebugPort = 6070
+
+// DumpRateLimitConfig fetches the config currently loaded by the envoy-ratelimit service via
+// its /rlconfig debug endpoint - the same one used by `egctl config envoy-ratelimit`.
+func DumpRateLimitConfig(t *testing.T, suite *suite.ConformanceTestSuite) (string, error) {
+	cli, err := kubernetes.NewForRestConfig(suite.RestConfig)
+	if err != nil {
+		return "", err
+	}
+
+	pods, err := cli.PodsForSelector("envoy-gateway-system", "app.kubernetes.io/name=envoy-ratelimit")
+	if err != nil {
+		return "", err
+	}
+
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("no envoy-ratelimit pod found")
+	}
+
+	fwd, err := kubernetes.NewLocalPortForwarder(cli, types.NamespacedName{
+		Namespace: "envoy-gateway-system",
+		Name:      pods.Items[0].Name,
+	}, 0, rateLimitDebugPort)
+	if err != nil {
+		return "", err
+	}
+	if err := fwd.Start(); err != nil {
+		return "", err
+	}
+	defer fwd.Stop()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("http://%s/rlconfig", fwd.Address()), nil)
+	if err != nil {
+		return "", err
+	}
+
+	httpClient := &http.Client{
+		Timeout: 3 * time.Second,
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// WaitForRateLimitDomainToBeLoaded polls the envoy-ratelimit service's /rlconfig debug endpoint
+// until it reports a loaded config for the given rate limit domain, failing the test if it
+// doesn't appear within the suite's MaxTimeToConsistency. This closes a race that
+// BackendTrafficPolicyMustBeAccepted alone cannot: the k8s Accepted status only means EG's
+// controller finished translating the policy, not that the ratelimit service - a separate
+// component, updated via its own xDS push from EG (see internal/globalratelimit/runner) - has
+// received and applied the descriptor config for this domain yet. Sending test traffic before
+// that happens can look like "rate limiting isn't working" (an unmatched domain is unlimited,
+// not rejected).
+//
+// domain must match EG's internal rate limit domain naming convention exactly - see
+// RateLimitListenerDomain and RateLimitSharedDomain, which build it correctly. That's an internal
+// implementation detail, not a stable public API, so this helper may need updating if that naming
+// convention ever changes.
+func WaitForRateLimitDomainToBeLoaded(t *testing.T, suite *suite.ConformanceTestSuite, domain string) {
+	t.Helper()
+	WaitForRateLimitDomainsToBeLoaded(t, suite, domain)
+}
+
+// WaitForRateLimitDomainsToBeLoaded is like WaitForRateLimitDomainToBeLoaded, but waits for all
+// of the given rate limit domains to be loaded, using a single poll loop. Use this when a test
+// exercises more than one domain (e.g. multiple listeners, or a mix of shared and non-shared
+// rules) so that traffic doesn't start until every domain it depends on is ready.
+func WaitForRateLimitDomainsToBeLoaded(t *testing.T, suite *suite.ConformanceTestSuite, domains ...string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		cfg, err := DumpRateLimitConfig(t, suite)
+		if err != nil {
+			tlog.Logf(t, "failed to fetch envoy-ratelimit config, retrying: %v", err)
+			return false
+		}
+		tlog.Logf(t, "dump rate limit config: %s", cfg)
+		// Dump() emits one line per configured descriptor limit, keyed as "<domain>.<descriptor
+		// path>: ...", so this substring is present only once the ratelimit service has actually
+		// loaded a limit for this domain.
+		for _, domain := range domains {
+			if !strings.Contains(cfg, domain) {
+				return false
+			}
+		}
+		return true
+	}, suite.TimeoutConfig.MaxTimeToConsistency, time.Second, "envoy-ratelimit service never loaded config for domains %v", domains)
+}
+
+// RateLimitListenerDomain returns the rate limit domain name EG assigns to a non-shared
+// (rule's "shared" field false or unset) global rate limit rule that applies to the given
+// listener - see irListenerName in internal/gatewayapi/helpers.go. This is the domain used
+// whether the policy directly targets that Gateway or targets an HTTPRoute attached to it, since
+// non-shared rules are always keyed by listener rather than by policy.
+func RateLimitListenerDomain(gwNN types.NamespacedName, listenerName string) string {
+	return fmt.Sprintf("%s/%s/%s.", gwNN.Namespace, gwNN.Name, listenerName)
+}
+
+// RateLimitSharedDomain returns the rate limit domain name EG assigns to a "shared: true" global
+// rate limit rule defined by the given BackendTrafficPolicy - see stripRuleIndexSuffix in
+// internal/xds/translator/ratelimit.go. Unlike non-shared rules, all shared rules on the same
+// policy collapse onto this one domain regardless of which listener(s) or route(s) they end up
+// applying to.
+func RateLimitSharedDomain(policyNN types.NamespacedName) string {
+	return fmt.Sprintf("%s/%s.", policyNN.Namespace, policyNN.Name)
 }
 
 func buildLokiQuery(keyValues map[string]string, match string) string {

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -824,6 +824,14 @@ func getOverLimitCount(cli kubernetes.CLIClient, pod *corev1.Pod) (int, error) {
 // /rlconfig endpoint used to dump the currently loaded rate limit config.
 const rateLimitDebugPort = 6070
 
+// rateLimitDebugAttemptTimeout bounds each attempt inside WaitForRateLimitDomainsToBeLoaded's
+// require.Eventually poll loop - both starting the port-forward and issuing the HTTP request -
+// so a single stuck attempt (the port-forward's Kubernetes upgrade/dial wedges, or the pod
+// stops responding) fails fast and lets Eventually retry, rather than hanging the whole call
+// (and therefore the test) until the suite-level timeout eventually kills it with a much less
+// useful error.
+const rateLimitDebugAttemptTimeout = 3 * time.Second
+
 // dumpRateLimitConfigForPod fetches the config currently loaded by one envoy-ratelimit pod via
 // its /rlconfig debug endpoint - the same one used by `egctl config envoy-ratelimit`. Callers
 // need one replica's config, not "the" config: WaitForRateLimitDomainsToBeLoaded calls this once
@@ -842,7 +850,13 @@ func dumpRateLimitConfigForPod(t *testing.T, suite *suite.ConformanceTestSuite, 
 	if err != nil {
 		return "", err
 	}
-	if err := fwd.Start(); err != nil {
+
+	// Bound port-forward startup by the same per-attempt timeout as the HTTP request below -
+	// see rateLimitDebugAttemptTimeout. Without this, a wedged Kubernetes upgrade/dial inside
+	// fwd.Start() could block this call indefinitely regardless of the HTTP client's timeout.
+	startCtx, cancel := context.WithTimeout(t.Context(), rateLimitDebugAttemptTimeout)
+	defer cancel()
+	if err := fwd.StartWithContext(startCtx); err != nil {
 		return "", err
 	}
 	defer fwd.Stop()
@@ -852,13 +866,10 @@ func dumpRateLimitConfigForPod(t *testing.T, suite *suite.ConformanceTestSuite, 
 		return "", err
 	}
 
-	// Use a bounded client instead of http.DefaultClient (no timeout). This request runs
-	// inside WaitForRateLimitDomainsToBeLoaded's require.Eventually poll loop, so a single
-	// stuck attempt - e.g. the port-forward wedges, or the pod stops responding - must fail
-	// fast and let Eventually retry, rather than hanging the whole call (and therefore the
-	// test) until the suite-level timeout eventually kills it with a much less useful error.
+	// Use a bounded client instead of http.DefaultClient (no timeout); see
+	// rateLimitDebugAttemptTimeout for why this must be bounded.
 	httpClient := &http.Client{
-		Timeout: 3 * time.Second,
+		Timeout: rateLimitDebugAttemptTimeout,
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -824,26 +824,20 @@ func getOverLimitCount(cli kubernetes.CLIClient, pod *corev1.Pod) (int, error) {
 // /rlconfig endpoint used to dump the currently loaded rate limit config.
 const rateLimitDebugPort = 6070
 
-// DumpRateLimitConfig fetches the config currently loaded by the envoy-ratelimit service via
-// its /rlconfig debug endpoint - the same one used by `egctl config envoy-ratelimit`.
-func DumpRateLimitConfig(t *testing.T, suite *suite.ConformanceTestSuite) (string, error) {
+// dumpRateLimitConfigForPod fetches the config currently loaded by one envoy-ratelimit pod via
+// its /rlconfig debug endpoint - the same one used by `egctl config envoy-ratelimit`. Callers
+// need one replica's config, not "the" config: WaitForRateLimitDomainsToBeLoaded calls this once
+// per pod and requires every one of them to have loaded a domain before treating it as ready,
+// since checking just one arbitrary replica is exactly the race that helper exists to close.
+func dumpRateLimitConfigForPod(t *testing.T, suite *suite.ConformanceTestSuite, podName string) (string, error) {
 	cli, err := kubernetes.NewForRestConfig(suite.RestConfig)
 	if err != nil {
 		return "", err
 	}
 
-	pods, err := cli.PodsForSelector("envoy-gateway-system", "app.kubernetes.io/name=envoy-ratelimit")
-	if err != nil {
-		return "", err
-	}
-
-	if len(pods.Items) == 0 {
-		return "", fmt.Errorf("no envoy-ratelimit pod found")
-	}
-
 	fwd, err := kubernetes.NewLocalPortForwarder(cli, types.NamespacedName{
 		Namespace: "envoy-gateway-system",
-		Name:      pods.Items[0].Name,
+		Name:      podName,
 	}, 0, rateLimitDebugPort)
 	if err != nil {
 		return "", err
@@ -858,6 +852,11 @@ func DumpRateLimitConfig(t *testing.T, suite *suite.ConformanceTestSuite) (strin
 		return "", err
 	}
 
+	// Use a bounded client instead of http.DefaultClient (no timeout). This request runs
+	// inside WaitForRateLimitDomainsToBeLoaded's require.Eventually poll loop, so a single
+	// stuck attempt - e.g. the port-forward wedges, or the pod stops responding - must fail
+	// fast and let Eventually retry, rather than hanging the whole call (and therefore the
+	// test) until the suite-level timeout eventually kills it with a much less useful error.
 	httpClient := &http.Client{
 		Timeout: 3 * time.Second,
 	}
@@ -901,23 +900,43 @@ func WaitForRateLimitDomainToBeLoaded(t *testing.T, suite *suite.ConformanceTest
 func WaitForRateLimitDomainsToBeLoaded(t *testing.T, suite *suite.ConformanceTestSuite, domains ...string) {
 	t.Helper()
 
+	cli, err := kubernetes.NewForRestConfig(suite.RestConfig)
+	require.NoErrorf(t, err, "failed to build client for envoy-ratelimit pod discovery")
+
 	require.Eventually(t, func() bool {
-		cfg, err := DumpRateLimitConfig(t, suite)
-		if err != nil {
-			tlog.Logf(t, "failed to fetch envoy-ratelimit config, retrying: %v", err)
+		pods, err := cli.PodsForSelector("envoy-gateway-system", "app.kubernetes.io/name=envoy-ratelimit")
+		if err != nil || len(pods.Items) == 0 {
+			tlog.Logf(t, "failed to list envoy-ratelimit pods, retrying: %v", err)
 			return false
 		}
-		tlog.Logf(t, "dump rate limit config: %s", cfg)
-		// Dump() emits one line per configured descriptor limit, keyed as "<domain>.<descriptor
-		// path>: ...", so this substring is present only once the ratelimit service has actually
-		// loaded a limit for this domain.
-		for _, domain := range domains {
-			if !strings.Contains(cfg, domain) {
+
+		// Every replica gets the xDS push independently (see internal/globalratelimit/runner), so
+		// a domain isn't actually ready until *every* replica has loaded it, not just whichever pod
+		// happens to be checked (previously always pods.Items[0]). Otherwise Envoy can send the
+		// next rate-limit RPC to a replica that hasn't caught up yet, which fails open (an
+		// unmatched domain is treated as unlimited) - reintroducing the same "expected 429, got
+		// 200" race this helper exists to close. This matters most for profiles like
+		// gateway-namespace-mode that run more than one ratelimit replica - see
+		// rateLimitDeployment.replicas in test/config/envoy-gateaway-config/gateway-namespace-mode.yaml.
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			cfg, err := dumpRateLimitConfigForPod(t, suite, pod.Name)
+			if err != nil {
+				tlog.Logf(t, "failed to fetch envoy-ratelimit config from pod %s, retrying: %v", pod.Name, err)
 				return false
+			}
+			tlog.Logf(t, "dump rate limit config from pod %s: %s", pod.Name, cfg)
+			// Dump() emits one line per configured descriptor limit, keyed as "<domain>.<descriptor
+			// path>: ...", so this substring is present only once the ratelimit service has actually
+			// loaded a limit for this domain.
+			for _, domain := range domains {
+				if !strings.Contains(cfg, domain) {
+					return false
+				}
 			}
 		}
 		return true
-	}, suite.TimeoutConfig.MaxTimeToConsistency, time.Second, "envoy-ratelimit service never loaded config for domains %v", domains)
+	}, suite.TimeoutConfig.MaxTimeToConsistency, time.Second, "envoy-ratelimit service never loaded config for domains %v on every replica", domains)
 }
 
 // RateLimitListenerDomain returns the rate limit domain name EG assigns to a non-shared


### PR DESCRIPTION
Fixes: https://github.com/envoyproxy/gateway/issues/9994 https://github.com/envoyproxy/gateway/issues/9993 https://github.com/envoyproxy/gateway/issues/9992

## Problem
The rate-limit e2e suite failed intermittently in CI with assertions like "expected 429, got 200" or "expected N matching responses, got M" — not hard errors, just occasional wrong-looking traffic outcomes. Several independent races were compounding to cause this, so tests could fail differently from run to run.

## Root causes fixed
1. Ratelimit config-sync race. BackendTrafficPolicyMustBeAccepted only confirms EG's controller finished translating a policy — not that the separate envoy-ratelimit service has received and applied the descriptor config for that domain over its own xDS stream (internal/globalratelimit/runner). Sending traffic before that lands looks like "rate limiting isn't working" (unmatched domain = unlimited, not rejected).
1. Gateway pod-readiness race. The Gateway/Service being Accepted (and getting an address via MetalLB) happens almost instantly, well before the newly-provisioned Envoy Proxy pod behind it is actually Ready — first request(s) could race pod startup.
1. Envoy→ratelimit-service RPC timeout too tight for CI. rateLimit.timeout defaults to 20ms when unset (api/v1alpha1/envoygateway_types.go), tuned for a colocated, low-latency deployment. That call also covers the ratelimit service's own Redis round trip, which can exceed 20ms under CI load. Since failClosed defaults to false, a timed-out check fails open (request let through unlimited) instead of erroring — the flaky extra 200 where a 429 was expected.
1. Shared/collision-prone test fixtures. Several tests reused generic Gateway names (same-namespace, eg-rate-limit) and paths (/), so concurrent or back-to-back tests could race on the same Gateway object, listener domain, or rate-limit budget.
1. Single-replica assumption in metrics helper. OverLimitCount only ever port-forwarded to pods.Items[0], undercounting when gateway-namespace-mode.yaml runs the ratelimit deployment with 2 replicas.

## Changes
1. New polling helpers ([utils.go](vscode-webview://10n6b240u78vonhqpsnov6t6o0agu9too6sc0cjbdqamgsn77gun/test/e2e/tests/utils.go)):
WaitForGatewayPodsReady — waits for the Envoy Proxy pod(s) behind a given Gateway to reach Ready before sending traffic.
1. DumpRateLimitConfig — fetches the envoy-ratelimit service's /rlconfig debug endpoint (port 6070), the same one egctl config envoy-ratelimit uses.
WaitForRateLimitDomainToBeLoaded / WaitForRateLimitDomainsToBeLoaded — polls /rlconfig until the domain(s) a test depends on are actually loaded, with a bounded (3s) HTTP client per attempt so a single stuck call can't hang the whole retry loop.
1. RateLimitListenerDomain / RateLimitSharedDomain — build EG's internal rate-limit domain names correctly for non-shared (listener-keyed) vs. shared (policy-keyed) rules, so tests can wait on the exact right domain.
OverLimitCount now sums the metric across all envoy-ratelimit pods instead of just the first, via extracted getOverLimitCount.
1 `rateLimit.timeout: 1s` added to all five e2e EnvoyGateway configs (test/config/envoy-gateaway-config/*.yaml), replacing the 20ms default, with an inline comment explaining why.
1. Test isolation: nearly every rate-limit test (test/e2e/testdata/ratelimit-*.yaml) now gets its own uniquely-named Gateway and request path instead of sharing same-namespace/eg-rate-limit//, and every test now calls the new WaitForGatewayPodsReady / WaitForRateLimitDomain(s)ToBeLoaded helpers before firing traffic ([ratelimit.go](vscode-webview://10n6b240u78vonhqpsnov6t6o0agu9too6sc0cjbdqamgsn77gun/test/e2e/tests/ratelimit.go)).
1. Fail-fast-on-first-error assertions: swapped t.Errorf for tlog.Fatalf (→ t.Fatal) on request-count/response assertions, so a subtest stops immediately on the first wrong outcome instead of cascading into confusing secondary failures (e.g. querying Prometheus after the traffic assertion already failed).
1. Minor: three ConformanceTest vars renamed for naming consistency (...Test suffix dropped to match ShortName); suiteOpts.FailFast commented out in e2e_test.go (worth double-checking before merge — this was useful for surfacing every flaky test during debugging, but may want re-enabling for normal CI runs).