### PR TITLE
fix(e2e flakiness) : write status to an object that was deleted and recreated

### DIFF
--- a/internal/gatewayapi/runner/runner.go
+++ b/internal/gatewayapi/runner/runner.go
@@ -72,17 +72,28 @@ type Runner struct {
 	done sync.WaitGroup
 }
 
+// uid is the identity of the object the status was computed from; see storeStatus.
 type aggregatedPolicyStatus struct {
 	status     *gwapiv1.PolicyStatus
 	generation int64
+	uid        types.UID
 }
 
 type aggregatedRouteStatus struct {
 	status     *gwapiv1.RouteStatus
 	generation int64
+	uid        types.UID
 }
 
-func mergeAggregatedRouteStatus(aggregated aggregatedRouteStatus, incoming *gwapiv1.RouteStatus, generation int64) aggregatedRouteStatus {
+type aggregatedEnvoyProxyStatus struct {
+	status *egv1a1.EnvoyProxyStatus
+	uid    types.UID
+}
+
+func mergeAggregatedRouteStatus(aggregated aggregatedRouteStatus, incoming *gwapiv1.RouteStatus, generation int64, uid types.UID) aggregatedRouteStatus {
+	// The same object is merged once per GatewayClass, so its identity is invariant
+	// across merges and is recorded before any early return.
+	aggregated.uid = uid
 	if incoming == nil {
 		return aggregated
 	}
@@ -101,7 +112,8 @@ func mergeAggregatedRouteStatus(aggregated aggregatedRouteStatus, incoming *gwap
 	return aggregated
 }
 
-func mergePolicyStatus(aggregated aggregatedPolicyStatus, incoming *gwapiv1.PolicyStatus, generation int64) aggregatedPolicyStatus {
+func mergePolicyStatus(aggregated aggregatedPolicyStatus, incoming *gwapiv1.PolicyStatus, generation int64, uid types.UID) aggregatedPolicyStatus {
+	aggregated.uid = uid
 	if incoming == nil {
 		return aggregated
 	}
@@ -272,7 +284,7 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 				SecurityPolicies        map[types.NamespacedName]aggregatedPolicyStatus
 				EnvoyExtensionPolicies  map[types.NamespacedName]aggregatedPolicyStatus
 				ExtensionServerPolicies map[message.NamespacedNameAndGVK]aggregatedPolicyStatus
-				EnvoyProxies            map[types.NamespacedName]*egv1a1.EnvoyProxyStatus
+				EnvoyProxies            map[types.NamespacedName]aggregatedEnvoyProxyStatus
 			}{
 				HTTPRoutes:              make(map[types.NamespacedName]aggregatedRouteStatus),
 				GRPCRoutes:              make(map[types.NamespacedName]aggregatedRouteStatus),
@@ -285,7 +297,7 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 				SecurityPolicies:        make(map[types.NamespacedName]aggregatedPolicyStatus),
 				EnvoyExtensionPolicies:  make(map[types.NamespacedName]aggregatedPolicyStatus),
 				ExtensionServerPolicies: make(map[message.NamespacedNameAndGVK]aggregatedPolicyStatus),
-				EnvoyProxies:            make(map[types.NamespacedName]*egv1a1.EnvoyProxyStatus),
+				EnvoyProxies:            make(map[types.NamespacedName]aggregatedEnvoyProxyStatus),
 			}
 
 			span.AddEvent("translate", trace.WithAttributes(attribute.Int("resources.count", len(*val))))
@@ -411,28 +423,25 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 				// Resources which can only belong to 1 GatewayClass (at most) get their statuses stored right away.
 				for _, gateway := range result.Gateways {
 					key := utils.NamespacedName(gateway)
-					r.ProviderResources.GatewayStatuses.Store(key, &gateway.Status)
+					storeStatus(&r.ProviderResources.GatewayStatuses, r.keyCache.GatewayStatus, key, gateway.UID, &gateway.Status)
 					gatewayStatusCount++
 					delete(keysToDelete.GatewayStatus, key)
-					r.keyCache.GatewayStatus[key] = true
 				}
 				for _, listenerSet := range result.ListenerSets {
 					key := utils.NamespacedName(listenerSet)
-					r.ProviderResources.ListenerSetStatuses.Store(key, &listenerSet.Status)
+					storeStatus(&r.ProviderResources.ListenerSetStatuses, r.keyCache.ListenerSetStatus, key, listenerSet.UID, &listenerSet.Status)
 					listenerSetStatusCount++
 					delete(keysToDelete.ListenerSetStatus, key)
-					r.keyCache.ListenerSetStatus[key] = true
 				}
 
 				// Backend statuses have no parents, so they are not aggregated.
 				for _, backend := range result.Backends {
 					key := utils.NamespacedName(backend)
 					if len(backend.Status.Conditions) > 0 {
-						r.ProviderResources.BackendStatuses.Store(key, &backend.Status)
+						storeStatus(&r.ProviderResources.BackendStatuses, r.keyCache.BackendStatus, key, backend.UID, &backend.Status)
 						backendStatusCount++
 					}
 					delete(keysToDelete.BackendStatus, key)
-					r.keyCache.BackendStatus[key] = true
 				}
 
 				// Resources which can belong to multiple GatewayClasses get their statuses aggregated,
@@ -440,61 +449,61 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 				for _, httpRoute := range result.HTTPRoutes {
 					if len(httpRoute.Status.Parents) != 0 {
 						key := utils.NamespacedName(httpRoute)
-						aggregatedStatuses.HTTPRoutes[key] = mergeAggregatedRouteStatus(aggregatedStatuses.HTTPRoutes[key], &httpRoute.Status.RouteStatus, httpRoute.Generation)
+						aggregatedStatuses.HTTPRoutes[key] = mergeAggregatedRouteStatus(aggregatedStatuses.HTTPRoutes[key], &httpRoute.Status.RouteStatus, httpRoute.Generation, httpRoute.UID)
 					}
 				}
 				for _, grpcRoute := range result.GRPCRoutes {
 					if len(grpcRoute.Status.Parents) != 0 {
 						key := utils.NamespacedName(grpcRoute)
-						aggregatedStatuses.GRPCRoutes[key] = mergeAggregatedRouteStatus(aggregatedStatuses.GRPCRoutes[key], &grpcRoute.Status.RouteStatus, grpcRoute.Generation)
+						aggregatedStatuses.GRPCRoutes[key] = mergeAggregatedRouteStatus(aggregatedStatuses.GRPCRoutes[key], &grpcRoute.Status.RouteStatus, grpcRoute.Generation, grpcRoute.UID)
 					}
 				}
 				for _, tlsRoute := range result.TLSRoutes {
 					if len(tlsRoute.Status.Parents) != 0 {
 						key := utils.NamespacedName(tlsRoute)
-						aggregatedStatuses.TLSRoutes[key] = mergeAggregatedRouteStatus(aggregatedStatuses.TLSRoutes[key], &tlsRoute.Status.RouteStatus, tlsRoute.Generation)
+						aggregatedStatuses.TLSRoutes[key] = mergeAggregatedRouteStatus(aggregatedStatuses.TLSRoutes[key], &tlsRoute.Status.RouteStatus, tlsRoute.Generation, tlsRoute.UID)
 					}
 				}
 				for _, tcpRoute := range result.TCPRoutes {
 					if len(tcpRoute.Status.Parents) != 0 {
 						key := utils.NamespacedName(tcpRoute)
-						aggregatedStatuses.TCPRoutes[key] = mergeAggregatedRouteStatus(aggregatedStatuses.TCPRoutes[key], &tcpRoute.Status.RouteStatus, tcpRoute.Generation)
+						aggregatedStatuses.TCPRoutes[key] = mergeAggregatedRouteStatus(aggregatedStatuses.TCPRoutes[key], &tcpRoute.Status.RouteStatus, tcpRoute.Generation, tcpRoute.UID)
 					}
 				}
 				for _, udpRoute := range result.UDPRoutes {
 					if len(udpRoute.Status.Parents) != 0 {
 						key := utils.NamespacedName(udpRoute)
-						aggregatedStatuses.UDPRoutes[key] = mergeAggregatedRouteStatus(aggregatedStatuses.UDPRoutes[key], &udpRoute.Status.RouteStatus, udpRoute.Generation)
+						aggregatedStatuses.UDPRoutes[key] = mergeAggregatedRouteStatus(aggregatedStatuses.UDPRoutes[key], &udpRoute.Status.RouteStatus, udpRoute.Generation, udpRoute.UID)
 					}
 				}
 				for _, backendTLSPolicy := range result.BackendTLSPolicies {
 					if len(backendTLSPolicy.Status.Ancestors) != 0 {
 						key := utils.NamespacedName(backendTLSPolicy)
-						aggregatedStatuses.BackendTLSPolicies[key] = mergePolicyStatus(aggregatedStatuses.BackendTLSPolicies[key], &backendTLSPolicy.Status, backendTLSPolicy.Generation)
+						aggregatedStatuses.BackendTLSPolicies[key] = mergePolicyStatus(aggregatedStatuses.BackendTLSPolicies[key], &backendTLSPolicy.Status, backendTLSPolicy.Generation, backendTLSPolicy.UID)
 					}
 				}
 				for _, clientTrafficPolicy := range result.ClientTrafficPolicies {
 					if len(clientTrafficPolicy.Status.Ancestors) != 0 {
 						key := utils.NamespacedName(clientTrafficPolicy)
-						aggregatedStatuses.ClientTrafficPolicies[key] = mergePolicyStatus(aggregatedStatuses.ClientTrafficPolicies[key], &clientTrafficPolicy.Status, clientTrafficPolicy.Generation)
+						aggregatedStatuses.ClientTrafficPolicies[key] = mergePolicyStatus(aggregatedStatuses.ClientTrafficPolicies[key], &clientTrafficPolicy.Status, clientTrafficPolicy.Generation, clientTrafficPolicy.UID)
 					}
 				}
 				for _, backendTrafficPolicy := range result.BackendTrafficPolicies {
 					if len(backendTrafficPolicy.Status.Ancestors) != 0 {
 						key := utils.NamespacedName(backendTrafficPolicy)
-						aggregatedStatuses.BackendTrafficPolicies[key] = mergePolicyStatus(aggregatedStatuses.BackendTrafficPolicies[key], &backendTrafficPolicy.Status, backendTrafficPolicy.Generation)
+						aggregatedStatuses.BackendTrafficPolicies[key] = mergePolicyStatus(aggregatedStatuses.BackendTrafficPolicies[key], &backendTrafficPolicy.Status, backendTrafficPolicy.Generation, backendTrafficPolicy.UID)
 					}
 				}
 				for _, securityPolicy := range result.SecurityPolicies {
 					if len(securityPolicy.Status.Ancestors) != 0 {
 						key := utils.NamespacedName(securityPolicy)
-						aggregatedStatuses.SecurityPolicies[key] = mergePolicyStatus(aggregatedStatuses.SecurityPolicies[key], &securityPolicy.Status, securityPolicy.Generation)
+						aggregatedStatuses.SecurityPolicies[key] = mergePolicyStatus(aggregatedStatuses.SecurityPolicies[key], &securityPolicy.Status, securityPolicy.Generation, securityPolicy.UID)
 					}
 				}
 				for _, envoyExtensionPolicy := range result.EnvoyExtensionPolicies {
 					if len(envoyExtensionPolicy.Status.Ancestors) != 0 {
 						key := utils.NamespacedName(envoyExtensionPolicy)
-						aggregatedStatuses.EnvoyExtensionPolicies[key] = mergePolicyStatus(aggregatedStatuses.EnvoyExtensionPolicies[key], &envoyExtensionPolicy.Status, envoyExtensionPolicy.Generation)
+						aggregatedStatuses.EnvoyExtensionPolicies[key] = mergePolicyStatus(aggregatedStatuses.EnvoyExtensionPolicies[key], &envoyExtensionPolicy.Status, envoyExtensionPolicy.Generation, envoyExtensionPolicy.UID)
 					}
 				}
 				for _, extServerPolicy := range result.ExtensionServerPolicies {
@@ -504,17 +513,25 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 							NamespacedName:   utils.NamespacedName(&extServerPolicy),
 							GroupVersionKind: extServerPolicy.GroupVersionKind(),
 						}
-						aggregatedStatuses.ExtensionServerPolicies[key] = mergePolicyStatus(aggregatedStatuses.ExtensionServerPolicies[key], &policyStatus, extServerPolicy.GetGeneration())
+						aggregatedStatuses.ExtensionServerPolicies[key] = mergePolicyStatus(aggregatedStatuses.ExtensionServerPolicies[key], &policyStatus, extServerPolicy.GetGeneration(), extServerPolicy.GetUID())
 					}
 				}
 				// EnvoyProxy status
 				for _, ep := range result.EnvoyProxiesForGateways {
-					r.Logger.Info("update envoyproxy status", "key", utils.NamespacedName(ep))
-					aggregatedStatuses.EnvoyProxies[utils.NamespacedName(ep)] = mergeEnvoyProxyStatus(aggregatedStatuses.EnvoyProxies[utils.NamespacedName(ep)], &ep.Status)
+					key := utils.NamespacedName(ep)
+					r.Logger.Info("update envoyproxy status", "key", key)
+					aggregatedStatuses.EnvoyProxies[key] = aggregatedEnvoyProxyStatus{
+						status: mergeEnvoyProxyStatus(aggregatedStatuses.EnvoyProxies[key].status, &ep.Status),
+						uid:    ep.UID,
+					}
 				}
 				if ep := result.EnvoyProxyForGatewayClass; ep != nil {
-					r.Logger.Info("update envoyproxy status", "key", utils.NamespacedName(ep))
-					aggregatedStatuses.EnvoyProxies[utils.NamespacedName(ep)] = mergeEnvoyProxyStatus(aggregatedStatuses.EnvoyProxies[utils.NamespacedName(ep)], &ep.Status)
+					key := utils.NamespacedName(ep)
+					r.Logger.Info("update envoyproxy status", "key", key)
+					aggregatedStatuses.EnvoyProxies[key] = aggregatedEnvoyProxyStatus{
+						status: mergeEnvoyProxyStatus(aggregatedStatuses.EnvoyProxies[key].status, &ep.Status),
+						uid:    ep.UID,
+					}
 				}
 			}
 			for _, resources := range *val {
@@ -525,93 +542,81 @@ func (r *Runner) subscribeAndTranslate(sub <-chan watchable.Snapshot[string, *re
 			for key, entry := range aggregatedStatuses.HTTPRoutes {
 				status.TruncateRouteParents(entry.status, entry.generation)
 				s := gwapiv1.HTTPRouteStatus{RouteStatus: *entry.status}
-				r.ProviderResources.HTTPRouteStatuses.Store(key, &s)
+				storeStatus(&r.ProviderResources.HTTPRouteStatuses, r.keyCache.HTTPRouteStatus, key, entry.uid, &s)
 				httpRouteStatusCount++
 				delete(keysToDelete.HTTPRouteStatus, key)
-				r.keyCache.HTTPRouteStatus[key] = true
 			}
 			for key, entry := range aggregatedStatuses.GRPCRoutes {
 				status.TruncateRouteParents(entry.status, entry.generation)
 				s := gwapiv1.GRPCRouteStatus{RouteStatus: *entry.status}
-				r.ProviderResources.GRPCRouteStatuses.Store(key, &s)
+				storeStatus(&r.ProviderResources.GRPCRouteStatuses, r.keyCache.GRPCRouteStatus, key, entry.uid, &s)
 				grpcRouteStatusCount++
 				delete(keysToDelete.GRPCRouteStatus, key)
-				r.keyCache.GRPCRouteStatus[key] = true
 			}
 			for key, entry := range aggregatedStatuses.TLSRoutes {
 				status.TruncateRouteParents(entry.status, entry.generation)
 				s := gwapiv1.TLSRouteStatus{RouteStatus: *entry.status}
-				r.ProviderResources.TLSRouteStatuses.Store(key, &s)
+				storeStatus(&r.ProviderResources.TLSRouteStatuses, r.keyCache.TLSRouteStatus, key, entry.uid, &s)
 				tlsRouteStatusCount++
 				delete(keysToDelete.TLSRouteStatus, key)
-				r.keyCache.TLSRouteStatus[key] = true
 			}
 			for key, entry := range aggregatedStatuses.TCPRoutes {
 				status.TruncateRouteParents(entry.status, entry.generation)
 				s := gwapiv1.TCPRouteStatus{RouteStatus: *entry.status}
-				r.ProviderResources.TCPRouteStatuses.Store(key, &s)
+				storeStatus(&r.ProviderResources.TCPRouteStatuses, r.keyCache.TCPRouteStatus, key, entry.uid, &s)
 				tcpRouteStatusCount++
 				delete(keysToDelete.TCPRouteStatus, key)
-				r.keyCache.TCPRouteStatus[key] = true
 			}
 			for key, entry := range aggregatedStatuses.UDPRoutes {
 				status.TruncateRouteParents(entry.status, entry.generation)
 				s := gwapiv1.UDPRouteStatus{RouteStatus: *entry.status}
-				r.ProviderResources.UDPRouteStatuses.Store(key, &s)
+				storeStatus(&r.ProviderResources.UDPRouteStatuses, r.keyCache.UDPRouteStatus, key, entry.uid, &s)
 				udpRouteStatusCount++
 				delete(keysToDelete.UDPRouteStatus, key)
-				r.keyCache.UDPRouteStatus[key] = true
 			}
 			for key, entry := range aggregatedStatuses.BackendTLSPolicies {
 				status.TruncatePolicyAncestors(entry.status, r.EnvoyGateway.Gateway.ControllerName, entry.generation)
-				r.ProviderResources.BackendTLSPolicyStatuses.Store(key, entry.status)
+				storeStatus(&r.ProviderResources.BackendTLSPolicyStatuses, r.keyCache.BackendTLSPolicyStatus, key, entry.uid, entry.status)
 				backendTLSPolicyStatusCount++
 				delete(keysToDelete.BackendTLSPolicyStatus, key)
-				r.keyCache.BackendTLSPolicyStatus[key] = true
 			}
 			for key, entry := range aggregatedStatuses.ClientTrafficPolicies {
 				status.TruncatePolicyAncestors(entry.status, r.EnvoyGateway.Gateway.ControllerName, entry.generation)
-				r.ProviderResources.ClientTrafficPolicyStatuses.Store(key, entry.status)
+				storeStatus(&r.ProviderResources.ClientTrafficPolicyStatuses, r.keyCache.ClientTrafficPolicyStatus, key, entry.uid, entry.status)
 				clientTrafficPolicyStatusCount++
 				delete(keysToDelete.ClientTrafficPolicyStatus, key)
-				r.keyCache.ClientTrafficPolicyStatus[key] = true
 			}
 			for key, entry := range aggregatedStatuses.BackendTrafficPolicies {
 				status.TruncatePolicyAncestors(entry.status, r.EnvoyGateway.Gateway.ControllerName, entry.generation)
-				r.ProviderResources.BackendTrafficPolicyStatuses.Store(key, entry.status)
+				storeStatus(&r.ProviderResources.BackendTrafficPolicyStatuses, r.keyCache.BackendTrafficPolicyStatus, key, entry.uid, entry.status)
 				backendTrafficPolicyStatusCount++
 				delete(keysToDelete.BackendTrafficPolicyStatus, key)
-				r.keyCache.BackendTrafficPolicyStatus[key] = true
 			}
 			for key, entry := range aggregatedStatuses.SecurityPolicies {
 				status.TruncatePolicyAncestors(entry.status, r.EnvoyGateway.Gateway.ControllerName, entry.generation)
-				r.ProviderResources.SecurityPolicyStatuses.Store(key, entry.status)
+				storeStatus(&r.ProviderResources.SecurityPolicyStatuses, r.keyCache.SecurityPolicyStatus, key, entry.uid, entry.status)
 				securityPolicyStatusCount++
 				delete(keysToDelete.SecurityPolicyStatus, key)
-				r.keyCache.SecurityPolicyStatus[key] = true
 			}
 			for key, entry := range aggregatedStatuses.EnvoyExtensionPolicies {
 				status.TruncatePolicyAncestors(entry.status, r.EnvoyGateway.Gateway.ControllerName, entry.generation)
-				r.ProviderResources.EnvoyExtensionPolicyStatuses.Store(key, entry.status)
+				storeStatus(&r.ProviderResources.EnvoyExtensionPolicyStatuses, r.keyCache.EnvoyExtensionPolicyStatus, key, entry.uid, entry.status)
 				envoyExtensionPolicyStatusCount++
 				delete(keysToDelete.EnvoyExtensionPolicyStatus, key)
-				r.keyCache.EnvoyExtensionPolicyStatus[key] = true
 			}
 			for key, entry := range aggregatedStatuses.ExtensionServerPolicies {
 				status.TruncatePolicyAncestors(entry.status, r.EnvoyGateway.Gateway.ControllerName, entry.generation)
-				r.ProviderResources.ExtensionPolicyStatuses.Store(key, entry.status)
+				storeStatus(&r.ProviderResources.ExtensionPolicyStatuses, r.keyCache.ExtensionServerPolicyStatus, key, entry.uid, entry.status)
 				extensionServerPolicyStatusCount++
 				delete(keysToDelete.ExtensionServerPolicyStatus, key)
-				r.keyCache.ExtensionServerPolicyStatus[key] = true
 			}
 			for key, entry := range aggregatedStatuses.EnvoyProxies {
 				s := egv1a1.EnvoyProxyStatus{
-					Ancestors: entry.Ancestors,
+					Ancestors: entry.status.Ancestors,
 				}
-				r.ProviderResources.EnvoyProxyStatuses.Store(key, &s)
+				storeStatus(&r.ProviderResources.EnvoyProxyStatuses, r.keyCache.EnvoyProxyStatus, key, entry.uid, &s)
 				envoyproxyStatusCount++
 				delete(keysToDelete.EnvoyProxyStatus, key)
-				r.keyCache.EnvoyProxyStatus[key] = true
 			}
 			// Publish aggregated metrics
 			message.PublishMetric(message.Metadata{Runner: r.Name(), Message: message.InfraIRMessageName}, infraIRCount)
@@ -753,27 +758,31 @@ type KeyCache struct {
 	// IR keys
 	IR map[string]bool
 
-	// Status keys
-	GatewayStatus          map[types.NamespacedName]bool
-	ListenerSetStatus      map[types.NamespacedName]bool
-	HTTPRouteStatus        map[types.NamespacedName]bool
-	GRPCRouteStatus        map[types.NamespacedName]bool
-	TLSRouteStatus         map[types.NamespacedName]bool
-	TCPRouteStatus         map[types.NamespacedName]bool
-	UDPRouteStatus         map[types.NamespacedName]bool
-	BackendTLSPolicyStatus map[types.NamespacedName]bool
+	// Status keys, mapped to the UID of the object the published status was computed
+	// from. The UID lets storeStatus tell "nothing changed" apart from "the object
+	// behind this name was replaced"; see its doc comment.
+	GatewayStatus          map[types.NamespacedName]types.UID
+	ListenerSetStatus      map[types.NamespacedName]types.UID
+	HTTPRouteStatus        map[types.NamespacedName]types.UID
+	GRPCRouteStatus        map[types.NamespacedName]types.UID
+	TLSRouteStatus         map[types.NamespacedName]types.UID
+	TCPRouteStatus         map[types.NamespacedName]types.UID
+	UDPRouteStatus         map[types.NamespacedName]types.UID
+	BackendTLSPolicyStatus map[types.NamespacedName]types.UID
 
-	ClientTrafficPolicyStatus   map[types.NamespacedName]bool
-	BackendTrafficPolicyStatus  map[types.NamespacedName]bool
-	SecurityPolicyStatus        map[types.NamespacedName]bool
-	EnvoyExtensionPolicyStatus  map[types.NamespacedName]bool
-	ExtensionServerPolicyStatus map[message.NamespacedNameAndGVK]bool
-	EnvoyProxyStatus            map[types.NamespacedName]bool
+	ClientTrafficPolicyStatus   map[types.NamespacedName]types.UID
+	BackendTrafficPolicyStatus  map[types.NamespacedName]types.UID
+	SecurityPolicyStatus        map[types.NamespacedName]types.UID
+	EnvoyExtensionPolicyStatus  map[types.NamespacedName]types.UID
+	ExtensionServerPolicyStatus map[message.NamespacedNameAndGVK]types.UID
+	EnvoyProxyStatus            map[types.NamespacedName]types.UID
 
-	BackendStatus map[types.NamespacedName]bool
+	BackendStatus map[types.NamespacedName]types.UID
 }
 
-// copy creates a deep copy of the KeyCache for mark-and-sweep deletion
+// copy creates a deep copy of the KeyCache for mark-and-sweep deletion.
+// Only the keys are carried over: the copy is the sweep set, and deleteKeys reads
+// keys alone.
 func (kc *KeyCache) copy() *KeyCache {
 	copied := newKeyCache()
 
@@ -784,77 +793,105 @@ func (kc *KeyCache) copy() *KeyCache {
 
 	// Copy status keys
 	for key := range kc.GatewayStatus {
-		copied.GatewayStatus[key] = true
+		copied.GatewayStatus[key] = ""
 	}
 	for key := range kc.ListenerSetStatus {
-		copied.ListenerSetStatus[key] = true
+		copied.ListenerSetStatus[key] = ""
 	}
 	for key := range kc.HTTPRouteStatus {
-		copied.HTTPRouteStatus[key] = true
+		copied.HTTPRouteStatus[key] = ""
 	}
 	for key := range kc.GRPCRouteStatus {
-		copied.GRPCRouteStatus[key] = true
+		copied.GRPCRouteStatus[key] = ""
 	}
 	for key := range kc.TLSRouteStatus {
-		copied.TLSRouteStatus[key] = true
+		copied.TLSRouteStatus[key] = ""
 	}
 	for key := range kc.TCPRouteStatus {
-		copied.TCPRouteStatus[key] = true
+		copied.TCPRouteStatus[key] = ""
 	}
 	for key := range kc.UDPRouteStatus {
-		copied.UDPRouteStatus[key] = true
+		copied.UDPRouteStatus[key] = ""
 	}
 	for key := range kc.BackendTLSPolicyStatus {
-		copied.BackendTLSPolicyStatus[key] = true
+		copied.BackendTLSPolicyStatus[key] = ""
 	}
 	for key := range kc.ClientTrafficPolicyStatus {
-		copied.ClientTrafficPolicyStatus[key] = true
+		copied.ClientTrafficPolicyStatus[key] = ""
 	}
 	for key := range kc.BackendTrafficPolicyStatus {
-		copied.BackendTrafficPolicyStatus[key] = true
+		copied.BackendTrafficPolicyStatus[key] = ""
 	}
 	for key := range kc.SecurityPolicyStatus {
-		copied.SecurityPolicyStatus[key] = true
+		copied.SecurityPolicyStatus[key] = ""
 	}
 	for key := range kc.EnvoyExtensionPolicyStatus {
-		copied.EnvoyExtensionPolicyStatus[key] = true
+		copied.EnvoyExtensionPolicyStatus[key] = ""
 	}
 	for key := range kc.ExtensionServerPolicyStatus {
-		copied.ExtensionServerPolicyStatus[key] = true
+		copied.ExtensionServerPolicyStatus[key] = ""
 	}
 	for key := range kc.EnvoyProxyStatus {
-		copied.EnvoyProxyStatus[key] = true
+		copied.EnvoyProxyStatus[key] = ""
 	}
 	for key := range kc.BackendStatus {
-		copied.BackendStatus[key] = true
+		copied.BackendStatus[key] = ""
 	}
 
 	return copied
 }
 
+// storeStatus publishes status under key and remembers which object it came from.
+//
+// The translated status is a pure function of spec and generation, so an object that is
+// deleted and recreated under the same name produces an identical value, which the
+// watchable subscriber drops as unchanged. Deleting the key first lets the store reach
+// subscribers, so the recreated object does not keep the default status from its CRD.
+// See issue #9536.
+//
+// A key absent from seen was never published, not replaced. An empty uid, which the
+// file provider produces, matches itself, so replacement is not detected there.
+func storeStatus[K comparable, V any](
+	m *watchable.Map[K, V],
+	seen map[K]types.UID,
+	key K,
+	uid types.UID,
+	status V,
+) {
+	if prev, ok := seen[key]; ok && prev != uid {
+		m.Delete(key)
+	}
+	m.Store(key, status)
+	seen[key] = uid
+}
+
 func newKeyCache() *KeyCache {
 	return &KeyCache{
 		IR:                          make(map[string]bool),
-		GatewayStatus:               make(map[types.NamespacedName]bool),
-		ListenerSetStatus:           make(map[types.NamespacedName]bool),
-		HTTPRouteStatus:             make(map[types.NamespacedName]bool),
-		GRPCRouteStatus:             make(map[types.NamespacedName]bool),
-		TLSRouteStatus:              make(map[types.NamespacedName]bool),
-		TCPRouteStatus:              make(map[types.NamespacedName]bool),
-		UDPRouteStatus:              make(map[types.NamespacedName]bool),
-		BackendTLSPolicyStatus:      make(map[types.NamespacedName]bool),
-		ClientTrafficPolicyStatus:   make(map[types.NamespacedName]bool),
-		BackendTrafficPolicyStatus:  make(map[types.NamespacedName]bool),
-		SecurityPolicyStatus:        make(map[types.NamespacedName]bool),
-		EnvoyExtensionPolicyStatus:  make(map[types.NamespacedName]bool),
-		ExtensionServerPolicyStatus: make(map[message.NamespacedNameAndGVK]bool),
-		EnvoyProxyStatus:            make(map[types.NamespacedName]bool),
-		BackendStatus:               make(map[types.NamespacedName]bool),
+		GatewayStatus:               make(map[types.NamespacedName]types.UID),
+		ListenerSetStatus:           make(map[types.NamespacedName]types.UID),
+		HTTPRouteStatus:             make(map[types.NamespacedName]types.UID),
+		GRPCRouteStatus:             make(map[types.NamespacedName]types.UID),
+		TLSRouteStatus:              make(map[types.NamespacedName]types.UID),
+		TCPRouteStatus:              make(map[types.NamespacedName]types.UID),
+		UDPRouteStatus:              make(map[types.NamespacedName]types.UID),
+		BackendTLSPolicyStatus:      make(map[types.NamespacedName]types.UID),
+		ClientTrafficPolicyStatus:   make(map[types.NamespacedName]types.UID),
+		BackendTrafficPolicyStatus:  make(map[types.NamespacedName]types.UID),
+		SecurityPolicyStatus:        make(map[types.NamespacedName]types.UID),
+		EnvoyExtensionPolicyStatus:  make(map[types.NamespacedName]types.UID),
+		ExtensionServerPolicyStatus: make(map[message.NamespacedNameAndGVK]types.UID),
+		EnvoyProxyStatus:            make(map[types.NamespacedName]types.UID),
+		BackendStatus:               make(map[types.NamespacedName]types.UID),
 	}
 }
 
 // populateKeyCache initializes the keyCache with existing keys from watchable stores
 // This is needed for restart scenarios where stores may already contain data
+//
+// Status keys are seeded with an empty UID, meaning "identity unknown": the store holds
+// a status but this process has not seen the object it came from, so storeStatus treats
+// the next publish as a plain store rather than as a replacement.
 func (r *Runner) populateKeyCache() {
 	// Populate IR keys
 	for key := range r.InfraIR.LoadAll() {
@@ -863,49 +900,49 @@ func (r *Runner) populateKeyCache() {
 
 	// Populate status keys
 	for key := range r.ProviderResources.GatewayStatuses.LoadAll() {
-		r.keyCache.GatewayStatus[key] = true
+		r.keyCache.GatewayStatus[key] = ""
 	}
 	for key := range r.ProviderResources.ListenerSetStatuses.LoadAll() {
-		r.keyCache.ListenerSetStatus[key] = true
+		r.keyCache.ListenerSetStatus[key] = ""
 	}
 	for key := range r.ProviderResources.HTTPRouteStatuses.LoadAll() {
-		r.keyCache.HTTPRouteStatus[key] = true
+		r.keyCache.HTTPRouteStatus[key] = ""
 	}
 	for key := range r.ProviderResources.GRPCRouteStatuses.LoadAll() {
-		r.keyCache.GRPCRouteStatus[key] = true
+		r.keyCache.GRPCRouteStatus[key] = ""
 	}
 	for key := range r.ProviderResources.TLSRouteStatuses.LoadAll() {
-		r.keyCache.TLSRouteStatus[key] = true
+		r.keyCache.TLSRouteStatus[key] = ""
 	}
 	for key := range r.ProviderResources.TCPRouteStatuses.LoadAll() {
-		r.keyCache.TCPRouteStatus[key] = true
+		r.keyCache.TCPRouteStatus[key] = ""
 	}
 	for key := range r.ProviderResources.UDPRouteStatuses.LoadAll() {
-		r.keyCache.UDPRouteStatus[key] = true
+		r.keyCache.UDPRouteStatus[key] = ""
 	}
 	for key := range r.ProviderResources.BackendTLSPolicyStatuses.LoadAll() {
-		r.keyCache.BackendTLSPolicyStatus[key] = true
+		r.keyCache.BackendTLSPolicyStatus[key] = ""
 	}
 	for key := range r.ProviderResources.ClientTrafficPolicyStatuses.LoadAll() {
-		r.keyCache.ClientTrafficPolicyStatus[key] = true
+		r.keyCache.ClientTrafficPolicyStatus[key] = ""
 	}
 	for key := range r.ProviderResources.BackendTrafficPolicyStatuses.LoadAll() {
-		r.keyCache.BackendTrafficPolicyStatus[key] = true
+		r.keyCache.BackendTrafficPolicyStatus[key] = ""
 	}
 	for key := range r.ProviderResources.SecurityPolicyStatuses.LoadAll() {
-		r.keyCache.SecurityPolicyStatus[key] = true
+		r.keyCache.SecurityPolicyStatus[key] = ""
 	}
 	for key := range r.ProviderResources.EnvoyExtensionPolicyStatuses.LoadAll() {
-		r.keyCache.EnvoyExtensionPolicyStatus[key] = true
+		r.keyCache.EnvoyExtensionPolicyStatus[key] = ""
 	}
 	for key := range r.ProviderResources.ExtensionPolicyStatuses.LoadAll() {
-		r.keyCache.ExtensionServerPolicyStatus[key] = true
+		r.keyCache.ExtensionServerPolicyStatus[key] = ""
 	}
 	for key := range r.ProviderResources.EnvoyProxyStatuses.LoadAll() {
-		r.keyCache.EnvoyProxyStatus[key] = true
+		r.keyCache.EnvoyProxyStatus[key] = ""
 	}
 	for key := range r.ProviderResources.BackendStatuses.LoadAll() {
-		r.keyCache.BackendStatus[key] = true
+		r.keyCache.BackendStatus[key] = ""
 	}
 }
 

--- a/internal/gatewayapi/runner/runner_test.go
+++ b/internal/gatewayapi/runner/runner_test.go
@@ -154,12 +154,12 @@ func TestDeleteKeys(t *testing.T) {
 	// Create KeyCache with subset of keys to delete (selective deletion)
 	keysToDelete := newKeyCache()
 	keysToDelete.IR["test-ir-1"] = true // Delete only one IR key
-	keysToDelete.GatewayStatus[keys[0]] = true
-	keysToDelete.HTTPRouteStatus[keys[1]] = true
-	keysToDelete.TLSRouteStatus[keys[3]] = true
-	keysToDelete.UDPRouteStatus[keys[5]] = true // Delete only one UDP route
-	keysToDelete.BackendTLSPolicyStatus[keys[8]] = true
-	keysToDelete.SecurityPolicyStatus[keys[11]] = true
+	keysToDelete.GatewayStatus[keys[0]] = ""
+	keysToDelete.HTTPRouteStatus[keys[1]] = ""
+	keysToDelete.TLSRouteStatus[keys[3]] = ""
+	keysToDelete.UDPRouteStatus[keys[5]] = "" // Delete only one UDP route
+	keysToDelete.BackendTLSPolicyStatus[keys[8]] = ""
+	keysToDelete.SecurityPolicyStatus[keys[11]] = ""
 	// Leave some keys to verify selective deletion works
 
 	// Test selective deletion
@@ -184,19 +184,19 @@ func TestDeleteKeys(t *testing.T) {
 	// Verify keyCache was updated correctly
 	require.False(t, r.keyCache.IR["test-ir-1"])
 	require.True(t, r.keyCache.IR["test-ir-2"]) // Should remain
-	require.False(t, r.keyCache.GatewayStatus[keys[0]])
-	require.False(t, r.keyCache.HTTPRouteStatus[keys[1]])
-	require.True(t, r.keyCache.GRPCRouteStatus[keys[2]]) // Should remain
-	require.False(t, r.keyCache.TLSRouteStatus[keys[3]])
-	require.True(t, r.keyCache.TCPRouteStatus[keys[4]]) // Should remain
-	require.False(t, r.keyCache.UDPRouteStatus[keys[5]])
-	require.True(t, r.keyCache.UDPRouteStatus[keys[6]]) // Should remain
-	require.True(t, r.keyCache.BackendStatus[keys[7]])  // Should remain
-	require.False(t, r.keyCache.BackendTLSPolicyStatus[keys[8]])
-	require.True(t, r.keyCache.ClientTrafficPolicyStatus[keys[9]])   // Should remain
-	require.True(t, r.keyCache.BackendTrafficPolicyStatus[keys[10]]) // Should remain
-	require.False(t, r.keyCache.SecurityPolicyStatus[keys[11]])
-	require.True(t, r.keyCache.EnvoyExtensionPolicyStatus[keys[12]]) // Should remain
+	require.NotContains(t, r.keyCache.GatewayStatus, keys[0])
+	require.NotContains(t, r.keyCache.HTTPRouteStatus, keys[1])
+	require.Contains(t, r.keyCache.GRPCRouteStatus, keys[2]) // Should remain
+	require.NotContains(t, r.keyCache.TLSRouteStatus, keys[3])
+	require.Contains(t, r.keyCache.TCPRouteStatus, keys[4]) // Should remain
+	require.NotContains(t, r.keyCache.UDPRouteStatus, keys[5])
+	require.Contains(t, r.keyCache.UDPRouteStatus, keys[6]) // Should remain
+	require.Contains(t, r.keyCache.BackendStatus, keys[7])  // Should remain
+	require.NotContains(t, r.keyCache.BackendTLSPolicyStatus, keys[8])
+	require.Contains(t, r.keyCache.ClientTrafficPolicyStatus, keys[9])   // Should remain
+	require.Contains(t, r.keyCache.BackendTrafficPolicyStatus, keys[10]) // Should remain
+	require.NotContains(t, r.keyCache.SecurityPolicyStatus, keys[11])
+	require.Contains(t, r.keyCache.EnvoyExtensionPolicyStatus, keys[12]) // Should remain
 }
 
 func TestDeleteAllKeys(t *testing.T) {
@@ -254,7 +254,7 @@ func TestMergePolicyStatus(t *testing.T) {
 			generation: 2,
 		}
 
-		got := mergePolicyStatus(existing, nil, 10)
+		got := mergePolicyStatus(existing, nil, 10, "")
 		require.Equal(t, existing, got)
 	})
 
@@ -268,7 +268,7 @@ func TestMergePolicyStatus(t *testing.T) {
 			},
 		}
 
-		got := mergePolicyStatus(aggregatedPolicyStatus{}, incoming, 7)
+		got := mergePolicyStatus(aggregatedPolicyStatus{}, incoming, 7, "")
 		require.Same(t, incoming, got.status)
 		require.Equal(t, int64(7), got.generation)
 	})
@@ -291,15 +291,15 @@ func TestMergePolicyStatus(t *testing.T) {
 			},
 		}
 
-		entry := mergePolicyStatus(aggregatedPolicyStatus{}, first, 3)
-		entry = mergePolicyStatus(entry, second, 9)
+		entry := mergePolicyStatus(aggregatedPolicyStatus{}, first, 3, "")
+		entry = mergePolicyStatus(entry, second, 9, "")
 
 		require.Len(t, entry.status.Ancestors, 2)
 		require.Equal(t, gwapiv1.ObjectName("gw-a"), entry.status.Ancestors[0].AncestorRef.Name)
 		require.Equal(t, gwapiv1.ObjectName("gw-b"), entry.status.Ancestors[1].AncestorRef.Name)
 		require.Equal(t, int64(9), entry.generation)
 
-		entry = mergePolicyStatus(entry, &gwapiv1.PolicyStatus{}, 4)
+		entry = mergePolicyStatus(entry, &gwapiv1.PolicyStatus{}, 4, "")
 		require.Equal(t, int64(9), entry.generation)
 	})
 
@@ -314,9 +314,9 @@ func TestMergePolicyStatus(t *testing.T) {
 		}
 
 		// First merge - status becomes both aggregated and incoming
-		entry := mergePolicyStatus(aggregatedPolicyStatus{}, status, 1)
+		entry := mergePolicyStatus(aggregatedPolicyStatus{}, status, 1, "")
 		// Second merge with same status - should not duplicate
-		entry = mergePolicyStatus(entry, status, 2)
+		entry = mergePolicyStatus(entry, status, 2, "")
 
 		// Should still have only one ancestor, not duplicated
 		require.Len(t, entry.status.Ancestors, 1)
@@ -408,7 +408,7 @@ func TestMergeRouteStatus(t *testing.T) {
 			generation: 2,
 		}
 
-		got := mergeAggregatedRouteStatus(existing, nil, 10)
+		got := mergeAggregatedRouteStatus(existing, nil, 10, "")
 		require.Equal(t, existing, got)
 	})
 
@@ -422,7 +422,7 @@ func TestMergeRouteStatus(t *testing.T) {
 			},
 		}
 
-		got := mergeAggregatedRouteStatus(aggregatedRouteStatus{}, incoming, 7)
+		got := mergeAggregatedRouteStatus(aggregatedRouteStatus{}, incoming, 7, "")
 		require.Same(t, incoming, got.status)
 		require.Equal(t, int64(7), got.generation)
 	})
@@ -445,15 +445,15 @@ func TestMergeRouteStatus(t *testing.T) {
 			},
 		}
 
-		entry := mergeAggregatedRouteStatus(aggregatedRouteStatus{}, first, 3)
-		entry = mergeAggregatedRouteStatus(entry, second, 9)
+		entry := mergeAggregatedRouteStatus(aggregatedRouteStatus{}, first, 3, "")
+		entry = mergeAggregatedRouteStatus(entry, second, 9, "")
 
 		require.Len(t, entry.status.Parents, 2)
 		require.Equal(t, gwapiv1.ObjectName("gw-a"), entry.status.Parents[0].ParentRef.Name)
 		require.Equal(t, gwapiv1.ObjectName("gw-b"), entry.status.Parents[1].ParentRef.Name)
 		require.Equal(t, int64(9), entry.generation)
 
-		entry = mergeAggregatedRouteStatus(entry, &gwapiv1.RouteStatus{}, 4)
+		entry = mergeAggregatedRouteStatus(entry, &gwapiv1.RouteStatus{}, 4, "")
 		require.Equal(t, int64(9), entry.generation)
 	})
 }

--- a/internal/gatewayapi/runner/status_test.go
+++ b/internal/gatewayapi/runner/status_test.go
@@ -1,0 +1,174 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/logging"
+	"github.com/envoyproxy/gateway/internal/message"
+)
+
+// acceptedStatus is the shape a Gateway's status has after translation: conditions with
+// an observedGeneration but no transition timestamps, which the provider stamps later.
+// Two generations of the same Gateway name and spec produce exactly this value.
+func acceptedStatus() *gwapiv1.GatewayStatus {
+	return &gwapiv1.GatewayStatus{
+		Conditions: []metav1.Condition{{
+			Type:               string(gwapiv1.GatewayConditionAccepted),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(gwapiv1.GatewayReasonAccepted),
+			ObservedGeneration: 1,
+		}},
+	}
+}
+
+// statusSubscriber drains a status map's subscription into a channel.
+type statusSubscriber struct {
+	updates chan message.Update[types.NamespacedName, *gwapiv1.GatewayStatus]
+}
+
+func subscribeToGatewayStatuses(t *testing.T, pr *message.ProviderResources) *statusSubscriber {
+	t.Helper()
+
+	s := &statusSubscriber{
+		updates: make(chan message.Update[types.NamespacedName, *gwapiv1.GatewayStatus], 16),
+	}
+	sub := pr.GatewayStatuses.Subscribe(t.Context())
+	go message.HandleSubscription(
+		logging.NewLogger(t.Output(), egv1a1.DefaultEnvoyGatewayLogging()),
+		message.Metadata{Runner: "test", Message: message.GatewayStatusMessageName},
+		sub,
+		func(update message.Update[types.NamespacedName, *gwapiv1.GatewayStatus], _ chan error) {
+			s.updates <- update
+		},
+	)
+	return s
+}
+
+// awaitStore waits for a store update for key, skipping the delete that a forced
+// republish emits. A delete and the store that follows it may arrive as one coalesced
+// update or as two, depending on how the subscriber and the coalescer interleave, so
+// only the store is asserted on.
+func (s *statusSubscriber) awaitStore(t *testing.T, key types.NamespacedName) *gwapiv1.GatewayStatus {
+	t.Helper()
+
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case update := <-s.updates:
+			if update.Key != key || update.Delete {
+				continue
+			}
+			return update.Value
+		case <-deadline:
+			t.Fatalf("timed out waiting for a status update for %s", key)
+			return nil
+		}
+	}
+}
+
+// requireNoStore asserts that no store update for key arrives.
+func (s *statusSubscriber) requireNoStore(t *testing.T, key types.NamespacedName) {
+	t.Helper()
+
+	deadline := time.After(500 * time.Millisecond)
+	for {
+		select {
+		case update := <-s.updates:
+			if update.Key != key || update.Delete {
+				continue
+			}
+			t.Fatalf("expected no status update for %s, got %+v", key, update.Value)
+		case <-deadline:
+			return
+		}
+	}
+}
+
+// TestStoreStatusRepublishesWhenObjectIsReplaced covers a Gateway deleted and recreated
+// under the same name within one translation cycle. The translated status is identical,
+// so the subscriber-side coalescer drops the store as unchanged and the recreated object
+// is left with the default status its CRD gave it. See envoyproxy/gateway#9536.
+func TestStoreStatusRepublishesWhenObjectIsReplaced(t *testing.T) {
+	pr := new(message.ProviderResources)
+	sub := subscribeToGatewayStatuses(t, pr)
+	key := types.NamespacedName{Namespace: "default", Name: "eg"}
+	seen := map[types.NamespacedName]types.UID{}
+
+	// The Gateway is translated for the first time.
+	storeStatus(&pr.GatewayStatuses, seen, key, "uid-1", acceptedStatus())
+	require.Equal(t, acceptedStatus(), sub.awaitStore(t, key))
+
+	// The same Gateway is translated again, unchanged. Dedup must still apply, or every
+	// reconcile would cost a status write per object.
+	storeStatus(&pr.GatewayStatuses, seen, key, "uid-1", acceptedStatus())
+	sub.requireNoStore(t, key)
+
+	// The Gateway is replaced: same name, same spec, new object. The value is identical,
+	// so only the identity distinguishes this from the no-op above.
+	storeStatus(&pr.GatewayStatuses, seen, key, "uid-2", acceptedStatus())
+	require.Equal(t, acceptedStatus(), sub.awaitStore(t, key))
+	require.Equal(t, types.UID("uid-2"), seen[key])
+}
+
+// TestStoreStatusFirstPublishIsNotAReplacement guards the presence check: a key absent
+// from the cache has never been published, so it must not be treated as replaced. Without
+// the check every key would emit a pointless delete on the first translation cycle.
+func TestStoreStatusFirstPublishIsNotAReplacement(t *testing.T) {
+	pr := new(message.ProviderResources)
+	sub := subscribeToGatewayStatuses(t, pr)
+	key := types.NamespacedName{Namespace: "default", Name: "eg"}
+
+	storeStatus(&pr.GatewayStatuses, map[types.NamespacedName]types.UID{}, key, "uid-1", acceptedStatus())
+
+	require.Equal(t, acceptedStatus(), sub.awaitStore(t, key))
+	select {
+	case update := <-sub.updates:
+		require.Failf(t, "unexpected update", "expected only a store, got %+v", update)
+	default:
+	}
+}
+
+// TestStoreStatusWithoutUIDs covers the file provider, which builds objects with no UID.
+// Replacement cannot be detected there, so this stays a plain store.
+func TestStoreStatusWithoutUIDs(t *testing.T) {
+	pr := new(message.ProviderResources)
+	sub := subscribeToGatewayStatuses(t, pr)
+	key := types.NamespacedName{Namespace: "default", Name: "eg"}
+	seen := map[types.NamespacedName]types.UID{}
+
+	storeStatus(&pr.GatewayStatuses, seen, key, "", acceptedStatus())
+	require.Equal(t, acceptedStatus(), sub.awaitStore(t, key))
+
+	storeStatus(&pr.GatewayStatuses, seen, key, "", acceptedStatus())
+	sub.requireNoStore(t, key)
+}
+
+// TestMergeCarriesObjectIdentity guards the identity the aggregated stores feed to
+// storeStatus: a route or policy is merged once per GatewayClass, and the UID has to
+// survive every merge for a replacement to be detectable.
+func TestMergeCarriesObjectIdentity(t *testing.T) {
+	first := &gwapiv1.RouteStatus{Parents: []gwapiv1.RouteParentStatus{{ControllerName: "a"}}}
+	second := &gwapiv1.RouteStatus{Parents: []gwapiv1.RouteParentStatus{{ControllerName: "b"}}}
+
+	entry := mergeAggregatedRouteStatus(aggregatedRouteStatus{}, first, 1, "uid-1")
+	require.Equal(t, types.UID("uid-1"), entry.uid)
+
+	entry = mergeAggregatedRouteStatus(entry, second, 1, "uid-1")
+	require.Equal(t, types.UID("uid-1"), entry.uid)
+	require.Len(t, entry.status.Parents, 2)
+
+	// A nil incoming status returns early; the identity is still recorded.
+	require.Equal(t, types.UID("uid-2"), mergeAggregatedRouteStatus(entry, nil, 1, "uid-2").uid)
+}

--- a/release-notes/current/bug_fixes/9932-status-on-object-recreate.md
+++ b/release-notes/current/bug_fixes/9932-status-on-object-recreate.md
@@ -1,0 +1,1 @@
+Fixed a Gateway, xRoute, policy, Backend or EnvoyProxy being left with no status when it is deleted and recreated with the same name and an unchanged spec within a single reconcile, which previously left the recreated object stuck at the default status its CRD defines until the controller was restarted.


### PR DESCRIPTION
An object deleted and recreated under the same name, with an unchanged spec, can end up with no status written to it at all until the controller restarts. The provider discards status before publishing the resource tree, so the translator recomputes it purely from spec and generation, and the two generations produce a byte-identical value that `watchable`'s coalescer drops as unchanged. The runner only sweeps a status key when the object is absent from a translation result, so a delete and a recreate coalesced into one reconcile keep the key alive and nothing is ever published. Therefore, the newly created Gateway/Route with the same name of the old one won't get status updated.

This records the UID each published status was computed from, and deletes the key before storing when it no longer matches — the same delete-then-store `updateGatewayStatus` already uses to force a publish. Routes and policies are the most exposed, since their status encodes nothing about the spec.

This is the root cause of a lot of recent e2e test flakiness. For example, #9921 and #9922 stopped three e2e suites from provoking this; xref #9536 for the production report.