### PR TITLE
api: support regex CORS origins in SecurityPolicy

### DIFF
--- a/api/v1alpha1/cors_types.go
+++ b/api/v1alpha1/cors_types.go
@@ -28,6 +28,18 @@ import gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 // +kubebuilder:validation:Pattern=`^(\*|[A-Za-z][A-Za-z0-9+.-]*:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$`
 type Origin string
 
+// CORSOriginRegex is a regular expression that is matched against the full Origin header value,
+// including the scheme and the port if present.
+// The regex string must adhere to the syntax documented in
+// https://github.com/google/re2/wiki/Syntax, except for the \C escape sequence,
+// which is not supported.
+// A regular expression that matches the literal string "*" is rejected.
+// The value "*" in AllowOrigins allows any origin.
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=1024
+type CORSOriginRegex string
+
 // CORS defines the configuration for Cross-Origin Resource Sharing (CORS).
 type CORS struct {
 	// AllowOrigins defines the origins that are allowed to make requests.
@@ -36,6 +48,13 @@ type CORS struct {
 	//
 	// +optional
 	AllowOrigins []Origin `json:"allowOrigins,omitempty"`
+
+	// AllowOriginRegexes defines regular expressions that are matched against the Origin header.
+	// It specifies additional allowed origins in the Access-Control-Allow-Origin CORS response header.
+	// An origin is allowed when it matches any entry in AllowOrigins or AllowOriginRegexes.
+	//
+	// +optional
+	AllowOriginRegexes []CORSOriginRegex `json:"allowOriginRegexes,omitempty"`
 
 	// AllowMethods defines the methods that are allowed to make requests.
 	// It specifies the allowed methods in the Access-Control-Allow-Methods CORS response header..

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1141,6 +1141,11 @@ func (in *CORS) DeepCopyInto(out *CORS) {
 		*out = make([]Origin, len(*in))
 		copy(*out, *in)
 	}
+	if in.AllowOriginRegexes != nil {
+		in, out := &in.AllowOriginRegexes, &out.AllowOriginRegexes
+		*out = make([]CORSOriginRegex, len(*in))
+		copy(*out, *in)
+	}
 	if in.AllowMethods != nil {
 		in, out := &in.AllowMethods, &out.AllowMethods
 		*out = make([]string, len(*in))

--- a/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/charts/gateway-crds-helm/templates/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -649,6 +649,24 @@ spec:
                     items:
                       type: string
                     type: array
+                  allowOriginRegexes:
+                    description: |-
+                      AllowOriginRegexes defines regular expressions that are matched against the Origin header.
+                      It specifies additional allowed origins in the Access-Control-Allow-Origin CORS response header.
+                      An origin is allowed when it matches any entry in AllowOrigins or AllowOriginRegexes.
+                    items:
+                      description: |-
+                        CORSOriginRegex is a regular expression that is matched against the full Origin header value,
+                        including the scheme and the port if present.
+                        The regex string must adhere to the syntax documented in
+                        https://github.com/google/re2/wiki/Syntax, except for the \C escape sequence,
+                        which is not supported.
+                        A regular expression that matches the literal string "*" is rejected.
+                        The value "*" in AllowOrigins allows any origin.
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                    type: array
                   allowOrigins:
                     description: |-
                       AllowOrigins defines the origins that are allowed to make requests.

--- a/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/charts/gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -648,6 +648,24 @@ spec:
                     items:
                       type: string
                     type: array
+                  allowOriginRegexes:
+                    description: |-
+                      AllowOriginRegexes defines regular expressions that are matched against the Origin header.
+                      It specifies additional allowed origins in the Access-Control-Allow-Origin CORS response header.
+                      An origin is allowed when it matches any entry in AllowOrigins or AllowOriginRegexes.
+                    items:
+                      description: |-
+                        CORSOriginRegex is a regular expression that is matched against the full Origin header value,
+                        including the scheme and the port if present.
+                        The regex string must adhere to the syntax documented in
+                        https://github.com/google/re2/wiki/Syntax, except for the \C escape sequence,
+                        which is not supported.
+                        A regular expression that matches the literal string "*" is rejected.
+                        The value "*" in AllowOrigins allows any origin.
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                    type: array
                   allowOrigins:
                     description: |-
                       AllowOrigins defines the origins that are allowed to make requests.

--- a/internal/gatewayapi/securitypolicy.go
+++ b/internal/gatewayapi/securitypolicy.go
@@ -1249,7 +1249,10 @@ func (t *Translator) translateSecurityPolicyForRoute(
 	)
 
 	if policy.Spec.CORS != nil {
-		cors = t.buildCORS(policy.Spec.CORS)
+		if cors, err = t.buildCORS(policy.Spec.CORS); err != nil {
+			err = perr.WithMessage(err, "CORS")
+			errs = errors.Join(errs, err)
+		}
 	}
 
 	var csrf *ir.CSRF
@@ -1541,7 +1544,10 @@ func (t *Translator) translateSecurityPolicyForListeners(
 	)
 
 	if policy.Spec.CORS != nil {
-		cors = t.buildCORS(policy.Spec.CORS)
+		if cors, err = t.buildCORS(policy.Spec.CORS); err != nil {
+			err = perr.WithMessage(err, "CORS")
+			errs = errors.Join(errs, err)
+		}
 	}
 
 	var csrf *ir.CSRF
@@ -1732,7 +1738,7 @@ func (t *Translator) translateSecurityPolicyForListeners(
 	return errs
 }
 
-func (t *Translator) buildCORS(cors *egv1a1.CORS) *ir.CORS {
+func (t *Translator) buildCORS(cors *egv1a1.CORS) (*ir.CORS, error) {
 	var allowOrigins []*ir.StringMatch
 
 	for _, origin := range cors.AllowOrigins {
@@ -1746,6 +1752,26 @@ func (t *Translator) buildCORS(cors *egv1a1.CORS) *ir.CORS {
 				Exact: (*string)(&origin),
 			})
 		}
+	}
+
+	for _, originRegex := range cors.AllowOriginRegexes {
+		regexStr := string(originRegex)
+		// Validate the pattern before it is anchored below, since anchoring an unbalanced pattern
+		// such as ")(" would make it valid.
+		if err := regex.Validate(regexStr); err != nil {
+			return nil, err
+		}
+		// Envoy's CORS filter tries each origin matcher against the literal "*" before the request
+		// origin, so a regex that fully matches "*" allows all origins.
+		// https://github.com/envoyproxy/envoy/blob/b579d07d3ad7ee11d32b105e91a5a39ad24718d7/source/extensions/filters/http/cors/cors_filter.cc#L208-L215
+		anchored, err := regexp.Compile("^(?:" + regexStr + ")$")
+		if err != nil {
+			return nil, err
+		}
+		if anchored.MatchString("*") {
+			return nil, fmt.Errorf(`origin regular expression %q must not match "*", use allowOrigins with value "*" to allow all origins`, regexStr)
+		}
+		allowOrigins = append(allowOrigins, &ir.StringMatch{SafeRegex: &regexStr})
 	}
 
 	irCORS := &ir.CORS{
@@ -1762,7 +1788,7 @@ func (t *Translator) buildCORS(cors *egv1a1.CORS) *ir.CORS {
 		}
 	}
 
-	return irCORS
+	return irCORS, nil
 }
 
 func (t *Translator) buildCSRF(csrf *egv1a1.CSRF) *ir.CSRF {

--- a/internal/gatewayapi/securitypolicy_test.go
+++ b/internal/gatewayapi/securitypolicy_test.go
@@ -27,6 +27,60 @@ import (
 	"github.com/envoyproxy/gateway/internal/ir"
 )
 
+func TestBuildCORSOriginRegexes(t *testing.T) {
+	tr := &Translator{}
+
+	tests := []struct {
+		name        string
+		originRegex string
+		wantError   string
+	}{
+		{
+			name:        "regex is preserved",
+			originRegex: `https://preview-[0-9]+\.example\.com(:8443)?`,
+		},
+		{
+			name:        "broad regex that does not match the wildcard is preserved",
+			originRegex: "https?://.*",
+		},
+		{
+			name:        "invalid regex",
+			originRegex: "[",
+			wantError:   `regex "[" is invalid`,
+		},
+		{
+			name:        "regex matching any host allows all origins",
+			originRegex: `[^/]+`,
+			wantError:   `origin regular expression "[^/]+" must not match "*", use allowOrigins with value "*" to allow all origins`,
+		},
+		{
+			name:        "regex matching anything allows all origins",
+			originRegex: ".*",
+			wantError:   `origin regular expression ".*" must not match "*", use allowOrigins with value "*" to allow all origins`,
+		},
+		{
+			name:        "escaped wildcard allows all origins",
+			originRegex: `\*`,
+			wantError:   `origin regular expression "\\*" must not match "*", use allowOrigins with value "*" to allow all origins`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tr.buildCORS(&egv1a1.CORS{
+				AllowOriginRegexes: []egv1a1.CORSOriginRegex{egv1a1.CORSOriginRegex(tt.originRegex)},
+			})
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, []*ir.StringMatch{{SafeRegex: &tt.originRegex}}, got.AllowOrigins)
+		})
+	}
+}
+
 func Test_wildcard2regex(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors-invalid-origin-regexes.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors-invalid-origin-regexes.in.yaml
@@ -1,0 +1,72 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    namespace: default
+    name: gateway-1
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-1
+  spec:
+    parentRefs:
+    - name: gateway-1
+    rules:
+    - matches:
+      - path:
+          value: /foo
+      backendRefs:
+      - name: service-1
+        port: 8080
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    namespace: default
+    name: httproute-2
+  spec:
+    parentRefs:
+    - name: gateway-1
+    rules:
+    - matches:
+      - path:
+          value: /bar
+      backendRefs:
+      - name: service-1
+        port: 8080
+securityPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: SecurityPolicy
+  metadata:
+    namespace: default
+    name: policy-for-gateway-1
+  spec:
+    targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-1
+    cors:
+      allowOrigins:
+      - https://app.example.com
+      allowOriginRegexes:
+      - '['
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: SecurityPolicy
+  metadata:
+    namespace: default
+    name: policy-for-route-1
+  spec:
+    targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httproute-2
+    cors:
+      allowOriginRegexes:
+      - '[^/]+'

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors-invalid-origin-regexes.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors-invalid-origin-regexes.out.yaml
@@ -1,0 +1,297 @@
+gateways:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: gateway-1
+    namespace: default
+  spec:
+    gatewayClassName: envoy-gateway-class
+    listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+  status:
+    listeners:
+    - attachedRoutes: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Sending translated listener configuration to the data plane
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Listener has been successfully translated
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Listener references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+httpRoutes:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-1
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          value: /foo
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: httproute-2
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gateway-1
+    rules:
+    - backendRefs:
+      - name: service-1
+        port: 8080
+      matches:
+      - path:
+          value: /bar
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: null
+        message: Route is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Resolved all the Object references for the Route
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+      parentRef:
+        name: gateway-1
+infraIR:
+  default/gateway-1:
+    proxy:
+      listeners:
+      - name: default/gateway-1/http
+        ports:
+        - containerPort: 10080
+          name: http-80
+          protocol: HTTP
+          servicePort: 80
+      metadata:
+        labels:
+          gateway.envoyproxy.io/owning-gateway-name: gateway-1
+          gateway.envoyproxy.io/owning-gateway-namespace: default
+        ownerReference:
+          kind: GatewayClass
+          name: envoy-gateway-class
+      name: default/gateway-1
+      namespace: envoy-gateway-system
+securityPolicies:
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: SecurityPolicy
+  metadata:
+    name: policy-for-route-1
+    namespace: default
+  spec:
+    cors:
+      allowOriginRegexes:
+      - '[^/]+'
+    targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httproute-2
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+      conditions:
+      - lastTransitionTime: null
+        message: 'CORS: origin regular expression "[^/]+" must not match "*", use
+          allowOrigins with value "*" to allow all origins.'
+        reason: Invalid
+        status: "False"
+        type: Accepted
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+- apiVersion: gateway.envoyproxy.io/v1alpha1
+  kind: SecurityPolicy
+  metadata:
+    name: policy-for-gateway-1
+    namespace: default
+  spec:
+    cors:
+      allowOriginRegexes:
+      - '['
+      allowOrigins:
+      - https://app.example.com
+    targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-1
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+      conditions:
+      - lastTransitionTime: null
+        message: 'CORS: regex "[" is invalid: error parsing regexp: missing closing
+          ]: `[`.'
+        reason: Invalid
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: 'This policy is being overridden by other securityPolicies for these
+          routes: [default/httproute-2]'
+        reason: Overridden
+        status: "True"
+        type: Overridden
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+xdsIR:
+  default/gateway-1:
+    accessLog:
+      json:
+      - path: /dev/stdout
+    globalResources:
+      proxyServiceCluster:
+        metadata:
+          kind: Service
+          name: envoy-default-gateway-1-bfd08ef4
+          namespace: envoy-gateway-system
+          sectionName: "8080"
+        name: default/gateway-1
+        settings:
+        - addressType: IP
+          endpoints:
+          - host: 7.6.5.4
+            port: 8080
+            zone: zone1
+          metadata:
+            kind: Service
+            name: envoy-default-gateway-1-bfd08ef4
+            namespace: envoy-gateway-system
+            sectionName: "8080"
+          name: default/gateway-1
+          protocol: TCP
+    http:
+    - address: 0.0.0.0
+      externalPort: 80
+      hostnames:
+      - '*'
+      metadata:
+        kind: Gateway
+        name: gateway-1
+        namespace: default
+        sectionName: http
+      name: default/gateway-1/http
+      path:
+        escapedSlashesAction: UnescapeAndRedirect
+        mergeSlashes: true
+      port: 10080
+      routes:
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-1
+            namespace: default
+          name: httproute/default/httproute-1/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-1/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        directResponse:
+          statusCode: 500
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-1
+          namespace: default
+        name: httproute/default/httproute-1/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /foo
+        security: {}
+      - destination:
+          metadata:
+            kind: HTTPRoute
+            name: httproute-2
+            namespace: default
+          name: httproute/default/httproute-2/rule/0
+          settings:
+          - addressType: IP
+            endpoints:
+            - host: 7.7.7.7
+              port: 8080
+            metadata:
+              kind: Service
+              name: service-1
+              namespace: default
+              sectionName: "8080"
+            name: httproute/default/httproute-2/rule/0/backend/0
+            protocol: HTTP
+            weight: 1
+        directResponse:
+          statusCode: 500
+        hostname: '*'
+        isHTTP2: false
+        metadata:
+          kind: HTTPRoute
+          name: httproute-2
+          namespace: default
+        name: httproute/default/httproute-2/rule/0/match/0/*
+        pathMatch:
+          distinct: false
+          name: ""
+          prefix: /bar
+        security: {}
+    readyListener:
+      address: 0.0.0.0
+      ipFamily: IPv4
+      path: /ready
+      port: 19003

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors.in.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors.in.yaml
@@ -111,6 +111,8 @@ securityPolicies:
       - "http://*.example.com"
       - "http://foo.bar.com"
       - "https://*"
+      allowOriginRegexes:
+      - 'https://preview-[0-9]+\.example\.com(:8443)?'
       allowMethods:
       - GET
       - POST
@@ -135,6 +137,8 @@ securityPolicies:
       allowOrigins:
       - "https://*.test.com:8080"
       - "https://www.test.org:8080"
+      allowOriginRegexes:
+      - 'https://preview-[0-9]+\.example\.com'
       allowMethods:
       - GET
       - POST

--- a/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
+++ b/internal/gatewayapi/testdata/securitypolicy-with-cors.out.yaml
@@ -293,6 +293,8 @@ securityPolicies:
       allowMethods:
       - GET
       - POST
+      allowOriginRegexes:
+      - https://preview-[0-9]+\.example\.com
       allowOrigins:
       - https://*.test.com:8080
       - https://www.test.org:8080
@@ -380,6 +382,8 @@ securityPolicies:
       allowMethods:
       - GET
       - POST
+      allowOriginRegexes:
+      - https://preview-[0-9]+\.example\.com(:8443)?
       allowOrigins:
       - http://*.example.com
       - http://foo.bar.com
@@ -500,6 +504,9 @@ xdsIR:
             - distinct: false
               name: ""
               safeRegex: https://.*
+            - distinct: false
+              name: ""
+              safeRegex: https://preview-[0-9]+\.example\.com(:8443)?
             exposeHeaders:
             - x-header-3
             - x-header-4
@@ -595,6 +602,9 @@ xdsIR:
             - distinct: false
               exact: https://www.test.org:8080
               name: ""
+            - distinct: false
+              name: ""
+              safeRegex: https://preview-[0-9]+\.example\.com
             exposeHeaders:
             - x-header-7
             - x-header-8

--- a/internal/xds/translator/testdata/in/xds-ir/cors.yaml
+++ b/internal/xds/translator/testdata/in/xds-ir/cors.yaml
@@ -26,6 +26,7 @@ http:
           safeRegex: "*.example.com"
         - name: foo.bar.com
           exact: foo.bar.com
+        - safeRegex: 'https://preview-[0-9]+\.example\.com(:8443)?'
         allowMethods:
         - GET
         - POST

--- a/internal/xds/translator/testdata/out/xds-ir/cors.routes.yaml
+++ b/internal/xds/translator/testdata/out/xds-ir/cors.routes.yaml
@@ -22,6 +22,8 @@
           - safeRegex:
               regex: '*.example.com'
           - exact: foo.bar.com
+          - safeRegex:
+              regex: https://preview-[0-9]+\.example\.com(:8443)?
           exposeHeaders: x-header-3, x-header-4
           forwardNotMatchingPreflights: false
           maxAge: "1000"

--- a/release-notes/current/new_features/9965-cors-origin-regexes.md
+++ b/release-notes/current/new_features/9965-cors-origin-regexes.md
@@ -1,0 +1,1 @@
+Added `SecurityPolicy.spec.cors.allowOriginRegexes` to allow CORS origins using regular expressions alongside existing `allowOrigins` entries.

--- a/site/content/en/latest/api/extension_types.md
+++ b/site/content/en/latest/api/extension_types.md
@@ -868,11 +868,29 @@ _Appears in:_
 | Field | Type | Required | Default | Description |
 | ---   | ---  | ---      | ---     | ---         |
 | `allowOrigins` | _[Origin](#origin) array_ |  false  |  | AllowOrigins defines the origins that are allowed to make requests.<br />It specifies the allowed origins in the Access-Control-Allow-Origin CORS response header.<br />The value "*" allows any origin to make requests. |
+| `allowOriginRegexes` | _[CORSOriginRegex](#corsoriginregex) array_ |  false  |  | AllowOriginRegexes defines regular expressions that are matched against the Origin header.<br />It specifies additional allowed origins in the Access-Control-Allow-Origin CORS response header.<br />An origin is allowed when it matches any entry in AllowOrigins or AllowOriginRegexes. |
 | `allowMethods` | _string array_ |  false  |  | AllowMethods defines the methods that are allowed to make requests.<br />It specifies the allowed methods in the Access-Control-Allow-Methods CORS response header..<br />The value "*" allows any method to be used. |
 | `allowHeaders` | _string array_ |  false  |  | AllowHeaders defines the headers that are allowed to be sent with requests.<br />It specifies the allowed headers in the Access-Control-Allow-Headers CORS response header..<br />The value "*" allows any header to be sent. |
 | `exposeHeaders` | _string array_ |  false  |  | ExposeHeaders defines which response headers should be made accessible to<br />scripts running in the browser.<br />It specifies the headers in the Access-Control-Expose-Headers CORS response header..<br />The value "*" allows any header to be exposed. |
 | `maxAge` | _[Duration](https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#duration)_ |  false  |  | MaxAge defines how long the results of a preflight request can be cached.<br />It specifies the value in the Access-Control-Max-Age CORS response header.. |
 | `allowCredentials` | _boolean_ |  false  |  | AllowCredentials indicates whether a request can include user credentials<br />like cookies, authentication headers, or TLS client certificates.<br />It specifies the value in the Access-Control-Allow-Credentials CORS response header. |
+
+
+#### CORSOriginRegex
+
+_Underlying type:_ _string_
+
+CORSOriginRegex is a regular expression that is matched against the full Origin header value,
+including the scheme and the port if present.
+The regex string must adhere to the syntax documented in
+https://github.com/google/re2/wiki/Syntax, except for the \C escape sequence,
+which is not supported.
+A regular expression that matches the literal string "*" is rejected.
+The value "*" in AllowOrigins allows any origin.
+
+_Appears in:_
+- [CORS](#cors)
+
 
 
 #### CSRF

--- a/site/content/en/latest/tasks/security/cors.md
+++ b/site/content/en/latest/tasks/security/cors.md
@@ -21,10 +21,15 @@ is only supported on the [HTTPRoute][] resource.
 When configuring CORS either an origin with a precise hostname can be configured or an hostname containing a wildcard prefix,
 allowing all subdomains of the specified hostname.
 In addition to that the entire origin (with or without specifying a scheme) can be a wildcard to allow all origins.
+A SecurityPolicy can also allow origins that match a regular expression in [`allowOriginRegexes`][CORSOriginRegex].
+Regular expressions use [RE2][] syntax, except for the `\C` escape sequence, which is not supported.
+The regular expression must match the entire origin, including the scheme and the port if present.
+A regular expression that matches the literal string `*` is rejected. Use `allowOrigins: ["*"]` to allow all origins.
 
 ### Configuring CORS with SecurityPolicy
 
-The below example defines a SecurityPolicy that allows CORS for requests originating from `http://*.foo.com`.
+The below example defines a SecurityPolicy that allows CORS for requests originating from `http://*.foo.com`, and from
+origins matching the regular expression `https://preview-[0-9]+\.example\.com`, such as `https://preview-123.example.com`.
 It also enables credentialed requests with `allowCredentials: true`.
 
 {{< tabpane text=true >}}
@@ -44,6 +49,8 @@ spec:
   cors:
     allowOrigins:
     - "http://*.foo.com"
+    allowOriginRegexes:
+    - 'https://preview-[0-9]+\.example\.com'
     allowCredentials: true
     allowMethods:
     - GET
@@ -75,6 +82,8 @@ spec:
   cors:
     allowOrigins:
     - "http://*.foo.com"
+    allowOriginRegexes:
+    - 'https://preview-[0-9]+\.example\.com'
     allowCredentials: true
     allowMethods:
     - GET
@@ -249,6 +258,27 @@ curl -H "Origin: http://www.foo.com:8080" \
   1> /dev/null
 ```
 
+If you applied the SecurityPolicy, a request from `https://preview-123.example.com` is also allowed because it matches
+the regular expression in `allowOriginRegexes`:
+
+```shell
+curl -H "Origin: https://preview-123.example.com" \
+  -H "Host: www.example.com" \
+  -H "Access-Control-Request-Method: GET" \
+  -X OPTIONS -v -s \
+  http://$GATEWAY_HOST \
+  1> /dev/null
+```
+
+You should see the below response, indicating that the request from `https://preview-123.example.com` is allowed:
+
+```shell
+< access-control-allow-origin: https://preview-123.example.com
+```
+
+A request from `https://preview-123.example.com:8443` is not allowed because the regular expression must match the
+entire origin, including the port number.
+
 Note:
 * CORS specification requires that the browsers to send a preflight request to the server to ask if it's allowed
 to access the limited resource in another domains. The browsers are supposed to follow the response from the server to
@@ -278,3 +308,5 @@ Checkout the [Developer Guide](/community/develop) to get involved in the projec
 [HTTPRoute]: https://gateway-api.sigs.k8s.io/reference/api-types/httproute/
 [GRPCRoute]: https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/
 [HTTPCORSFilter]: https://gateway-api.sigs.k8s.io/reference/api-spec/1.4/spec/#httpcorsfilter
+[RE2]: https://github.com/google/re2/wiki/Syntax
+[CORSOriginRegex]: ../../../api/extension_types#corsoriginregex

--- a/test/cel-validation/securitypolicy_test.go
+++ b/test/cel-validation/securitypolicy_test.go
@@ -2275,6 +2275,80 @@ func TestSecurityPolicyTarget(t *testing.T) {
 	}
 }
 
+func TestSecurityPolicyCORSOriginRegexes(t *testing.T) {
+	ctx := context.Background()
+	baseSP := egv1a1.SecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sp",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: egv1a1.SecurityPolicySpec{
+			PolicyTargetReferences: egv1a1.PolicyTargetReferences{
+				TargetRef: &gwapiv1.LocalPolicyTargetReferenceWithSectionName{
+					LocalPolicyTargetReference: gwapiv1.LocalPolicyTargetReference{
+						Group: gwapiv1.Group("gateway.networking.k8s.io"),
+						Kind:  gwapiv1.Kind("Gateway"),
+						Name:  gwapiv1.ObjectName("eg"),
+					},
+				},
+			},
+			CORS: &egv1a1.CORS{},
+		},
+	}
+
+	cases := []struct {
+		desc               string
+		allowOriginRegexes []egv1a1.CORSOriginRegex
+		wantErrors         []string
+	}{
+		{
+			desc: "valid regular expression",
+			allowOriginRegexes: []egv1a1.CORSOriginRegex{
+				`https://preview-[0-9]+\.example\.com`,
+			},
+		},
+		{
+			desc: "empty regular expression",
+			allowOriginRegexes: []egv1a1.CORSOriginRegex{
+				"",
+			},
+			wantErrors: []string{"spec.cors.allowOriginRegexes[0]", "should be at least 1 chars long"},
+		},
+		{
+			desc: "regular expression too long",
+			allowOriginRegexes: []egv1a1.CORSOriginRegex{
+				egv1a1.CORSOriginRegex(strings.Repeat("a", 1025)),
+			},
+			// The exact wording after "Too long" varies across apiserver versions,
+			// so only assert on the stable prefix.
+			wantErrors: []string{"spec.cors.allowOriginRegexes[0]", "Too long"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sp := baseSP.DeepCopy()
+			sp.Name = fmt.Sprintf("sp-cors-origin-regexes-%v", time.Now().UnixNano())
+			sp.Spec.CORS.AllowOriginRegexes = tc.allowOriginRegexes
+
+			err := c.Create(ctx, sp)
+			if (len(tc.wantErrors) != 0) != (err != nil) {
+				t.Fatalf("Unexpected response while creating SecurityPolicy; got err=\n%v\n;want error=%v", err, tc.wantErrors)
+			}
+
+			var missingErrorStrings []string
+			for _, wantError := range tc.wantErrors {
+				if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(wantError)) {
+					missingErrorStrings = append(missingErrorStrings, wantError)
+				}
+			}
+			if len(missingErrorStrings) != 0 {
+				t.Errorf("Unexpected response while creating SecurityPolicy; got err=\n%v\n;missing strings within error=%q", err, missingErrorStrings)
+			}
+		})
+	}
+}
+
 func TestSecurityPolicyAPIKeyAuthExtractFrom(t *testing.T) {
 	ctx := context.Background()
 	baseSP := egv1a1.SecurityPolicy{

--- a/test/e2e/testdata/cors-security-policy.yaml
+++ b/test/e2e/testdata/cors-security-policy.yaml
@@ -80,3 +80,84 @@ spec:
     - "*"
     exposeHeaders:
     - "*"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-with-cors-origin-regexes
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /cors-origin-regexes
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: cors-origin-regexes
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: http-with-cors-origin-regexes
+  cors:
+    allowOrigins:
+    - "https://www.foo.com"
+    allowOriginRegexes:
+    - 'https://preview-[0-9]+\.example\.com(:8443)?'
+    allowMethods:
+    - GET
+    - POST
+    - PUT
+    - PATCH
+    - DELETE
+    - OPTIONS
+    allowHeaders:
+    - "x-header-1"
+    - "x-header-2"
+    exposeHeaders:
+    - "x-header-3"
+    - "x-header-4"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-with-cors-origin-regexes-allow-all
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /cors-origin-regexes-allow-all
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: cors-origin-regexes-allow-all
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: http-with-cors-origin-regexes-allow-all
+  cors:
+    allowOrigins:
+    - "https://app.example.com"
+    allowOriginRegexes:
+    - '[^/]+'
+    allowMethods:
+    - GET

--- a/test/e2e/tests/cors.go
+++ b/test/e2e/tests/cors.go
@@ -36,8 +36,11 @@ var CORSFromSecurityPolicyTest = suite.ConformanceTest{
 func runCORStest(t *testing.T, suite *suite.ConformanceTestSuite) {
 	ns := "gateway-conformance-infra"
 	routeNN := types.NamespacedName{Name: "http-with-cors-exact", Namespace: ns}
+	originRegexesRouteNN := types.NamespacedName{Name: "http-with-cors-origin-regexes", Namespace: ns}
+	allowAllRegexRouteNN := types.NamespacedName{Name: "http-with-cors-origin-regexes-allow-all", Namespace: ns}
 	gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-	gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN)
+	gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName,
+		kubernetes.NewGatewayRef(gwNN), &gwapiv1.HTTPRoute{}, false, routeNN, originRegexesRouteNN, allowAllRegexRouteNN)
 
 	ancestorRef := gwapiv1.ParentReference{
 		Group:     gatewayapi.GroupPtr(gwapiv1.GroupName),
@@ -47,6 +50,12 @@ func runCORStest(t *testing.T, suite *suite.ConformanceTestSuite) {
 	}
 
 	SecurityPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "cors-exact", Namespace: ns}, suite.ControllerName, ancestorRef)
+	SecurityPolicyMustBeAccepted(t, suite.Client, types.NamespacedName{Name: "cors-origin-regexes", Namespace: ns}, suite.ControllerName, ancestorRef)
+	SecurityPolicyMustFail(
+		t, suite.Client,
+		types.NamespacedName{Name: "cors-origin-regexes-allow-all", Namespace: ns},
+		suite.ControllerName,
+		ancestorRef, `origin regular expression "[^/]+" must not match "*"`)
 
 	t.Run("should enable cors with Allow Origin Exact", func(t *testing.T) {
 		expectedResponse := http.ExpectedResponse{
@@ -184,6 +193,162 @@ func runCORStest(t *testing.T, suite *suite.ConformanceTestSuite) {
 				},
 			},
 			Namespace: "",
+		}
+
+		http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
+	})
+
+	t.Run("should enable cors with allowOriginRegexes", func(t *testing.T) {
+		expectedResponse := http.ExpectedResponse{
+			Request: http.Request{
+				Path:   "/cors-origin-regexes",
+				Method: "OPTIONS",
+				Headers: map[string]string{
+					"Origin":                         "https://preview-123.example.com",
+					"access-control-request-method":  "GET",
+					"access-control-request-headers": "x-header-1, x-header-2",
+				},
+			},
+			// Set the expected request properties to empty strings.
+			// This is a workaround to avoid the test failure.
+			// The response body is empty because the request is a preflight request.
+			ExpectedRequest: &http.ExpectedRequest{
+				Request: http.Request{
+					Host:    "",
+					Method:  "OPTIONS",
+					Path:    "",
+					Headers: nil,
+				},
+			},
+			Response: http.Response{
+				StatusCodes: []int{200},
+				Headers: map[string]string{
+					"access-control-allow-origin":   "https://preview-123.example.com",
+					"access-control-allow-methods":  "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+					"access-control-allow-headers":  "x-header-1, x-header-2",
+					"access-control-expose-headers": "x-header-3, x-header-4",
+				},
+			},
+			Namespace: "",
+		}
+
+		http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
+	})
+
+	t.Run("should enable cors with allowOriginRegexes and port", func(t *testing.T) {
+		expectedResponse := http.ExpectedResponse{
+			Request: http.Request{
+				Path:   "/cors-origin-regexes",
+				Method: "OPTIONS",
+				Headers: map[string]string{
+					"Origin":                         "https://preview-123.example.com:8443",
+					"access-control-request-method":  "GET",
+					"access-control-request-headers": "x-header-1, x-header-2",
+				},
+			},
+			// Set the expected request properties to empty strings.
+			// This is a workaround to avoid the test failure.
+			// The response body is empty because the request is a preflight request.
+			ExpectedRequest: &http.ExpectedRequest{
+				Request: http.Request{
+					Host:    "",
+					Method:  "OPTIONS",
+					Path:    "",
+					Headers: nil,
+				},
+			},
+			Response: http.Response{
+				StatusCodes: []int{200},
+				Headers: map[string]string{
+					"access-control-allow-origin":   "https://preview-123.example.com:8443",
+					"access-control-allow-methods":  "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+					"access-control-allow-headers":  "x-header-1, x-header-2",
+					"access-control-expose-headers": "x-header-3, x-header-4",
+				},
+			},
+			Namespace: "",
+		}
+
+		http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
+	})
+
+	t.Run("should enable cors with allowOrigins alongside allowOriginRegexes", func(t *testing.T) {
+		expectedResponse := http.ExpectedResponse{
+			Request: http.Request{
+				Path:   "/cors-origin-regexes",
+				Method: "OPTIONS",
+				Headers: map[string]string{
+					"Origin":                         "https://www.foo.com",
+					"access-control-request-method":  "GET",
+					"access-control-request-headers": "x-header-1, x-header-2",
+				},
+			},
+			// Set the expected request properties to empty strings.
+			// This is a workaround to avoid the test failure.
+			// The response body is empty because the request is a preflight request.
+			ExpectedRequest: &http.ExpectedRequest{
+				Request: http.Request{
+					Host:    "",
+					Method:  "OPTIONS",
+					Path:    "",
+					Headers: nil,
+				},
+			},
+			Response: http.Response{
+				StatusCodes: []int{200},
+				Headers: map[string]string{
+					"access-control-allow-origin":   "https://www.foo.com",
+					"access-control-allow-methods":  "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+					"access-control-allow-headers":  "x-header-1, x-header-2",
+					"access-control-expose-headers": "x-header-3, x-header-4",
+				},
+			},
+			Namespace: "",
+		}
+
+		http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
+	})
+
+	t.Run("should not contain cors headers when Origin does not match allowOriginRegexes", func(t *testing.T) {
+		expectedResponse := http.ExpectedResponse{
+			Request: http.Request{
+				Path:   "/cors-origin-regexes",
+				Method: "OPTIONS",
+				Headers: map[string]string{
+					"Origin":                         "https://preview-abc.example.com",
+					"access-control-request-method":  "GET",
+					"access-control-request-headers": "x-header-1, x-header-2",
+				},
+			},
+			// Set the expected request properties to empty strings.
+			// This is a workaround to avoid the test failure.
+			// The response body is empty because the request is a preflight request.
+			ExpectedRequest: &http.ExpectedRequest{
+				Request: http.Request{
+					Host:    "",
+					Method:  "OPTIONS",
+					Path:    "",
+					Headers: nil,
+				},
+			},
+			Response: http.Response{
+				AbsentHeaders: []string{"access-control-allow-origin"},
+			},
+			Namespace: "",
+		}
+
+		http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)
+	})
+
+	t.Run("http route with failed SecurityPolicy", func(t *testing.T) {
+		expectedResponse := http.ExpectedResponse{
+			Request: http.Request{
+				Path: "/cors-origin-regexes-allow-all",
+			},
+			Response: http.Response{
+				StatusCodes: []int{500},
+			},
+			Namespace: ns,
 		}
 
 		http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expectedResponse)

--- a/test/helm/gateway-crds-helm/all.out.yaml
+++ b/test/helm/gateway-crds-helm/all.out.yaml
@@ -54581,6 +54581,24 @@ spec:
                     items:
                       type: string
                     type: array
+                  allowOriginRegexes:
+                    description: |-
+                      AllowOriginRegexes defines regular expressions that are matched against the Origin header.
+                      It specifies additional allowed origins in the Access-Control-Allow-Origin CORS response header.
+                      An origin is allowed when it matches any entry in AllowOrigins or AllowOriginRegexes.
+                    items:
+                      description: |-
+                        CORSOriginRegex is a regular expression that is matched against the full Origin header value,
+                        including the scheme and the port if present.
+                        The regex string must adhere to the syntax documented in
+                        https://github.com/google/re2/wiki/Syntax, except for the \C escape sequence,
+                        which is not supported.
+                        A regular expression that matches the literal string "*" is rejected.
+                        The value "*" in AllowOrigins allows any origin.
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                    type: array
                   allowOrigins:
                     description: |-
                       AllowOrigins defines the origins that are allowed to make requests.

--- a/test/helm/gateway-crds-helm/e2e.out.yaml
+++ b/test/helm/gateway-crds-helm/e2e.out.yaml
@@ -30519,6 +30519,24 @@ spec:
                     items:
                       type: string
                     type: array
+                  allowOriginRegexes:
+                    description: |-
+                      AllowOriginRegexes defines regular expressions that are matched against the Origin header.
+                      It specifies additional allowed origins in the Access-Control-Allow-Origin CORS response header.
+                      An origin is allowed when it matches any entry in AllowOrigins or AllowOriginRegexes.
+                    items:
+                      description: |-
+                        CORSOriginRegex is a regular expression that is matched against the full Origin header value,
+                        including the scheme and the port if present.
+                        The regex string must adhere to the syntax documented in
+                        https://github.com/google/re2/wiki/Syntax, except for the \C escape sequence,
+                        which is not supported.
+                        A regular expression that matches the literal string "*" is rejected.
+                        The value "*" in AllowOrigins allows any origin.
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                    type: array
                   allowOrigins:
                     description: |-
                       AllowOrigins defines the origins that are allowed to make requests.

--- a/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
+++ b/test/helm/gateway-crds-helm/envoy-gateway-crds.out.yaml
@@ -30519,6 +30519,24 @@ spec:
                     items:
                       type: string
                     type: array
+                  allowOriginRegexes:
+                    description: |-
+                      AllowOriginRegexes defines regular expressions that are matched against the Origin header.
+                      It specifies additional allowed origins in the Access-Control-Allow-Origin CORS response header.
+                      An origin is allowed when it matches any entry in AllowOrigins or AllowOriginRegexes.
+                    items:
+                      description: |-
+                        CORSOriginRegex is a regular expression that is matched against the full Origin header value,
+                        including the scheme and the port if present.
+                        The regex string must adhere to the syntax documented in
+                        https://github.com/google/re2/wiki/Syntax, except for the \C escape sequence,
+                        which is not supported.
+                        A regular expression that matches the literal string "*" is rejected.
+                        The value "*" in AllowOrigins allows any origin.
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                    type: array
                   allowOrigins:
                     description: |-
                       AllowOrigins defines the origins that are allowed to make requests.


### PR DESCRIPTION
Fixes #9965

**What this PR does / why we need it**:

Add `cors.allowOriginRegexes` to `SecurityPolicy` for origins such as `https://preview-123.example.com`, where allowing every subdomain with a wildcard is too broad.

The new field is a list of `CORSOriginRegex` strings. Use `allowOrigins` for exact origins, hostname wildcards, and allow-all. An origin is allowed if it matches either list.

```yaml
spec:
  cors:
    allowOrigins:
      - https://app.example.com
    allowOriginRegexes:
      - "https://preview-[0-9]+\\.example\\.com"
```

Regexes use [RE2 syntax](https://github.com/google/re2/wiki/Syntax), the same contract as the other regular expression fields in the API, and are validated with the existing `regex.Validate` helper. They match the full Origin header, including the scheme and port when present. Invalid patterns follow the existing SecurityPolicy error handling: `Accepted=False` and a 500 response on affected routes. Regular expressions that match the literal string `"*"` are rejected because Envoy's CORS filter treats any matcher that matches `"*"` as allow-all; use `allowOrigins: ["*"]` to allow any origin explicitly.

**Which issue(s) this PR fixes**:

Fixes #9965

---

**PR Checklist**

- [x] **Authorship & ownership**: I have reviewed every change, understand how and why it works, can explain and maintain it, and take full responsibility for this PR.
- [x] **DCO**: All commits are signed off.
- [ ] **API agreed first**: Proposed in #9965. The field name `allowOriginRegexes` and the `CORSOriginRegex` type follow @zhaohuabing's suggestion in this PR; awaiting maintainer sign-off.
- [ ] **Required checks pass**: GitHub Actions is awaiting maintainer approval.
- [x] **Tests added/updated**: Translator, admission, status, and E2E coverage added.
- [x] **Docs**: CORS task and API reference updated.
- [x] **Release notes**: Added `9965-cors-origin-regexes.md`.
- [x] **Generated files committed**: `make gen-check` passes with a clean working tree.
- [x] **Scope & compatibility**: Existing `allowOrigins` behavior is preserved.
- [x] **Codex review**
- [ ] **Copilot review**
