### PR TITLE
fix(gatewayapi): isolate nested wildcard listeners on a shared port

### DIFF
--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -8,6 +8,7 @@ package gatewayapi
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"slices"
 	"sort"
@@ -371,16 +372,68 @@ func computeHosts(routeHostnames []string, listenerContext *ListenerContext) []s
 		if listener.hostnameConflictLoser {
 			continue
 		}
+		// A listener that lost a protocol conflict is never programmed, so it cannot own
+		// a hostname either. Letting it delete one would strip the route from the valid
+		// listener and leave it attached to nothing.
+		if listener.protocolConflicted {
+			continue
+		}
 		if listenerContext != nil && listenerContext.Port != listener.Port {
 			continue
 		}
 		if listener.Hostname == nil {
 			continue
 		}
-		hostnamesSet.Delete(string(*listener.Hostname))
+		siblingHostname := string(*listener.Hostname)
+
+		// A sibling listener owns a hostname when it matches that hostname at least as
+		// specifically as this listener does. Deleting the sibling's own hostname as a
+		// literal string only landed when the set happened to hold that same string, so
+		// a concrete route hostname under a nested wildcard sibling was never removed.
+		//
+		// Equal specificity means an identical hostname, where the winner is picked by
+		// the hostnameConflictLoser guard above: only the loser reaches this loop with
+		// the winner as its sibling, so the two can never delete each other's hosts.
+		for _, h := range hostnamesSet.UnsortedList() {
+			if hostnameMatches(siblingHostname, h) &&
+				hostnameSpecificity(siblingHostname) >= hostnameSpecificity(listenerHostnameVal) {
+				hostnamesSet.Delete(h)
+			}
+		}
 	}
 
 	return sets.List(hostnamesSet)
+}
+
+// hostnameMatches reports whether listenerHostname matches hostname, treating a
+// leading "*" in listenerHostname as a wildcard. Identical strings match:
+// wildcardHostnameMatchesHostname deliberately returns false when both sides are the
+// same wildcard, so that case is handled here rather than there.
+func hostnameMatches(listenerHostname, hostname string) bool {
+	if listenerHostname == hostname {
+		return true
+	}
+	if strings.HasPrefix(listenerHostname, "*") {
+		return wildcardHostnameMatchesHostname(listenerHostname, hostname)
+	}
+	return false
+}
+
+// hostnameSpecificity ranks how narrowly a listener hostname matches. An exact
+// hostname is more specific than any wildcard; between two wildcards the longer
+// suffix wins, so "*.dev.example.com" outranks "*.example.com"; and an empty
+// hostname, which matches everything, is less specific than either.
+func hostnameSpecificity(hostname string) int {
+	// An empty listener hostname matches every hostname, making it the least specific
+	// listener there is. It has no "*" prefix, so without this it would fall through
+	// to the exact-hostname branch and rank as the most specific instead.
+	if hostname == "" {
+		return -1
+	}
+	if !strings.HasPrefix(hostname, "*") {
+		return math.MaxInt
+	}
+	return len(strings.TrimPrefix(hostname, "*"))
 }
 
 // wildcardHostnameMatchesHostname returns true if wildcardHostname matches hostname.

--- a/internal/gatewayapi/helpers_test.go
+++ b/internal/gatewayapi/helpers_test.go
@@ -1844,3 +1844,114 @@ func structWithFieldSet[T any](fieldName string) *T {
 	}
 	return specPtr
 }
+
+// A route hostname that is more specifically matched by a sibling listener's nested
+// wildcard still attaches to the broader apex listener.
+//
+// The filter loop at the end of computeHosts does
+//
+//	hostnamesSet.Delete(string(*listener.Hostname))
+//
+// (helpers.go:380), which removes the sibling's hostname as a literal string. The set
+// holds whatever the match phase resolved the route hostname to, so the delete only
+// lands when those two strings happen to be equal. A concrete route hostname under a
+// wildcard sibling never matches, and the apex listener keeps a host it does not own.
+//
+// The first two cases below share identical listeners and differ only in the route
+// hostname, which is what makes the route hostname - not the listener topology - the
+// discriminator for whether isolation happens at all.
+func TestComputeHostsNestedWildcardIsolation(t *testing.T) {
+	newListener := func(gateway *GatewayContext, name, listenerHostname string) *ListenerContext {
+		hostname := gwapiv1.Hostname(listenerHostname)
+		return &ListenerContext{
+			Listener: &gwapiv1.Listener{
+				Name:     gwapiv1.SectionName(name),
+				Port:     80,
+				Protocol: gwapiv1.HTTPProtocolType,
+				Hostname: &hostname,
+			},
+			gateway: gateway,
+		}
+	}
+
+	tests := []struct {
+		name string
+		// hostname of the listener we are computing hosts FOR
+		subject string
+		// hostname of the other listener on the same port
+		sibling string
+		// siblingProtocolConflicted marks the sibling as having lost a protocol conflict
+		siblingProtocolConflicted bool
+		// the HTTPRoute's hostname
+		route string
+		want  []string
+	}{
+		{
+			// test.dev.example.com is more specifically matched by the sibling
+			// *.dev.example.com, so the apex listener should not claim it. The match
+			// phase resolves the set to the concrete "test.dev.example.com" while the
+			// filter deletes the literal "*.dev.example.com", so nothing is removed.
+			name:    "concrete route under a nested wildcard sibling is not isolated",
+			subject: "*.example.com",
+			sibling: "*.dev.example.com",
+			route:   "test.dev.example.com",
+			want:    []string{},
+		},
+		{
+			// Same two listeners as above. Here the match phase resolves the set to
+			// "*.dev.example.com", which is exactly the string the filter deletes, so
+			// isolation works. This case passes today.
+			name:    "wildcard route matching the sibling exactly is isolated",
+			subject: "*.example.com",
+			sibling: "*.dev.example.com",
+			route:   "*.dev.example.com",
+			want:    []string{},
+		},
+		{
+			// The mirror of the first case: the nested listener legitimately owns it.
+			name:    "nested wildcard listener claims its own concrete host",
+			subject: "*.dev.example.com",
+			sibling: "*.example.com",
+			route:   "test.dev.example.com",
+			want:    []string{"test.dev.example.com"},
+		},
+		{
+			// Control: a non-overlapping exact sibling must not cost the apex listener
+			// its route. Guards against a fix that over-deletes.
+			name:    "apex wildcard keeps its host when the sibling does not overlap",
+			subject: "*.example.com",
+			sibling: "other.example.com",
+			route:   "test.dev.example.com",
+			want:    []string{"test.dev.example.com"},
+		},
+		{
+			// A sibling that lost a protocol conflict is never programmed, so it cannot own
+			// a hostname. Deleting the route from the valid listener would leave it attached
+			// to nothing at all.
+			name:                      "protocol-conflicted sibling does not own a hostname",
+			subject:                   "*.example.com",
+			sibling:                   "*.dev.example.com",
+			siblingProtocolConflicted: true,
+			route:                     "test.dev.example.com",
+			want:                      []string{"test.dev.example.com"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gateway := &GatewayContext{Gateway: &gwapiv1.Gateway{}}
+			subject := newListener(gateway, "subject", tc.subject)
+			sibling := newListener(gateway, "sibling", tc.sibling)
+			sibling.protocolConflicted = tc.siblingProtocolConflicted
+			gateway.listeners = []*ListenerContext{subject, sibling}
+			gateway.Status.Listeners = []gwapiv1.ListenerStatus{
+				{Name: subject.Name},
+				{Name: sibling.Name},
+			}
+			subject.listenerStatusIdx = 0
+			sibling.listenerStatusIdx = 1
+
+			require.ElementsMatch(t, tc.want, computeHosts([]string{tc.route}, subject))
+		})
+	}
+}

--- a/internal/gatewayapi/testdata/gateway-http-listener-with-nested-wildcard-hostnames.in.yaml
+++ b/internal/gatewayapi/testdata/gateway-http-listener-with-nested-wildcard-hostnames.in.yaml
@@ -1,0 +1,100 @@
+gateways:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: gateway-1
+      namespace: envoy-gateway
+    spec:
+      gatewayClassName: envoy-gateway-class
+      listeners:
+        - name: wildcard-example-com
+          port: 80
+          protocol: HTTP
+          hostname: "*.example.com"
+          allowedRoutes:
+            namespaces:
+              from: All
+        - name: wildcard-dev-example-com
+          port: 80
+          protocol: HTTP
+          hostname: "*.dev.example.com"
+          allowedRoutes:
+            namespaces:
+              from: All
+httpRoutes:
+  # Attaches by hostname alone, with no sectionName, which is the shape that
+  # reproduces the bug. test.dev.example.com is matched by both listeners, but
+  # wildcard-dev-example-com matches it more specifically and therefore owns it,
+  # so the route must appear only there and not on wildcard-example-com.
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: httproute-nested
+      namespace: envoy-gateway
+    spec:
+      parentRefs:
+        - name: gateway-1
+          namespace: envoy-gateway
+      hostnames:
+        - "test.dev.example.com"
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /nested
+          backendRefs:
+            - name: service-1
+              port: 8080
+  # Control. other.example.com is matched only by the broader listener, so it must
+  # still attach there - this is what fails if the isolation over-deletes.
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: httproute-apex
+      namespace: envoy-gateway
+    spec:
+      parentRefs:
+        - name: gateway-1
+          namespace: envoy-gateway
+      hostnames:
+        - "other.example.com"
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /apex
+          backendRefs:
+            - name: service-1
+              port: 8080
+services:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      namespace: envoy-gateway
+      name: service-1
+    spec:
+      selector:
+        app: service-1
+      ports:
+        - name: http
+          protocol: TCP
+          port: 8080
+
+endpointslices:
+  - apiVersion: discovery.k8s.io/v1
+    kind: EndpointSlice
+    metadata:
+      namespace: envoy-gateway
+      name: service-1
+      labels:
+        kubernetes.io/service-name: service-1
+    addressType: IPv4
+    ports:
+      - name: http
+        protocol: TCP
+        port: 8080
+    endpoints:
+      - addresses:
+          - 7.7.7.7
+        conditions:
+          ready: true

--- a/internal/gatewayapi/testdata/gateway-http-listener-with-nested-wildcard-hostnames.out.yaml
+++ b/internal/gatewayapi/testdata/gateway-http-listener-with-nested-wildcard-hostnames.out.yaml
@@ -1,0 +1,285 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: envoy-gateway
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      hostname: '*.example.com'
+      name: wildcard-example-com
+      port: 80
+      protocol: HTTP
+    - allowedRoutes:
+        namespaces:
+          from: All
+      hostname: '*.dev.example.com'
+      name: wildcard-dev-example-com
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: wildcard-example-com
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: wildcard-dev-example-com
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-nested
+    namespace: envoy-gateway
+  spec:
+    hostnames:
+    - test.dev.example.com
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          type: PathPrefix
+          value: /nested
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-apex
+    namespace: envoy-gateway
+  spec:
+    hostnames:
+    - other.example.com
+    parentRefs:
+    - name: gateway-1
+      namespace: envoy-gateway
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          type: PathPrefix
+          value: /apex
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+        namespace: envoy-gateway
+infraIR:
+  envoy-gateway/gateway-1:
+    proxy:
+      listeners:
+      - name: envoy-gateway/gateway-1/wildcard-example-com
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: envoy-gateway
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: envoy-gateway/gateway-1
+      namespace: envoy-gateway-system
+xdsIR:
+  envoy-gateway/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-envoy-gateway-gateway-1-196ae069
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: envoy-gateway/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-envoy-gateway-gateway-1-196ae069
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: envoy-gateway/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*.example.com'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: wildcard-example-com
+      name: envoy-gateway/gateway-1/wildcard-example-com
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-apex
+            namespace: envoy-gateway
+          name: httproute/envoy-gateway/httproute-apex/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: envoy-gateway
+              sectionName: "8080"
+            name: httproute/envoy-gateway/httproute-apex/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: other.example.com
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-apex
+          namespace: envoy-gateway
+        name: httproute/envoy-gateway/httproute-apex/rule/0/match/0/other_example_com
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /apex
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*.dev.example.com'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: envoy-gateway
+        sectionName: wildcard-dev-example-com
+      name: envoy-gateway/gateway-1/wildcard-dev-example-com
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-nested
+            namespace: envoy-gateway
+          name: httproute/envoy-gateway/httproute-nested/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: envoy-gateway
+              sectionName: "8080"
+            name: httproute/envoy-gateway/httproute-nested/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        hostname: test.dev.example.com
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-nested
+          namespace: envoy-gateway
+        name: httproute/envoy-gateway/httproute-nested/rule/0/match/0/test_dev_example_com
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /nested
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/release-notes/current/bug_fixes/9895-nested-wildcard-listener-isolation.md
+++ b/release-notes/current/bug_fixes/9895-nested-wildcard-listener-isolation.md
@@ -1,0 +1,11 @@
+Fixed a route with a concrete hostname attaching to a less specific wildcard listener when a nested
+wildcard listener on the same port already owned that hostname, so both listeners served the route.
+The listener isolation filter removed a sibling listener's hostname from the route's matched set as a
+literal string, which only deleted anything when the set happened to hold that exact string: a concrete
+route hostname such as `test.dev.example.com` under a `*.dev.example.com` sibling was never removed, and
+the apex `*.example.com` listener kept it. Envoy Gateway now removes any matched hostname that a sibling
+listener matches at least as specifically as the listener being computed, ranking an exact hostname above
+any wildcard, a longer wildcard suffix above a shorter one, and an empty listener hostname below both.
+The failure was invisible in status - every listener stayed `Programmed: True`, the correct certificate
+was served on the HTTPS variant, and nothing was logged - so the only reliable detection was comparing
+each listener's `rds.route_config_name` against the names actually present in `RoutesConfigDump`.


### PR DESCRIPTION
**What this PR does / why we need it**:

A route with a concrete hostname attaches to a less specific wildcard listener even when a nested wildcard listener on the same port already owns that hostname, so both listeners serve the route.

The filter at the end of computeHosts removed a sibling listener's hostname from the route's matched set as a literal string:
    hostnamesSet.Delete(string(*listener.Hostname))

That only deletes something when the set happens to hold that exact string. The match phase resolves the set to whatever the route asked for, so with a sibling `*.dev.example.com` and a route hostname `test.dev.example.com` the set holds the concrete name, the delete matches nothing, and the apex `*.example.com` listener keeps a host it does not own. That is at odds with the function's own doc comment, which says it returns hostnames "that don't intersect with other listener hostnames".

This replaces the literal delete with a specificity comparison: a sibling removes any matched hostname it matches at least as specifically as the listener being computed. Specificity ranks an exact hostname above any wildcard, a longer wildcard suffix above a shorter one, and an empty listener hostname - which matches everything - below both.

Behaviour for existing configurations is unchanged: an exact sibling outranks any wildcard and still deletes, exactly as the literal delete did.

Notes for reviewers:

- The comparison is `>=`, not `>`. Equal specificity means an identical hostname, and only the  loser of that conflict reaches this loop with the winner as its sibling, because the hostnameConflictLoser guard skips the other direction - so the two can never delete each other's hosts. A strict `>` regresses TestComputeHostsConflictOwnership.
- hostnameMatches handles string equality itself, because wildcardHostnameMatchesHostname returns false for two identical wildcards: its `remaining` is empty and it requires len(remaining) > 0.
- The empty listener hostname is ranked lowest explicitly. A first attempt let it fall through to the exact-hostname branch, since it has no "*" prefix, which made the most permissive listener rank as the most specific. The existing gateway-http-listener-with-hostname-intersection fixture caught that.
- No existing golden file changed. A filter that deletes more could easily have shifted testdata output and none of it moved; the gateway-http-listener-with-nested-wildcard-hostnames fixture is newly added rather than a modified expectation.

The failure is invisible in status: every listener stays Programmed: True, the correct certificate is served on the HTTPS variant, and nothing is logged though, so the only reliable detection is comparing each listener's rds.route_config_name against the names actually present in RoutesConfigDump.

It was reported by @steache, who confirmed across five clusters that the discriminator is the route hostname rather than the Envoy Gateway version; and also @TheisFerre confirmed the guard added in https://github.com/envoyproxy/gateway/pull/9768 is a no-op for this shape.

**Which issue(s) this PR fixes**:

Fixes https://github.com/envoyproxy/gateway/issues/9895