### PR TITLE
chore: align admins with steering committee

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,8 @@
 admins:
 
+- guydc
+- kai-tillman
 - mattklein123
-- pydctw
-- richarddli
-- skasisom6
 - Xunzhuo
 - zinuga
 


### PR DESCRIPTION
Align admins with the steering committee update in #5400. Add guydc for SAP, replace richarddli with kai-tillman for Ambassador Labs, and remove pydctw and skasisom6. Retain mattklein123, Xunzhuo, and zinuga. Source: https://github.com/envoyproxy/gateway/pull/5400