### PR TITLE
kubernetes: use AWS physical zone IDs for locality

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -141,7 +141,7 @@ type subscriptions struct {
 
 // newGatewayAPIController
 func newGatewayAPIController(ctx context.Context, mgr manager.Manager, cfg *config.Server, su Updater,
-	resources *message.ProviderResources,
+	resources *message.ProviderResources, store *kubernetesProviderStore,
 ) error {
 	// Gather additional resources to watch from registered extensions
 	var extServerPoliciesGVKs []schema.GroupVersionKind
@@ -171,7 +171,7 @@ func newGatewayAPIController(ctx context.Context, mgr manager.Manager, cfg *conf
 		resources:            resources,
 		subscriptions:        &subscriptions{},
 		extGVKs:              extGVKs,
-		store:                newProviderStore(),
+		store:                store,
 		envoyGateway:         cfg.EnvoyGateway,
 		mergeGateways:        sets.New[string](),
 		extServerPolicies:    extServerPoliciesGVKs,
@@ -625,6 +625,8 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, _ reconcile.Reques
 			}
 		}
 	}
+
+	r.applyAWSZoneIDs(gwcResources)
 
 	// Sort before storing to:
 	// 1. ensure identical resources are not retranslated
@@ -2709,10 +2711,10 @@ func (r *gatewayAPIReconciler) watchResources(ctx context.Context, mgr manager.M
 		}
 	}
 
-	// Watch Node CRUDs to update Gateway Address exposed by Service of type NodePort.
+	// Watch Nodes for locality changes and Gateway addresses exposed by NodePort Services.
 	// Node creation/deletion and ExternalIP updates would require update in the Gateway
 	nPredicates := []predicate.TypedPredicate[*corev1.Node]{
-		predicate.TypedGenerationChangedPredicate[*corev1.Node]{},
+		r.nodePredicate(),
 		predicate.NewTypedPredicateFuncs(func(node *corev1.Node) bool {
 			return r.handleNode(node)
 		}),

--- a/internal/provider/kubernetes/kubernetes.go
+++ b/internal/provider/kubernetes/kubernetes.go
@@ -362,6 +362,7 @@ func newProvider(ctx context.Context, restCfg *rest.Config, svrCfg *ec.Server,
 		})
 	}
 
+	store := newProviderStore()
 	mgr, err := ctrl.NewManager(restCfg, mgrOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create manager: %w", err)
@@ -374,6 +375,7 @@ func newProvider(ctx context.Context, restCfg *rest.Config, svrCfg *ec.Server,
 				APIReader: mgr.GetAPIReader(),
 				Logger:    svrCfg.Logger.WithName("proxy-topology-injector"),
 				Decoder:   admission.NewDecoder(mgr.GetScheme()),
+				platform:  &store.platform,
 			},
 		})
 	}
@@ -383,7 +385,7 @@ func newProvider(ctx context.Context, restCfg *rest.Config, svrCfg *ec.Server,
 	}
 
 	// Create and register the controllers with the manager.
-	if err := newGatewayAPIController(ctx, mgr, svrCfg, updateHandler.Writer(), resources); err != nil {
+	if err := newGatewayAPIController(ctx, mgr, svrCfg, updateHandler.Writer(), resources, store); err != nil {
 		return nil, fmt.Errorf("failed to create gatewayapi controller: %w", err)
 	}
 

--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -69,9 +69,13 @@ func TestProvider(t *testing.T) {
 	svr, err := config.New(os.Stdout, os.Stderr)
 	require.NoError(t, err)
 
-	// Disable webhook server for provider test to avoid non-existent cert errors
-	svr.EnvoyGateway.Provider.Kubernetes.TopologyInjector = &egv1a1.EnvoyGatewayTopologyInjector{Disable: new(true)}
-	require.NoError(t, err)
+	// Use the test environment certificate and port for the topology injector.
+	previousCertDir, previousPort := webhookTLSCertDir, webhookTLSPort
+	webhookTLSCertDir = testEnv.WebhookInstallOptions.LocalServingCertDir
+	webhookTLSPort = testEnv.WebhookInstallOptions.LocalServingPort
+	t.Cleanup(func() {
+		webhookTLSCertDir, webhookTLSPort = previousCertDir, previousPort
+	})
 	resources, provider, err := newProviderWithMetricsServerDisabled(t, cliCfg, svr)
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -89,6 +93,9 @@ func TestProvider(t *testing.T) {
 		cancel()
 		_ = testEnv.Stop()
 	})
+
+	webhookStarted := provider.manager.GetWebhookServer().StartedChecker()
+	require.Eventually(t, func() bool { return webhookStarted(nil) == nil }, defaultWait, defaultTick)
 
 	testcases := map[string]func(context.Context, *testing.T, *Provider, *message.ProviderResources){
 		"gatewayclass controller name":         testGatewayClassController,

--- a/internal/provider/kubernetes/locality.go
+++ b/internal/provider/kubernetes/locality.go
@@ -1,0 +1,77 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package kubernetes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/envoyproxy/gateway/internal/gatewayapi/resource"
+)
+
+const (
+	endpointSliceControllerName          = "endpointslice-controller.k8s.io"
+	endpointSliceMirroringControllerName = "endpointslicemirroring-controller.k8s.io"
+)
+
+// applyAWSZoneIDs resolves local endpoints without changing cached EndpointSlices.
+func (r *gatewayAPIReconciler) applyAWSZoneIDs(resources resource.ControllerResources) {
+	if !r.store.platform.aws.Load() {
+		return
+	}
+
+	zoneIDs := make(map[string]string)
+	for _, res := range resources {
+		for i, slice := range res.EndpointSlices {
+			// Slices from other controllers can refer to nodes in another cluster.
+			managedBy := slice.Labels[discoveryv1.LabelManagedBy]
+			if managedBy != endpointSliceControllerName &&
+				managedBy != endpointSliceMirroringControllerName {
+				continue
+			}
+			var updated *discoveryv1.EndpointSlice
+			for j, endpoint := range slice.Endpoints {
+				if endpoint.NodeName == nil || *endpoint.NodeName == "" {
+					continue
+				}
+				zoneID, found := zoneIDs[*endpoint.NodeName]
+				if !found {
+					zoneID = r.store.nodeZoneID(*endpoint.NodeName)
+					zoneIDs[*endpoint.NodeName] = zoneID
+				}
+				if zoneID == "" || (endpoint.Zone != nil && *endpoint.Zone == zoneID) {
+					continue
+				}
+				if updated == nil {
+					updated = slice.DeepCopy()
+				}
+				if updated.Endpoints[j].Zone == nil {
+					updated.Endpoints[j].Zone = new(zoneID)
+				} else {
+					*updated.Endpoints[j].Zone = zoneID
+				}
+			}
+			if updated != nil {
+				res.EndpointSlices[i] = updated
+			}
+		}
+	}
+}
+
+func (r *gatewayAPIReconciler) nodePredicate() predicate.TypedPredicate[*corev1.Node] {
+	return predicate.Or(
+		predicate.TypedGenerationChangedPredicate[*corev1.Node]{},
+		predicate.TypedFuncs[*corev1.Node]{
+			UpdateFunc: func(e event.TypedUpdateEvent[*corev1.Node]) bool {
+				return e.ObjectOld != nil && e.ObjectNew != nil &&
+					(e.ObjectOld.Spec.ProviderID != e.ObjectNew.Spec.ProviderID ||
+						e.ObjectOld.Labels[awsZoneIDLabel] != e.ObjectNew.Labels[awsZoneIDLabel])
+			},
+		},
+	)
+}

--- a/internal/provider/kubernetes/locality_test.go
+++ b/internal/provider/kubernetes/locality_test.go
@@ -1,0 +1,186 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package kubernetes
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	mcsapiv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	egv1a1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/envoyproxy/gateway/internal/envoygateway/config"
+	"github.com/envoyproxy/gateway/internal/gatewayapi"
+	"github.com/envoyproxy/gateway/internal/gatewayapi/resource"
+	"github.com/envoyproxy/gateway/internal/infrastructure/kubernetes/proxy"
+	"github.com/envoyproxy/gateway/internal/message"
+	"github.com/envoyproxy/gateway/internal/provider/kubernetes/test"
+	xdstranslator "github.com/envoyproxy/gateway/internal/xds/translator"
+)
+
+func TestClusterPlatform(t *testing.T) {
+	platform := &clusterPlatform{}
+	node := &corev1.Node{Spec: corev1.NodeSpec{ProviderID: "aws:///us-east-1d/i-123"}}
+	require.Empty(t, platform.zoneID(node))
+	require.True(t, platform.aws.Load())
+
+	// Nodes supply their own IDs after the controller detects AWS.
+	for _, zoneID := range []string{"use1-az6", "use1-az2", ""} {
+		node = &corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{awsZoneIDLabel: zoneID}}}
+		require.Equal(t, zoneID, platform.zoneID(node))
+	}
+}
+
+func TestApplyAWSZoneIDs(t *testing.T) {
+	local := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{discoveryv1.LabelManagedBy: endpointSliceControllerName}},
+		Endpoints: []discoveryv1.Endpoint{
+			{NodeName: new("node"), Zone: new("us-east-1d")},
+			{NodeName: new("node")},
+			{NodeName: new("no-id"), Zone: new("us-east-1b")},
+			{NodeName: new("empty-id"), Zone: new("us-east-1b")},
+			{NodeName: new("missing"), Zone: new("us-east-1c")},
+			{Zone: new("explicit")},
+		},
+	}
+	local.Labels[mcsapiv1a1.LabelServiceName] = "also-exported"
+	imported := local.DeepCopy()
+	imported.Labels[mcsapiv1a1.LabelServiceName] = "remote"
+	imported.Labels[discoveryv1.LabelManagedBy] = "mcs-controller"
+	custom := local.DeepCopy()
+	custom.Labels[discoveryv1.LabelManagedBy] = "custom-controller"
+	mirrored := local.DeepCopy()
+	mirrored.Labels[discoveryv1.LabelManagedBy] = endpointSliceMirroringControllerName
+	original := local.DeepCopy()
+	resources := resource.ControllerResources{
+		{EndpointSlices: []*discoveryv1.EndpointSlice{local, imported, custom, mirrored}},
+		{EndpointSlices: []*discoveryv1.EndpointSlice{local}},
+	}
+	store := newProviderStore()
+	r := &gatewayAPIReconciler{store: store}
+	r.applyAWSZoneIDs(resources)
+	require.Same(t, local, resources[0].EndpointSlices[0])
+	for _, node := range []*corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node", Labels: map[string]string{awsZoneIDLabel: "use1-az6"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "no-id"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "empty-id", Labels: map[string]string{awsZoneIDLabel: ""}}},
+	} {
+		store.addNode(node)
+	}
+	r.applyAWSZoneIDs(resources)
+	for _, res := range resources {
+		require.Equal(t, "use1-az6", *res.EndpointSlices[0].Endpoints[0].Zone)
+		require.Equal(t, "use1-az6", *res.EndpointSlices[0].Endpoints[1].Zone)
+		require.Equal(t, original.Endpoints[2:], res.EndpointSlices[0].Endpoints[2:])
+	}
+	require.Equal(t, original, local)
+	require.Equal(t, "use1-az6", *resources[0].EndpointSlices[3].Endpoints[0].Zone)
+	require.Same(t, imported, resources[0].EndpointSlices[1])
+	require.Same(t, custom, resources[0].EndpointSlices[2])
+	require.Equal(t, original.Endpoints, imported.Endpoints)
+	require.Equal(t, original.Endpoints, custom.Endpoints)
+}
+
+func TestAWSZoneIDNodeUpdates(t *testing.T) {
+	r := &gatewayAPIReconciler{}
+	old := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node"}}
+	updated := old.DeepCopy()
+	updated.Labels = map[string]string{awsZoneIDLabel: "use1-az6"}
+	for _, nodes := range [][2]*corev1.Node{{old, updated}, {updated, old}} {
+		require.True(t, r.nodePredicate().Update(event.TypedUpdateEvent[*corev1.Node]{ObjectOld: nodes[0], ObjectNew: nodes[1]}))
+	}
+	require.False(t, r.nodePredicate().Update(event.TypedUpdateEvent[*corev1.Node]{ObjectOld: updated, ObjectNew: updated}))
+	old = updated.DeepCopy()
+	updated.Spec.ProviderID = "aws:///us-east-1d/i-123"
+	require.True(t, r.nodePredicate().Update(event.TypedUpdateEvent[*corev1.Node]{ObjectOld: old, ObjectNew: updated}))
+	old = updated.DeepCopy()
+	updated.Generation++
+	require.True(t, r.nodePredicate().Update(event.TypedUpdateEvent[*corev1.Node]{ObjectOld: old, ObjectNew: updated}))
+}
+
+func TestAWSZoneIDLocalityXDS(t *testing.T) {
+	cfg, err := config.New(os.Stdout, os.Stderr)
+	require.NoError(t, err)
+	cfg.EnvoyGateway.Provider = &egv1a1.EnvoyGatewayProvider{Type: egv1a1.ProviderTypeCustom}
+	updates := new(message.ProviderResources)
+	r, err := NewOfflineGatewayAPIController(t.Context(), cfg, nil, updates)
+	require.NoError(t, err)
+	defer updates.Close()
+	gateway := test.GetGateway(types.NamespacedName{Namespace: "default", Name: "gateway"}, "eg", 80)
+	fleet := test.GetService(types.NamespacedName{
+		Namespace: cfg.ControllerNamespace, Name: proxy.ExpectedResourceHashedName("default/gateway"),
+	}, gatewayapi.OwnerLabels(gateway, false), map[string]int32{"dummy": 8080})
+	backend := test.GetService(types.NamespacedName{Namespace: "default", Name: "backend"}, nil, map[string]int32{"dummy": 8080})
+	backend.Spec.TrafficDistribution = new("PreferClose")
+	fleetSlice := test.GetEndpointSlice(types.NamespacedName{Namespace: fleet.Namespace, Name: "fleet"}, fleet.Name, false)
+	backendSlice := test.GetEndpointSlice(types.NamespacedName{Namespace: backend.Namespace, Name: "backend"}, backend.Name, false)
+	for i, slice := range []*discoveryv1.EndpointSlice{fleetSlice, backendSlice} {
+		slice.AddressType = discoveryv1.AddressTypeIPv4
+		slice.Labels[discoveryv1.LabelManagedBy] = endpointSliceControllerName
+		slice.Endpoints[0].NodeName = new("node")
+		slice.Endpoints[0].Zone = new("us-east-1d")
+		slice.Endpoints[0].Addresses = []string{fmt.Sprintf("192.0.2.%d", i+1)}
+	}
+	remoteSlice := backendSlice.DeepCopy()
+	remoteSlice.Name = "remote"
+	remoteSlice.Labels[discoveryv1.LabelManagedBy] = "remote-controller"
+	remoteSlice.Endpoints[0].Zone = new("use1-az2")
+	remoteSlice.Endpoints[0].Addresses = []string{"192.0.2.3"}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node", Labels: map[string]string{
+		corev1.LabelTopologyZone: "us-east-1d", awsZoneIDLabel: "use1-az6",
+	}}}
+	for _, obj := range []client.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cfg.ControllerNamespace}},
+		test.GetGatewayClass("eg", egv1a1.GatewayControllerName, nil), gateway, fleet, backend,
+		fleetSlice, backendSlice, remoteSlice, node,
+		test.GetHTTPRoute(types.NamespacedName{Namespace: "default", Name: "route"}, gateway.Name,
+			test.GetServiceBackendRef(types.NamespacedName{Name: backend.Name}, 8080), ""),
+	} {
+		require.NoError(t, r.Client.Create(t.Context(), obj))
+	}
+	r.store.addNode(node)
+	require.NoError(t, r.Reconcile(t.Context()))
+	published, ok := updates.GatewayAPIResources.Load(cfg.EnvoyGateway.Gateway.ControllerName)
+	require.True(t, ok)
+	require.Len(t, *published.Resources, 1)
+	gt := &gatewayapi.Translator{
+		GatewayControllerName: egv1a1.GatewayControllerName, GatewayClassName: "eg",
+		ControllerNamespace: cfg.ControllerNamespace, Logger: cfg.Logger,
+	}
+	translated, err := gt.Translate(t.Context(), (*published.Resources)[0])
+	require.NoError(t, err)
+	require.Len(t, translated.XdsIR, 1)
+	zones := map[string]string{}
+	for _, xdsIR := range translated.XdsIR {
+		xt := &xdstranslator.Translator{Logger: cfg.Logger}
+		table, err := xt.Translate(t.Context(), xdsIR)
+		require.NoError(t, err)
+		for _, entry := range table.XdsResources[resourcev3.EndpointType] {
+			for _, locality := range entry.(*endpointv3.ClusterLoadAssignment).Endpoints {
+				for _, endpoint := range locality.LbEndpoints {
+					zones[endpoint.GetEndpoint().Address.GetSocketAddress().Address] = locality.Locality.GetZone()
+				}
+			}
+		}
+	}
+	require.Equal(t, map[string]string{
+		"192.0.2.1": "use1-az6", "192.0.2.2": "use1-az6", "192.0.2.3": "use1-az2",
+	}, zones)
+	var stored discoveryv1.EndpointSlice
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(backendSlice), &stored))
+	require.Equal(t, "us-east-1d", *stored.Endpoints[0].Zone)
+}

--- a/internal/provider/kubernetes/platform.go
+++ b/internal/provider/kubernetes/platform.go
@@ -1,0 +1,31 @@
+// Copyright Envoy Gateway Authors
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package kubernetes
+
+import (
+	"strings"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const awsZoneIDLabel = "topology.k8s.aws/zone-id"
+
+// clusterPlatform shares cloud detection across proxy and endpoint locality lookups.
+type clusterPlatform struct {
+	aws atomic.Bool
+}
+
+// zoneID detects the platform from Node metadata and returns the zone ID for this Node.
+func (p *clusterPlatform) zoneID(node *corev1.Node) string {
+	if !p.aws.Load() {
+		if !strings.HasPrefix(node.Spec.ProviderID, "aws://") && node.Labels[awsZoneIDLabel] == "" {
+			return ""
+		}
+		p.aws.Store(true)
+	}
+	return node.Labels[awsZoneIDLabel]
+}

--- a/internal/provider/kubernetes/store.go
+++ b/internal/provider/kubernetes/store.go
@@ -17,15 +17,15 @@ import (
 type nodeDetails struct {
 	name      string
 	addresses status.NodeAddresses
+	zoneID    string
 }
 
 // kubernetesProviderStore holds cached information for the kubernetes provider.
 type kubernetesProviderStore struct {
-	// nodes holds information required for updating Gateway status with the Node
-	// addresses, in case the Gateway is exposed on every Node of the cluster, using
-	// Service of type NodePort.
-	nodes map[string]nodeDetails
-	mu    sync.Mutex
+	// nodes holds addresses for NodePort status and zone IDs for locality.
+	nodes    map[string]nodeDetails
+	mu       sync.Mutex
+	platform clusterPlatform
 }
 
 func newProviderStore() *kubernetesProviderStore {
@@ -35,7 +35,7 @@ func newProviderStore() *kubernetesProviderStore {
 }
 
 func (p *kubernetesProviderStore) addNode(n *corev1.Node) {
-	details := nodeDetails{name: n.Name}
+	details := nodeDetails{name: n.Name, zoneID: p.platform.zoneID(n)}
 
 	var internalIPs, externalIPs status.NodeAddresses
 	for _, addr := range n.Status.Addresses {
@@ -72,6 +72,12 @@ func (p *kubernetesProviderStore) removeNode(n *corev1.Node) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	delete(p.nodes, n.Name)
+}
+
+func (p *kubernetesProviderStore) nodeZoneID(name string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.nodes[name].zoneID
 }
 
 func (p *kubernetesProviderStore) listNodeAddresses() status.NodeAddresses {

--- a/internal/provider/kubernetes/topology_injector.go
+++ b/internal/provider/kubernetes/topology_injector.go
@@ -25,6 +25,7 @@ type ProxyTopologyInjector struct {
 	APIReader client.Reader
 	Decoder   admission.Decoder
 	Logger    logging.Logger
+	platform  *clusterPlatform
 }
 
 // Handle implements admission.Handler; the interface requires admission.Request by value.
@@ -83,7 +84,12 @@ func (m *ProxyTopologyInjector) Handle(ctx context.Context, req admission.Reques
 	}
 	logger = logger.WithValues("node", node)
 
-	if zone, ok := node.Labels[corev1.LabelTopologyZone]; ok {
+	zone, hasZone := node.Labels[corev1.LabelTopologyZone]
+	if zoneID := m.platform.zoneID(node); zoneID != "" {
+		zone = zoneID
+		hasZone = true
+	}
+	if hasZone {
 		if binding.Annotations == nil {
 			binding.Annotations = map[string]string{}
 		}

--- a/internal/provider/kubernetes/topology_injector_test.go
+++ b/internal/provider/kubernetes/topology_injector_test.go
@@ -45,6 +45,17 @@ func TestProxyTopologyInjector_Handle(t *testing.T) {
 		},
 	}
 
+	awsNode := defaultNode.DeepCopy()
+	awsNode.Labels = map[string]string{
+		corev1.LabelTopologyZone:   "us-east-1d",
+		"topology.k8s.aws/zone-id": "use1-az6",
+	}
+
+	awsOnlyNode := awsNode.DeepCopy()
+	delete(awsOnlyNode.Labels, corev1.LabelTopologyZone)
+	emptyAWSNode := awsNode.DeepCopy()
+	emptyAWSNode.Labels[awsZoneIDLabel] = ""
+
 	cases := []struct {
 		caseName          string
 		obj               client.Object
@@ -69,6 +80,48 @@ func TestProxyTopologyInjector_Handle(t *testing.T) {
 				Value: map[string]interface{}{
 					"topology.kubernetes.io/zone": "\"0\"",
 				},
+			}},
+		},
+		{
+			caseName: "AWS zone ID",
+			obj: &corev1.Binding{
+				ObjectMeta: metav1.ObjectMeta{Name: defaultPod.Name, Namespace: defaultPod.Namespace},
+				Target:     corev1.ObjectReference{Name: awsNode.Name},
+			},
+			node: awsNode,
+			pod:  defaultPod,
+			expectedPatchResp: []jsonpatch.JsonPatchOperation{{
+				Operation: "add",
+				Path:      "/metadata/annotations",
+				Value:     map[string]interface{}{corev1.LabelTopologyZone: "\"use1-az6\""},
+			}},
+		},
+		{
+			caseName: "AWS zone ID without standard label",
+			obj: &corev1.Binding{
+				ObjectMeta: metav1.ObjectMeta{Name: defaultPod.Name, Namespace: defaultPod.Namespace},
+				Target:     corev1.ObjectReference{Name: awsNode.Name},
+			},
+			node: awsOnlyNode,
+			pod:  defaultPod,
+			expectedPatchResp: []jsonpatch.JsonPatchOperation{{
+				Operation: "add",
+				Path:      "/metadata/annotations",
+				Value:     map[string]interface{}{corev1.LabelTopologyZone: "\"use1-az6\""},
+			}},
+		},
+		{
+			caseName: "empty AWS zone ID",
+			obj: &corev1.Binding{
+				ObjectMeta: metav1.ObjectMeta{Name: defaultPod.Name, Namespace: defaultPod.Namespace},
+				Target:     corev1.ObjectReference{Name: awsNode.Name},
+			},
+			node: emptyAWSNode,
+			pod:  defaultPod,
+			expectedPatchResp: []jsonpatch.JsonPatchOperation{{
+				Operation: "add",
+				Path:      "/metadata/annotations",
+				Value:     map[string]interface{}{corev1.LabelTopologyZone: "\"us-east-1d\""},
 			}},
 		},
 		{
@@ -122,8 +175,9 @@ func TestProxyTopologyInjector_Handle(t *testing.T) {
 				Build()
 
 			mutator := &ProxyTopologyInjector{
-				Client:  fakeClient,
-				Decoder: decoder,
+				Client:   fakeClient,
+				Decoder:  decoder,
+				platform: &clusterPlatform{},
 			}
 
 			objBytes, err := json.Marshal(tc.obj)

--- a/release-notes/current/breaking_changes/9960-aws-zone-id-locality.md
+++ b/release-notes/current/breaking_changes/9960-aws-zone-id-locality.md
@@ -1,0 +1,3 @@
+Use physical AWS zone IDs for proxy and local Kubernetes-managed endpoint locality when the node
+label is available. Update Backend zones, `weightedZones`, and imported or custom EndpointSlices to
+use IDs.

--- a/site/content/en/latest/tasks/traffic/zone-aware-routing.md
+++ b/site/content/en/latest/tasks/traffic/zone-aware-routing.md
@@ -33,9 +33,15 @@ The `zoneAware` field supports two modes: `preferLocal` (prefer same-zone endpoi
 `preferLocal` and `weightedZones` are mutually exclusive and cannot be set together for any policy.
 
 ## Prerequisites
-* The Kubernetes cluster's nodes must indicate topology information via the `topology.kubernetes.io/zone` [well-known label][Kubernetes well-known metadata].
+* Nodes must use the `topology.kubernetes.io/zone` [well-known label][Kubernetes well-known metadata], or the more accurate `topology.k8s.aws/zone-id` on AWS (see below).
 * There must be at least two valid topology zones for scheduling.
 * {{< boilerplate prerequisites >}}
+
+## AWS zone IDs
+
+The controller detects AWS from Node provider IDs or nonempty AWS zone-ID labels. Proxy and endpoint locality use the same platform selection.
+
+When the `topology.k8s.aws/zone-id` node label is nonempty, Envoy Gateway prefers it for proxy locality. It also uses the label for local endpoints managed by Kubernetes EndpointSlice controllers. Imported and custom EndpointSlices retain their supplied zones. For routing across AWS accounts, their producers must supply physical AZ IDs in `endpoints[].zone`.
 
 ## Configuration
 


### PR DESCRIPTION
**What this PR does / why we need it**:

AWS zone names are logical and can identify _different_ physical zones across accounts. That is, Account A's `us-east-1a` is not guaranteed to be Account B's `us-east-1a`.

AWS also has physical IDs that are _consistent_ across accounts. Account A's `use1-az1` is guaranteed to be Account B's `use1-az1`. These physical IDs are part of AWS EKS nodes from EKS 1.30+ in the node label: `topology.k8s.aws/zone-id`.

Envoy Gateway currently uses the AWS zone name populated in the standard Kubernetes node label: `topology.kubernetes.io/zone` when comparing for locality routing, which can route cross-account traffic to the wrong physical zone.

Related:

- [AWS provider #1185](https://github.com/kubernetes/cloud-provider-aws/issues/1185)
- [AWS provider #300](https://github.com/kubernetes/cloud-provider-aws/issues/300)

This change uses the `topology.k8s.aws/zone-id` Node label for proxy locality and local endpoint locality when it is available. It supports EndpointSlices from the Kubernetes EndpointSlice controller and the EndpointSlice mirroring controller. It retains the current zone when the ID is missing or empty. Imported and custom EndpointSlices keep the zones supplied by their producers, though these producers should also considerg supplying the accurated physical IDs for cross-account AWS routing.

Validation:

- `make format generate manifests helm-template protos go.testdata.complete` with a stable second generation pass
- `make generate-manifests`
- `make lint`
- `GOMAXPROCS=4 make go.test.coverage`
- Three adversarial code-review rounds

**Which issue(s) this PR fixes**:

https://github.com/envoyproxy/gateway/issues/9959

---

**PR Checklist**

- [ ] **Authorship & ownership**: Coding agents / AI assistants are welcome, but I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR. I have not submitted generated output I do not understand.

- [ ] **DCO**: All commits are signed off (`git commit -s`). See [DCO: Sign your work](https://gateway.envoyproxy.io/community/contributing/#dco-sign-your-work).

- [x] **API agreed first**: N/A: this PR does not change files under `/api`.

- [x] **Required checks pass**: `make generate gen-check`, `make lint`, and the unit-test/coverage build pass. (The local generation-equivalent check ran each `gen-check` prerequisite twice and compared the output because the worktree has uncommitted changes.)

- [x] **Tests added/updated**: New/changed code is covered by appropriate tests.

- [x] **Docs**: User-facing changes update the [docs](https://github.com/envoyproxy/gateway/tree/main/site).

- [ ] **Release notes**: The fragment is ready. Rename it with the PR or issue number before merge.

- [x] **Generated files committed**: N/A: this PR does not change generated inputs.

- [x] **Scope & compatibility**: The PR is limited to AWS locality identity. The breaking default change is in the release note and migration guide.

- [x] **Codex review**: Three adversarial reviews found no open code defect.

- [ ] **Copilot review**: Request a Copilot review and address all comments after the PR opens.
