### PR TITLE
session persistence: always set cookie Path to /

### DIFF
--- a/internal/xds/translator/session_persistence.go
+++ b/internal/xds/translator/session_persistence.go
@@ -8,7 +8,6 @@ package translator
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -114,7 +113,12 @@ func buildStatefulSessionFilterConfig(route *ir.HTTPRoute) (*statefulsessionv3.S
 		cookieCfg := &cookiev3.CookieBasedSessionState{
 			Cookie: &httpv3.Cookie{
 				Name: sp.Cookie.Name,
-				Path: routePathToCookiePath(route.PathMatch),
+				// GEP-1619 defaults the cookie Path to "/" so that session
+				// persistence keeps working when the client-visible path differs
+				// from the matched route path, e.g. an edge proxy rewrites "/" to
+				// "/foo/bar" before the request reaches Envoy Gateway.
+				// https://gateway-api.sigs.k8s.io/geps/gep-1619/#path
+				Path: "/",
 			},
 		}
 
@@ -153,40 +157,6 @@ func buildStatefulSessionFilterPerRouteConfig(route *ir.HTTPRoute) (*statefulses
 			StatefulSession: statefulSession,
 		},
 	}, nil
-}
-
-func routePathToCookiePath(path *ir.StringMatch) string {
-	if path == nil {
-		return "/"
-	}
-	switch {
-	case path.Exact != nil:
-		return *path.Exact
-	case path.Prefix != nil:
-		return *path.Prefix
-	case path.SafeRegex != nil:
-		return getLongestNonRegexPrefix(*path.SafeRegex)
-	}
-
-	// Shouldn't reach here because the path should be either of the above three kinds.
-	return "/"
-}
-
-// getLongestNonRegexPrefix takes a regex path and returns the longest non-regex prefix.
-// > 3. For an xRoute using a path that is a regex, the Path should be set to the longest non-regex prefix
-// (.e.g. if the path is /p1/p2/*/p3 and the request path was /p1/p2/foo/p3, then the cookie path would be /p1/p2).
-// https://gateway-api.sigs.k8s.io/geps/gep-1619/#path
-func getLongestNonRegexPrefix(path string) string {
-	parts := strings.Split(path, "/")
-	longestNonRegexPrefix := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if part == "*" || strings.Contains(part, "*") {
-			break
-		}
-		longestNonRegexPrefix = append(longestNonRegexPrefix, part)
-	}
-
-	return strings.Join(longestNonRegexPrefix, "/")
 }
 
 // patchRoute patches the provide Route with a filter's Route level configuration.

--- a/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/http-route-session-persistence.routes.yaml
@@ -40,7 +40,7 @@
                 '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
                 cookie:
                   name: session-header
-                  path: /v1
+                  path: /
                   ttl: 3600s
     - match:
         pathSeparatedPrefix: /v2
@@ -59,7 +59,7 @@
                 '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
                 cookie:
                   name: session-header
-                  path: /v2/
+                  path: /
     - match:
         path: /v3/user
       name: cookie-based-session-persistence-route-exact
@@ -77,5 +77,5 @@
                 '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
                 cookie:
                   name: session-cookie
-                  path: /v3/user
+                  path: /
                   ttl: 3600s

--- a/release-notes/current/breaking_changes/8580-session-persistence-cookie-path.md
+++ b/release-notes/current/breaking_changes/8580-session-persistence-cookie-path.md
@@ -6,5 +6,6 @@ an edge proxy rewrites `/` to `/foo/bar` before the request reaches the gateway:
 Because the cookie is now sent to every route on the same host, HTTPRoute rules on the same host that
 enable cookie-based session persistence must use distinct `sessionName` values. Rules that share a
 `sessionName` previously got separate cookies because their paths differed; they now overwrite each other's
-cookie and session persistence stops working for both. Clients holding a cookie scoped to the old path keep
+cookie and session persistence stops working for both. Omitting `sessionName` makes Envoy Gateway generate a
+unique cookie name per rule. Clients holding a cookie scoped to the old path keep
 sending it until it expires, and are issued a new one at `Path=/` on their next request.

--- a/release-notes/current/breaking_changes/8580-session-persistence-cookie-path.md
+++ b/release-notes/current/breaking_changes/8580-session-persistence-cookie-path.md
@@ -1,0 +1,10 @@
+The cookie-based session persistence cookie is now always issued with `Path=/`, following the updated
+GEP-1619 guidance, instead of being scoped to the matched HTTPRoute path. This fixes session persistence
+breaking when the path the client requests differs from the path Envoy Gateway matches, for example when
+an edge proxy rewrites `/` to `/foo/bar` before the request reaches the gateway: the cookie was scoped to
+`/foo/bar`, so the browser never sent it back on the client-visible URL.
+Because the cookie is now sent to every route on the same host, HTTPRoute rules on the same host that
+enable cookie-based session persistence must use distinct `sessionName` values. Rules that share a
+`sessionName` previously got separate cookies because their paths differed; they now overwrite each other's
+cookie and session persistence stops working for both. Clients holding a cookie scoped to the old path keep
+sending it until it expires, and are issued a new one at `Path=/` on their next request.

--- a/release-notes/current/breaking_changes/8580-session-persistence-cookie-path.md
+++ b/release-notes/current/breaking_changes/8580-session-persistence-cookie-path.md
@@ -1,11 +1,3 @@
-The cookie-based session persistence cookie is now always issued with `Path=/`, following the updated
-GEP-1619 guidance, instead of being scoped to the matched HTTPRoute path. This fixes session persistence
-breaking when the path the client requests differs from the path Envoy Gateway matches, for example when
-an edge proxy rewrites `/` to `/foo/bar` before the request reaches the gateway: the cookie was scoped to
-`/foo/bar`, so the browser never sent it back on the client-visible URL.
-Because the cookie is now sent to every route on the same host, HTTPRoute rules on the same host that
-enable cookie-based session persistence must use distinct `sessionName` values. Rules that share a
-`sessionName` previously got separate cookies because their paths differed; they now overwrite each other's
-cookie and session persistence stops working for both. Omitting `sessionName` makes Envoy Gateway generate a
-unique cookie name per rule. Clients holding a cookie scoped to the old path keep
-sending it until it expires, and are issued a new one at `Path=/` on their next request.
+Cookie-based session persistence now always uses `Path=/` instead of the matched HTTPRoute path, following updated GEP-1619 guidance. This fixes persistence when an upstream proxy rewrites the request path.
+
+Rules on the same host must use distinct `sessionName` values to avoid cookie conflicts, or omit `sessionName` to generate unique names per rule. Existing cookies remain until they expire; clients receive a new cookie with `Path=/` on their next request.

--- a/release-notes/current/bug_fixes/8580-session-persistence-cookie-path.md
+++ b/release-notes/current/bug_fixes/8580-session-persistence-cookie-path.md
@@ -1,8 +1,0 @@
-Fixed cookie-based session persistence breaking when the path the client requests differs from the
-path Envoy Gateway matches, for example when an edge proxy rewrites `/` to `/foo/bar` before the
-request reaches the gateway. The session cookie was scoped to the matched HTTPRoute path (`Path=/foo/bar`),
-so the browser never sent it back on the client-visible URL and every request landed on a new backend.
-Following the updated GEP-1619 guidance, the session persistence cookie is now always issued with `Path=/`.
-Note this is broader than before: the cookie is sent to every route on the same host, not only the one
-that set it. Clients holding a cookie scoped to the old path keep using it until it expires, and are
-issued a new one at `Path=/` on their next request.

--- a/release-notes/current/bug_fixes/8580-session-persistence-cookie-path.md
+++ b/release-notes/current/bug_fixes/8580-session-persistence-cookie-path.md
@@ -1,0 +1,8 @@
+Fixed cookie-based session persistence breaking when the path the client requests differs from the
+path Envoy Gateway matches, for example when an edge proxy rewrites `/` to `/foo/bar` before the
+request reaches the gateway. The session cookie was scoped to the matched HTTPRoute path (`Path=/foo/bar`),
+so the browser never sent it back on the client-visible URL and every request landed on a new backend.
+Following the updated GEP-1619 guidance, the session persistence cookie is now always issued with `Path=/`.
+Note this is broader than before: the cookie is sent to every route on the same host, not only the one
+that set it. Clients holding a cookie scoped to the old path keep using it until it expires, and are
+issued a new one at `Path=/` on their next request.

--- a/site/content/en/latest/tasks/traffic/session-persistence.md
+++ b/site/content/en/latest/tasks/traffic/session-persistence.md
@@ -87,6 +87,10 @@ The session cookie is always issued with `Path=/`, as recommended by [GEP-1619](
 so it keeps working when the path seen by the client differs from the path matched by the HTTPRoute, for example
 when an edge proxy rewrites the request path before it reaches Envoy Gateway.
 
+Because the cookie is sent to every route on the same host, each HTTPRoute rule on a host that enables
+cookie-based session persistence must use a distinct `sessionName`. Rules that share a `sessionName` overwrite
+each other's cookie, and session persistence stops working for both.
+
 {{< boilerplate rollout-envoy-gateway >}}
 
 ### Testing

--- a/site/content/en/latest/tasks/traffic/session-persistence.md
+++ b/site/content/en/latest/tasks/traffic/session-persistence.md
@@ -83,6 +83,10 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
+The session cookie is always issued with `Path=/`, as recommended by [GEP-1619](https://gateway-api.sigs.k8s.io/geps/gep-1619/#path),
+so it keeps working when the path seen by the client differs from the path matched by the HTTPRoute, for example
+when an edge proxy rewrites the request path before it reaches Envoy Gateway.
+
 {{< boilerplate rollout-envoy-gateway >}}
 
 ### Testing

--- a/site/content/en/latest/tasks/traffic/session-persistence.md
+++ b/site/content/en/latest/tasks/traffic/session-persistence.md
@@ -89,7 +89,9 @@ when an edge proxy rewrites the request path before it reaches Envoy Gateway.
 
 Because the cookie is sent to every route on the same host, each HTTPRoute rule on a host that enables
 cookie-based session persistence must use a distinct `sessionName`. Rules that share a `sessionName` overwrite
-each other's cookie, and session persistence stops working for both.
+each other's cookie, and session persistence stops working for both. If `sessionName` is omitted, Envoy Gateway
+generates a unique cookie name for the rule, so leaving it unset is the safest choice unless the cookie name has
+to match an existing one, such as `JSESSIONID`.
 
 {{< boilerplate rollout-envoy-gateway >}}
 

--- a/test/e2e/tests/session_persistence.go
+++ b/test/e2e/tests/session_persistence.go
@@ -136,7 +136,7 @@ var SessionPersistenceTest = suite.ConformanceTest{
 					if diff := cmp.Diff(cookie, &stdhttp.Cookie{
 						Name:     "Session-A",
 						MaxAge:   10,
-						Path:     requestPath,
+						Path:     "/",
 						HttpOnly: true,
 						Quoted:   true,
 					}, cmpopts.IgnoreFields(stdhttp.Cookie{}, "Value", "Raw"), // Ignore the value as it is random.


### PR DESCRIPTION
The session persistence cookie was scoped to the matched HTTPRoute path, so it was never sent back when the client-visible path differs from the path Envoy matches, e.g. when an edge proxy rewrites `/` to `/foo/bar` before the request reaches the gateway.

The GEP-1619 spec was changed in kubernetes-sigs/gateway-api#5046: the cookie `Path` now defaults to `/` instead of being derived from the route match, and a new `cookieConfig.path` field lets users override it. This PR follows the new default. The explicit `path` field is not in Gateway API 1.6.2 yet, so wiring the override is left for the 1.7 bump.

This is a breaking change: the cookie is now sent to every route on the same host, so HTTPRoute rules on the same host that enable cookie-based session persistence must use distinct `sessionName` values. Rules sharing a `sessionName` used to get separate cookies because their paths differed; they now overwrite each other's cookie. The release note and the session persistence task doc call this out.

Related to #8580
