### PR TITLE
fix: flaky HTTPRouteMixedProtocols e2e test

### DIFF
--- a/test/e2e/tests/httproute_mixed_protocols.go
+++ b/test/e2e/tests/httproute_mixed_protocols.go
@@ -84,19 +84,8 @@ var HTTPRouteMixedProtocols = suite.ConformanceTest{
 			},
 		}
 
-		// A single matching response is enough, so the requests are not sent through
-		// MakeRequestAndExpectEventuallyConsistentResponse: that helper asks for
-		// TimeoutConfig.RequiredConsecutiveSuccesses (3) consecutive matches, and every
-		// mismatch resets the count. The /mixed-protocols rule has two backendRefs, which
-		// Envoy translates into weighted Clusters and picks between per request, so waiting
-		// for the same backend to answer three times in a row is waiting for a coin to land
-		// on the same side three times: it usually happens within the timeout, but not
-		// always, which is what made this test flaky. What is asserted here is only that the
-		// mixed HTTP and HTTPS backends are both reachable through the same rule, and one
-		// response from each proves that.
 		for _, res := range responses {
-			req := http.MakeRequest(t, &res, gwAddr, "HTTP", "http")
-			http.WaitForConsistentResponse(t, suite.RoundTripper, req, res, 1, suite.TimeoutConfig.MaxTimeToConsistency)
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, res)
 		}
 	},
 }

--- a/test/e2e/tests/utils.go
+++ b/test/e2e/tests/utils.go
@@ -80,7 +80,7 @@ func TimeoutConfig() config.TimeoutConfig {
 	// The default value of RequiredConsecutiveSuccesses is 3,
 	// which means a test needs to pass 3 times in a row to be considered successful.
 	// This's not necessary for E2E test.
-	timeout.RequiredConsecutiveSuccesses = 0
+	timeout.RequiredConsecutiveSuccesses = 1
 	return timeout
 }
 


### PR DESCRIPTION
revert: https://github.com/envoyproxy/gateway/pull/9680

fixed: https://github.com/envoyproxy/gateway/issues/9916

xref: https://github.com/kubernetes-sigs/gateway-api/pull/5066