### PR TITLE
test(e2e): give each access log test its own Gateway

### DIFF
--- a/test/e2e/testdata/accesslog-als.yaml
+++ b/test/e2e/testdata/accesslog-als.yaml
@@ -1,7 +1,10 @@
+# The Gateway is named for this test alone: a name shared with another test gets
+# deleted and recreated back to back as the suite moves on, and the recreated
+# Gateway can end up without status. xref https://github.com/envoyproxy/gateway/issues/8677
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: accesslog-gtw
+  name: accesslog-als-gtw
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
@@ -47,7 +50,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: accesslog-gtw
+    - name: accesslog-als-gtw
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/accesslog-otel-default.yaml
+++ b/test/e2e/testdata/accesslog-otel-default.yaml
@@ -1,7 +1,10 @@
+# The Gateway is named for this test alone: a name shared with another test gets
+# deleted and recreated back to back as the suite moves on, and the recreated
+# Gateway can end up without status. xref https://github.com/envoyproxy/gateway/issues/8677
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: accesslog-gtw
+  name: accesslog-otel-default-gtw
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: {GATEWAY_CLASS_NAME}
@@ -64,7 +67,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: accesslog-gtw
+    - name: accesslog-otel-default-gtw
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/accesslog-otel-json.yaml
+++ b/test/e2e/testdata/accesslog-otel-json.yaml
@@ -1,7 +1,10 @@
+# The Gateway is named for this test alone: a name shared with another test gets
+# deleted and recreated back to back as the suite moves on, and the recreated
+# Gateway can end up without status. xref https://github.com/envoyproxy/gateway/issues/8677
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: accesslog-gtw
+  name: accesslog-otel-json-gtw
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: {GATEWAY_CLASS_NAME}
@@ -68,7 +71,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: accesslog-gtw
+    - name: accesslog-otel-json-gtw
   rules:
     - matches:
         - path:

--- a/test/e2e/testdata/accesslog-otel.yaml
+++ b/test/e2e/testdata/accesslog-otel.yaml
@@ -1,7 +1,10 @@
+# The Gateway is named for this test alone: a name shared with another test gets
+# deleted and recreated back to back as the suite moves on, and the recreated
+# Gateway can end up without status. xref https://github.com/envoyproxy/gateway/issues/8677
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: accesslog-gtw
+  name: accesslog-otel-gtw
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
@@ -54,7 +57,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: accesslog-gtw
+    - name: accesslog-otel-gtw
   rules:
     - matches:
         - path:

--- a/test/e2e/tests/accesslog.go
+++ b/test/e2e/tests/accesslog.go
@@ -138,7 +138,7 @@ var OpenTelemetryTestText = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		labels := getOTELLabels(ns)
 		routeNN := types.NamespacedName{Name: "accesslog-otel", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "accesslog-gtw", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "accesslog-otel-gtw", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
 
 		t.Run("Positive", func(t *testing.T) {
@@ -187,7 +187,7 @@ var OpenTelemetryTestJSONAsDefault = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		labels := getOTELLabels(ns)
 		routeNN := types.NamespacedName{Name: "accesslog-otel", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "accesslog-gtw", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "accesslog-otel-default-gtw", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
 
 		t.Run("Positive", func(t *testing.T) {
@@ -236,7 +236,7 @@ var OpenTelemetryTestJSON = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		labels := getOTELLabels(ns)
 		routeNN := types.NamespacedName{Name: "accesslog-otel", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "accesslog-gtw", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "accesslog-otel-json-gtw", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
 
 		t.Run("Positive", func(t *testing.T) {
@@ -290,7 +290,7 @@ var ALSTest = suite.ConformanceTest{
 		t.Run("HTTP", func(t *testing.T) {
 			ns := "gateway-conformance-infra"
 			routeNN := types.NamespacedName{Name: "accesslog-als", Namespace: ns}
-			gwNN := types.NamespacedName{Name: "accesslog-gtw", Namespace: ns}
+			gwNN := types.NamespacedName{Name: "accesslog-als-gtw", Namespace: ns}
 			gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
 
 			expectedResponse := httputils.ExpectedResponse{


### PR DESCRIPTION
Four access log manifests declare `accesslog-gtw` with the same spec, and the conformance suite deletes a test's resources when it finishes, so the Gateway is deleted and recreated back to back as the suite moves from one test to the next. The recreated object can be left sitting at the CRD's default status (`Accepted`/`Programmed` Unknown, `observedGeneration: 0`), and the test then times out waiting for an address.

Seen on `OpenTelemetryAccessLogJSON`, which recreates the Gateway `OpenTelemetryTextAccessLog` had just deleted. Same shape as #9921. The controller-side reason a recreated Gateway can lose its status write is a separate bug and will get its own fix.

xref #8677