### PR TITLE
docs(site): add release announcement banner to landing page

### DIFF
--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -1819,3 +1819,136 @@ details {
     }
   }
 }
+
+// Announcement Banner
+.announcement-banner {
+  background: linear-gradient(135deg, $gradient-start 0%, $gradient-end 100%);
+  color: $white;
+  padding: 0.75rem 0;
+  position: relative;
+  z-index: 1000;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+
+  .announcement-content {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem 0;
+
+    @media (max-width: 768px) {
+      flex-direction: column;
+      text-align: center;
+      gap: 0.5rem;
+    }
+  }
+
+  .announcement-icon {
+    font-size: 1.25rem;
+    color: rgba(255, 255, 255, 0.9);
+    flex-shrink: 0;
+
+    @media (max-width: 768px) {
+      display: none;
+    }
+  }
+
+  .announcement-text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+
+    @media (max-width: 768px) {
+      text-align: center;
+    }
+  }
+
+  .announcement-title {
+    font-weight: 600;
+    font-size: 1rem;
+    display: block;
+
+    @media (max-width: 768px) {
+      font-size: 0.9rem;
+    }
+  }
+
+  .announcement-message {
+    font-size: 0.9rem;
+    opacity: 0.95;
+
+    @media (max-width: 768px) {
+      font-size: 0.8rem;
+    }
+  }
+
+  .announcement-link {
+    color: $white;
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 255, 255, 0.5);
+    font-weight: 500;
+    transition: all 0.2s ease;
+    margin-left: 0.5rem;
+
+    &:hover {
+      color: $white;
+      text-decoration-color: $white;
+      text-shadow: 0 0 8px rgba(255, 255, 255, 0.3);
+    }
+
+    i {
+      font-size: 0.8em;
+      margin-left: 0.25rem;
+    }
+
+    @media (max-width: 768px) {
+      margin-left: 0;
+      margin-top: 0.25rem;
+      display: inline-block;
+    }
+  }
+
+  .announcement-close {
+    background: rgba(255, 255, 255, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    color: $white;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+    backdrop-filter: blur(4px);
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.25);
+      border-color: rgba(255, 255, 255, 0.5);
+      transform: scale(1.05);
+    }
+
+    &:active {
+      transform: scale(0.95);
+    }
+
+    i {
+      font-size: 0.75rem;
+    }
+
+    @media (max-width: 768px) {
+      position: absolute;
+      top: 0.5rem;
+      right: 1rem;
+      width: 1.5rem;
+      height: 1.5rem;
+
+      i {
+        font-size: 0.6rem;
+      }
+    }
+  }
+}

--- a/site/content/en/_index.md
+++ b/site/content/en/_index.md
@@ -3,6 +3,8 @@ title: Gateway
 no_list: true
 ---
 
+{{ partial "announcement-banner.html" . }}
+
 <div class="home-header">
   <div class="container">
     <img src="/icons/logo-white.svg" alt="Gateway Logo" class="mb-5" style="height: 120px;">

--- a/site/layouts/partials/announcement-banner.html
+++ b/site/layouts/partials/announcement-banner.html
@@ -1,0 +1,48 @@
+{{ $latest_version := .Site.Params.version }}
+{{ $github_repo := .Site.Params.github_repo }}
+
+<!-- Announcement Banner -->
+<div class="announcement-banner" id="announcement-banner">
+  <div class="container">
+    <div class="announcement-content">
+      <div class="announcement-icon">
+        <i class="fas fa-rocket"></i>
+      </div>
+      <div class="announcement-text">
+        <span class="announcement-title">🎉 New Release Available!</span>
+        <span class="announcement-message">
+          Envoy Gateway {{ $latest_version }} is now available with enhanced features and improved performance.
+          <a href="{{ $github_repo }}/releases/tag/{{ $latest_version }}" target="_blank" class="announcement-link">
+            View Release Notes <i class="fas fa-external-link-alt"></i>
+          </a>
+        </span>
+      </div>
+      <button class="announcement-close" onclick="dismissBanner()" aria-label="Close announcement">
+        <i class="fas fa-times"></i>
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+function dismissBanner() {
+  const banner = document.getElementById('announcement-banner');
+  banner.style.transform = 'translateY(-100%)';
+  banner.style.opacity = '0';
+  setTimeout(() => {
+    banner.style.display = 'none';
+  }, 300);
+
+  // Store dismissal in localStorage to remember user preference
+  localStorage.setItem('announcement-banner-dismissed-{{ $latest_version }}', 'true');
+}
+
+// Check if banner was previously dismissed for this version
+document.addEventListener('DOMContentLoaded', function() {
+  const dismissed = localStorage.getItem('announcement-banner-dismissed-{{ $latest_version }}');
+  if (dismissed === 'true') {
+    const banner = document.getElementById('announcement-banner');
+    banner.style.display = 'none';
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- Add a dismissible announcement banner component to the docs landing page
- Banner displays the current release version with a link to GitHub release notes
- Dismissal state is persisted per version in localStorage

## Test plan
- [ ] Build the docs site locally (`make docs` or `hugo server` in `site/`)
- [ ] Verify the banner appears at the top of the landing page
- [ ] Verify the release version and link point to the correct GitHub release
- [ ] Verify the dismiss button hides the banner and persists across page reloads

Fixes #6225