### PR TITLE
chore: bump Go to 1.27.1

### DIFF
--- a/examples/backend-utilization/go.mod
+++ b/examples/backend-utilization/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-backend-utilization
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2

--- a/examples/dynamic-module-test/go.mod
+++ b/examples/dynamic-module-test/go.mod
@@ -1,5 +1,5 @@
 module github.com/envoyproxy/gateway/examples/dynamic-module-test
 
-go 1.27.0
+go 1.27.1
 
 require github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260305043144-94d5888d4c19

--- a/examples/envoy-ext-auth/go.mod
+++ b/examples/envoy-ext-auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-grcp-ext-auth
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.39.0

--- a/examples/extension-server/go.mod
+++ b/examples/extension-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/exampleorg/envoygateway-extension
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/envoyproxy/gateway v1.3.1

--- a/examples/grpc-ext-proc/go.mod
+++ b/examples/grpc-ext-proc/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-grpc-ext-proc
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.39.0

--- a/examples/preserve-case-backend/go.mod
+++ b/examples/preserve-case-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-preserve-case-backend
 
-go 1.27.0
+go 1.27.1
 
 require github.com/valyala/fasthttp v1.73.0
 

--- a/examples/preserve-case-backend/main.go
+++ b/examples/preserve-case-backend/main.go
@@ -27,7 +27,7 @@ func HandleFastHTTP(ctx *fasthttp.RequestCtx) {
 	if d, err := json.MarshalIndent(headers, "", "  "); err != nil {
 		ctx.Error(fmt.Sprintf("%s", err), fasthttp.StatusBadRequest)
 	} else {
-		fmt.Fprintf(ctx, string(d)+"\n")
+		fmt.Fprintf(ctx, "%s\n", d)
 	}
 }
 

--- a/examples/remote-infra/go.mod
+++ b/examples/remote-infra/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-remote-infra
 
-go 1.27.0
+go 1.27.1
 
 require (
 	google.golang.org/grpc v1.83.1

--- a/examples/sds-test-server/go.mod
+++ b/examples/sds-test-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-sds-test-server
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/envoyproxy/go-control-plane v0.14.1-0.20260409050421-3f47accd6e14

--- a/examples/simple-extension-server/go.mod
+++ b/examples/simple-extension-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway-simple-extension-server
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/envoyproxy/gateway v1.9.0

--- a/examples/static-file-server/go.mod
+++ b/examples/static-file-server/go.mod
@@ -1,3 +1,3 @@
 module github.com/envoyproxy/static-file-server
 
-go 1.27.0
+go 1.27.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway
 
-go 1.27.0
+go 1.27.1
 
 require (
 	cel.dev/expr v0.25.3

--- a/release-notes/current/security_updates/9920-go-1-27-1.md
+++ b/release-notes/current/security_updates/9920-go-1-27-1.md
@@ -1,0 +1,1 @@
+Bumped Go to 1.27.1, which includes the latest fixes from upstream Go.

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/docsy-example
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 // indirect

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/gateway/test
 
-go 1.27.0
+go 1.27.1
 
 replace github.com/envoyproxy/gateway => ../
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.27.0
+go 1.27.1
 
 tool (
 	github.com/bufbuild/buf/cmd/buf


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the Go directive from 1.27.0 to 1.27.1 across the main module, test/tools/site modules, and example modules.

It also fixes a Go 1.27 vet finding in the preserve-case backend example by using a constant `fmt.Fprintf` format string.

Note: Docker Hub does not currently publish `golang:1.27.1`, and `golang:1.27` still reports `go1.27.0`, so the pinned example Dockerfile builder images are intentionally left at `golang:1.27.0`.

**Which issue(s) this PR fixes**:

N/A

---

**PR Checklist**

- [ ] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.
- [x] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).
- [x] **API agreed first**: N/A: this PR does not contain API changes.
- [ ] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass.
- [x] **Tests added/updated**: N/A: this PR updates the Go toolchain version and fixes a vet finding.
- [x] **Docs**: N/A: this PR does not contain user-facing changes.
- [x] **Release notes**: Added a release-note fragment under `release-notes/current/security_updates/`.
- [ ] **Generated files committed**: `make gen-check` not run.
- [x] **Scope & compatibility**: The PR is reasonably scoped and preserves backward compatibility.
- [ ] **Codex review**: Requested a Codex review and addressed all of its comments.
- [ ] **Copilot review**: Requested a Copilot review and addressed all of its comments.

Local testing:

- `go test ./...`
- Secondary module loop: `go test ./...` in `test`, `tools`, and example modules; `site` has no Go packages to test
- `make go.mod.lint` was run; it completed tidy steps but exits non-zero because this branch intentionally changes `go.mod`
