### PR TITLE
test(e2e): give each MultipleGC test its own internet Gateway

### DIFF
--- a/test/e2e/testdata/httproute-status-multiple-gc.yaml
+++ b/test/e2e/testdata/httproute-status-multiple-gc.yaml
@@ -1,7 +1,11 @@
+# The Gateways below are named for this test alone. The suite deletes a test's
+# resources when it finishes, so a Gateway name shared with another test is deleted
+# and recreated back to back, and the recreated Gateway can end up without status.
+# xref https://github.com/envoyproxy/gateway/issues/8677
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: internet-gateway
+  name: internet-gateway-for-hr-status
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: internet
@@ -81,7 +85,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-  - name: internet-gateway
+  - name: internet-gateway-for-hr-status
     sectionName: http
   - name: private-gateway-for-hr-status
     sectionName: http

--- a/test/e2e/testdata/policy-status-multiple-gc.yaml
+++ b/test/e2e/testdata/policy-status-multiple-gc.yaml
@@ -1,7 +1,11 @@
+# The Gateways below are named for this test alone. The suite deletes a test's
+# resources when it finishes, so a Gateway name shared with another test is deleted
+# and recreated back to back, and the recreated Gateway can end up without status.
+# xref https://github.com/envoyproxy/gateway/issues/8677
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: internet-gateway
+  name: internet-gateway-for-pol-status
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: internet
@@ -37,7 +41,7 @@ spec:
   targetRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway
-    name: internet-gateway
+    name: internet-gateway-for-pol-status
     sectionName: http
   - group: gateway.networking.k8s.io
     kind: Gateway

--- a/test/e2e/tests/multiple_gc.go
+++ b/test/e2e/tests/multiple_gc.go
@@ -100,7 +100,7 @@ var HTTPRouteStatusAggregatesAcrossGatewayClassesTest = suite.ConformanceTest{
 		t.Run("httproute status aggregates across gateway classes", func(t *testing.T) {
 			ns := "gateway-conformance-infra"
 			routeNN := types.NamespacedName{Name: "multiple-gc-route", Namespace: ns}
-			internetGatewayNN := types.NamespacedName{Name: "internet-gateway", Namespace: ns}
+			internetGatewayNN := types.NamespacedName{Name: "internet-gateway-for-hr-status", Namespace: ns}
 			privateGatewayNN := types.NamespacedName{Name: "private-gateway-for-hr-status", Namespace: ns}
 
 			_, err := kubernetes.WaitForGatewayAddress(t, suite.Client, suite.TimeoutConfig, kubernetes.NewGatewayRef(internetGatewayNN))
@@ -131,7 +131,7 @@ var PolicyStatusAggregatesAcrossGatewayClassesTest = suite.ConformanceTest{
 		t.Run("backendtrafficpolicy status aggregates across gateway classes", func(t *testing.T) {
 			ns := "gateway-conformance-infra"
 			policyNN := types.NamespacedName{Name: "multiple-gc-btp", Namespace: ns}
-			internetGatewayNN := types.NamespacedName{Name: "internet-gateway", Namespace: ns}
+			internetGatewayNN := types.NamespacedName{Name: "internet-gateway-for-pol-status", Namespace: ns}
 			privateGatewayNN := types.NamespacedName{Name: "private-gateway-for-pol-status", Namespace: ns}
 
 			_, err := kubernetes.WaitForGatewayAddress(t, suite.Client, suite.TimeoutConfig, kubernetes.NewGatewayRef(internetGatewayNN))


### PR DESCRIPTION
All three Internet GC tests declare `internet-gateway`, and the conformance suite deletes a test's resources when it finishes, so the Gateway is deleted and recreated back to back between subtests. The recreated object can be left sitting at the CRD's default status (`Accepted`/`Programmed` Unknown, `observedGeneration: 0`), and the test then times out waiting for an address.

#8448 gave the private Gateways per-test names for the same reason; this does the same for the internet ones. The controller-side reason a recreated Gateway can lose its status write is a separate bug and will get its own fix.

xref #8677