### PR TITLE
docs: local rate limit supports Distinct matching

### DIFF
--- a/site/content/en/latest/tasks/traffic/local-rate-limit.md
+++ b/site/content/en/latest/tasks/traffic/local-rate-limit.md
@@ -611,8 +611,72 @@ transfer-encoding: chunked
 
 ```
 
-**Note:** Local rate limiting does not support `distinct` matching. If you want to rate limit based on distinct values,
-you should use [Global Rate Limiting][].
+**Note:** Local rate limiting supports `Distinct` matching since v1.4.0. See [Rate Limit Distinct Clients](#rate-limit-distinct-clients).
+
+## Rate Limit Distinct Clients
+
+With a selector of type `Distinct`, every distinct value seen in the traffic gets its own token bucket: a `sourceCIDR` of type `Distinct` limits each client IP separately, and a header of type `Distinct` limits each header value separately.
+
+This example limits each client IP to 10 requests/Minute. The `0.0.0.0/0` CIDR only covers IPv4 clients; add a second rule with `::/0` to limit IPv6 clients too.
+
+{{< tabpane text=true >}}
+{{% tab header="Apply from stdin" %}}
+
+```shell
+cat <<EOF | kubectl apply -f -
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: policy-httproute
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: http-ratelimit
+  rateLimit:
+    local:
+      rules:
+      - clientSelectors:
+        - sourceCIDR:
+            type: Distinct
+            value: 0.0.0.0/0
+        limit:
+          requests: 10
+          unit: Minute
+EOF
+```
+
+{{% /tab %}}
+{{% tab header="Apply from file" %}}
+Save and apply the following resource to your cluster:
+
+```yaml
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: policy-httproute
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: http-ratelimit
+  rateLimit:
+    local:
+      rules:
+      - clientSelectors:
+        - sourceCIDR:
+            type: Distinct
+            value: 0.0.0.0/0
+        limit:
+          requests: 10
+          unit: Minute
+```
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+The buckets live in the memory of each Envoy proxy: a client whose requests reach different proxies gets a separate budget on each, and every bucket starts full again when the proxy restarts. Use [Global Rate Limiting][] when the limit must be shared across proxies.
 
 ## Rate Limit Based on Path
 

--- a/site/content/en/latest/tasks/traffic/local-rate-limit.md
+++ b/site/content/en/latest/tasks/traffic/local-rate-limit.md
@@ -615,7 +615,9 @@ transfer-encoding: chunked
 
 ## Rate Limit Distinct Clients
 
-With a selector of type `Distinct`, every distinct value seen in the traffic gets its own token bucket: a `sourceCIDR` of type `Distinct` limits each client IP separately, and a header of type `Distinct` limits each header value separately.
+For a single selector of type `Distinct`, local rate limiting keeps a separate token bucket per distinct matched value, subject to the cache capacity described below. A `sourceCIDR` selector distinguishes the detected client IP addresses within the CIDR, and a header selector distinguishes header values.
+
+Envoy keys a `sourceCIDR` selector on the client address it detects. When clients reach Envoy through trusted proxies that pass their addresses in `X-Forwarded-For`, first configure `clientIPDetection` in a `ClientTrafficPolicy` targeting the Gateway for that proxy chain; see [Configure Client IP Detection](../client-traffic-policy/#configure-client-ip-detection). Otherwise the directly connected peer's address is used, and every client behind the same proxy shares one bucket.
 
 This example limits each client IP to 10 requests/Minute. The `0.0.0.0/0` CIDR only covers IPv4 clients; add a second rule with `::/0` to limit IPv6 clients too.
 
@@ -676,7 +678,7 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-The buckets live in the memory of each Envoy proxy: a client whose requests reach different proxies gets a separate budget on each, and every bucket starts full again when the proxy restarts. Use [Global Rate Limiting][] when the limit must be shared across proxies.
+Each Envoy proxy keeps these buckets in its own memory, in a bounded least recently used cache per rule with a `Distinct` selector on each route. A client whose requests reach different proxies gets a separate budget on each, and every bucket starts full again when the proxy restarts. When a new value does not fit in the cache, the least recently used entry is evicted; if that value appears again, its bucket starts full, so cache churn can let a value exceed its configured rate. Use [Global Rate Limiting][] when the limit must be shared across proxies.
 
 ## Rate Limit Based on Path
 

--- a/site/content/en/v1.8/tasks/traffic/local-rate-limit.md
+++ b/site/content/en/v1.8/tasks/traffic/local-rate-limit.md
@@ -611,8 +611,72 @@ transfer-encoding: chunked
 
 ```
 
-**Note:** Local rate limiting does not support `distinct` matching. If you want to rate limit based on distinct values,
-you should use [Global Rate Limiting][].
+**Note:** Local rate limiting supports `Distinct` matching since v1.4.0. See [Rate Limit Distinct Clients](#rate-limit-distinct-clients).
+
+## Rate Limit Distinct Clients
+
+With a selector of type `Distinct`, every distinct value seen in the traffic gets its own token bucket: a `sourceCIDR` of type `Distinct` limits each client IP separately, and a header of type `Distinct` limits each header value separately.
+
+This example limits each client IP to 10 requests/Minute. The `0.0.0.0/0` CIDR only covers IPv4 clients; add a second rule with `::/0` to limit IPv6 clients too.
+
+{{< tabpane text=true >}}
+{{% tab header="Apply from stdin" %}}
+
+```shell
+cat <<EOF | kubectl apply -f -
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: policy-httproute
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: http-ratelimit
+  rateLimit:
+    local:
+      rules:
+      - clientSelectors:
+        - sourceCIDR:
+            type: Distinct
+            value: 0.0.0.0/0
+        limit:
+          requests: 10
+          unit: Minute
+EOF
+```
+
+{{% /tab %}}
+{{% tab header="Apply from file" %}}
+Save and apply the following resource to your cluster:
+
+```yaml
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: policy-httproute
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: http-ratelimit
+  rateLimit:
+    local:
+      rules:
+      - clientSelectors:
+        - sourceCIDR:
+            type: Distinct
+            value: 0.0.0.0/0
+        limit:
+          requests: 10
+          unit: Minute
+```
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+The buckets live in the memory of each Envoy proxy: a client whose requests reach different proxies gets a separate budget on each, and every bucket starts full again when the proxy restarts. Use [Global Rate Limiting][] when the limit must be shared across proxies.
 
 ## Rate Limit Based on Path
 

--- a/site/content/en/v1.8/tasks/traffic/local-rate-limit.md
+++ b/site/content/en/v1.8/tasks/traffic/local-rate-limit.md
@@ -615,7 +615,9 @@ transfer-encoding: chunked
 
 ## Rate Limit Distinct Clients
 
-With a selector of type `Distinct`, every distinct value seen in the traffic gets its own token bucket: a `sourceCIDR` of type `Distinct` limits each client IP separately, and a header of type `Distinct` limits each header value separately.
+For a single selector of type `Distinct`, local rate limiting keeps a separate token bucket per distinct matched value, subject to the cache capacity described below. A `sourceCIDR` selector distinguishes the detected client IP addresses within the CIDR, and a header selector distinguishes header values.
+
+Envoy keys a `sourceCIDR` selector on the client address it detects. When clients reach Envoy through trusted proxies that pass their addresses in `X-Forwarded-For`, first configure `clientIPDetection` in a `ClientTrafficPolicy` targeting the Gateway for that proxy chain; see [Configure Client IP Detection](../client-traffic-policy/#configure-client-ip-detection). Otherwise the directly connected peer's address is used, and every client behind the same proxy shares one bucket.
 
 This example limits each client IP to 10 requests/Minute. The `0.0.0.0/0` CIDR only covers IPv4 clients; add a second rule with `::/0` to limit IPv6 clients too.
 
@@ -676,7 +678,7 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-The buckets live in the memory of each Envoy proxy: a client whose requests reach different proxies gets a separate budget on each, and every bucket starts full again when the proxy restarts. Use [Global Rate Limiting][] when the limit must be shared across proxies.
+Each Envoy proxy keeps these buckets in its own memory, in a bounded least recently used cache per rule with a `Distinct` selector on each route. A client whose requests reach different proxies gets a separate budget on each, and every bucket starts full again when the proxy restarts. When a new value does not fit in the cache, the least recently used entry is evicted; if that value appears again, its bucket starts full, so cache churn can let a value exceed its configured rate. Use [Global Rate Limiting][] when the limit must be shared across proxies.
 
 ## Rate Limit Based on Path
 

--- a/site/content/en/v1.9/tasks/traffic/local-rate-limit.md
+++ b/site/content/en/v1.9/tasks/traffic/local-rate-limit.md
@@ -611,8 +611,72 @@ transfer-encoding: chunked
 
 ```
 
-**Note:** Local rate limiting does not support `distinct` matching. If you want to rate limit based on distinct values,
-you should use [Global Rate Limiting][].
+**Note:** Local rate limiting supports `Distinct` matching since v1.4.0. See [Rate Limit Distinct Clients](#rate-limit-distinct-clients).
+
+## Rate Limit Distinct Clients
+
+With a selector of type `Distinct`, every distinct value seen in the traffic gets its own token bucket: a `sourceCIDR` of type `Distinct` limits each client IP separately, and a header of type `Distinct` limits each header value separately.
+
+This example limits each client IP to 10 requests/Minute. The `0.0.0.0/0` CIDR only covers IPv4 clients; add a second rule with `::/0` to limit IPv6 clients too.
+
+{{< tabpane text=true >}}
+{{% tab header="Apply from stdin" %}}
+
+```shell
+cat <<EOF | kubectl apply -f -
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: policy-httproute
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: http-ratelimit
+  rateLimit:
+    local:
+      rules:
+      - clientSelectors:
+        - sourceCIDR:
+            type: Distinct
+            value: 0.0.0.0/0
+        limit:
+          requests: 10
+          unit: Minute
+EOF
+```
+
+{{% /tab %}}
+{{% tab header="Apply from file" %}}
+Save and apply the following resource to your cluster:
+
+```yaml
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: policy-httproute
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: http-ratelimit
+  rateLimit:
+    local:
+      rules:
+      - clientSelectors:
+        - sourceCIDR:
+            type: Distinct
+            value: 0.0.0.0/0
+        limit:
+          requests: 10
+          unit: Minute
+```
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+The buckets live in the memory of each Envoy proxy: a client whose requests reach different proxies gets a separate budget on each, and every bucket starts full again when the proxy restarts. Use [Global Rate Limiting][] when the limit must be shared across proxies.
 
 ## Rate Limit Based on Path
 

--- a/site/content/en/v1.9/tasks/traffic/local-rate-limit.md
+++ b/site/content/en/v1.9/tasks/traffic/local-rate-limit.md
@@ -615,7 +615,9 @@ transfer-encoding: chunked
 
 ## Rate Limit Distinct Clients
 
-With a selector of type `Distinct`, every distinct value seen in the traffic gets its own token bucket: a `sourceCIDR` of type `Distinct` limits each client IP separately, and a header of type `Distinct` limits each header value separately.
+For a single selector of type `Distinct`, local rate limiting keeps a separate token bucket per distinct matched value, subject to the cache capacity described below. A `sourceCIDR` selector distinguishes the detected client IP addresses within the CIDR, and a header selector distinguishes header values.
+
+Envoy keys a `sourceCIDR` selector on the client address it detects. When clients reach Envoy through trusted proxies that pass their addresses in `X-Forwarded-For`, first configure `clientIPDetection` in a `ClientTrafficPolicy` targeting the Gateway for that proxy chain; see [Configure Client IP Detection](../client-traffic-policy/#configure-client-ip-detection). Otherwise the directly connected peer's address is used, and every client behind the same proxy shares one bucket.
 
 This example limits each client IP to 10 requests/Minute. The `0.0.0.0/0` CIDR only covers IPv4 clients; add a second rule with `::/0` to limit IPv6 clients too.
 
@@ -676,7 +678,7 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-The buckets live in the memory of each Envoy proxy: a client whose requests reach different proxies gets a separate budget on each, and every bucket starts full again when the proxy restarts. Use [Global Rate Limiting][] when the limit must be shared across proxies.
+Each Envoy proxy keeps these buckets in its own memory, in a bounded least recently used cache per rule with a `Distinct` selector on each route. A client whose requests reach different proxies gets a separate budget on each, and every bucket starts full again when the proxy restarts. When a new value does not fit in the cache, the least recently used entry is evicted; if that value appears again, its bucket starts full, so cache churn can let a value exceed its configured rate. Use [Global Rate Limiting][] when the limit must be shared across proxies.
 
 ## Rate Limit Based on Path
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The local rate limit task page still says Distinct matching is not supported and points readers to global rate limiting. Distinct matching for local rate limits shipped in v1.4.0 (#5319). This replaces the note with a "Rate Limit Distinct Clients" example (a per-client-IP limit via `sourceCIDR` of type `Distinct`, with the IPv6 caveat) and explains what per-proxy buckets mean, on `latest`, `v1.8` and `v1.9`.

**Which issue(s) this PR fixes**:

None, documentation correction.

---

**PR Checklist**

- [x] **Authorship & ownership**: I have reviewed every change and take full responsibility for this PR.
- [x] **DCO**: all commits are signed off.
- [x] **API agreed first**: N/A.
- [x] **Required checks pass**: N/A, documentation only.
- [x] **Tests added/updated**: N/A.
- [x] **Docs**: this PR.
- [x] **Release notes**: N/A.
- [x] **Generated files committed**: N/A.
- [x] **Scope & compatibility**: documentation only.
