### PR TITLE
chore: bump to use Gateway API 1.6.2

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -34,8 +34,8 @@ require (
 	k8s.io/client-go v0.37.0
 	k8s.io/kubectl v0.37.0
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/gateway-api v1.6.2-0.20260830170607-35a901ee76da
-	sigs.k8s.io/gateway-api/conformance v1.6.2-0.20260830170607-35a901ee76da
+	sigs.k8s.io/gateway-api v1.6.2
+	sigs.k8s.io/gateway-api/conformance v1.6.2
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -832,10 +832,10 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.36.0 h1:/YpDJ4vReG7Zm
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.36.0/go.mod h1:tJo1aepTXyR+8Xs3sUsGBDk4Ub2AM5dPAPKJx0mpm5c=
 sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=
 sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
-sigs.k8s.io/gateway-api v1.6.2-0.20260830170607-35a901ee76da h1:+/4q6EskRZVt4it+yY20gs9y31t6EFRmlhEgf+fR3BI=
-sigs.k8s.io/gateway-api v1.6.2-0.20260830170607-35a901ee76da/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
-sigs.k8s.io/gateway-api/conformance v1.6.2-0.20260830170607-35a901ee76da h1:0yl6aJO+p0dNMCAcxc5BX+iuRMeBcT772oyNoD+KKxs=
-sigs.k8s.io/gateway-api/conformance v1.6.2-0.20260830170607-35a901ee76da/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
+sigs.k8s.io/gateway-api v1.6.2 h1:vh5YzKlbdBivEaLX61+APKLGRq4tZ7Fj4XfGkv08xB4=
+sigs.k8s.io/gateway-api v1.6.2/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
+sigs.k8s.io/gateway-api/conformance v1.6.2 h1:41gszNdu1oSZj/3k7AMxgFA5mTic/aNTsKaKTMaPYSk=
+sigs.k8s.io/gateway-api/conformance v1.6.2/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kubectl-validate v0.0.5-0.20250915070809-d2f2d68fba09 h1:JQbPOwLjSztom+aSDQIi6UZq8V0Gbv7BjAlYQSgycCI=

--- a/tools/make/kube.mk
+++ b/tools/make/kube.mk
@@ -39,7 +39,8 @@ E2E_TEST_ARGS ?= -v -tags e2e -timeout $(E2E_TIMEOUT)
 E2E_DEBUG ?= $(if $(filter true yes 1,$(ACTIONS_STEP_DEBUG)),true,false)
 E2E_DISABLE_PARALLEL ?= false
 # If you want to skip crds version check, add `--allow-crds-mismatch` to E2E_TEST_SUITE_ARGS
-E2E_TEST_SUITE_ARGS ?= --debug=$(E2E_DEBUG) --cleanup-test-resources=$(E2E_CLEANUP) --disable-parallel-tests=$(E2E_DISABLE_PARALLEL)
+# TODO: remove --allow-crds-mismatch once we bump the Gateway API version to v1.7.0 or later in the e2e tests.
+E2E_TEST_SUITE_ARGS ?= --debug=$(E2E_DEBUG) --cleanup-test-resources=$(E2E_CLEANUP) --disable-parallel-tests=$(E2E_DISABLE_PARALLEL) --allow-crds-mismatch
 
 # Define the Gateway API channel used in tests
 E2E_GATEWAY_API_CHANNEL ?= experimental


### PR DESCRIPTION
There's no API change, so we just bump for test.