### PR TITLE
Add deployment.minReadySeconds/progressDeadlineSeconds values field to gateway-helm chart

### DIFF
--- a/charts/gateway-helm/README.md
+++ b/charts/gateway-helm/README.md
@@ -130,6 +130,7 @@ helm uninstall eg -n envoy-gateway-system
 | deployment.envoyGateway.startupProbe.timeoutSeconds | int | `1` |  |
 | deployment.envoyGateway.strategy | object | `{}` | Volume source for the Wasm module cache mounted at /var/lib/eg/wasm. Defaults to an emptyDir when left empty. Example: persist the Wasm module cache across controller restarts by backing it with a PersistentVolumeClaim:   wasmCacheVolume:     persistentVolumeClaim:       claimName: envoy-gateway-wasm-cache |
 | deployment.envoyGateway.wasmCacheVolume | object | `{}` |  |
+| deployment.minReadySeconds | int | `0` | Minimum number of seconds a newly created Pod must be Ready, with no container crashing, before Kubernetes considers it available and proceeds to replace the next Pod during a rolling update. Zero (the Kubernetes default) means each new replica is eligible as soon as its readiness probe passes, so on a multi-replica deployment the whole rollout can replace every replica within seconds of each other. Raising this gives already-connected Envoy proxies (and anything else relying on this controller's xDS/SDS streams) a bake period to reconnect and resync against a stable subset of replicas before the next one is cycled, bounding how many proxies can be disrupted at once by a single controller rollout. |
 | deployment.pod.affinity | object | `{}` |  |
 | deployment.pod.annotations."prometheus.io/port" | string | `"19001"` |  |
 | deployment.pod.annotations."prometheus.io/scrape" | string | `"true"` |  |
@@ -157,6 +158,7 @@ helm uninstall eg -n envoy-gateway-system
 | deployment.ports[3].port | int | `19001` |  |
 | deployment.ports[3].targetPort | int | `19001` |  |
 | deployment.priorityClassName | string | `nil` |  |
+| deployment.progressDeadlineSeconds | int | `0` | Kubernetes' Deployment.spec.progressDeadlineSeconds, i.e. how long a rollout can run without making progress before it's marked failed. Kubernetes requires this to be strictly greater than minReadySeconds and defaults it to 600 when unset — so minReadySeconds values of 600 or more will make the Deployment fail to apply unless this is also raised to exceed it. Leave unset (the default here) to accept Kubernetes' own default of 600. |
 | deployment.replicas | int | `1` |  |
 | global.imagePullSecrets | list | `[]` | Global override for image pull secrets |
 | global.imageRegistry | string | `""` | Global override for image registry |

--- a/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
+++ b/charts/gateway-helm/templates/envoy-gateway-deployment.yaml
@@ -18,6 +18,12 @@ spec:
   strategy:
     {{- toYaml . | nindent 4 }}
 {{- end }}
+{{- with .Values.deployment.minReadySeconds }}
+  minReadySeconds: {{ . }}
+{{- end }}
+{{- with .Values.deployment.progressDeadlineSeconds }}
+  progressDeadlineSeconds: {{ . }}
+{{- end }}
   selector:
     matchLabels:
       control-plane: envoy-gateway

--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -126,6 +126,21 @@ deployment:
       targetPort: 19001
   priorityClassName: null
   replicas: 1
+  # -- Minimum number of seconds a newly created Pod must be Ready, with no container crashing,
+  # before Kubernetes considers it available and proceeds to replace the next Pod during a
+  # rolling update. Zero (the Kubernetes default) means each new replica is eligible as soon as
+  # its readiness probe passes, so on a multi-replica deployment the whole rollout can replace
+  # every replica within seconds of each other. Raising this gives already-connected Envoy
+  # proxies (and anything else relying on this controller's xDS/SDS streams) a bake period to
+  # reconnect and resync against a stable subset of replicas before the next one is cycled,
+  # bounding how many proxies can be disrupted at once by a single controller rollout.
+  minReadySeconds: 0
+  # -- Kubernetes' Deployment.spec.progressDeadlineSeconds, i.e. how long a rollout can run
+  # without making progress before it's marked failed. Kubernetes requires this to be strictly
+  # greater than minReadySeconds and defaults it to 600 when unset — so minReadySeconds values of
+  # 600 or more will make the Deployment fail to apply unless this is also raised to exceed it.
+  # Leave unset (the default here) to accept Kubernetes' own default of 600.
+  progressDeadlineSeconds: 0
   pod:
     affinity: {}
     annotations:

--- a/release-notes/current/new_features/9919-deployment-minreadyseconds.md
+++ b/release-notes/current/new_features/9919-deployment-minreadyseconds.md
@@ -1,0 +1,1 @@
+Added `deployment.minReadySeconds` and `deployment.progressDeadlineSeconds` values to the gateway-helm chart, letting the envoy-gateway controller's own rollout add a bake period between replica replacements instead of replacing all replicas within seconds of each other.

--- a/site/content/en/latest/install/gateway-helm-api.md
+++ b/site/content/en/latest/install/gateway-helm-api.md
@@ -69,6 +69,7 @@ The Helm chart for Envoy Gateway
 | deployment.envoyGateway.startupProbe.timeoutSeconds | int | `1` |  |
 | deployment.envoyGateway.strategy | object | `{}` | Volume source for the Wasm module cache mounted at /var/lib/eg/wasm. Defaults to an emptyDir when left empty. Example: persist the Wasm module cache across controller restarts by backing it with a PersistentVolumeClaim:   wasmCacheVolume:     persistentVolumeClaim:       claimName: envoy-gateway-wasm-cache |
 | deployment.envoyGateway.wasmCacheVolume | object | `{}` |  |
+| deployment.minReadySeconds | int | `0` | Minimum number of seconds a newly created Pod must be Ready, with no container crashing, before Kubernetes considers it available and proceeds to replace the next Pod during a rolling update. Zero (the Kubernetes default) means each new replica is eligible as soon as its readiness probe passes, so on a multi-replica deployment the whole rollout can replace every replica within seconds of each other. Raising this gives already-connected Envoy proxies (and anything else relying on this controller's xDS/SDS streams) a bake period to reconnect and resync against a stable subset of replicas before the next one is cycled, bounding how many proxies can be disrupted at once by a single controller rollout. |
 | deployment.pod.affinity | object | `{}` |  |
 | deployment.pod.annotations."prometheus.io/port" | string | `"19001"` |  |
 | deployment.pod.annotations."prometheus.io/scrape" | string | `"true"` |  |
@@ -96,6 +97,7 @@ The Helm chart for Envoy Gateway
 | deployment.ports[3].port | int | `19001` |  |
 | deployment.ports[3].targetPort | int | `19001` |  |
 | deployment.priorityClassName | string | `nil` |  |
+| deployment.progressDeadlineSeconds | int | `0` | Kubernetes' Deployment.spec.progressDeadlineSeconds, i.e. how long a rollout can run without making progress before it's marked failed. Kubernetes requires this to be strictly greater than minReadySeconds and defaults it to 600 when unset — so minReadySeconds values of 600 or more will make the Deployment fail to apply unless this is also raised to exceed it. Leave unset (the default here) to accept Kubernetes' own default of 600. |
 | deployment.replicas | int | `1` |  |
 | global.imagePullSecrets | list | `[]` | Global override for image pull secrets |
 | global.imageRegistry | string | `""` | Global override for image registry |


### PR DESCRIPTION
**What this does:** exposes the standard Kubernetes `Deployment.spec.minReadySeconds` field as a chart value (`deployment.minReadySeconds`, defaulting to `0`, matching the Kubernetes default — no behaviour change unless set).

**Why:** the chart already lets you tune `deployment.envoyGateway.strategy` (`maxSurge`/`maxUnavailable`), which controls how many replicas can be mid-rollout at once, but there's no way to add a bake period *between* replacement steps. On a rolling update with `maxUnavailable: 0, maxSurge: 1` (the effective default at low replica counts), each new pod is considered available the instant its readiness probe passes, and the controller immediately proceeds to replace the next replica. On a 3-replica deployment this means a full rollout can cycle every replica within seconds — fine for the controller's own availability, but it doesn't leave time for downstream consumers of its xDS/SDS streams (Envoy proxy pods maintaining long-lived gRPC subscriptions against this controller) to actually reconnect and resync before the next replica goes down too. We hit exactly this: a full-fleet restart within ~13 seconds forced effectively every connected proxy through a reconnect-and-resubscribe cycle inside one tight window, rather than spreading that load out one replica at a time.

`minReadySeconds` is the standard Kubernetes lever for this — a mandatory pause after a new pod becomes Ready before the rollout controller treats it as available and proceeds to the next replacement. It's already supported natively by `Deployment`; this chart just doesn't expose it as a value yet, so it can't be set without a post-render patch.

**Scope:** minimal — one new value, one new conditional block in the existing deployment template, following the same `{{- with ... }}` pattern already used for `strategy` immediately above it. No default behaviour change (`0` is the Kubernetes default).

**Testing:** rendered the chart locally with `deployment.minReadySeconds: 90` set and confirmed `spec.minReadySeconds: 90` appears on the rendered `Deployment`, with the field omitted entirely (as before) when left at the default `0`/unset. Regenerated `README.md`/`api.md` via `make helm-readme-gen.gateway-helm`.